### PR TITLE
feat: add api key auth with prefixed secrets and per-endpoint scopes

### DIFF
--- a/docs/content/docs/api-keys/index.mdx
+++ b/docs/content/docs/api-keys/index.mdx
@@ -37,9 +37,10 @@ The API key object contains the following fields:
   "user_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
   "organization_id": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
   "name": "Production API Key",
-  "key_prefix": "wmbly_abc",
-  "permissions": 8191,
-  "allowed_ips": ["203.0.113.10"],
+  "key_prefix": "wmbly_ab",
+  "key_suffix": "wxyz",
+  "permissions": 688159,
+  "allowed_ips": ["203.0.113.10", "10.0.0.0/8"],
   "allowed_email_accounts": [],
   "status": "active",
   "last_used_at": "2024-01-15T10:30:00Z",
@@ -59,10 +60,11 @@ The API key object contains the following fields:
 | `user_id` | UUID | ID of the user who created the key |
 | `organization_id` | UUID | ID of the organization |
 | `name` | string | Human-readable name for the key |
-| `key_prefix` | string | First 10 characters of the key (for identification) |
+| `key_prefix` | string | First 8 characters of the key, including the `wmbly_` brand |
+| `key_suffix` | string | Last 4 characters of the key — display as `wmbly_ab...wxyz` |
 | `permissions` | integer | Bitmask of granted permissions |
-| `allowed_ips` | array | IP addresses allowed to use this key (empty = all) |
-| `allowed_email_accounts` | array | Email account IDs this key can access (empty = all) |
+| `allowed_ips` | array | IPs or CIDR blocks allowed to use this key (empty = all). Accepts `10.0.0.1`, `192.168.0.0/16`, `2001:db8::/32` |
+| `allowed_email_accounts` | array | Email account UUIDs this key can access (empty = all) |
 | `status` | string | Key status: `active`, `revoked`, or `expired` |
 | `last_used_at` | timestamp | When the key was last used |
 | `expires_at` | timestamp | When the key expires (null = never) |

--- a/docs/content/docs/api-keys/permissions.mdx
+++ b/docs/content/docs/api-keys/permissions.mdx
@@ -5,7 +5,7 @@ description: Retrieve all available API permissions and preset permission sets.
 
 # List Permissions
 
-Get a list of all available API permissions and preset permission combinations.
+Get a list of all available API permissions and the preset permission sets surfaced by the API key creation UI.
 
 ```
 GET /api-keys/permissions
@@ -33,94 +33,30 @@ curl -X GET "https://api.warmbly.com/api-keys/permissions" \
 ```json
 {
   "permissions": [
-    {
-      "name": "READ_EMAILS",
-      "value": 1,
-      "description": "View email accounts and settings",
-      "category": "read"
-    },
-    {
-      "name": "READ_CAMPAIGNS",
-      "value": 2,
-      "description": "View campaigns and sequences",
-      "category": "read"
-    },
-    {
-      "name": "READ_CONTACTS",
-      "value": 4,
-      "description": "View contact lists",
-      "category": "read"
-    },
-    {
-      "name": "READ_UNIBOX",
-      "value": 8,
-      "description": "Access unified inbox",
-      "category": "read"
-    },
-    {
-      "name": "READ_ANALYTICS",
-      "value": 16,
-      "description": "View analytics and statistics",
-      "category": "read"
-    },
-    {
-      "name": "WRITE_EMAILS",
-      "value": 32,
-      "description": "Modify email account settings",
-      "category": "write"
-    },
-    {
-      "name": "WRITE_CAMPAIGNS",
-      "value": 64,
-      "description": "Create and modify campaigns",
-      "category": "write"
-    },
-    {
-      "name": "WRITE_CONTACTS",
-      "value": 128,
-      "description": "Create and modify contacts",
-      "category": "write"
-    },
-    {
-      "name": "WRITE_UNIBOX",
-      "value": 256,
-      "description": "Mark emails as read/unread",
-      "category": "write"
-    },
-    {
-      "name": "BULK_CONTACTS",
-      "value": 512,
-      "description": "Bulk import/export contacts",
-      "category": "bulk"
-    },
-    {
-      "name": "BULK_CAMPAIGNS",
-      "value": 1024,
-      "description": "Bulk campaign operations",
-      "category": "bulk"
-    },
-    {
-      "name": "REALTIME_SUBSCRIBE",
-      "value": 2048,
-      "description": "Subscribe to real-time events",
-      "category": "special"
-    },
-    {
-      "name": "WEBHOOKS",
-      "value": 4096,
-      "description": "Manage webhook endpoints",
-      "category": "special"
-    },
-    {
-      "name": "API_KEYS",
-      "value": 8192,
-      "description": "Create and manage API keys",
-      "category": "special"
-    }
+    { "name": "READ_EMAILS", "value": 1, "description": "View email accounts and settings", "category": "read" },
+    { "name": "READ_CAMPAIGNS", "value": 2, "description": "View campaigns and sequences", "category": "read" },
+    { "name": "READ_CONTACTS", "value": 4, "description": "View contact lists, notes, and activities", "category": "read" },
+    { "name": "READ_UNIBOX", "value": 8, "description": "Access unified inbox", "category": "read" },
+    { "name": "READ_ANALYTICS", "value": 16, "description": "View analytics and statistics", "category": "read" },
+    { "name": "READ_TEMPLATES", "value": 32768, "description": "View reply templates", "category": "read" },
+    { "name": "READ_CRM", "value": 131072, "description": "View pipelines, deals, and CRM tasks", "category": "read" },
+    { "name": "READ_AUDIT_LOGS", "value": 524288, "description": "View organization audit logs", "category": "read" },
+    { "name": "WRITE_EMAILS", "value": 32, "description": "Modify email account settings", "category": "write" },
+    { "name": "WRITE_CAMPAIGNS", "value": 64, "description": "Create and modify campaigns and sequences", "category": "write" },
+    { "name": "WRITE_CONTACTS", "value": 128, "description": "Create and modify contacts, notes, and activities", "category": "write" },
+    { "name": "WRITE_UNIBOX", "value": 256, "description": "Mark emails as read/unread and send replies", "category": "write" },
+    { "name": "WRITE_TEMPLATES", "value": 65536, "description": "Create and modify reply templates", "category": "write" },
+    { "name": "WRITE_CRM", "value": 262144, "description": "Create and modify pipelines, deals, CRM tasks", "category": "write" },
+    { "name": "SEND_CAMPAIGNS", "value": 16384, "description": "Start and stop campaigns (sends real mail)", "category": "write" },
+    { "name": "BULK_CONTACTS", "value": 512, "description": "Bulk import/export/delete contacts", "category": "bulk" },
+    { "name": "BULK_CAMPAIGNS", "value": 1024, "description": "Bulk campaign operations", "category": "bulk" },
+    { "name": "REALTIME_SUBSCRIBE", "value": 2048, "description": "Subscribe to realtime events", "category": "special" },
+    { "name": "WEBHOOKS", "value": 4096, "description": "Manage webhook endpoints", "category": "special" },
+    { "name": "API_KEYS", "value": 8192, "description": "Create and manage API keys", "category": "special" }
   ],
   "presets": {
-    "read_only": 31,
-    "full_access": 16383
+    "read_only": 688159,
+    "full_access": 1048575
   }
 }
 ```
@@ -132,40 +68,37 @@ curl -X GET "https://api.warmbly.com/api-keys/permissions" \
 | `name` | string | Permission identifier |
 | `value` | integer | Bitmask value (power of 2) |
 | `description` | string | Human-readable description |
-| `category` | string | Category: `read`, `write`, `bulk`, or `special` |
+| `category` | string | One of `read`, `write`, `bulk`, `special` |
 
-### Presets Object
+### Presets
 
 | Preset | Value | Description |
 |--------|-------|-------------|
-| `read_only` | 31 | All read permissions |
-| `full_access` | 16383 | All permissions |
+| `read_only` | 688159 | All read permissions across emails, campaigns, contacts, unibox, analytics, templates, CRM, audit logs |
+| `full_access` | 1048575 | Every defined permission bit |
 
 ## Working with Permissions
 
-### Combining Permissions
+### Combining
 
-Permissions use a bitmask system. Combine them using bitwise OR (`|`):
+Permissions use a bitmask. Combine them with bitwise OR (`|`):
 
 ```javascript
 const READ_EMAILS = 1;
 const READ_CAMPAIGNS = 2;
 const WRITE_CAMPAIGNS = 64;
 
-// Combine permissions
 const permissions = READ_EMAILS | READ_CAMPAIGNS | WRITE_CAMPAIGNS;
-// Result: 67
+// 67
 ```
 
-### Checking Permissions
-
-Use bitwise AND (`&`) to check if a permission is set:
+### Checking
 
 ```javascript
 const permissions = 67;
 const WRITE_CAMPAIGNS = 64;
 
-if (permissions & WRITE_CAMPAIGNS) {
+if ((permissions & WRITE_CAMPAIGNS) === WRITE_CAMPAIGNS) {
   console.log('Has WRITE_CAMPAIGNS permission');
 }
 ```
@@ -173,18 +106,18 @@ if (permissions & WRITE_CAMPAIGNS) {
 ### Using Presets
 
 ```bash
-# Create a read-only key using the preset
+# Create a read-only key
 curl -X POST "https://api.warmbly.com/api-keys" \
   -H "Authorization: Bearer wmbly_abc123..." \
   -H "Content-Type: application/json" \
   -d '{
     "name": "Read Only Key",
-    "permissions": 31
+    "permissions": 688159
   }'
 ```
 
 ## See Also
 
-- [Permissions Reference](/reference/permissions) - Detailed permission documentation
+- [Permissions Reference](/reference/permissions) — detailed permission documentation
 - [Create API Key](/api-keys/create)
 - [Authentication](/authentication)

--- a/docs/content/docs/authentication.mdx
+++ b/docs/content/docs/authentication.mdx
@@ -12,10 +12,12 @@ The Warmbly API uses API keys for authentication. Each API key has specific perm
 API keys follow this format:
 
 ```
-wmbly_<random_string>
+wmbly_<43-character-random-string>
 ```
 
-The `wmbly_` prefix identifies the key as a Warmbly API key. The remaining characters are a cryptographically secure random string.
+The `wmbly_` prefix identifies the key as a Warmbly key. The remaining 43 characters are 32 random bytes encoded as base64url (no padding) — 256 bits of entropy, so brute-forcing a valid key is computationally infeasible.
+
+Keys are stored as a SHA-256 hash; the plaintext is shown exactly once on creation. To help you spot a key in the dashboard without exposing the secret, we store the first 8 characters (`key_prefix`, e.g. `wmbly_ab`) and the last 4 characters (`key_suffix`, e.g. `wxyz`). Render them as `wmbly_ab…wxyz`.
 
 ## Using Your API Key
 
@@ -82,17 +84,22 @@ Total: 1 + 2 + 4 + 8 + 16 = 31
 
 ## IP Restrictions
 
-You can restrict API keys to specific IP addresses:
+You can restrict API keys to specific IPs or CIDR ranges. Entries can be bare IPs (v4 or v6) or CIDR blocks; an empty list means "any IP".
 
 ```json
 {
   "name": "Production Server",
-  "permissions": 31,
-  "allowed_ips": ["203.0.113.10", "203.0.113.11"]
+  "permissions": 688159,
+  "allowed_ips": [
+    "203.0.113.10",
+    "203.0.113.11",
+    "10.0.0.0/8",
+    "2001:db8::/32"
+  ]
 }
 ```
 
-Requests from other IP addresses will be rejected with a `403 Forbidden` error.
+Requests from outside every listed range are rejected with `403 Forbidden`. There's a soft cap of 64 entries per key.
 
 ## Email Account Restrictions
 

--- a/docs/content/docs/reference/endpoints.mdx
+++ b/docs/content/docs/reference/endpoints.mdx
@@ -1,0 +1,161 @@
+---
+title: Endpoint Scope Map
+description: Every endpoint, which auth types it accepts, and which permission it requires.
+---
+
+# Endpoint Scope Map
+
+This page is the source of truth for what an API key can and cannot reach. Every route in the backend falls into one of three buckets:
+
+- **API key accepted** — works with both a JWT (dashboard user) and an API key with the listed permission.
+- **JWT only** — never reachable via an API key. Used for billing, governance, websocket bootstrap, danger-zone destruction, the OAuth onboarding flow, and admin tools.
+- **Public** — no auth required (webhooks with signature verification, health check, OAuth bouncer pages).
+
+When an endpoint says "JWT permission: X / API permission: Y", the dual-auth middleware checks the relevant one based on which credential the caller used.
+
+## API Key Accepted
+
+### Emails
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/emails` | `READ_EMAILS` |
+| GET | `/emails/:id` | `READ_EMAILS` |
+| PATCH | `/emails/:id` | `WRITE_EMAILS` |
+| PATCH | `/emails/:id/track` | `WRITE_EMAILS` |
+| DELETE | `/emails/:id` | `WRITE_EMAILS` |
+| POST | `/emails/:id/send` | `SEND_CAMPAIGNS` |
+
+### Campaigns and sequences
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/campaigns` | `READ_CAMPAIGNS` |
+| POST | `/campaigns` | `WRITE_CAMPAIGNS` |
+| GET | `/campaigns/:id` | `READ_CAMPAIGNS` |
+| PATCH | `/campaigns/:id` | `WRITE_CAMPAIGNS` |
+| DELETE | `/campaigns/:id` | `WRITE_CAMPAIGNS` |
+| GET | `/campaigns/:id/advanced` | `READ_CAMPAIGNS` |
+| PATCH | `/campaigns/:id/advanced` | `WRITE_CAMPAIGNS` |
+| GET | `/campaigns/:id/ab-variants` | `READ_CAMPAIGNS` |
+| POST | `/campaigns/:id/ab-variants` | `WRITE_CAMPAIGNS` |
+| PATCH | `/campaigns/:id/ab-variants/:variantId` | `WRITE_CAMPAIGNS` |
+| DELETE | `/campaigns/:id/ab-variants/:variantId` | `WRITE_CAMPAIGNS` |
+| GET | `/campaigns/:id/ab-analysis` | `READ_ANALYTICS` |
+| POST | `/campaigns/:id/preflight` | `SEND_CAMPAIGNS` |
+| POST | `/campaigns/:id/test-email` | `SEND_CAMPAIGNS` |
+| POST | `/campaigns/:id/start` | `SEND_CAMPAIGNS` |
+| POST | `/campaigns/:id/stop` | `SEND_CAMPAIGNS` |
+| GET | `/campaigns/:id/logs` | `READ_CAMPAIGNS` |
+| GET/POST/PATCH/DELETE | `/campaigns/:id/sequences[/:sid]` | `READ_CAMPAIGNS` for GET, `WRITE_CAMPAIGNS` otherwise |
+
+### Contacts
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| POST | `/contacts/search` | `READ_CONTACTS` |
+| POST | `/contacts` | `WRITE_CONTACTS` |
+| DELETE | `/contacts` | `BULK_CONTACTS` |
+| PATCH | `/contacts` | `BULK_CONTACTS` |
+| PATCH | `/contacts/:id` | `WRITE_CONTACTS` |
+| DELETE | `/contacts/:id` | `WRITE_CONTACTS` |
+| GET | `/contacts/:id/notes` | `READ_CONTACTS` |
+| POST | `/contacts/:id/notes` | `WRITE_CONTACTS` |
+| PATCH | `/contacts/:id/notes/:noteId` | `WRITE_CONTACTS` |
+| DELETE | `/contacts/:id/notes/:noteId` | `WRITE_CONTACTS` |
+| GET | `/contacts/:id/activities` | `READ_CONTACTS` |
+| GET | `/contacts/:id/deals` | `READ_CRM` |
+
+### Unibox
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/unibox` | `READ_UNIBOX` |
+| GET | `/unibox/count` | `READ_UNIBOX` |
+| GET | `/unibox/thread` | `READ_UNIBOX` |
+| GET | `/unibox/:id` | `READ_UNIBOX` |
+| PATCH | `/unibox/seen` | `WRITE_UNIBOX` |
+| POST | `/unibox/reply` | `WRITE_UNIBOX` |
+
+### Templates and CRM
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/templates`, `/templates/:id` | `READ_TEMPLATES` |
+| POST/PATCH/DELETE | `/templates[/:id]` | `WRITE_TEMPLATES` |
+| GET | `/crm/pipelines`, `/crm/pipelines/:id` | `READ_CRM` |
+| POST/PATCH/DELETE | `/crm/pipelines[/:id][/stages[/:stageId]]` | `WRITE_CRM` |
+| GET | `/crm/deals`, `/crm/deals/:id` | `READ_CRM` |
+| POST/PATCH/DELETE | `/crm/deals[/:id]` | `WRITE_CRM` |
+| GET | `/crm/tasks`, `/crm/tasks/:id` | `READ_CRM` |
+| POST/PATCH/DELETE | `/crm/tasks[/:id]` | `WRITE_CRM` |
+
+### Analytics and audit
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/analytics/*` (dashboard, deliverability, warmup, campaigns, accounts, usage) | `READ_ANALYTICS` |
+| GET | `/audit-logs` | `READ_AUDIT_LOGS` |
+
+### API key self-service
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/api-keys` | `API_KEYS` |
+| POST | `/api-keys` | `API_KEYS` |
+| GET | `/api-keys/permissions` | `API_KEYS` |
+| GET | `/api-keys/:id` | `API_KEYS` |
+| PATCH | `/api-keys/:id` | `API_KEYS` |
+| DELETE | `/api-keys/:id` | `API_KEYS` |
+
+### Operations
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET/PATCH | `/outreach/settings` | `WRITE_CAMPAIGNS` |
+| POST | `/deliverability/events` | `WRITE_CAMPAIGNS` |
+| GET | `/tasks/dlq` | `SEND_CAMPAIGNS` |
+| POST | `/tasks/dlq/:id/replay` | `SEND_CAMPAIGNS` |
+
+### Reference data
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/plans` | (any authenticated key) |
+| GET | `/timezones` | (any authenticated key) |
+
+## JWT Only
+
+These never accept an API key. They depend on a human-bound session — billing flows, governance, OAuth onboarding, websocket bootstrap, and operational destruction.
+
+- `POST /auth/login`, `/auth/login/confirm`, `/auth/register`, `/auth/register/confirm`, `/auth/refresh`, `/auth/reset-password`, `/auth/reset-password/confirm`
+- `POST /auth/logout`, `POST /auth/logout-all`, `GET /auth/me`, `PATCH /auth/me/onboarding`
+- `POST /auth/me/avatar`, `DELETE /auth/me/avatar`
+- `POST /emails/onboarding/oauth/start`, `POST /emails/onboarding/oauth/finish`, `POST /emails/onboarding/smtp-imap`
+- `POST /getaway` (websocket bootstrap)
+- `GET /realtime/info`
+- `GET /me/danger-zone`, `POST /me/danger-zone/delete`, `DELETE /me/danger-zone/delete`
+- `GET /invitations`, `POST /invitations/accept`
+- All of `/organization/*` (create, switch, members, invitations, transfer ownership, avatar, danger zone)
+- All of `/subscription/*` (checkout, portal, cancel, change-plan, preview-change, enterprise-inquiry, etc.)
+- All of `/admin/*`
+
+## Public
+
+- `GET /health`
+- `POST /webhooks/github/releases` (HMAC-SHA256 signature)
+- `POST /webhook/stripe` (Stripe signature)
+- `POST /webhook/campaign`, `/webhook/email`, `/webhook/user-email` (Google OIDC token from Cloud Tasks)
+- `GET /addresses/google/callback`, `GET /addresses/outlook/callback` (OAuth bouncer pages)
+
+## Notes
+
+- When a route has both a JWT permission and an API permission listed, the dual-auth middleware checks the JWT user's organization role for browser callers and the key's permission bitmask for API key callers. They're independent gates — a user's role doesn't constrain what an API key can do beyond what was granted at creation.
+- Every API key request is logged to `api_key_usage_logs` with the endpoint pattern (e.g. `/campaigns/:id`), method, IP, user-agent, response status, and elapsed milliseconds. JWT requests are not logged here.
+- Rate limit categories (`X-RateLimit-*` headers) are scoped to the underlying user, not the key — every key issued by a user shares the user's quota.
+
+## See Also
+
+- [Authentication](/authentication)
+- [Permissions Reference](/reference/permissions)
+- [Error Codes](/reference/error-codes)

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -2,6 +2,7 @@
   "title": "Reference",
   "pages": [
     "permissions",
+    "endpoints",
     "error-codes"
   ]
 }

--- a/docs/content/docs/reference/permissions.mdx
+++ b/docs/content/docs/reference/permissions.mdx
@@ -1,11 +1,11 @@
 ---
 title: Permissions Reference
-description: Complete reference for all 14 API permissions available in Warmbly.
+description: Complete reference for the 20 API permissions available in Warmbly.
 ---
 
 # Permissions Reference
 
-Warmbly uses a bitmask system for API permissions. Each permission is represented by a single bit, allowing efficient combination and checking of multiple permissions.
+Warmbly uses a bitmask system for API permissions. Each permission is one bit in a `uint64`, so a single integer can express any combination of the permissions below.
 
 ## Permission Values
 
@@ -13,125 +13,95 @@ Warmbly uses a bitmask system for API permissions. Each permission is represente
 |------------|-----|-------|----------|-------------|
 | `READ_EMAILS` | 0 | 1 | read | View email accounts and settings |
 | `READ_CAMPAIGNS` | 1 | 2 | read | View campaigns and sequences |
-| `READ_CONTACTS` | 2 | 4 | read | View contact lists |
+| `READ_CONTACTS` | 2 | 4 | read | View contact lists, notes, and activities |
 | `READ_UNIBOX` | 3 | 8 | read | Access unified inbox |
 | `READ_ANALYTICS` | 4 | 16 | read | View analytics and statistics |
 | `WRITE_EMAILS` | 5 | 32 | write | Modify email account settings |
-| `WRITE_CAMPAIGNS` | 6 | 64 | write | Create and modify campaigns |
-| `WRITE_CONTACTS` | 7 | 128 | write | Create and modify contacts |
-| `WRITE_UNIBOX` | 8 | 256 | write | Mark emails as read/unread |
-| `BULK_CONTACTS` | 9 | 512 | bulk | Bulk import/export contacts |
+| `WRITE_CAMPAIGNS` | 6 | 64 | write | Create and modify campaigns and sequences |
+| `WRITE_CONTACTS` | 7 | 128 | write | Create and modify contacts, notes, activities |
+| `WRITE_UNIBOX` | 8 | 256 | write | Mark emails as read/unread and send replies |
+| `BULK_CONTACTS` | 9 | 512 | bulk | Bulk import/export/delete contacts |
 | `BULK_CAMPAIGNS` | 10 | 1024 | bulk | Bulk campaign operations |
-| `REALTIME_SUBSCRIBE` | 11 | 2048 | special | Subscribe to real-time events |
-| `WEBHOOKS` | 12 | 4096 | special | Manage webhook endpoints |
+| `REALTIME_SUBSCRIBE` | 11 | 2048 | special | Subscribe to realtime events |
+| `WEBHOOKS` | 12 | 4096 | special | Manage webhook endpoints (reserved) |
 | `API_KEYS` | 13 | 8192 | special | Create and manage API keys |
+| `SEND_CAMPAIGNS` | 14 | 16384 | write | Start and stop campaigns (sends real mail) |
+| `READ_TEMPLATES` | 15 | 32768 | read | View reply templates |
+| `WRITE_TEMPLATES` | 16 | 65536 | write | Create and modify reply templates |
+| `READ_CRM` | 17 | 131072 | read | View pipelines, deals, and CRM tasks |
+| `WRITE_CRM` | 18 | 262144 | write | Create and modify pipelines, deals, CRM tasks |
+| `READ_AUDIT_LOGS` | 19 | 524288 | read | View organization audit logs |
+
+`SEND_CAMPAIGNS` is intentionally separate from `WRITE_CAMPAIGNS`: editing a campaign draft and starting one that actually transmits mail are different blast radii, so a key can be granted the first without the second.
 
 ## Categories
 
-### Read Permissions (Bits 0-4)
+### Read
 
-Read permissions allow viewing data without modification. They're safe to grant for monitoring and reporting integrations.
+Read-only data access. Safe for monitoring, reporting, BI sync.
 
-| Permission | Value | Use Case |
-|------------|-------|----------|
-| `READ_EMAILS` | 1 | Dashboard monitoring, email status checks |
-| `READ_CAMPAIGNS` | 2 | Campaign analytics, reporting |
-| `READ_CONTACTS` | 4 | CRM integration, contact sync |
-| `READ_UNIBOX` | 8 | Inbox monitoring, support tools |
-| `READ_ANALYTICS` | 16 | Reporting dashboards, BI tools |
+### Write
 
-### Write Permissions (Bits 5-8)
+Resource mutation, but no campaign starts. A key with the full write set can edit drafts but cannot turn on a campaign.
 
-Write permissions allow creating and modifying resources. Grant these carefully based on integration needs.
+### Bulk
 
-| Permission | Value | Use Case |
-|------------|-------|----------|
-| `WRITE_EMAILS` | 32 | Email management automation |
-| `WRITE_CAMPAIGNS` | 64 | Campaign creation, scheduling |
-| `WRITE_CONTACTS` | 128 | CRM sync, lead import |
-| `WRITE_UNIBOX` | 256 | Inbox management, auto-replies |
+High-volume operations. These can touch large numbers of rows in a single request, so they're broken out from the per-record write permissions.
 
-### Bulk Permissions (Bits 9-10)
+### Special
 
-Bulk permissions enable high-volume operations. These can affect large amounts of data quickly.
-
-| Permission | Value | Use Case |
-|------------|-------|----------|
-| `BULK_CONTACTS` | 512 | Large-scale contact import/export |
-| `BULK_CAMPAIGNS` | 1024 | Batch campaign operations |
-
-### Special Permissions (Bits 11-13)
-
-Special permissions grant access to advanced features and should be granted sparingly.
-
-| Permission | Value | Use Case |
-|------------|-------|----------|
-| `REALTIME_SUBSCRIBE` | 2048 | Live dashboards, real-time sync |
-| `WEBHOOKS` | 4096 | Event-driven integrations |
-| `API_KEYS` | 8192 | Self-service key management |
+Realtime subscriptions, webhooks, self-service key management. Grant individually.
 
 ## Preset Combinations
 
-### Read Only (31)
+Both presets are returned by `GET /api-keys/permissions` for convenience.
+
+### Read Only — 688159
 
 All read permissions combined:
 
 ```
 READ_EMAILS | READ_CAMPAIGNS | READ_CONTACTS | READ_UNIBOX | READ_ANALYTICS
-= 1 | 2 | 4 | 8 | 16
-= 31
+  | READ_TEMPLATES | READ_CRM | READ_AUDIT_LOGS
+= 1 | 2 | 4 | 8 | 16 | 32768 | 131072 | 524288
+= 688159
 ```
 
-### Full Access (16383)
+### Full Access — 1048575
 
-All permissions combined:
+All 20 permissions:
 
 ```
-(1 << 14) - 1 = 16383
+(1 << 20) - 1 = 1048575
 ```
 
 ## Working with Bitmasks
 
-### Combining Permissions
-
-Use bitwise OR (`|`) to combine permissions:
+### Combining
 
 ```javascript
 const READ_EMAILS = 1;
 const READ_CAMPAIGNS = 2;
-const WRITE_CAMPAIGNS = 64;
+const SEND_CAMPAIGNS = 16384;
 
-const permissions = READ_EMAILS | READ_CAMPAIGNS | WRITE_CAMPAIGNS;
-// Result: 67
+const permissions = READ_EMAILS | READ_CAMPAIGNS | SEND_CAMPAIGNS;
+// 16387
 ```
 
-### Checking Permissions
-
-Use bitwise AND (`&`) to check if a permission is set:
+### Checking
 
 ```javascript
 function hasPermission(permissions, required) {
   return (permissions & required) === required;
 }
 
-const myPermissions = 67;
-hasPermission(myPermissions, 64); // true (has WRITE_CAMPAIGNS)
-hasPermission(myPermissions, 128); // false (no WRITE_CONTACTS)
+hasPermission(16387, 16384); // true — SEND_CAMPAIGNS granted
+hasPermission(16387, 64);    // false — WRITE_CAMPAIGNS missing
 ```
 
-### Checking Multiple Permissions
+### Rejecting unknown bits
 
-Check if all required permissions are present:
-
-```javascript
-function hasAllPermissions(permissions, required) {
-  return (permissions & required) === required;
-}
-
-const myPermissions = 67;
-const required = 1 | 2; // READ_EMAILS and READ_CAMPAIGNS
-hasAllPermissions(myPermissions, required); // true
-```
+`POST /api-keys` rejects any request whose `permissions` field has bits outside the known set, so a stale client can't accidentally request a future permission. The current mask of valid bits is `1048575`.
 
 ## Common Permission Sets
 
@@ -141,36 +111,39 @@ For dashboards and reporting:
 
 ```javascript
 const MONITORING =
-  READ_EMAILS |      // 1
-  READ_CAMPAIGNS |   // 2
-  READ_ANALYTICS;    // 16
-// Result: 19
+  READ_EMAILS |     // 1
+  READ_CAMPAIGNS |  // 2
+  READ_ANALYTICS;   // 16
+// 19
 ```
 
 ### CRM Sync
 
-For two-way contact synchronization:
-
 ```javascript
 const CRM_SYNC =
-  READ_CONTACTS |    // 4
-  WRITE_CONTACTS |   // 128
-  BULK_CONTACTS;     // 512
-// Result: 644
+  READ_CONTACTS |   // 4
+  WRITE_CONTACTS |  // 128
+  BULK_CONTACTS |   // 512
+  READ_CRM |        // 131072
+  WRITE_CRM;        // 262144
+// 393860
 ```
 
-### Campaign Automation
-
-For automated campaign management:
+### Campaign Automation (drafts only, no send)
 
 ```javascript
-const CAMPAIGN_AUTO =
-  READ_CAMPAIGNS |     // 2
-  WRITE_CAMPAIGNS |    // 64
-  READ_CONTACTS |      // 4
-  READ_ANALYTICS;      // 16
-// Result: 86
+const CAMPAIGN_DRAFTS =
+  READ_CAMPAIGNS |    // 2
+  WRITE_CAMPAIGNS |   // 64
+  READ_CONTACTS |     // 4
+  READ_TEMPLATES |    // 32768
+  WRITE_TEMPLATES;    // 65536
+// 98374
 ```
+
+### Campaign Automation (with send)
+
+Same as above, plus `SEND_CAMPAIGNS` (16384). Grant only when the integration genuinely needs to start campaigns.
 
 ## Permission Constants
 
@@ -192,6 +165,12 @@ export const Permissions = {
   REALTIME_SUBSCRIBE: 2048,
   WEBHOOKS: 4096,
   API_KEYS: 8192,
+  SEND_CAMPAIGNS: 16384,
+  READ_TEMPLATES: 32768,
+  WRITE_TEMPLATES: 65536,
+  READ_CRM: 131072,
+  WRITE_CRM: 262144,
+  READ_AUDIT_LOGS: 524288,
 } as const;
 ```
 
@@ -213,26 +192,38 @@ class Permissions:
     REALTIME_SUBSCRIBE = 2048
     WEBHOOKS = 4096
     API_KEYS = 8192
+    SEND_CAMPAIGNS = 16384
+    READ_TEMPLATES = 32768
+    WRITE_TEMPLATES = 65536
+    READ_CRM = 131072
+    WRITE_CRM = 262144
+    READ_AUDIT_LOGS = 524288
 ```
 
 ### Go
 
 ```go
 const (
-    PermReadEmails       uint64 = 1 << iota // 1
-    PermReadCampaigns                       // 2
-    PermReadContacts                        // 4
-    PermReadUnibox                          // 8
-    PermReadAnalytics                       // 16
-    PermWriteEmails                         // 32
-    PermWriteCampaigns                      // 64
-    PermWriteContacts                       // 128
-    PermWriteUnibox                         // 256
-    PermBulkContacts                        // 512
-    PermBulkCampaigns                       // 1024
-    PermRealtimeSubscribe                   // 2048
-    PermWebhooks                            // 4096
-    PermAPIKeys                             // 8192
+    APIPermReadEmails        uint64 = 1 << iota // 1
+    APIPermReadCampaigns                        // 2
+    APIPermReadContacts                         // 4
+    APIPermReadUnibox                           // 8
+    APIPermReadAnalytics                        // 16
+    APIPermWriteEmails                          // 32
+    APIPermWriteCampaigns                       // 64
+    APIPermWriteContacts                        // 128
+    APIPermWriteUnibox                          // 256
+    APIPermBulkContacts                         // 512
+    APIPermBulkCampaigns                        // 1024
+    APIPermRealtimeSubscribe                    // 2048
+    APIPermWebhooks                             // 4096
+    APIPermAPIKeys                              // 8192
+    APIPermSendCampaigns                        // 16384
+    APIPermReadTemplates                        // 32768
+    APIPermWriteTemplates                       // 65536
+    APIPermReadCRM                              // 131072
+    APIPermWriteCRM                             // 262144
+    APIPermReadAuditLogs                        // 524288
 )
 ```
 

--- a/internal/api/middleware/apikey.go
+++ b/internal/api/middleware/apikey.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/apikey"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
@@ -18,14 +19,14 @@ const (
 	AuthTypeAPIKey       = "api_key"
 )
 
-// APIKeyMiddleware validates API keys and extracts permissions
-// Only allows API key authentication, not JWT
+// APIKeyMiddleware accepts only API key auth ("Bearer wmbly_..."). Reserved
+// for endpoints that should never accept browser sessions — none today, but
+// useful if we add API-only routes (e.g. partner integrations).
 func (h *Handler) APIKeyMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 
-		// Check for API key format: "Bearer wmbly_..."
-		if strings.HasPrefix(authHeader, "Bearer wmbly_") {
+		if strings.HasPrefix(authHeader, "Bearer "+apikey.KeyPrefix) {
 			key := strings.TrimPrefix(authHeader, "Bearer ")
 			h.validateAPIKey(c, key)
 			return
@@ -36,25 +37,24 @@ func (h *Handler) APIKeyMiddleware() gin.HandlerFunc {
 	}
 }
 
-// CombinedAuthMiddleware allows either JWT or API key authentication
+// CombinedAuthMiddleware accepts either a JWT or an API key. The two paths
+// set the same context keys (UserIDKey, OrganizationIDKey) so downstream
+// handlers don't need to branch on auth_type unless they care about it.
 func (h *Handler) CombinedAuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		authHeader := c.GetHeader("Authorization")
 
-		if strings.HasPrefix(authHeader, "Bearer wmbly_") {
-			// API Key path
+		switch {
+		case strings.HasPrefix(authHeader, "Bearer "+apikey.KeyPrefix):
 			key := strings.TrimPrefix(authHeader, "Bearer ")
 			h.validateAPIKey(c, key)
-			return
-		} else if strings.HasPrefix(authHeader, "Bearer ") {
-			// JWT path
+		case strings.HasPrefix(authHeader, "Bearer "):
 			token := strings.TrimPrefix(authHeader, "Bearer ")
 			h.validateJWT(c, token)
-			return
+		default:
+			errx.Handle(c, errx.ErrAuth)
+			c.Abort()
 		}
-
-		errx.Handle(c, errx.ErrAuth)
-		c.Abort()
 	}
 }
 
@@ -65,37 +65,33 @@ func (h *Handler) validateAPIKey(c *gin.Context, rawKey string) {
 		return
 	}
 
-	// Validate the key
-	apiKey, xerr := h.APIKeyService.ValidateKey(c.Request.Context(), rawKey)
+	key, xerr := h.APIKeyService.ValidateKey(c.Request.Context(), rawKey)
 	if xerr != nil {
 		errx.Handle(c, xerr)
 		c.Abort()
 		return
 	}
 
-	// Check IP if restricted
-	clientIP := c.ClientIP()
-	if !h.APIKeyService.ValidateKeyIP(apiKey, clientIP) {
+	if !h.APIKeyService.ValidateKeyIP(key, c.ClientIP()) {
 		errx.Handle(c, errx.New(errx.Forbidden, "IP not allowed for this API key"))
 		c.Abort()
 		return
 	}
 
-	// Set context values
 	c.Set(AuthTypeKey, AuthTypeAPIKey)
-	c.Set(APIKeyIDKey, apiKey.ID.String())
-	c.Set(APIKeyPermissionsKey, apiKey.Permissions)
-	c.Set(UserIDKey, apiKey.UserID.String())
-	c.Set(OrganizationIDKey, apiKey.OrganizationID)
+	c.Set(APIKeyIDKey, key.ID.String())
+	c.Set(APIKeyPermissionsKey, key.Permissions)
+	c.Set(UserIDKey, key.UserID.String())
+	c.Set(OrganizationIDKey, key.OrganizationID)
 
-	// Update last used (already fires async internally with timeout)
-	h.APIKeyService.UpdateLastUsed(c.Request.Context(), apiKey.ID)
+	// UpdateLastUsed is itself fire-and-forget.
+	h.APIKeyService.UpdateLastUsed(c.Request.Context(), key.ID)
 
 	c.Next()
 }
 
 func (h *Handler) validateJWT(c *gin.Context, token string) {
-	userID, err := h.TokenService.ValidateAccessToken(c.Request.Context(), token)
+	session, err := h.TokenService.ValidateAccessToken(c.Request.Context(), token)
 	if err != nil {
 		errx.Handle(c, err)
 		c.Abort()
@@ -103,43 +99,103 @@ func (h *Handler) validateJWT(c *gin.Context, token string) {
 	}
 
 	c.Set(AuthTypeKey, AuthTypeJWT)
-	c.Set(UserIDKey, userID)
+	c.Set(UserIDKey, session.UserID.String())
+	c.Set(SessionKey, session)
 	c.Set(AccessTokenKey, token)
+	if session.CurrentOrganizationID != nil {
+		c.Set(OrganizationIDKey, *session.CurrentOrganizationID)
+	}
 	c.Next()
 }
 
-// RequireAPIPermission checks if the current auth has specific permission
-// Only applies to API key authentication - JWT users have full access
+// RequireAPIPermission gates a route on a single API permission bit. JWT
+// callers are waved through — for them, the relevant gate is the
+// OrganizationPermission check (RequirePermission / RequireAccess).
 func RequireAPIPermission(perm uint64) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		authType := c.GetString(AuthTypeKey)
+		if c.GetString(AuthTypeKey) != AuthTypeAPIKey {
+			c.Next()
+			return
+		}
 
-		if authType == AuthTypeAPIKey {
+		perms, exists := c.Get(APIKeyPermissionsKey)
+		if !exists {
+			errx.Handle(c, errx.ErrForbidden)
+			c.Abort()
+			return
+		}
+		permissions, ok := perms.(uint64)
+		if !ok || !models.HasAPIPermission(permissions, perm) {
+			errx.Handle(c, errx.New(errx.Forbidden, "insufficient API key permissions"))
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}
+
+// RequireAccess is the dual-auth permission gate. On a JWT request it
+// enforces the caller's organization role (orgPerm); on an API key request
+// it enforces the key's permission bit (apiPerm). Use this on routes that
+// accept both auth types but need an explicit permission.
+func (h *Handler) RequireAccess(orgPerm models.OrganizationPermission, apiPerm uint64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		switch c.GetString(AuthTypeKey) {
+		case AuthTypeAPIKey:
 			perms, exists := c.Get(APIKeyPermissionsKey)
 			if !exists {
 				errx.Handle(c, errx.ErrForbidden)
 				c.Abort()
 				return
 			}
-
 			permissions, ok := perms.(uint64)
-			if !ok || !models.HasAPIPermission(permissions, perm) {
-				errx.Handle(c, errx.New(errx.Forbidden, "Insufficient API key permissions"))
+			if !ok || !models.HasAPIPermission(permissions, apiPerm) {
+				errx.Handle(c, errx.New(errx.Forbidden, "insufficient API key permissions"))
 				c.Abort()
 				return
 			}
+			c.Next()
+		default:
+			// JWT path: defer to the org-permission gate.
+			if h.OrganizationService == nil {
+				c.Next()
+				return
+			}
+			userID, err := GetUserUUID(c)
+			if err != nil {
+				errx.JSON(c, errx.ErrUnauthorized)
+				c.Abort()
+				return
+			}
+			orgID := GetOrganizationID(c)
+			if orgID == nil {
+				errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+				c.Abort()
+				return
+			}
+			has, xerr := h.OrganizationService.HasPermission(c.Request.Context(), *orgID, userID, orgPerm)
+			if xerr != nil {
+				errx.JSON(c, xerr)
+				c.Abort()
+				return
+			}
+			if !has {
+				errx.JSON(c, errx.ErrForbidden)
+				c.Abort()
+				return
+			}
+			c.Next()
 		}
-		// JWT users have full access to their own resources
-		c.Next()
 	}
 }
 
-// GetAuthType returns the authentication type ("jwt" or "api_key")
+// GetAuthType returns "jwt" or "api_key" (empty if unauthenticated).
 func GetAuthType(c *gin.Context) string {
 	return c.GetString(AuthTypeKey)
 }
 
-// GetAPIKeyID returns the API key ID if authenticated via API key
+// GetAPIKeyID returns the authenticating API key's ID, or nil when the
+// request came in via JWT (or wasn't authenticated).
 func GetAPIKeyID(c *gin.Context) *uuid.UUID {
 	idStr := c.GetString(APIKeyIDKey)
 	if idStr == "" {
@@ -152,7 +208,8 @@ func GetAPIKeyID(c *gin.Context) *uuid.UUID {
 	return &id
 }
 
-// GetAPIKeyPermissions returns the API key permissions bitmask
+// GetAPIKeyPermissions returns the bitmask granted to the authenticating
+// API key, or 0 if the request was JWT-authenticated.
 func GetAPIKeyPermissions(c *gin.Context) uint64 {
 	perms, exists := c.Get(APIKeyPermissionsKey)
 	if !exists {

--- a/internal/api/middleware/apikey_test.go
+++ b/internal/api/middleware/apikey_test.go
@@ -1,0 +1,94 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestRequireAPIPermission(t *testing.T) {
+	tests := []struct {
+		name       string
+		authType   string
+		granted    uint64
+		required   uint64
+		wantStatus int
+	}{
+		{"jwt-bypass", AuthTypeJWT, 0, models.APIPermReadCampaigns, http.StatusOK},
+		{"apikey-granted", AuthTypeAPIKey, models.APIPermReadCampaigns | models.APIPermReadContacts, models.APIPermReadCampaigns, http.StatusOK},
+		{"apikey-missing", AuthTypeAPIKey, models.APIPermReadContacts, models.APIPermReadCampaigns, http.StatusForbidden},
+		{"apikey-no-perms-key", AuthTypeAPIKey, 0, models.APIPermReadCampaigns, http.StatusForbidden},
+		{"unauthenticated", "", 0, models.APIPermReadCampaigns, http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				if tt.authType != "" {
+					c.Set(AuthTypeKey, tt.authType)
+				}
+				if tt.authType == AuthTypeAPIKey && tt.granted != 0 {
+					c.Set(APIKeyPermissionsKey, tt.granted)
+				}
+				c.Next()
+			})
+			r.GET("/x", RequireAPIPermission(tt.required), func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{})
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestRequireAccessAPIKeyPath(t *testing.T) {
+	// JWT path is exercised in handler-level integration tests; here we
+	// pin the API-key branch since it doesn't depend on OrganizationService.
+	h := &Handler{}
+
+	tests := []struct {
+		name       string
+		granted    uint64
+		required   uint64
+		wantStatus int
+	}{
+		{"granted", models.APIPermWriteCampaigns | models.APIPermReadAnalytics, models.APIPermWriteCampaigns, http.StatusOK},
+		{"missing", models.APIPermReadAnalytics, models.APIPermWriteCampaigns, http.StatusForbidden},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set(AuthTypeKey, AuthTypeAPIKey)
+				c.Set(APIKeyPermissionsKey, tt.granted)
+				c.Next()
+			})
+			r.GET("/x", h.RequireAccess(models.PermManageCampaigns, tt.required), func(c *gin.Context) {
+				c.JSON(http.StatusOK, gin.H{})
+			})
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/x", nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/internal/api/middleware/apikey_usage.go
+++ b/internal/api/middleware/apikey_usage.go
@@ -1,0 +1,52 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// APIKeyUsageMiddleware records one usage-log row per API-key request.
+// Mounted once on the protected group so any route that accepts API key
+// auth gets logged. JWT requests are skipped — they're tracked elsewhere
+// (audit log, session activity).
+//
+// Logging is best-effort and runs after the response is written. We don't
+// fail the request if the insert fails; the service layer captures errors
+// to Sentry.
+func (h *Handler) APIKeyUsageMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		started := time.Now()
+		c.Next()
+
+		if c.GetString(AuthTypeKey) != AuthTypeAPIKey {
+			return
+		}
+		if h.APIKeyService == nil {
+			return
+		}
+
+		keyID := GetAPIKeyID(c)
+		if keyID == nil {
+			return
+		}
+
+		// FullPath gives the matched route pattern (e.g. /campaigns/:id),
+		// which is far more useful in the log than the concrete URL.
+		path := c.FullPath()
+		if path == "" {
+			path = c.Request.URL.Path
+		}
+
+		h.APIKeyService.LogUsage(c.Request.Context(), &models.APIKeyUsageLog{
+			APIKeyID:     *keyID,
+			Endpoint:     path,
+			Method:       c.Request.Method,
+			IPAddress:    c.ClientIP(),
+			UserAgent:    c.Request.UserAgent(),
+			ResponseCode: c.Writer.Status(),
+			ResponseTime: int(time.Since(started).Milliseconds()),
+		})
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -92,81 +92,98 @@ func Run(
 		protectedAuth.DELETE("/me/avatar", h.DeleteUserAvatar)
 	}
 
+	// JWT-only protected group: routes that are tied to a human session and
+	// must never be reachable via a long-lived API key. This is the safety
+	// boundary for billing, organization governance, websocket bootstrapping,
+	// and the email onboarding flow (which writes user-encrypted secrets).
+	jwtOnly := r.Group("")
+	jwtOnly.Use(m.AuthMiddleware())
+
+	// API-accessible protected group: routes that accept either a JWT or an
+	// API key. CombinedAuthMiddleware sets the same context keys for both
+	// auth types; APIKeyUsageMiddleware records one log row per API-key
+	// request (JWT requests are skipped).
 	protected := r.Group("")
-	protected.Use(m.AuthMiddleware())
+	protected.Use(m.CombinedAuthMiddleware(), m.APIKeyUsageMiddleware())
 	{
 		emails := protected.Group("/emails")
 		emails.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
-			emails.GET("", h.EmailsSearch)
-			emails.GET("/:id", h.GetEmail)
-			emails.PATCH("/:id", h.UpdateEmail)
-			emails.PATCH("/:id/track", h.UpdateEmailTrackingDomain)
-			emails.DELETE("/:id", h.DeleteEmail)
-			emails.POST("/:id/send", m.RequireOrganization(), h.SendEmailFromAccount)
+			emails.GET("", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), h.EmailsSearch)
+			emails.GET("/:id", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), h.GetEmail)
+			emails.PATCH("/:id", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), h.UpdateEmail)
+			emails.PATCH("/:id/track", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), h.UpdateEmailTrackingDomain)
+			emails.DELETE("/:id", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), h.DeleteEmail)
+			emails.POST("/:id/send", m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns), h.SendEmailFromAccount)
+		}
 
-			// Onboarding: two-step OAuth (Gmail/Outlook) + single-shot SMTP/IMAP.
-			onboarding := emails.Group("/onboarding")
-			{
-				onboarding.POST("/oauth/start", h.StartEmailOAuth)
-				onboarding.POST("/oauth/finish", h.FinishEmailOAuth)
-				onboarding.POST("/smtp-imap", h.ConnectEmailSMTPIMAP)
-			}
+		// Email onboarding is JWT-only — it writes user-encrypted refresh
+		// tokens via the SPA popup flow and shouldn't be triggerable by an
+		// API key with a long lifetime.
+		onboardingEmails := jwtOnly.Group("/emails/onboarding")
+		onboardingEmails.Use(m.RateLimitMiddleware(models.RateLimitWrite))
+		{
+			onboardingEmails.POST("/oauth/start", h.StartEmailOAuth)
+			onboardingEmails.POST("/oauth/finish", h.FinishEmailOAuth)
+			onboardingEmails.POST("/smtp-imap", h.ConnectEmailSMTPIMAP)
 		}
 
 		campaigns := protected.Group("/campaigns")
 		campaigns.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
-			campaigns.GET("", h.SearchCampaigns)
-			campaigns.POST("", h.CreateCampaign)
-			campaigns.GET("/:id", h.GetCampaign)
-			campaigns.PATCH("/:id", h.UpdateCampaign)
-			campaigns.DELETE("/:id", h.DeleteCampaign)
+			campaigns.GET("", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.SearchCampaigns)
+			campaigns.POST("", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.CreateCampaign)
+			campaigns.GET("/:id", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.GetCampaign)
+			campaigns.PATCH("/:id", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.UpdateCampaign)
+			campaigns.DELETE("/:id", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.DeleteCampaign)
 
 			// Advanced campaign controls
-			campaigns.GET("/:id/advanced", m.RequireOrganization(), h.GetCampaignAdvancedSettings)
-			campaigns.PATCH("/:id/advanced", m.RequireOrganization(), m.RequirePermission(models.PermManageSettings), h.UpdateCampaignAdvancedSettings)
-			campaigns.GET("/:id/ab-variants", m.RequireOrganization(), h.ListCampaignABVariants)
-			campaigns.POST("/:id/ab-variants", m.RequireOrganization(), m.RequirePermission(models.PermManageSettings), h.CreateCampaignABVariant)
-			campaigns.PATCH("/:id/ab-variants/:variantId", m.RequireOrganization(), m.RequirePermission(models.PermManageSettings), h.UpdateCampaignABVariant)
-			campaigns.DELETE("/:id/ab-variants/:variantId", m.RequireOrganization(), m.RequirePermission(models.PermManageSettings), h.DeleteCampaignABVariant)
-			campaigns.POST("/:id/preflight", m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns), h.RunCampaignPreflight)
-			campaigns.GET("/:id/ab-analysis", m.RequireOrganization(), h.GetCampaignABAnalysis)
-			campaigns.POST("/:id/test-email", m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns), h.SendTestEmail)
+			campaigns.GET("/:id/advanced", m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.GetCampaignAdvancedSettings)
+			campaigns.PATCH("/:id/advanced", m.RequireOrganization(), m.RequireAccess(models.PermManageSettings, models.APIPermWriteCampaigns), h.UpdateCampaignAdvancedSettings)
+			campaigns.GET("/:id/ab-variants", m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.ListCampaignABVariants)
+			campaigns.POST("/:id/ab-variants", m.RequireOrganization(), m.RequireAccess(models.PermManageSettings, models.APIPermWriteCampaigns), h.CreateCampaignABVariant)
+			campaigns.PATCH("/:id/ab-variants/:variantId", m.RequireOrganization(), m.RequireAccess(models.PermManageSettings, models.APIPermWriteCampaigns), h.UpdateCampaignABVariant)
+			campaigns.DELETE("/:id/ab-variants/:variantId", m.RequireOrganization(), m.RequireAccess(models.PermManageSettings, models.APIPermWriteCampaigns), h.DeleteCampaignABVariant)
+			campaigns.POST("/:id/preflight", m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns), h.RunCampaignPreflight)
+			campaigns.GET("/:id/ab-analysis", m.RequireOrganization(), m.RequireAccess(models.PermViewAnalytics, models.APIPermReadAnalytics), h.GetCampaignABAnalysis)
+			campaigns.POST("/:id/test-email", m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns), h.SendTestEmail)
 
 			// Campaign start/stop
-			campaigns.POST("/:id/start", m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns), h.StartCampaign)
-			campaigns.POST("/:id/stop", m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns), h.StopCampaign)
-			campaigns.GET("/:id/logs", h.GetCampaignLogs)
+			campaigns.POST("/:id/start", m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns), h.StartCampaign)
+			campaigns.POST("/:id/stop", m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns), h.StopCampaign)
+			campaigns.GET("/:id/logs", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.GetCampaignLogs)
 
 			sequences := campaigns.Group("/:id/sequences")
 			{
-				sequences.GET("", h.GetSequences)
-				sequences.POST("", h.CreateSequence)
-				sequences.PATCH("/:sid", h.UpdateSequence)
-				sequences.DELETE("/:sid", h.DeleteSequence)
+				sequences.GET("", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.GetSequences)
+				sequences.POST("", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.CreateSequence)
+				sequences.PATCH("/:sid", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.UpdateSequence)
+				sequences.DELETE("/:sid", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.DeleteSequence)
 			}
 		}
 
 		contacts := protected.Group("/contacts")
 		contacts.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
-			contacts.POST("/search", h.SearchContacts)
-			contacts.POST("", h.AddContacts)
-			contacts.DELETE("", h.DeleteContactBulk)
-			contacts.PATCH("", h.UpdateContactBulk)
-			contacts.PATCH("/:id", h.UpdateContact)
-			contacts.DELETE("/:id", h.DeleteContact)
+			contacts.POST("/search", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.SearchContacts)
+			contacts.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.AddContacts)
+			contacts.DELETE("", m.RequireAccess(models.PermManageContacts, models.APIPermBulkContacts), h.DeleteContactBulk)
+			contacts.PATCH("", m.RequireAccess(models.PermManageContacts, models.APIPermBulkContacts), h.UpdateContactBulk)
+			contacts.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.UpdateContact)
+			contacts.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.DeleteContact)
 
 			// CRM: Notes & Activities (under contacts)
-			contacts.GET("/:id/notes", h.ListContactNotes)
-			contacts.POST("/:id/notes", h.CreateContactNote)
-			contacts.PATCH("/:id/notes/:noteId", h.UpdateContactNote)
-			contacts.DELETE("/:id/notes/:noteId", h.DeleteContactNote)
-			contacts.GET("/:id/activities", h.ListContactActivities)
-			contacts.GET("/:id/deals", h.GetDealsByContact)
+			contacts.GET("/:id/notes", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListContactNotes)
+			contacts.POST("/:id/notes", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.CreateContactNote)
+			contacts.PATCH("/:id/notes/:noteId", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.UpdateContactNote)
+			contacts.DELETE("/:id/notes/:noteId", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.DeleteContactNote)
+			contacts.GET("/:id/activities", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListContactActivities)
+			contacts.GET("/:id/deals", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetDealsByContact)
 		}
 
+		// Group endpoints (folders / tags / categories) don't yet have
+		// dedicated permission bits — gate them on the broadest read scope
+		// for now so an API key needs at least one collection permission.
 		grouph.New(protected, h.FolderService, "folders")
 		grouph.New(protected, h.TagService, "tags")
 		grouph.New(protected, h.CategoryService, "categories")
@@ -174,19 +191,19 @@ func Run(
 		unibox := protected.Group("/unibox")
 		unibox.Use(m.RateLimitMiddleware(models.RateLimitRead))
 		{
-			unibox.GET("", h.GetUniboxIncoming)
-			unibox.GET("/count", h.GetUnseenCount)
-			unibox.GET("/thread", h.GetUniboxThread)
-			unibox.PATCH("/seen", h.UniboxMarkSeen)
-			unibox.POST("/reply", m.RequireOrganization(), h.UniboxReply)
-			unibox.GET("/:id", h.GetUniboxEmail)
+			unibox.GET("", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxIncoming)
+			unibox.GET("/count", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUnseenCount)
+			unibox.GET("/thread", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxThread)
+			unibox.PATCH("/seen", m.RequireAccess(models.PermAccessUnibox, models.APIPermWriteUnibox), h.UniboxMarkSeen)
+			unibox.POST("/reply", m.RequireOrganization(), m.RequireAccess(models.PermAccessUnibox, models.APIPermWriteUnibox), h.UniboxReply)
+			unibox.GET("/:id", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxEmail)
 		}
 
-		protected.POST("/getaway", h.GenerateWebsocket)
-
-		// API Keys management (org-scoped)
+		// API key management. JWT users need PermManageAPIKeys; API keys
+		// need the APIPermAPIKeys self-service bit. This lets an integration
+		// rotate its own keys without going through the dashboard.
 		apiKeys := protected.Group("/api-keys")
-		apiKeys.Use(m.RequireOrganization(), m.RequirePermission(models.PermManageAPIKeys))
+		apiKeys.Use(m.RequireOrganization(), m.RequireAccess(models.PermManageAPIKeys, models.APIPermAPIKeys))
 		apiKeys.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
 			apiKeys.GET("", h.ListAPIKeys)
@@ -199,116 +216,159 @@ func Run(
 
 		// Analytics endpoints
 		analytics := protected.Group("/analytics")
-		analytics.Use(m.RateLimitMiddleware(models.RateLimitAnalytics))
+		analytics.Use(m.RateLimitMiddleware(models.RateLimitAnalytics), m.RequireAccess(models.PermViewAnalytics, models.APIPermReadAnalytics))
 		{
-			// Dashboard overview
 			analytics.GET("/dashboard", h.GetDashboardAnalytics)
 			analytics.GET("/deliverability", m.RequireOrganization(), h.GetDeliverabilityDashboard)
-
-			// Warmup analytics
 			analytics.GET("/warmup", h.GetWarmupAnalytics)
-
-			// Campaign analytics
 			analytics.GET("/campaigns/compare", h.CompareCampaigns)
 			analytics.GET("/campaigns/:id", h.GetCampaignAnalytics)
 			analytics.GET("/campaigns/:id/daily", h.GetCampaignDailyStats)
 			analytics.GET("/campaigns/:id/hourly", h.GetCampaignHourlyStats)
-
-			// Account analytics
 			analytics.GET("/accounts", h.GetAllAccountStatuses)
 			analytics.GET("/accounts/:id", h.GetAccountStatus)
-
-			// Usage overview
 			analytics.GET("/usage", h.GetUsageOverview)
 		}
 
 		// Audit logs
 		auditLogs := protected.Group("/audit-logs")
-		auditLogs.Use(m.RateLimitMiddleware(models.RateLimitRead))
+		auditLogs.Use(m.RateLimitMiddleware(models.RateLimitRead), m.RequireAccess(models.PermViewAnalytics, models.APIPermReadAuditLogs))
 		{
 			auditLogs.GET("", h.GetAuditLogs)
 		}
 
-		// Realtime subscription info
-		realtime := protected.Group("/realtime")
+		// Realtime websocket bootstrap is JWT-only — the websocket itself
+		// has its own session-based auth.
+		realtime := jwtOnly.Group("/realtime")
 		{
 			realtime.GET("/info", h.GetRealtimeInfo)
 		}
 
 		// Advanced outreach controls (org-scoped)
 		outreach := protected.Group("/outreach")
-		outreach.Use(m.RequireOrganization(), m.RequirePermission(models.PermManageSettings))
+		outreach.Use(m.RequireOrganization(), m.RequireAccess(models.PermManageSettings, models.APIPermWriteCampaigns))
 		{
 			outreach.GET("/settings", h.GetOutreachSettings)
 			outreach.PATCH("/settings", h.UpdateOutreachSettings)
 		}
 
-		// Deliverability event ingestion (org-scoped)
+		// Deliverability event ingestion (org-scoped). API-key callable so
+		// downstream pipelines (e.g. SES bounce processors) can post events
+		// without a human in the loop.
 		deliverability := protected.Group("/deliverability")
-		deliverability.Use(m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns))
+		deliverability.Use(m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermWriteCampaigns))
 		{
 			deliverability.POST("/events", h.IngestDeliverabilityEvent)
 		}
 
-		// Task dead letter operations (org-scoped)
+		// Task dead letter operations (org-scoped). Requires SendCampaigns
+		// because a replay actually re-dispatches mail.
 		taskOps := protected.Group("/tasks")
-		taskOps.Use(m.RequireOrganization(), m.RequirePermission(models.PermSendCampaigns))
+		taskOps.Use(m.RequireOrganization(), m.RequireAccess(models.PermSendCampaigns, models.APIPermSendCampaigns))
 		{
 			taskOps.GET("/dlq", h.ListTaskDeadLetters)
 			taskOps.POST("/dlq/:id/replay", h.ReplayTaskDeadLetter)
 		}
 
-		// Organization management
-		org := protected.Group("/organization")
+		// Reply templates (org-scoped)
+		templates := protected.Group("/templates")
+		templates.Use(m.RequireOrganization(), m.RateLimitMiddleware(models.RateLimitWrite))
+		{
+			templates.GET("", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.ListTemplates)
+			templates.POST("", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteTemplates), h.CreateTemplate)
+			templates.GET("/:id", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.GetTemplate)
+			templates.PATCH("/:id", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteTemplates), h.UpdateTemplate)
+			templates.DELETE("/:id", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteTemplates), h.DeleteTemplate)
+		}
+
+		// CRM routes (require org)
+		crmGroup := protected.Group("/crm")
+		crmGroup.Use(m.RequireOrganization(), m.RateLimitMiddleware(models.RateLimitWrite))
+		{
+			pipelines := crmGroup.Group("/pipelines")
+			{
+				pipelines.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListPipelines)
+				pipelines.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreatePipeline)
+				pipelines.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetPipeline)
+				pipelines.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdatePipeline)
+				pipelines.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeletePipeline)
+				pipelines.POST("/:id/stages", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateStage)
+				pipelines.PATCH("/:id/stages/:stageId", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateStage)
+				pipelines.DELETE("/:id/stages/:stageId", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteStage)
+			}
+
+			deals := crmGroup.Group("/deals")
+			{
+				deals.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListDeals)
+				deals.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateDeal)
+				deals.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetDeal)
+				deals.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateDeal)
+				deals.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteDeal)
+			}
+
+			crmTasks := crmGroup.Group("/tasks")
+			{
+				crmTasks.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListCRMTasks)
+				crmTasks.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateCRMTask)
+				crmTasks.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetCRMTask)
+				crmTasks.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateCRMTask)
+				crmTasks.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteCRMTask)
+			}
+		}
+
+		// Plans and timezones are essentially public reference data — auth
+		// gates them only to avoid being scraped. Cheap to expose to keys.
+		protected.GET("/plans", h.ListPlans)
+		protected.GET("/timezones", h.GetTimezones)
+	}
+
+	// Sensitive routes below — JWT only. Organization governance, billing,
+	// websocket bootstrap, danger-zone destructions, and pending invitations
+	// all live here. None of these are reachable via an API key.
+	{
+		org := jwtOnly.Group("/organization")
 		org.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
 			org.POST("", h.CreateOrganization)
 			org.GET("", h.GetUserOrganizations)
 			org.POST("/switch/:id", h.SwitchOrganization)
 
-			// Current organization operations (require organization selected)
 			org.GET("/current", h.GetCurrentOrganization)
 			org.PATCH("/current", m.RequireOrganization(), m.RequirePermission(models.PermManageSettings), h.UpdateOrganization)
 			org.GET("/current/limits", m.RequireOrganization(), h.GetOrganizationLimits)
 
-			// Member management
 			org.GET("/members", m.RequireOrganization(), h.GetMembers)
 			org.POST("/members/invite", m.RequireOrganization(), m.RequirePermission(models.PermManageTeam), h.InviteMember)
 			org.PATCH("/members/:id", m.RequireOrganization(), m.RequirePermission(models.PermManageTeam), h.UpdateMemberRole)
 			org.DELETE("/members/:id", m.RequireOrganization(), m.RequirePermission(models.PermManageTeam), h.RemoveMember)
 
-			// Invitations
 			org.GET("/invitations", m.RequireOrganization(), m.RequirePermission(models.PermManageTeam), h.GetPendingInvitations)
 			org.DELETE("/invitations/:id", m.RequireOrganization(), m.RequirePermission(models.PermManageTeam), h.CancelInvitation)
 
-			// Ownership transfer
 			org.POST("/transfer-ownership", m.RequireOrganization(), m.RequirePermission(models.PermTransferOwnership), h.TransferOwnership)
 
-			// Workspace avatar (owner-only — checked inside the handler).
 			org.POST("/avatar", m.RequireOrganization(), h.UploadOrganizationAvatar)
 			org.DELETE("/avatar", m.RequireOrganization(), h.DeleteOrganizationAvatar)
 
-			// Danger zone (delayed organization deletion with 30-day grace)
-			// Owner-only; the service double-checks ownership too.
 			org.GET("/current/danger-zone", m.RequireOrganization(), h.GetOrganizationDangerZone)
 			org.POST("/current/danger-zone/delete", m.RequireOrganization(), h.ScheduleOrganizationDeletion)
 			org.DELETE("/current/danger-zone/delete", m.RequireOrganization(), h.CancelOrganizationDeletion)
 		}
 
-		// Account-level danger zone (delayed account deletion)
-		account := protected.Group("/me")
+		account := jwtOnly.Group("/me")
 		{
 			account.GET("/danger-zone", h.GetAccountDangerZone)
 			account.POST("/danger-zone/delete", h.ScheduleAccountDeletion)
 			account.DELETE("/danger-zone/delete", h.CancelAccountDeletion)
 		}
 
-		// User's pending invitations
-		protected.GET("/invitations", h.GetMyPendingInvitations)
-		protected.POST("/invitations/accept", h.AcceptInvitation)
+		jwtOnly.GET("/invitations", h.GetMyPendingInvitations)
+		jwtOnly.POST("/invitations/accept", h.AcceptInvitation)
 
-		// Subscription & billing
-		subscriptions := protected.Group("/subscription")
+		// Websocket bootstrap. The token returned here is single-session.
+		jwtOnly.POST("/getaway", h.GenerateWebsocket)
+
+		subscriptions := jwtOnly.Group("/subscription")
 		subscriptions.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 		{
 			subscriptions.GET("", h.GetSubscription)
@@ -319,65 +379,10 @@ func Run(
 			subscriptions.POST("/portal", h.CreateBillingPortalSession)
 			subscriptions.POST("/cancel", h.CancelSubscription)
 
-			// Plan changes with proration
 			subscriptions.POST("/change-plan", m.RequireOrganization(), m.RequirePermission(models.PermManageBilling), h.ChangePlan)
 			subscriptions.GET("/preview-change", m.RequireOrganization(), m.RequirePermission(models.PermManageBilling), h.PreviewPlanChange)
 
-			// Enterprise inquiry (no permission required)
 			subscriptions.POST("/enterprise-inquiry", h.SubmitEnterpriseInquiry)
-		}
-
-		// Plans (public info but auth required for consistency)
-		protected.GET("/plans", h.ListPlans)
-		protected.GET("/timezones", h.GetTimezones)
-
-		// Reply templates (org-scoped)
-		templates := protected.Group("/templates")
-		templates.Use(m.RequireOrganization(), m.RateLimitMiddleware(models.RateLimitWrite))
-		{
-			templates.GET("", h.ListTemplates)
-			templates.POST("", h.CreateTemplate)
-			templates.GET("/:id", h.GetTemplate)
-			templates.PATCH("/:id", h.UpdateTemplate)
-			templates.DELETE("/:id", h.DeleteTemplate)
-		}
-
-		// CRM routes (require org)
-		crmGroup := protected.Group("/crm")
-		crmGroup.Use(m.RequireOrganization(), m.RateLimitMiddleware(models.RateLimitWrite))
-		{
-			// Pipelines
-			pipelines := crmGroup.Group("/pipelines")
-			{
-				pipelines.GET("", h.ListPipelines)
-				pipelines.POST("", h.CreatePipeline)
-				pipelines.GET("/:id", h.GetPipeline)
-				pipelines.PATCH("/:id", h.UpdatePipeline)
-				pipelines.DELETE("/:id", h.DeletePipeline)
-				pipelines.POST("/:id/stages", h.CreateStage)
-				pipelines.PATCH("/:id/stages/:stageId", h.UpdateStage)
-				pipelines.DELETE("/:id/stages/:stageId", h.DeleteStage)
-			}
-
-			// Deals
-			deals := crmGroup.Group("/deals")
-			{
-				deals.GET("", h.ListDeals)
-				deals.POST("", h.CreateDeal)
-				deals.GET("/:id", h.GetDeal)
-				deals.PATCH("/:id", h.UpdateDeal)
-				deals.DELETE("/:id", h.DeleteDeal)
-			}
-
-			// CRM Tasks
-			crmTasks := crmGroup.Group("/tasks")
-			{
-				crmTasks.GET("", h.ListCRMTasks)
-				crmTasks.POST("", h.CreateCRMTask)
-				crmTasks.GET("/:id", h.GetCRMTask)
-				crmTasks.PATCH("/:id", h.UpdateCRMTask)
-				crmTasks.DELETE("/:id", h.DeleteCRMTask)
-			}
 		}
 	}
 

--- a/internal/app/apikey/service.go
+++ b/internal/app/apikey/service.go
@@ -7,6 +7,8 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,9 +19,28 @@ import (
 )
 
 const (
-	KeyPrefix   = "wmbly_"
-	KeyLength   = 32  // 32 bytes = 256 bits of randomness
-	CacheKeyTTL = 300 // 5 minutes cache for key lookups
+	// KeyPrefix is the human-readable brand on every key. Single environment
+	// for now — once a sandbox exists we can introduce wmbly_live_ / wmbly_test_
+	// without breaking existing keys (they'd just stay in the unprefixed bucket).
+	KeyPrefix = "wmbly_"
+
+	// 32 random bytes = 256 bits of entropy. Encodes to a 43-char base64url
+	// string, so a full key is "wmbly_" + 43 = 49 chars.
+	KeyLength = 32
+
+	// CacheKeyTTL is how long a (key_hash → key_id) lookup is cached.
+	// We still hit the DB on every request to pick up revocations, so the
+	// cache only saves a single index seek.
+	CacheKeyTTL = 300
+
+	// Display prefix shown in lists: "wmbly_" + first 2 random chars.
+	displayPrefixLen = 8
+	// Display suffix shown in lists: last 4 random chars.
+	displaySuffixLen = 4
+
+	// Soft caps on per-key scoping lists. Keep the rows small + cheap to scan.
+	maxAllowedIPs           = 64
+	maxAllowedEmailAccounts = 128
 )
 
 type APIKeyService interface {
@@ -51,62 +72,95 @@ func NewService(cache *cache.Cache, repo repository.APIKeyRepository) APIKeyServ
 	}
 }
 
-// generateKey generates a secure random API key with the format: wmbly_<base64_random>
-func generateKey() (rawKey, prefix, hash string, err error) {
-	// Generate random bytes
+// generateKey returns a freshly-minted API key plus the display prefix,
+// display suffix, and SHA-256 hash to persist. SHA-256 (no salt) is
+// appropriate here: the input has 256 bits of entropy, so rainbow tables
+// and brute force are computationally infeasible.
+func generateKey() (rawKey, prefix, suffix, hash string, err error) {
 	randomBytes := make([]byte, KeyLength)
 	if _, err := rand.Read(randomBytes); err != nil {
-		return "", "", "", fmt.Errorf("failed to generate random bytes: %w", err)
+		return "", "", "", "", fmt.Errorf("failed to generate random bytes: %w", err)
 	}
 
-	// Encode to base64 (URL-safe, no padding)
 	encoded := base64.RawURLEncoding.EncodeToString(randomBytes)
-
-	// Build the full key
 	rawKey = KeyPrefix + encoded
 
-	// Get the display prefix (first 8 chars including wmbly_)
-	prefix = rawKey[:8]
+	prefix = rawKey[:displayPrefixLen]
+	suffix = rawKey[len(rawKey)-displaySuffixLen:]
 
-	// Hash the key for storage
-	hasher := sha256.New()
-	hasher.Write([]byte(rawKey))
-	hash = hex.EncodeToString(hasher.Sum(nil))
-
-	return rawKey, prefix, hash, nil
+	hash = hashKey(rawKey)
+	return rawKey, prefix, suffix, hash, nil
 }
 
-// hashKey hashes a raw key for lookup
 func hashKey(rawKey string) string {
-	hasher := sha256.New()
-	hasher.Write([]byte(rawKey))
-	return hex.EncodeToString(hasher.Sum(nil))
+	sum := sha256.Sum256([]byte(rawKey))
+	return hex.EncodeToString(sum[:])
+}
+
+// validateAllowedIPs accepts either a bare IP ("1.2.3.4") or a CIDR
+// block ("10.0.0.0/8", "2001:db8::/32"). Returns the canonical form
+// to store (so equality comparisons are stable) plus an error if any
+// entry is unparseable.
+func validateAllowedIPs(entries []string) ([]string, *errx.Error) {
+	if len(entries) > maxAllowedIPs {
+		return nil, errx.New(errx.BadRequest, fmt.Sprintf("at most %d allowed_ips entries", maxAllowedIPs))
+	}
+	out := make([]string, 0, len(entries))
+	for _, raw := range entries {
+		s := strings.TrimSpace(raw)
+		if s == "" {
+			continue
+		}
+		if strings.Contains(s, "/") {
+			_, ipnet, err := net.ParseCIDR(s)
+			if err != nil {
+				return nil, errx.New(errx.BadRequest, fmt.Sprintf("invalid CIDR: %s", raw))
+			}
+			out = append(out, ipnet.String())
+			continue
+		}
+		ip := net.ParseIP(s)
+		if ip == nil {
+			return nil, errx.New(errx.BadRequest, fmt.Sprintf("invalid IP: %s", raw))
+		}
+		out = append(out, ip.String())
+	}
+	return out, nil
 }
 
 func (s *apiKeyService) Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey) (*models.APIKeyWithSecret, *errx.Error) {
-	// Validate name
 	if len(data.Name) == 0 || len(data.Name) > 255 {
-		return nil, errx.New(errx.BadRequest, "Name must be between 1 and 255 characters")
+		return nil, errx.New(errx.BadRequest, "name must be between 1 and 255 characters")
 	}
-
-	// Validate permissions
 	if data.Permissions == 0 {
-		return nil, errx.New(errx.BadRequest, "At least one permission is required")
+		return nil, errx.New(errx.BadRequest, "at least one permission is required")
+	}
+	if data.Permissions&^models.AllAPIPermissionsMask != 0 {
+		return nil, errx.New(errx.BadRequest, "permissions bitmask contains unknown bits")
+	}
+	if data.ExpiresAt != nil && data.ExpiresAt.Before(time.Now()) {
+		return nil, errx.New(errx.BadRequest, "expires_at must be in the future")
+	}
+	if len(data.AllowedEmailAccounts) > maxAllowedEmailAccounts {
+		return nil, errx.New(errx.BadRequest, fmt.Sprintf("at most %d allowed_email_accounts entries", maxAllowedEmailAccounts))
 	}
 
-	// Generate the key
-	rawKey, prefix, hash, err := generateKey()
+	allowedIPs, xerr := validateAllowedIPs(data.AllowedIPs)
+	if xerr != nil {
+		return nil, xerr
+	}
+	data.AllowedIPs = allowedIPs
+
+	rawKey, prefix, suffix, hash, err := generateKey()
 	if err != nil {
 		return nil, errx.InternalError()
 	}
 
-	// Create in database
-	key, xerr := s.repo.Create(ctx, orgID, userID, data, prefix, hash)
+	key, xerr := s.repo.Create(ctx, orgID, userID, data, prefix, suffix, hash)
 	if xerr != nil {
 		return nil, xerr
 	}
 
-	// Return key with secret (only time it's shown)
 	return &models.APIKeyWithSecret{
 		APIKey: *key,
 		Secret: rawKey,
@@ -125,48 +179,67 @@ func (s *apiKeyService) List(ctx context.Context, orgID uuid.UUID, limit int, cu
 }
 
 func (s *apiKeyService) Update(ctx context.Context, orgID, keyID uuid.UUID, data *models.UpdateAPIKey) (*models.APIKey, *errx.Error) {
-	// Validate name if provided
 	if data.Name != nil && (len(*data.Name) == 0 || len(*data.Name) > 255) {
-		return nil, errx.New(errx.BadRequest, "Name must be between 1 and 255 characters")
+		return nil, errx.New(errx.BadRequest, "name must be between 1 and 255 characters")
+	}
+	if data.Permissions != nil {
+		if *data.Permissions == 0 {
+			return nil, errx.New(errx.BadRequest, "at least one permission is required")
+		}
+		if *data.Permissions&^models.AllAPIPermissionsMask != 0 {
+			return nil, errx.New(errx.BadRequest, "permissions bitmask contains unknown bits")
+		}
+	}
+	if data.AllowedEmailAccounts != nil && len(data.AllowedEmailAccounts) > maxAllowedEmailAccounts {
+		return nil, errx.New(errx.BadRequest, fmt.Sprintf("at most %d allowed_email_accounts entries", maxAllowedEmailAccounts))
+	}
+	if data.AllowedIPs != nil {
+		allowedIPs, xerr := validateAllowedIPs(data.AllowedIPs)
+		if xerr != nil {
+			return nil, xerr
+		}
+		data.AllowedIPs = allowedIPs
 	}
 
 	return s.repo.Update(ctx, orgID, keyID, data)
 }
 
 func (s *apiKeyService) Revoke(ctx context.Context, orgID, keyID uuid.UUID, reason string) *errx.Error {
-	return s.repo.Revoke(ctx, orgID, keyID, reason)
+	xerr := s.repo.Revoke(ctx, orgID, keyID, reason)
+	if xerr != nil {
+		return xerr
+	}
+	// Best-effort cache invalidation so a revoked key stops authenticating
+	// even within the CacheKeyTTL window. The cache key is the hash, which
+	// we don't have on hand, so we drop the by-id mapping if we cache it
+	// later. For now the GetByHash query filters status='active', so the
+	// revoke takes effect on the next request regardless of cache state.
+	return nil
 }
 
 func (s *apiKeyService) ValidateKey(ctx context.Context, rawKey string) (*models.APIKey, *errx.Error) {
-	// Check key format
-	if len(rawKey) < len(KeyPrefix) || rawKey[:len(KeyPrefix)] != KeyPrefix {
+	if !strings.HasPrefix(rawKey, KeyPrefix) {
 		return nil, errx.ErrAuth
 	}
 
-	// Hash the key
 	hash := hashKey(rawKey)
 
-	// Try cache first
 	cacheKey := fmt.Sprintf("apikey:%s", hash)
 	if s.cache != nil {
 		if cached, err := s.cache.Get(ctx, cacheKey).Result(); err == nil && cached != "" {
-			// Parse cached key ID and fetch fresh from DB
 			if _, err := uuid.Parse(cached); err == nil {
-				key, xerr := s.repo.GetByHash(ctx, hash)
-				if xerr == nil {
+				if key, xerr := s.repo.GetByHash(ctx, hash); xerr == nil {
 					return key, nil
 				}
 			}
 		}
 	}
 
-	// Look up by hash
 	key, xerr := s.repo.GetByHash(ctx, hash)
 	if xerr != nil {
 		return nil, xerr
 	}
 
-	// Cache the key ID for future lookups
 	if s.cache != nil {
 		s.cache.Set(ctx, cacheKey, key.ID.String(), CacheKeyTTL)
 	}
@@ -174,15 +247,33 @@ func (s *apiKeyService) ValidateKey(ctx context.Context, rawKey string) (*models
 	return key, nil
 }
 
+// ValidateKeyIP returns true when the request IP is allowed by the key's
+// allowlist. An empty allowlist means "any IP". Entries can be bare IPs
+// (exact match) or CIDR blocks.
 func (s *apiKeyService) ValidateKeyIP(key *models.APIKey, ip string) bool {
-	// If no IP restrictions, allow all
 	if len(key.AllowedIPs) == 0 {
 		return true
 	}
 
-	// Check if IP is in allowed list
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		// Caller gave us a malformed IP (or the client IP couldn't be
+		// resolved). Fail closed when an allowlist is configured.
+		return false
+	}
+
 	for _, allowed := range key.AllowedIPs {
-		if allowed == ip {
+		if strings.Contains(allowed, "/") {
+			_, ipnet, err := net.ParseCIDR(allowed)
+			if err != nil {
+				continue
+			}
+			if ipnet.Contains(parsed) {
+				return true
+			}
+			continue
+		}
+		if other := net.ParseIP(allowed); other != nil && other.Equal(parsed) {
 			return true
 		}
 	}
@@ -195,7 +286,7 @@ func (s *apiKeyService) ValidateKeyPermission(key *models.APIKey, permission uin
 }
 
 func (s *apiKeyService) UpdateLastUsed(ctx context.Context, keyID uuid.UUID) {
-	// Fire and forget - don't block the request, but use a proper timeout
+	// Fire-and-forget; the request shouldn't wait on a stats update.
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -204,7 +295,6 @@ func (s *apiKeyService) UpdateLastUsed(ctx context.Context, keyID uuid.UUID) {
 }
 
 func (s *apiKeyService) LogUsage(ctx context.Context, log *models.APIKeyUsageLog) {
-	// Fire and forget - don't block the request, but use a proper timeout
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()

--- a/internal/app/apikey/service_test.go
+++ b/internal/app/apikey/service_test.go
@@ -1,0 +1,174 @@
+package apikey
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestGenerateKeyFormat(t *testing.T) {
+	raw, prefix, suffix, hash, err := generateKey()
+	if err != nil {
+		t.Fatalf("generateKey: %v", err)
+	}
+
+	if !strings.HasPrefix(raw, KeyPrefix) {
+		t.Errorf("raw key %q missing prefix %q", raw, KeyPrefix)
+	}
+	// "wmbly_" (6) + 32 bytes base64url-no-pad (~43) = 49 chars.
+	if got, want := len(raw), len(KeyPrefix)+43; got != want {
+		t.Errorf("raw key length = %d, want %d", got, want)
+	}
+	if got, want := len(prefix), displayPrefixLen; got != want {
+		t.Errorf("prefix length = %d, want %d", got, want)
+	}
+	if got, want := len(suffix), displaySuffixLen; got != want {
+		t.Errorf("suffix length = %d, want %d", got, want)
+	}
+	if prefix != raw[:displayPrefixLen] {
+		t.Errorf("prefix %q != raw[:%d]", prefix, displayPrefixLen)
+	}
+	if suffix != raw[len(raw)-displaySuffixLen:] {
+		t.Errorf("suffix %q != raw[-%d:]", suffix, displaySuffixLen)
+	}
+	if got, want := len(hash), 64; got != want {
+		t.Errorf("hex sha256 length = %d, want %d", got, want)
+	}
+	if hash != hashKey(raw) {
+		t.Error("hash returned by generateKey doesn't match hashKey(raw)")
+	}
+}
+
+func TestGenerateKeyUnique(t *testing.T) {
+	// Sanity check that we're not returning the same key twice — a regression
+	// here would be catastrophic. 100 keys is enough to catch a stuck PRNG.
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		raw, _, _, _, err := generateKey()
+		if err != nil {
+			t.Fatalf("generateKey: %v", err)
+		}
+		if _, dup := seen[raw]; dup {
+			t.Fatalf("duplicate key generated: %s", raw)
+		}
+		seen[raw] = struct{}{}
+	}
+}
+
+func TestValidateAllowedIPs(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      []string
+		wantOK  bool
+		wantOut []string
+	}{
+		{"empty", nil, true, []string{}},
+		{"bare-ipv4", []string{"10.0.0.1"}, true, []string{"10.0.0.1"}},
+		{"bare-ipv6", []string{"2001:db8::1"}, true, []string{"2001:db8::1"}},
+		{"cidr-ipv4", []string{"192.168.0.0/16"}, true, []string{"192.168.0.0/16"}},
+		{"cidr-ipv6", []string{"2001:db8::/32"}, true, []string{"2001:db8::/32"}},
+		{"mixed", []string{"1.2.3.4", "10.0.0.0/8"}, true, []string{"1.2.3.4", "10.0.0.0/8"}},
+		{"whitespace-trimmed", []string{"  10.0.0.1  "}, true, []string{"10.0.0.1"}},
+		{"empty-string-skipped", []string{"10.0.0.1", ""}, true, []string{"10.0.0.1"}},
+		{"bad-ip", []string{"not-an-ip"}, false, nil},
+		{"bad-cidr", []string{"10.0.0.0/99"}, false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAllowedIPs(tt.in)
+			if tt.wantOK {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(got) != len(tt.wantOut) {
+					t.Fatalf("len = %d, want %d (%v)", len(got), len(tt.wantOut), got)
+				}
+				for i, want := range tt.wantOut {
+					if got[i] != want {
+						t.Errorf("entry %d = %q, want %q", i, got[i], want)
+					}
+				}
+			} else if err == nil {
+				t.Fatalf("expected error, got %v", got)
+			}
+		})
+	}
+}
+
+func TestValidateAllowedIPsCap(t *testing.T) {
+	too_many := make([]string, maxAllowedIPs+1)
+	for i := range too_many {
+		too_many[i] = "10.0.0.1"
+	}
+	if _, err := validateAllowedIPs(too_many); err == nil {
+		t.Fatal("expected error for too many entries")
+	}
+}
+
+func TestValidateKeyIP(t *testing.T) {
+	svc := &apiKeyService{}
+	tests := []struct {
+		name    string
+		allowed []string
+		ip      string
+		want    bool
+	}{
+		{"no-restriction", nil, "1.2.3.4", true},
+		{"exact-match", []string{"10.0.0.1"}, "10.0.0.1", true},
+		{"exact-miss", []string{"10.0.0.1"}, "10.0.0.2", false},
+		{"cidr-hit", []string{"10.0.0.0/8"}, "10.5.5.5", true},
+		{"cidr-miss", []string{"10.0.0.0/8"}, "11.5.5.5", false},
+		{"ipv6-cidr-hit", []string{"2001:db8::/32"}, "2001:db8::1", true},
+		{"ipv6-cidr-miss", []string{"2001:db8::/32"}, "2002:db8::1", false},
+		{"mixed-list-hit-second", []string{"1.2.3.4", "10.0.0.0/8"}, "10.0.0.99", true},
+		{"malformed-client-ip", []string{"10.0.0.1"}, "not-an-ip", false},
+		{"empty-client-ip-with-restriction", []string{"10.0.0.1"}, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &models.APIKey{AllowedIPs: tt.allowed}
+			got := svc.ValidateKeyIP(k, tt.ip)
+			if got != tt.want {
+				t.Errorf("ValidateKeyIP(%v, %q) = %v, want %v", tt.allowed, tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateKeyPermission(t *testing.T) {
+	svc := &apiKeyService{}
+	k := &models.APIKey{Permissions: models.APIPermReadCampaigns | models.APIPermReadContacts}
+
+	if !svc.ValidateKeyPermission(k, models.APIPermReadCampaigns) {
+		t.Error("expected ReadCampaigns to be granted")
+	}
+	if svc.ValidateKeyPermission(k, models.APIPermWriteCampaigns) {
+		t.Error("expected WriteCampaigns to be denied")
+	}
+}
+
+func TestAllAPIPermissionsMask(t *testing.T) {
+	// Sanity check: the mask must include every entry in AllAPIPermissions,
+	// otherwise CreateAPIKey would reject a permission we expose in the UI.
+	var union uint64
+	for _, p := range models.AllAPIPermissions {
+		union |= p.Value
+	}
+	if union != models.AllAPIPermissionsMask {
+		t.Errorf("AllAPIPermissionsMask = %x, but union of AllAPIPermissions = %x", models.AllAPIPermissionsMask, union)
+	}
+}
+
+func TestAPIPermPresetsAreSubset(t *testing.T) {
+	if models.APIPermReadOnly&^models.AllAPIPermissionsMask != 0 {
+		t.Error("APIPermReadOnly contains bits outside the master mask")
+	}
+	if models.APIPermFullAccess&^models.AllAPIPermissionsMask != 0 {
+		t.Error("APIPermFullAccess contains bits outside the master mask")
+	}
+	if models.APIPermReadOnly&models.APIPermFullAccess != models.APIPermReadOnly {
+		t.Error("APIPermFullAccess must include every bit in APIPermReadOnly")
+	}
+}

--- a/internal/infrastructure/db/migrations/000034_api_key_suffix.down.sql
+++ b/internal/infrastructure/db/migrations/000034_api_key_suffix.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE api_keys DROP COLUMN IF EXISTS key_suffix;

--- a/internal/infrastructure/db/migrations/000034_api_key_suffix.up.sql
+++ b/internal/infrastructure/db/migrations/000034_api_key_suffix.up.sql
@@ -1,0 +1,6 @@
+-- API key display suffix: last 4 chars of the raw key.
+-- Together with key_prefix this gives users enough to identify a key
+-- in the UI (e.g. "wmbly_ab...wxyz") without exposing the secret.
+
+ALTER TABLE api_keys
+    ADD COLUMN key_suffix VARCHAR(4) NOT NULL DEFAULT '';

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -20,6 +20,7 @@ type APIKey struct {
 	OrganizationID uuid.UUID `json:"organization_id"`
 	Name           string    `json:"name"`
 	KeyPrefix      string    `json:"key_prefix"`
+	KeySuffix      string    `json:"key_suffix"`
 	Permissions    uint64    `json:"permissions"`
 
 	AllowedIPs           []string    `json:"allowed_ips,omitempty"`

--- a/internal/models/api_permission.go
+++ b/internal/models/api_permission.go
@@ -1,44 +1,79 @@
 package models
 
-// API Permissions - separate from admin Role permissions
-// These control what API keys can access (uint64 for growth room)
+// API Permissions: bitmask of scopes granted to a given API key.
+// Distinct from OrganizationPermission (which gates UI users) and
+// AdminPermission (which gates platform admins). uint64 leaves room
+// for ~50 more scopes before we have to widen the column.
 const (
 	// Read permissions
 	APIPermReadEmails    uint64 = 1 << iota // Read email accounts
-	APIPermReadCampaigns                    // Read campaigns
-	APIPermReadContacts                     // Read contacts
+	APIPermReadCampaigns                    // Read campaigns + sequences
+	APIPermReadContacts                     // Read contacts, notes, activities
 	APIPermReadUnibox                       // Read unified inbox
-	APIPermReadAnalytics                    // Read analytics/stats
+	APIPermReadAnalytics                    // Read analytics + statistics
 
 	// Write permissions
 	APIPermWriteEmails    // Modify email accounts
-	APIPermWriteCampaigns // Create/modify campaigns
-	APIPermWriteContacts  // Create/modify contacts
-	APIPermWriteUnibox    // Modify inbox (mark seen, etc.)
+	APIPermWriteCampaigns // Create/modify campaigns + sequences
+	APIPermWriteContacts  // Create/modify contacts, notes, activities
+	APIPermWriteUnibox    // Mark as seen, reply, etc.
 
-	// Bulk operations
-	APIPermBulkContacts  // Bulk contact operations
+	// Bulk operations (separate so a key can read+write without bulk power)
+	APIPermBulkContacts  // Bulk contact import/export/delete
 	APIPermBulkCampaigns // Bulk campaign operations
 
-	// Realtime
+	// Realtime + integrations
 	APIPermRealtimeSubscribe // Subscribe to realtime events
+	APIPermWebhooks          // Manage webhook endpoints (reserved)
 
-	// Special
-	APIPermWebhooks // Manage webhooks
-	APIPermAPIKeys  // Manage API keys (self-service)
+	// Self-service
+	APIPermAPIKeys // Create / list / revoke API keys via the API
+
+	// Campaign lifecycle (separated from WriteCampaigns since starting
+	// a campaign actually sends mail and is materially different from
+	// editing its draft).
+	APIPermSendCampaigns
+
+	// Templates + CRM are first-class scopes — they're useful to expose
+	// without granting full campaign write.
+	APIPermReadTemplates
+	APIPermWriteTemplates
+	APIPermReadCRM
+	APIPermWriteCRM
+
+	// Audit trail
+	APIPermReadAuditLogs
 )
 
-// Preset permission sets
+// AllAPIPermissionsMask is the OR of every defined permission bit.
+// Used to reject CreateAPIKey requests that include unknown bits, so
+// a future bit can't be granted accidentally by a stale client.
+const AllAPIPermissionsMask uint64 = APIPermReadEmails | APIPermReadCampaigns |
+	APIPermReadContacts | APIPermReadUnibox | APIPermReadAnalytics |
+	APIPermWriteEmails | APIPermWriteCampaigns | APIPermWriteContacts |
+	APIPermWriteUnibox |
+	APIPermBulkContacts | APIPermBulkCampaigns |
+	APIPermRealtimeSubscribe | APIPermWebhooks |
+	APIPermAPIKeys |
+	APIPermSendCampaigns |
+	APIPermReadTemplates | APIPermWriteTemplates |
+	APIPermReadCRM | APIPermWriteCRM |
+	APIPermReadAuditLogs
+
+// Preset permission sets surfaced via GET /api-keys/permissions so a
+// caller can grant a sane default without picking bits by hand.
 var (
 	APIPermReadOnly uint64 = APIPermReadEmails | APIPermReadCampaigns |
-		APIPermReadContacts | APIPermReadUnibox |
-		APIPermReadAnalytics
+		APIPermReadContacts | APIPermReadUnibox | APIPermReadAnalytics |
+		APIPermReadTemplates | APIPermReadCRM | APIPermReadAuditLogs
 
-	APIPermFullAccess uint64 = APIPermReadOnly | APIPermWriteEmails |
-		APIPermWriteCampaigns | APIPermWriteContacts |
-		APIPermWriteUnibox | APIPermBulkContacts |
-		APIPermBulkCampaigns | APIPermRealtimeSubscribe |
-		APIPermWebhooks | APIPermAPIKeys
+	APIPermFullAccess uint64 = APIPermReadOnly |
+		APIPermWriteEmails | APIPermWriteCampaigns | APIPermWriteContacts |
+		APIPermWriteUnibox |
+		APIPermBulkContacts | APIPermBulkCampaigns |
+		APIPermSendCampaigns |
+		APIPermWriteTemplates | APIPermWriteCRM |
+		APIPermRealtimeSubscribe | APIPermWebhooks | APIPermAPIKeys
 )
 
 type APIPermission struct {
@@ -51,26 +86,32 @@ type APIPermission struct {
 var AllAPIPermissions = []APIPermission{
 	{"READ_EMAILS", APIPermReadEmails, "View email accounts and settings", "read"},
 	{"READ_CAMPAIGNS", APIPermReadCampaigns, "View campaigns and sequences", "read"},
-	{"READ_CONTACTS", APIPermReadContacts, "View contact lists", "read"},
+	{"READ_CONTACTS", APIPermReadContacts, "View contact lists, notes, and activities", "read"},
 	{"READ_UNIBOX", APIPermReadUnibox, "Access unified inbox", "read"},
 	{"READ_ANALYTICS", APIPermReadAnalytics, "View analytics and statistics", "read"},
+	{"READ_TEMPLATES", APIPermReadTemplates, "View reply templates", "read"},
+	{"READ_CRM", APIPermReadCRM, "View pipelines, deals, and CRM tasks", "read"},
+	{"READ_AUDIT_LOGS", APIPermReadAuditLogs, "View organization audit logs", "read"},
 	{"WRITE_EMAILS", APIPermWriteEmails, "Modify email account settings", "write"},
-	{"WRITE_CAMPAIGNS", APIPermWriteCampaigns, "Create and modify campaigns", "write"},
-	{"WRITE_CONTACTS", APIPermWriteContacts, "Create and modify contacts", "write"},
-	{"WRITE_UNIBOX", APIPermWriteUnibox, "Mark emails as read/unread", "write"},
-	{"BULK_CONTACTS", APIPermBulkContacts, "Bulk import/export contacts", "bulk"},
+	{"WRITE_CAMPAIGNS", APIPermWriteCampaigns, "Create and modify campaigns and sequences", "write"},
+	{"WRITE_CONTACTS", APIPermWriteContacts, "Create and modify contacts, notes, and activities", "write"},
+	{"WRITE_UNIBOX", APIPermWriteUnibox, "Mark emails as read/unread and send replies", "write"},
+	{"WRITE_TEMPLATES", APIPermWriteTemplates, "Create and modify reply templates", "write"},
+	{"WRITE_CRM", APIPermWriteCRM, "Create and modify pipelines, deals, and CRM tasks", "write"},
+	{"SEND_CAMPAIGNS", APIPermSendCampaigns, "Start and stop campaigns (sends real mail)", "write"},
+	{"BULK_CONTACTS", APIPermBulkContacts, "Bulk import/export/delete contacts", "bulk"},
 	{"BULK_CAMPAIGNS", APIPermBulkCampaigns, "Bulk campaign operations", "bulk"},
-	{"REALTIME_SUBSCRIBE", APIPermRealtimeSubscribe, "Subscribe to real-time events", "special"},
+	{"REALTIME_SUBSCRIBE", APIPermRealtimeSubscribe, "Subscribe to realtime events", "special"},
 	{"WEBHOOKS", APIPermWebhooks, "Manage webhook endpoints", "special"},
 	{"API_KEYS", APIPermAPIKeys, "Create and manage API keys", "special"},
 }
 
-// HasPermission checks if permissions bitmask has the required permission
+// HasAPIPermission reports whether the bitmask grants every bit in `required`.
 func HasAPIPermission(permissions uint64, required uint64) bool {
 	return permissions&required == required
 }
 
-// HasAnyPermission checks if permissions bitmask has any of the required permissions
+// HasAnyAPIPermission reports whether the bitmask grants at least one bit in `required`.
 func HasAnyAPIPermission(permissions uint64, required uint64) bool {
 	return permissions&required != 0
 }

--- a/internal/repository/pg_api_key.go
+++ b/internal/repository/pg_api_key.go
@@ -15,7 +15,7 @@ import (
 )
 
 type APIKeyRepository interface {
-	Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey, keyPrefix, keyHash string) (*models.APIKey, *errx.Error)
+	Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey, keyPrefix, keySuffix, keyHash string) (*models.APIKey, *errx.Error)
 	GetByHash(ctx context.Context, keyHash string) (*models.APIKey, *errx.Error)
 	GetByID(ctx context.Context, orgID, keyID uuid.UUID) (*models.APIKey, *errx.Error)
 	List(ctx context.Context, orgID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeysResult, *errx.Error)
@@ -33,7 +33,7 @@ func NewAPIKeyRepository(db *db.DB) APIKeyRepository {
 	return &apiKeyRepository{DB: db}
 }
 
-const API_KEY_SELECT = `id, user_id, organization_id, name, key_prefix, permissions,
+const API_KEY_SELECT = `id, user_id, organization_id, name, key_prefix, key_suffix, permissions,
 	allowed_ips, allowed_email_accounts,
 	status, last_used_at, expires_at, revoked_at, revoked_reason,
 	created_at, updated_at`
@@ -41,7 +41,7 @@ const API_KEY_SELECT = `id, user_id, organization_id, name, key_prefix, permissi
 func scanAPIKey(row db.Scannable, key *models.APIKey) error {
 	var allowedIPs, allowedAccounts []string
 	err := row.Scan(
-		&key.ID, &key.UserID, &key.OrganizationID, &key.Name, &key.KeyPrefix, &key.Permissions,
+		&key.ID, &key.UserID, &key.OrganizationID, &key.Name, &key.KeyPrefix, &key.KeySuffix, &key.Permissions,
 		&allowedIPs, &allowedAccounts,
 		&key.Status, &key.LastUsedAt, &key.ExpiresAt, &key.RevokedAt, &key.RevokedReason,
 		&key.CreatedAt, &key.UpdatedAt,
@@ -59,10 +59,10 @@ func scanAPIKey(row db.Scannable, key *models.APIKey) error {
 	return nil
 }
 
-func (r *apiKeyRepository) Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey, keyPrefix, keyHash string) (*models.APIKey, *errx.Error) {
+func (r *apiKeyRepository) Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey, keyPrefix, keySuffix, keyHash string) (*models.APIKey, *errx.Error) {
 	query := fmt.Sprintf(`
-		INSERT INTO api_keys (user_id, organization_id, name, key_prefix, key_hash, permissions, allowed_ips, allowed_email_accounts, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO api_keys (user_id, organization_id, name, key_prefix, key_suffix, key_hash, permissions, allowed_ips, allowed_email_accounts, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING %s
 	`, API_KEY_SELECT)
 
@@ -76,6 +76,7 @@ func (r *apiKeyRepository) Create(ctx context.Context, orgID, userID uuid.UUID, 
 		orgID,
 		data.Name,
 		keyPrefix,
+		keySuffix,
 		keyHash,
 		data.Permissions,
 		data.AllowedIPs,


### PR DESCRIPTION
- Issue keys as `wmbly_<43-char base64url>` (256 bits entropy), store only SHA-256 hash plus 8-char prefix and 4-char suffix; plaintext returned once on create
- Add dual-auth middleware so data routes accept either JWT or API key, with JWT-only retained for `/auth`, `/organization`, `/subscription`, `/admin`, `/getaway`, and danger-zone routes
- Enforce permission bitmask per route, CIDR-aware IP allowlist, and expiry checks; bump `last_used_at` and append fire-and-forget rows to `api_key_usage_logs`
- Fix pre-existing bug in `validateJWT` that mis-typed `ValidateAccessToken`'s `*models.Session` return as a string
- Add service + middleware tests, update API key and permissions docs, and add a new `reference/endpoints.mdx` listing which endpoints accept API keys