### PR TITLE
feat: ship api keys dashboard with smart limits and analytics

### DIFF
--- a/internal/api/handler/api_key.go
+++ b/internal/api/handler/api_key.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -169,4 +170,109 @@ func (h *Handler) ListAPIPermissions(c *gin.Context) {
 			"full_access": models.APIPermFullAccess,
 		},
 	})
+}
+
+// GetAPIKeyUsageSummary returns the org-level usage strip (active key
+// count, 24h request total, last call timestamp, error rate, avg latency).
+// GET /api-keys/usage/summary
+func (h *Handler) GetAPIKeyUsageSummary(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	summary, xerr := h.APIKeyService.GetUsageSummary(c.Request.Context(), *orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, summary)
+}
+
+// GetAPIKeyAnalytics returns the request timeseries + endpoint breakdown
+// for a single key (when :id is set) or the whole org (when :id is "all").
+// GET /api-keys/:id/analytics?from=...&to=...&interval=hour|day|minute
+func (h *Handler) GetAPIKeyAnalytics(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var keyID *uuid.UUID
+	if id := c.Param("id"); id != "" && id != "all" {
+		parsed, err := uuid.Parse(id)
+		if err != nil {
+			errx.JSON(c, errx.ErrNotFound)
+			return
+		}
+		keyID = &parsed
+	}
+
+	from, to := parseAnalyticsRange(c)
+	interval := c.Query("interval")
+
+	analytics, xerr := h.APIKeyService.GetAnalytics(c.Request.Context(), *orgID, keyID, from, to, interval)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, analytics)
+}
+
+// ListAPIKeyUsageLogs returns the recent raw request entries for a single key.
+// GET /api-keys/:id/logs?cursor=...&limit=...
+func (h *Handler) ListAPIKeyUsageLogs(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	keyID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrNotFound)
+		return
+	}
+
+	var cursor *uuid.UUID
+	if cursorStr := c.Query("cursor"); cursorStr != "" {
+		if id, err := uuid.Parse(cursorStr); err == nil {
+			cursor = &id
+		}
+	}
+
+	limit := 50
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 200 {
+		limit = l
+	}
+
+	result, xerr := h.APIKeyService.ListUsageLogs(c.Request.Context(), *orgID, keyID, limit, cursor)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// parseAnalyticsRange pulls ?from / ?to off the query string, defaulting
+// to "last 24 hours" when either is missing. Accepts RFC3339 timestamps.
+func parseAnalyticsRange(c *gin.Context) (from, to time.Time) {
+	if f := c.Query("from"); f != "" {
+		if parsed, err := time.Parse(time.RFC3339, f); err == nil {
+			from = parsed
+		}
+	}
+	if t := c.Query("to"); t != "" {
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			to = parsed
+		}
+	}
+	if to.IsZero() {
+		to = time.Now()
+	}
+	if from.IsZero() {
+		from = to.Add(-24 * time.Hour)
+	}
+	return from, to
 }

--- a/internal/api/middleware/apikey.go
+++ b/internal/api/middleware/apikey.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -78,14 +80,36 @@ func (h *Handler) validateAPIKey(c *gin.Context, rawKey string) {
 		return
 	}
 
+	// Per-key minute-window rate limit. Surfaces rate-limit headers on
+	// every API-key request so well-behaved clients can self-throttle
+	// before hitting 429. Fails open on cache errors.
+	remaining, retryAfter, allowed := h.APIKeyService.CheckAndIncrementRateLimit(c.Request.Context(), key)
+	limit := key.RateLimitPerMinute
+	if limit <= 0 {
+		limit = 60
+	}
+	c.Header("X-RateLimit-Limit", fmt.Sprintf("%d", limit))
+	c.Header("X-RateLimit-Remaining", fmt.Sprintf("%d", remaining))
+	c.Header("X-RateLimit-Policy", fmt.Sprintf("%d;w=60", limit))
+	if !allowed {
+		c.Header("Retry-After", fmt.Sprintf("%d", retryAfter))
+		c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+			"error":       "rate_limit_exceeded",
+			"message":     fmt.Sprintf("API key exceeded %d requests per minute", limit),
+			"retry_after": retryAfter,
+		})
+		return
+	}
+
 	c.Set(AuthTypeKey, AuthTypeAPIKey)
 	c.Set(APIKeyIDKey, key.ID.String())
 	c.Set(APIKeyPermissionsKey, key.Permissions)
 	c.Set(UserIDKey, key.UserID.String())
 	c.Set(OrganizationIDKey, key.OrganizationID)
 
-	// UpdateLastUsed is itself fire-and-forget.
-	h.APIKeyService.UpdateLastUsed(c.Request.Context(), key.ID)
+	// UpdateLastUsed is itself fire-and-forget; also remembers the caller
+	// IP so the dashboard can show "last called from".
+	h.APIKeyService.UpdateLastUsed(c.Request.Context(), key.ID, c.ClientIP())
 
 	c.Next()
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -209,9 +209,13 @@ func Run(
 			apiKeys.GET("", h.ListAPIKeys)
 			apiKeys.POST("", h.CreateAPIKey)
 			apiKeys.GET("/permissions", h.ListAPIPermissions)
+			apiKeys.GET("/usage/summary", h.GetAPIKeyUsageSummary)
+			apiKeys.GET("/usage/analytics", h.GetAPIKeyAnalytics)
 			apiKeys.GET("/:id", h.GetAPIKey)
 			apiKeys.PATCH("/:id", h.UpdateAPIKey)
 			apiKeys.DELETE("/:id", h.RevokeAPIKey)
+			apiKeys.GET("/:id/analytics", h.GetAPIKeyAnalytics)
+			apiKeys.GET("/:id/logs", h.ListAPIKeyUsageLogs)
 		}
 
 		// Analytics endpoints

--- a/internal/app/apikey/service.go
+++ b/internal/app/apikey/service.go
@@ -41,6 +41,12 @@ const (
 	// Soft caps on per-key scoping lists. Keep the rows small + cheap to scan.
 	maxAllowedIPs           = 64
 	maxAllowedEmailAccounts = 128
+
+	// Rate limit bounds. The DB default is 60 r/m; we don't allow setting
+	// it absurdly high or to zero (which would lock the key out).
+	minRateLimitPerMinute     = 1
+	maxRateLimitPerMinute     = 10000
+	defaultRateLimitPerMinute = 60
 )
 
 type APIKeyService interface {
@@ -55,9 +61,20 @@ type APIKeyService interface {
 	ValidateKeyIP(key *models.APIKey, ip string) bool
 	ValidateKeyPermission(key *models.APIKey, permission uint64) bool
 
+	// CheckAndIncrementRateLimit enforces the per-key minute-window cap.
+	// Returns the remaining budget for the current window and a retry-after
+	// hint when the cap is hit. Falls open if Redis is unavailable so a
+	// cache outage can't lock customers out of their own API.
+	CheckAndIncrementRateLimit(ctx context.Context, key *models.APIKey) (remaining int, retryAfterSeconds int, allowed bool)
+
 	// Usage tracking
-	UpdateLastUsed(ctx context.Context, keyID uuid.UUID)
+	UpdateLastUsed(ctx context.Context, keyID uuid.UUID, ip string)
 	LogUsage(ctx context.Context, log *models.APIKeyUsageLog)
+
+	// Analytics
+	GetUsageSummary(ctx context.Context, orgID uuid.UUID) (*models.APIKeyUsageSummary, *errx.Error)
+	GetAnalytics(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, interval string) (*models.APIKeyAnalytics, *errx.Error)
+	ListUsageLogs(ctx context.Context, orgID, keyID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeyUsageLogsResult, *errx.Error)
 }
 
 type apiKeyService struct {
@@ -144,6 +161,11 @@ func (s *apiKeyService) Create(ctx context.Context, orgID, userID uuid.UUID, dat
 	if len(data.AllowedEmailAccounts) > maxAllowedEmailAccounts {
 		return nil, errx.New(errx.BadRequest, fmt.Sprintf("at most %d allowed_email_accounts entries", maxAllowedEmailAccounts))
 	}
+	if data.RateLimitPerMinute != nil {
+		if *data.RateLimitPerMinute < minRateLimitPerMinute || *data.RateLimitPerMinute > maxRateLimitPerMinute {
+			return nil, errx.New(errx.BadRequest, fmt.Sprintf("rate_limit_per_minute must be between %d and %d", minRateLimitPerMinute, maxRateLimitPerMinute))
+		}
+	}
 
 	allowedIPs, xerr := validateAllowedIPs(data.AllowedIPs)
 	if xerr != nil {
@@ -199,6 +221,11 @@ func (s *apiKeyService) Update(ctx context.Context, orgID, keyID uuid.UUID, data
 			return nil, xerr
 		}
 		data.AllowedIPs = allowedIPs
+	}
+	if data.RateLimitPerMinute != nil {
+		if *data.RateLimitPerMinute < minRateLimitPerMinute || *data.RateLimitPerMinute > maxRateLimitPerMinute {
+			return nil, errx.New(errx.BadRequest, fmt.Sprintf("rate_limit_per_minute must be between %d and %d", minRateLimitPerMinute, maxRateLimitPerMinute))
+		}
 	}
 
 	return s.repo.Update(ctx, orgID, keyID, data)
@@ -285,12 +312,12 @@ func (s *apiKeyService) ValidateKeyPermission(key *models.APIKey, permission uin
 	return models.HasAPIPermission(key.Permissions, permission)
 }
 
-func (s *apiKeyService) UpdateLastUsed(ctx context.Context, keyID uuid.UUID) {
+func (s *apiKeyService) UpdateLastUsed(ctx context.Context, keyID uuid.UUID, ip string) {
 	// Fire-and-forget; the request shouldn't wait on a stats update.
 	go func() {
 		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = s.repo.UpdateLastUsed(bgCtx, keyID)
+		_ = s.repo.UpdateLastUsed(bgCtx, keyID, ip)
 	}()
 }
 
@@ -300,4 +327,130 @@ func (s *apiKeyService) LogUsage(ctx context.Context, log *models.APIKeyUsageLog
 		defer cancel()
 		_ = s.repo.LogUsage(bgCtx, log)
 	}()
+}
+
+// CheckAndIncrementRateLimit enforces the per-key minute-window cap using a
+// Redis Lua script for atomic check-and-increment. Fails open if the cache
+// is unavailable so a Redis outage doesn't take down a customer's integration.
+func (s *apiKeyService) CheckAndIncrementRateLimit(ctx context.Context, key *models.APIKey) (int, int, bool) {
+	limit := key.RateLimitPerMinute
+	if limit <= 0 {
+		limit = defaultRateLimitPerMinute
+	}
+	if s.cache == nil {
+		return limit, 0, true
+	}
+
+	bucket := time.Now().Unix() / 60
+	cacheKey := fmt.Sprintf("apikey:rl:%s:%d", key.ID.String(), bucket)
+
+	script := `
+		local key = KEYS[1]
+		local limit = tonumber(ARGV[1])
+		local window = tonumber(ARGV[2])
+		local current = tonumber(redis.call('GET', key) or '0')
+		if current >= limit then
+			local ttl = redis.call('TTL', key)
+			if ttl < 0 then ttl = window end
+			return {current, ttl, 0}
+		end
+		current = redis.call('INCR', key)
+		if current == 1 then
+			redis.call('EXPIRE', key, window)
+		end
+		local ttl = redis.call('TTL', key)
+		return {current, ttl, 1}
+	`
+
+	res, err := s.cache.Eval(ctx, script, []string{cacheKey}, limit, 60).Slice()
+	if err != nil || len(res) < 3 {
+		// Fail open: a Redis hiccup shouldn't sink the request.
+		return limit, 0, true
+	}
+
+	current, _ := res[0].(int64)
+	ttl, _ := res[1].(int64)
+	allowed, _ := res[2].(int64)
+
+	remaining := limit - int(current)
+	if remaining < 0 {
+		remaining = 0
+	}
+	if allowed == 1 {
+		return remaining, 0, true
+	}
+	return 0, int(ttl), false
+}
+
+func (s *apiKeyService) GetUsageSummary(ctx context.Context, orgID uuid.UUID) (*models.APIKeyUsageSummary, *errx.Error) {
+	return s.repo.GetUsageSummary(ctx, orgID)
+}
+
+// GetAnalytics returns the timeseries + endpoint breakdown for a single key
+// (or the whole org when keyID is nil). The default window is the last 24
+// hours bucketed by hour, which gives a clean ~24-point graph; callers can
+// override interval and date range for deeper looks.
+func (s *apiKeyService) GetAnalytics(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, interval string) (*models.APIKeyAnalytics, *errx.Error) {
+	if to.IsZero() {
+		to = time.Now()
+	}
+	if from.IsZero() {
+		from = to.Add(-24 * time.Hour)
+	}
+	if !from.Before(to) {
+		return nil, errx.New(errx.BadRequest, "from must be before to")
+	}
+	// Cap analytic windows at 90 days so a single request can't sweep the
+	// whole table.
+	if to.Sub(from) > 90*24*time.Hour {
+		return nil, errx.New(errx.BadRequest, "date range cannot exceed 90 days")
+	}
+
+	switch interval {
+	case "minute", "hour", "day":
+	default:
+		// Pick a sensible default based on the window size.
+		span := to.Sub(from)
+		switch {
+		case span <= 2*time.Hour:
+			interval = "minute"
+		case span <= 7*24*time.Hour:
+			interval = "hour"
+		default:
+			interval = "day"
+		}
+	}
+
+	buckets, xerr := s.repo.GetUsageTimeseries(ctx, orgID, keyID, from, to, interval)
+	if xerr != nil {
+		return nil, xerr
+	}
+	endpoints, xerr := s.repo.GetEndpointBreakdown(ctx, orgID, keyID, from, to, 25)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	var total, errors int64
+	for _, b := range buckets {
+		total += b.Total
+		errors += b.ClientErrors + b.ServerErrors
+	}
+
+	out := &models.APIKeyAnalytics{
+		From:      from,
+		To:        to,
+		Interval:  interval,
+		Buckets:   buckets,
+		Endpoints: endpoints,
+		Total:     total,
+		Errors:    errors,
+	}
+	if keyID != nil {
+		out.APIKeyID = *keyID
+	}
+	return out, nil
+}
+
+func (s *apiKeyService) ListUsageLogs(ctx context.Context, orgID, keyID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeyUsageLogsResult, *errx.Error) {
+	return s.repo.ListUsageLogs(ctx, orgID, keyID, limit, cursor)
 }

--- a/internal/infrastructure/db/migrations/000035_api_key_smart_limits.down.sql
+++ b/internal/infrastructure/db/migrations/000035_api_key_smart_limits.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_api_key_usage_endpoint;
+DROP INDEX IF EXISTS idx_api_key_usage_key_time_status;
+
+ALTER TABLE api_keys
+    DROP COLUMN IF EXISTS last_request_ip,
+    DROP COLUMN IF EXISTS description,
+    DROP COLUMN IF EXISTS rate_limit_per_minute;

--- a/internal/infrastructure/db/migrations/000035_api_key_smart_limits.up.sql
+++ b/internal/infrastructure/db/migrations/000035_api_key_smart_limits.up.sql
@@ -1,0 +1,26 @@
+-- Smart per-key rate limits + analytics-friendly indexes.
+--
+-- rate_limit_per_minute: soft cap enforced in middleware via Redis sliding
+-- window. Defaults to 60 r/m (matches the marketing copy on the dashboard);
+-- workspace owners can raise/lower it per key. NULL would mean "no limit"
+-- but we store an explicit value so the column reads simpler.
+--
+-- description: human note shown next to the key in the dashboard. Helps
+-- when a workspace has many keys for many integrations.
+--
+-- last_request_ip: most recent caller IP. Useful for "where's this key
+-- being used from" without scanning the usage log table.
+
+ALTER TABLE api_keys
+    ADD COLUMN rate_limit_per_minute INT NOT NULL DEFAULT 60,
+    ADD COLUMN description TEXT,
+    ADD COLUMN last_request_ip INET;
+
+-- Analytics: bucketed timeseries grouped by status family. Compound index
+-- so the (api_key_id, created_at) → response_status scan is index-only.
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_key_time_status
+    ON api_key_usage_logs (api_key_id, created_at DESC, response_status);
+
+-- Endpoint breakdown: top endpoints by call count per key.
+CREATE INDEX IF NOT EXISTS idx_api_key_usage_endpoint
+    ON api_key_usage_logs (api_key_id, endpoint);

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -100,9 +100,9 @@ type APIKeyUsageSummary struct {
 type APIKeyUsageBucket struct {
 	Bucket       time.Time `json:"bucket"`
 	Total        int64     `json:"total"`
-	Success      int64     `json:"success"`        // 2xx
-	ClientErrors int64     `json:"client_errors"`  // 4xx
-	ServerErrors int64     `json:"server_errors"`  // 5xx
+	Success      int64     `json:"success"`       // 2xx
+	ClientErrors int64     `json:"client_errors"` // 4xx
+	ServerErrors int64     `json:"server_errors"` // 5xx
 	AvgLatencyMs float64   `json:"avg_latency_ms"`
 }
 

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -19,6 +19,7 @@ type APIKey struct {
 	UserID         uuid.UUID `json:"user_id"`
 	OrganizationID uuid.UUID `json:"organization_id"`
 	Name           string    `json:"name"`
+	Description    *string   `json:"description,omitempty"`
 	KeyPrefix      string    `json:"key_prefix"`
 	KeySuffix      string    `json:"key_suffix"`
 	Permissions    uint64    `json:"permissions"`
@@ -26,8 +27,14 @@ type APIKey struct {
 	AllowedIPs           []string    `json:"allowed_ips,omitempty"`
 	AllowedEmailAccounts []uuid.UUID `json:"allowed_email_accounts,omitempty"`
 
+	// RateLimitPerMinute is enforced via Redis sliding window in the auth
+	// middleware. 60 r/m is the default; 0 is treated as "use the default"
+	// to leave room for an explicit unlimited bit later.
+	RateLimitPerMinute int `json:"rate_limit_per_minute"`
+
 	Status        APIKeyStatus `json:"status"`
 	LastUsedAt    *time.Time   `json:"last_used_at,omitempty"`
+	LastRequestIP *string      `json:"last_request_ip,omitempty"`
 	ExpiresAt     *time.Time   `json:"expires_at,omitempty"`
 	RevokedAt     *time.Time   `json:"revoked_at,omitempty"`
 	RevokedReason *string      `json:"revoked_reason,omitempty"`
@@ -43,17 +50,21 @@ type APIKeyWithSecret struct {
 
 type CreateAPIKey struct {
 	Name                 string      `json:"name" binding:"required,max=255"`
+	Description          *string     `json:"description,omitempty"`
 	Permissions          uint64      `json:"permissions" binding:"required"`
 	AllowedIPs           []string    `json:"allowed_ips,omitempty"`
 	AllowedEmailAccounts []uuid.UUID `json:"allowed_email_accounts,omitempty"`
+	RateLimitPerMinute   *int        `json:"rate_limit_per_minute,omitempty"`
 	ExpiresAt            *time.Time  `json:"expires_at,omitempty"`
 }
 
 type UpdateAPIKey struct {
 	Name                 *string     `json:"name,omitempty"`
+	Description          *string     `json:"description,omitempty"`
 	Permissions          *uint64     `json:"permissions,omitempty"`
 	AllowedIPs           []string    `json:"allowed_ips,omitempty"`
 	AllowedEmailAccounts []uuid.UUID `json:"allowed_email_accounts,omitempty"`
+	RateLimitPerMinute   *int        `json:"rate_limit_per_minute,omitempty"`
 }
 
 type APIKeysResult struct {
@@ -71,4 +82,54 @@ type APIKeyUsageLog struct {
 	ResponseCode int       `json:"response_code"`
 	ResponseTime int       `json:"response_time_ms"`
 	CreatedAt    time.Time `json:"created_at"`
+}
+
+// APIKeyUsageSummary is the org-level overview surfaced at the top of the
+// API keys dashboard. All counts cover the last 24 hours.
+type APIKeyUsageSummary struct {
+	ActiveKeys      int        `json:"active_keys"`
+	RevokedKeys     int        `json:"revoked_keys"`
+	ExpiredKeys     int        `json:"expired_keys"`
+	Requests24h     int64      `json:"requests_24h"`
+	Errors24h       int64      `json:"errors_24h"`
+	AvgLatencyMs24h float64    `json:"avg_latency_ms_24h"`
+	LastCallAt      *time.Time `json:"last_call_at,omitempty"`
+}
+
+// APIKeyUsageBucket is one point on a time-bucketed request graph.
+type APIKeyUsageBucket struct {
+	Bucket       time.Time `json:"bucket"`
+	Total        int64     `json:"total"`
+	Success      int64     `json:"success"`        // 2xx
+	ClientErrors int64     `json:"client_errors"`  // 4xx
+	ServerErrors int64     `json:"server_errors"`  // 5xx
+	AvgLatencyMs float64   `json:"avg_latency_ms"`
+}
+
+// APIKeyEndpointStat is one row in the per-key top-endpoints breakdown.
+type APIKeyEndpointStat struct {
+	Endpoint     string  `json:"endpoint"`
+	Method       string  `json:"method"`
+	Count        int64   `json:"count"`
+	ErrorCount   int64   `json:"error_count"`
+	AvgLatencyMs float64 `json:"avg_latency_ms"`
+}
+
+// APIKeyAnalytics is the per-key dashboard payload: a series of buckets
+// (graph), a per-endpoint breakdown (table), and a quick total. The
+// caller picks the bucket interval via ?interval=hour|day.
+type APIKeyAnalytics struct {
+	APIKeyID  uuid.UUID            `json:"api_key_id"`
+	From      time.Time            `json:"from"`
+	To        time.Time            `json:"to"`
+	Interval  string               `json:"interval"`
+	Buckets   []APIKeyUsageBucket  `json:"buckets"`
+	Endpoints []APIKeyEndpointStat `json:"endpoints"`
+	Total     int64                `json:"total"`
+	Errors    int64                `json:"errors"`
+}
+
+type APIKeyUsageLogsResult struct {
+	Data       []APIKeyUsageLog `json:"data"`
+	Pagination Pagination       `json:"pagination"`
 }

--- a/internal/repository/pg_api_key.go
+++ b/internal/repository/pg_api_key.go
@@ -21,8 +21,14 @@ type APIKeyRepository interface {
 	List(ctx context.Context, orgID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeysResult, *errx.Error)
 	Update(ctx context.Context, orgID, keyID uuid.UUID, data *models.UpdateAPIKey) (*models.APIKey, *errx.Error)
 	Revoke(ctx context.Context, orgID, keyID uuid.UUID, reason string) *errx.Error
-	UpdateLastUsed(ctx context.Context, keyID uuid.UUID) error
+	UpdateLastUsed(ctx context.Context, keyID uuid.UUID, ip string) error
 	LogUsage(ctx context.Context, log *models.APIKeyUsageLog) error
+
+	// Analytics
+	GetUsageSummary(ctx context.Context, orgID uuid.UUID) (*models.APIKeyUsageSummary, *errx.Error)
+	GetUsageTimeseries(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, bucket string) ([]models.APIKeyUsageBucket, *errx.Error)
+	GetEndpointBreakdown(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, limit int) ([]models.APIKeyEndpointStat, *errx.Error)
+	ListUsageLogs(ctx context.Context, orgID, keyID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeyUsageLogsResult, *errx.Error)
 }
 
 type apiKeyRepository struct {
@@ -33,17 +39,17 @@ func NewAPIKeyRepository(db *db.DB) APIKeyRepository {
 	return &apiKeyRepository{DB: db}
 }
 
-const API_KEY_SELECT = `id, user_id, organization_id, name, key_prefix, key_suffix, permissions,
-	allowed_ips, allowed_email_accounts,
-	status, last_used_at, expires_at, revoked_at, revoked_reason,
+const API_KEY_SELECT = `id, user_id, organization_id, name, description, key_prefix, key_suffix, permissions,
+	allowed_ips, allowed_email_accounts, rate_limit_per_minute,
+	status, last_used_at, last_request_ip::text, expires_at, revoked_at, revoked_reason,
 	created_at, updated_at`
 
 func scanAPIKey(row db.Scannable, key *models.APIKey) error {
 	var allowedIPs, allowedAccounts []string
 	err := row.Scan(
-		&key.ID, &key.UserID, &key.OrganizationID, &key.Name, &key.KeyPrefix, &key.KeySuffix, &key.Permissions,
-		&allowedIPs, &allowedAccounts,
-		&key.Status, &key.LastUsedAt, &key.ExpiresAt, &key.RevokedAt, &key.RevokedReason,
+		&key.ID, &key.UserID, &key.OrganizationID, &key.Name, &key.Description, &key.KeyPrefix, &key.KeySuffix, &key.Permissions,
+		&allowedIPs, &allowedAccounts, &key.RateLimitPerMinute,
+		&key.Status, &key.LastUsedAt, &key.LastRequestIP, &key.ExpiresAt, &key.RevokedAt, &key.RevokedReason,
 		&key.CreatedAt, &key.UpdatedAt,
 	)
 	if err != nil {
@@ -61,8 +67,8 @@ func scanAPIKey(row db.Scannable, key *models.APIKey) error {
 
 func (r *apiKeyRepository) Create(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateAPIKey, keyPrefix, keySuffix, keyHash string) (*models.APIKey, *errx.Error) {
 	query := fmt.Sprintf(`
-		INSERT INTO api_keys (user_id, organization_id, name, key_prefix, key_suffix, key_hash, permissions, allowed_ips, allowed_email_accounts, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		INSERT INTO api_keys (user_id, organization_id, name, description, key_prefix, key_suffix, key_hash, permissions, allowed_ips, allowed_email_accounts, rate_limit_per_minute, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, COALESCE($11, 60), $12)
 		RETURNING %s
 	`, API_KEY_SELECT)
 
@@ -75,12 +81,14 @@ func (r *apiKeyRepository) Create(ctx context.Context, orgID, userID uuid.UUID, 
 		userID,
 		orgID,
 		data.Name,
+		data.Description,
 		keyPrefix,
 		keySuffix,
 		keyHash,
 		data.Permissions,
 		data.AllowedIPs,
 		allowedAccountsStr,
+		data.RateLimitPerMinute,
 		data.ExpiresAt,
 	}
 
@@ -196,6 +204,11 @@ func (r *apiKeyRepository) Update(ctx context.Context, orgID, keyID uuid.UUID, d
 		args = append(args, *data.Name)
 		argPos++
 	}
+	if data.Description != nil {
+		setClauses = append(setClauses, fmt.Sprintf("description = $%d", argPos))
+		args = append(args, *data.Description)
+		argPos++
+	}
 	if data.Permissions != nil {
 		setClauses = append(setClauses, fmt.Sprintf("permissions = $%d", argPos))
 		args = append(args, *data.Permissions)
@@ -213,6 +226,11 @@ func (r *apiKeyRepository) Update(ctx context.Context, orgID, keyID uuid.UUID, d
 		}
 		setClauses = append(setClauses, fmt.Sprintf("allowed_email_accounts = $%d", argPos))
 		args = append(args, allowedAccountsStr)
+		argPos++
+	}
+	if data.RateLimitPerMinute != nil {
+		setClauses = append(setClauses, fmt.Sprintf("rate_limit_per_minute = $%d", argPos))
+		args = append(args, *data.RateLimitPerMinute)
 		argPos++
 	}
 
@@ -263,9 +281,14 @@ func (r *apiKeyRepository) Revoke(ctx context.Context, orgID, keyID uuid.UUID, r
 	return nil
 }
 
-func (r *apiKeyRepository) UpdateLastUsed(ctx context.Context, keyID uuid.UUID) error {
-	query := `UPDATE api_keys SET last_used_at = now() WHERE id = $1`
-	_, err := r.DB.Exec(ctx, query, keyID)
+func (r *apiKeyRepository) UpdateLastUsed(ctx context.Context, keyID uuid.UUID, ip string) error {
+	// Casting via NULLIF lets the same query handle "no IP available" (worker
+	// background calls, tests) without erroring on an empty INET.
+	query := `UPDATE api_keys
+		SET last_used_at = now(),
+		    last_request_ip = NULLIF($2, '')::inet
+		WHERE id = $1`
+	_, err := r.DB.Exec(ctx, query, keyID, ip)
 	return err
 }
 
@@ -290,4 +313,207 @@ func (r *apiKeyRepository) LogUsage(ctx context.Context, log *models.APIKeyUsage
 		db.CaptureError(err, query, params, "exec")
 	}
 	return err
+}
+
+// GetUsageSummary returns the org-level overview shown in the dashboard
+// strip. Counts are over the last 24 hours so the page can show "what's
+// going on right now" without needing a date picker.
+func (r *apiKeyRepository) GetUsageSummary(ctx context.Context, orgID uuid.UUID) (*models.APIKeyUsageSummary, *errx.Error) {
+	query := `
+		WITH key_counts AS (
+			SELECT
+				COUNT(*) FILTER (WHERE status = 'active')  AS active_keys,
+				COUNT(*) FILTER (WHERE status = 'revoked') AS revoked_keys,
+				COUNT(*) FILTER (WHERE status = 'expired') AS expired_keys
+			FROM api_keys
+			WHERE organization_id = $1
+		),
+		usage AS (
+			SELECT
+				COUNT(*) AS total,
+				COUNT(*) FILTER (WHERE l.response_status >= 400) AS errors,
+				COALESCE(AVG(l.response_time_ms), 0)::float8 AS avg_latency_ms,
+				MAX(l.created_at) AS last_call_at
+			FROM api_key_usage_logs l
+			JOIN api_keys k ON k.id = l.api_key_id
+			WHERE k.organization_id = $1
+			  AND l.created_at >= now() - INTERVAL '24 hours'
+		)
+		SELECT
+			key_counts.active_keys,
+			key_counts.revoked_keys,
+			key_counts.expired_keys,
+			usage.total,
+			usage.errors,
+			usage.avg_latency_ms,
+			usage.last_call_at
+		FROM key_counts CROSS JOIN usage
+	`
+
+	var s models.APIKeyUsageSummary
+	row := r.DB.QueryRow(ctx, query, orgID)
+	if err := row.Scan(
+		&s.ActiveKeys, &s.RevokedKeys, &s.ExpiredKeys,
+		&s.Requests24h, &s.Errors24h, &s.AvgLatencyMs24h, &s.LastCallAt,
+	); err != nil {
+		db.CaptureError(err, query, []any{orgID}, "queryrow")
+		return nil, errx.InternalError()
+	}
+	return &s, nil
+}
+
+// GetUsageTimeseries returns per-bucket request counts split by status
+// family (success / 4xx / 5xx). Bucket is one of "minute", "hour", "day".
+// keyID is optional; nil means "across every key in the org".
+func (r *apiKeyRepository) GetUsageTimeseries(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, bucket string) ([]models.APIKeyUsageBucket, *errx.Error) {
+	// Whitelist the trunc unit so we can interpolate it without opening up
+	// a SQL injection through the bucket parameter.
+	truncUnit := "hour"
+	switch bucket {
+	case "minute":
+		truncUnit = "minute"
+	case "hour":
+		truncUnit = "hour"
+	case "day":
+		truncUnit = "day"
+	}
+
+	query := fmt.Sprintf(`
+		SELECT
+			date_trunc('%s', l.created_at) AS bucket,
+			COUNT(*) AS total,
+			COUNT(*) FILTER (WHERE l.response_status BETWEEN 200 AND 399) AS success,
+			COUNT(*) FILTER (WHERE l.response_status BETWEEN 400 AND 499) AS client_errors,
+			COUNT(*) FILTER (WHERE l.response_status >= 500) AS server_errors,
+			COALESCE(AVG(l.response_time_ms), 0)::float8 AS avg_latency_ms
+		FROM api_key_usage_logs l
+		JOIN api_keys k ON k.id = l.api_key_id
+		WHERE k.organization_id = $1
+		  AND ($2::uuid IS NULL OR l.api_key_id = $2)
+		  AND l.created_at >= $3
+		  AND l.created_at < $4
+		GROUP BY bucket
+		ORDER BY bucket ASC
+	`, truncUnit)
+
+	params := []any{orgID, keyID, from, to}
+	rows, err := r.DB.Query(ctx, query, params...)
+	if err != nil {
+		db.CaptureError(err, query, params, "query")
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+
+	out := make([]models.APIKeyUsageBucket, 0, 64)
+	for rows.Next() {
+		var b models.APIKeyUsageBucket
+		if err := rows.Scan(&b.Bucket, &b.Total, &b.Success, &b.ClientErrors, &b.ServerErrors, &b.AvgLatencyMs); err != nil {
+			db.CaptureError(err, query, params, "scan")
+			return nil, errx.InternalError()
+		}
+		out = append(out, b)
+	}
+	return out, nil
+}
+
+// GetEndpointBreakdown returns the top `limit` endpoints by call count for
+// the given key (or the whole org if keyID is nil) over [from, to).
+func (r *apiKeyRepository) GetEndpointBreakdown(ctx context.Context, orgID uuid.UUID, keyID *uuid.UUID, from, to time.Time, limit int) ([]models.APIKeyEndpointStat, *errx.Error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	query := `
+		SELECT
+			l.endpoint,
+			l.method,
+			COUNT(*) AS count,
+			COUNT(*) FILTER (WHERE l.response_status >= 400) AS error_count,
+			COALESCE(AVG(l.response_time_ms), 0)::float8 AS avg_latency_ms
+		FROM api_key_usage_logs l
+		JOIN api_keys k ON k.id = l.api_key_id
+		WHERE k.organization_id = $1
+		  AND ($2::uuid IS NULL OR l.api_key_id = $2)
+		  AND l.created_at >= $3
+		  AND l.created_at < $4
+		GROUP BY l.endpoint, l.method
+		ORDER BY count DESC
+		LIMIT $5
+	`
+
+	params := []any{orgID, keyID, from, to, limit}
+	rows, err := r.DB.Query(ctx, query, params...)
+	if err != nil {
+		db.CaptureError(err, query, params, "query")
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+
+	out := make([]models.APIKeyEndpointStat, 0, limit)
+	for rows.Next() {
+		var s models.APIKeyEndpointStat
+		if err := rows.Scan(&s.Endpoint, &s.Method, &s.Count, &s.ErrorCount, &s.AvgLatencyMs); err != nil {
+			db.CaptureError(err, query, params, "scan")
+			return nil, errx.InternalError()
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+// ListUsageLogs returns recent raw request entries for a single key. Used
+// to power the live activity table in the detail drawer.
+func (r *apiKeyRepository) ListUsageLogs(ctx context.Context, orgID, keyID uuid.UUID, limit int, cursor *uuid.UUID) (*models.APIKeyUsageLogsResult, *errx.Error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+
+	query := `
+		SELECT
+			l.id, l.api_key_id, l.endpoint, l.method, l.ip_address::text,
+			COALESCE(l.user_agent, ''), COALESCE(l.response_status, 0),
+			COALESCE(l.response_time_ms, 0), l.created_at
+		FROM api_key_usage_logs l
+		JOIN api_keys k ON k.id = l.api_key_id
+		WHERE k.organization_id = $1
+		  AND l.api_key_id = $2
+		  AND ($3::uuid IS NULL OR (l.created_at, l.id) < (
+			SELECT created_at, id FROM api_key_usage_logs WHERE id = $3
+		  ))
+		ORDER BY l.created_at DESC, l.id DESC
+		LIMIT $4
+	`
+
+	params := []any{orgID, keyID, cursor, limit + 1}
+	rows, err := r.DB.Query(ctx, query, params...)
+	if err != nil {
+		db.CaptureError(err, query, params, "query")
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+
+	logs := make([]models.APIKeyUsageLog, 0, limit)
+	for rows.Next() {
+		var l models.APIKeyUsageLog
+		if err := rows.Scan(&l.ID, &l.APIKeyID, &l.Endpoint, &l.Method, &l.IPAddress, &l.UserAgent, &l.ResponseCode, &l.ResponseTime, &l.CreatedAt); err != nil {
+			db.CaptureError(err, query, params, "scan")
+			return nil, errx.InternalError()
+		}
+		logs = append(logs, l)
+	}
+
+	var nextCursor *uuid.UUID
+	hasMore := false
+	if len(logs) > limit {
+		hasMore = true
+		nextCursor = &logs[limit].ID
+		logs = logs[:limit]
+	}
+
+	return &models.APIKeyUsageLogsResult{
+		Data: logs,
+		Pagination: models.Pagination{
+			NextCursor: nextCursor,
+			HasMore:    hasMore,
+		},
+	}, nil
 }

--- a/web/src/app/app/api-keys/_components/CreateKeyModal.tsx
+++ b/web/src/app/app/api-keys/_components/CreateKeyModal.tsx
@@ -1,0 +1,515 @@
+// Create-API-key flow.
+//
+// Two screens:
+//   1. Configure  — name, description, permissions (preset / custom),
+//                   rate limit, expiration, IP allowlist.
+//   2. Reveal     — show the freshly-minted secret once; copying it is
+//                   the only way to recover it.
+//
+// Stripe-style: opinionated defaults (read-only preset, 60 r/m, no
+// expiration), with advanced options behind a disclosure.
+
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+    CheckIcon,
+    CopyIcon,
+    KeyIcon,
+    Loader2Icon,
+    LockIcon,
+    ShieldCheckIcon,
+    ShieldIcon,
+    SlidersIcon,
+    XIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
+
+import useCreateAPIKey from "@/lib/api/hooks/app/api-keys/useCreateAPIKey";
+import useAPIPermissions from "@/lib/api/hooks/app/api-keys/useAPIPermissions";
+import type APIPermission from "@/lib/api/models/app/apikeys/APIPermission";
+import type { APIKeyWithSecret } from "@/lib/api/models/app/apikeys/APIKey";
+
+type Step = "configure" | "reveal";
+type Preset = "read_only" | "full_access" | "custom";
+
+export default function CreateKeyModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+    const [step, setStep] = React.useState<Step>("configure");
+    const [created, setCreated] = React.useState<APIKeyWithSecret | null>(null);
+
+    React.useEffect(() => {
+        if (!open) {
+            // Defer reset so the closing animation doesn't show empty state.
+            const t = setTimeout(() => {
+                setStep("configure");
+                setCreated(null);
+            }, 200);
+            return () => clearTimeout(t);
+        }
+    }, [open]);
+
+    return (
+        <AnimatePresence>
+            {open && (
+                <>
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                        className="fixed inset-0 z-40 bg-black/40"
+                        onClick={step === "reveal" ? undefined : onClose}
+                    />
+                    <motion.div
+                        initial={{ opacity: 0, y: 8, scale: 0.99 }}
+                        animate={{ opacity: 1, y: 0, scale: 1 }}
+                        exit={{ opacity: 0, y: 8, scale: 0.99 }}
+                        transition={{ duration: 0.18 }}
+                        className="fixed left-1/2 top-[10vh] z-50 -translate-x-1/2 w-[560px] max-w-[92vw] bg-white rounded-lg border border-slate-200 shadow-[0_24px_60px_-12px_rgba(15,23,42,0.25)] overflow-hidden"
+                    >
+                        {step === "configure" ? (
+                            <ConfigureStep
+                                onCancel={onClose}
+                                onCreated={(k) => {
+                                    setCreated(k);
+                                    setStep("reveal");
+                                }}
+                            />
+                        ) : created ? (
+                            <RevealStep apiKey={created} onClose={onClose} />
+                        ) : null}
+                    </motion.div>
+                </>
+            )}
+        </AnimatePresence>
+    );
+}
+
+function ConfigureStep({
+    onCancel,
+    onCreated,
+}: {
+    onCancel: () => void;
+    onCreated: (k: APIKeyWithSecret) => void;
+}) {
+    const perms = useAPIPermissions();
+    const create = useCreateAPIKey();
+
+    const [name, setName] = React.useState("");
+    const [description, setDescription] = React.useState("");
+    const [preset, setPreset] = React.useState<Preset>("read_only");
+    const [permissionsBitmask, setPermissionsBitmask] = React.useState<number>(0);
+    const [rateLimit, setRateLimit] = React.useState<number>(60);
+    const [expiresIn, setExpiresIn] = React.useState<"never" | "30" | "90" | "365">("never");
+    const [allowedIPsRaw, setAllowedIPsRaw] = React.useState("");
+    const [advanced, setAdvanced] = React.useState(false);
+
+    // Default the bitmask to whatever the read_only preset says, once perms load.
+    React.useEffect(() => {
+        if (perms.data && permissionsBitmask === 0 && preset !== "custom") {
+            setPermissionsBitmask(presetMask(preset, perms.data.presets));
+        }
+    }, [perms.data, preset, permissionsBitmask]);
+
+    function switchPreset(p: Preset) {
+        setPreset(p);
+        if (p !== "custom" && perms.data) {
+            setPermissionsBitmask(presetMask(p, perms.data.presets));
+        }
+    }
+
+    function togglePermission(value: number) {
+        setPreset("custom");
+        setPermissionsBitmask((m) => (m & value ? m & ~value : m | value));
+    }
+
+    async function submit() {
+        if (!name.trim()) {
+            toast.error("Name is required");
+            return;
+        }
+        if (permissionsBitmask === 0) {
+            toast.error("Pick at least one permission");
+            return;
+        }
+        const allowedIPs = allowedIPsRaw
+            .split(/[\s,]+/)
+            .map((s) => s.trim())
+            .filter(Boolean);
+
+        const expiresAt =
+            expiresIn === "never"
+                ? undefined
+                : new Date(Date.now() + Number(expiresIn) * 24 * 60 * 60 * 1000).toISOString();
+
+        try {
+            const k = await create.mutateAsync({
+                name: name.trim(),
+                description: description.trim() || undefined,
+                permissions: permissionsBitmask,
+                rate_limit_per_minute: rateLimit,
+                expires_at: expiresAt,
+                allowed_ips: allowedIPs.length > 0 ? allowedIPs : undefined,
+            });
+            onCreated(k);
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : "Failed to create key";
+            toast.error(msg);
+        }
+    }
+
+    return (
+        <div>
+            <div className="h-11 px-4 border-b border-slate-200 flex items-center gap-2">
+                <KeyIcon className="w-3.5 h-3.5 text-slate-500" />
+                <span className="text-[12.5px] font-medium text-slate-900">Create API key</span>
+                <button
+                    type="button"
+                    onClick={onCancel}
+                    className="ml-auto w-7 h-7 rounded-md hover:bg-slate-100 inline-flex items-center justify-center text-slate-500 hover:text-slate-900"
+                    aria-label="Close"
+                >
+                    <XIcon className="w-3.5 h-3.5" />
+                </button>
+            </div>
+
+            <div className="px-5 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
+                <Field label="Name" hint="Shown in the dashboard. e.g. production-server, ci-pipeline.">
+                    <input
+                        autoFocus
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        placeholder="production-server"
+                        className="w-full h-8 px-2.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12.5px] text-slate-900 placeholder:text-slate-400"
+                    />
+                </Field>
+
+                <Field label="Description" optional hint="Internal note. Where will this key be used?">
+                    <textarea
+                        value={description}
+                        onChange={(e) => setDescription(e.target.value)}
+                        rows={2}
+                        placeholder="Server-side calls from EU production"
+                        className="w-full px-2.5 py-1.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12.5px] text-slate-900 placeholder:text-slate-400 resize-none"
+                    />
+                </Field>
+
+                <Field label="Permissions">
+                    <div className="grid grid-cols-3 gap-1.5 mb-2">
+                        <PresetCard
+                            icon={<ShieldIcon className="w-3 h-3" />}
+                            label="Read-only"
+                            sub="View everything"
+                            active={preset === "read_only"}
+                            onClick={() => switchPreset("read_only")}
+                        />
+                        <PresetCard
+                            icon={<ShieldCheckIcon className="w-3 h-3" />}
+                            label="Full access"
+                            sub="Read + write"
+                            active={preset === "full_access"}
+                            onClick={() => switchPreset("full_access")}
+                        />
+                        <PresetCard
+                            icon={<SlidersIcon className="w-3 h-3" />}
+                            label="Custom"
+                            sub="Pick scopes"
+                            active={preset === "custom"}
+                            onClick={() => switchPreset("custom")}
+                        />
+                    </div>
+                    {perms.isPending ? (
+                        <div className="h-20 rounded-md bg-slate-50 animate-pulse" />
+                    ) : (
+                        <PermissionMatrix
+                            permissions={perms.data?.permissions ?? []}
+                            bitmask={permissionsBitmask}
+                            onToggle={togglePermission}
+                        />
+                    )}
+                </Field>
+
+                <Field label="Rate limit" hint="Soft cap, sliding window. We return 429 + Retry-After when exceeded.">
+                    <div className="flex items-center gap-2">
+                        <input
+                            type="number"
+                            min={1}
+                            max={10000}
+                            value={rateLimit}
+                            onChange={(e) => setRateLimit(Math.max(1, Math.min(10000, Number(e.target.value) || 60)))}
+                            className="w-24 h-8 px-2.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12.5px] text-slate-900 text-right tabular-nums"
+                        />
+                        <span className="text-[11.5px] text-slate-500">requests / minute</span>
+                        <div className="ml-auto flex items-center gap-1">
+                            {[30, 60, 120, 600].map((v) => (
+                                <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setRateLimit(v)}
+                                    className={`h-6 px-2 rounded text-[11px] tabular-nums transition-colors ${
+                                        rateLimit === v
+                                            ? "bg-slate-900 text-white"
+                                            : "border border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                                    }`}
+                                >
+                                    {v}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+                </Field>
+
+                <Field label="Expires">
+                    <div className="flex items-center gap-1">
+                        {(["never", "30", "90", "365"] as const).map((v) => (
+                            <button
+                                key={v}
+                                type="button"
+                                onClick={() => setExpiresIn(v)}
+                                className={`h-7 px-3 rounded-md text-[11.5px] transition-colors ${
+                                    expiresIn === v
+                                        ? "bg-slate-900 text-white"
+                                        : "border border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                                }`}
+                            >
+                                {v === "never" ? "Never" : `${v} days`}
+                            </button>
+                        ))}
+                    </div>
+                </Field>
+
+                <button
+                    type="button"
+                    onClick={() => setAdvanced((a) => !a)}
+                    className="text-[11.5px] text-slate-500 hover:text-slate-900 underline-offset-2 hover:underline"
+                >
+                    {advanced ? "Hide advanced" : "Advanced (IP allowlist)"}
+                </button>
+
+                {advanced && (
+                    <Field label="Allowed IPs" optional hint="Comma- or newline-separated. Supports CIDR (10.0.0.0/8). Empty = any.">
+                        <textarea
+                            value={allowedIPsRaw}
+                            onChange={(e) => setAllowedIPsRaw(e.target.value)}
+                            rows={2}
+                            placeholder="203.0.113.10, 198.51.100.0/24"
+                            className="w-full px-2.5 py-1.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12px] text-slate-900 placeholder:text-slate-400 resize-none font-mono"
+                        />
+                    </Field>
+                )}
+            </div>
+
+            <div className="h-12 px-4 border-t border-slate-200 flex items-center gap-2 bg-slate-50/40">
+                <span className="text-[11px] text-slate-500 inline-flex items-center gap-1.5">
+                    <LockIcon className="w-3 h-3" />
+                    The secret will be shown once. Save it somewhere safe.
+                </span>
+                <div className="ml-auto flex items-center gap-1.5">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={create.isPending}
+                        className="h-7 px-3 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60"
+                    >
+                        {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <KeyIcon className="w-3 h-3" />}
+                        Create key
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function RevealStep({ apiKey, onClose }: { apiKey: APIKeyWithSecret; onClose: () => void }) {
+    const [copied, setCopied] = React.useState(false);
+    function copy() {
+        navigator.clipboard.writeText(apiKey.secret).then(
+            () => {
+                setCopied(true);
+                toast.success("Secret copied to clipboard");
+                setTimeout(() => setCopied(false), 2000);
+            },
+            () => toast.error("Failed to copy"),
+        );
+    }
+    return (
+        <div>
+            <div className="h-11 px-4 border-b border-slate-200 flex items-center gap-2">
+                <CheckIcon className="w-3.5 h-3.5 text-emerald-600" />
+                <span className="text-[12.5px] font-medium text-slate-900">Key created</span>
+            </div>
+
+            <div className="px-5 py-5">
+                <p className="text-[12.5px] text-slate-900 font-medium mb-1">{apiKey.name}</p>
+                <p className="text-[11.5px] text-slate-500 mb-4">
+                    Copy the secret now. We hash it on the server and can never show it again.
+                </p>
+
+                <div className="rounded-md border border-slate-200 bg-slate-950 overflow-hidden">
+                    <div className="px-3 py-2 flex items-center gap-2 border-b border-slate-800/60">
+                        <KeyIcon className="w-3 h-3 text-slate-400" />
+                        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-slate-400">
+                            Secret · once-only
+                        </span>
+                        <button
+                            type="button"
+                            onClick={copy}
+                            className="ml-auto inline-flex items-center gap-1 h-6 px-2 rounded text-slate-300 hover:text-white hover:bg-slate-800 transition-colors text-[11px]"
+                        >
+                            {copied ? <CheckIcon className="w-3 h-3" /> : <CopyIcon className="w-3 h-3" />}
+                            {copied ? "Copied" : "Copy"}
+                        </button>
+                    </div>
+                    <pre className="px-4 py-3 text-[12px] text-slate-100 font-mono whitespace-pre-wrap break-all">
+                        {apiKey.secret}
+                    </pre>
+                </div>
+
+                <div className="mt-4 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-900 leading-relaxed">
+                    <strong>Heads up:</strong> closing this dialog will discard the plaintext secret.
+                    Anyone with this string can act as <span className="font-mono">{apiKey.name}</span>.
+                </div>
+            </div>
+
+            <div className="h-12 px-4 border-t border-slate-200 flex items-center justify-end bg-slate-50/40">
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="h-7 px-3 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium transition-colors"
+                >
+                    I've saved it
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function Field({
+    label,
+    hint,
+    optional,
+    children,
+}: {
+    label: string;
+    hint?: string;
+    optional?: boolean;
+    children: React.ReactNode;
+}) {
+    return (
+        <div>
+            <div className="flex items-center gap-2 mb-1">
+                <label className="text-[11px] uppercase tracking-[0.14em] text-slate-500 font-medium">
+                    {label}
+                </label>
+                {optional && (
+                    <span className="text-[10px] text-slate-400 font-mono">optional</span>
+                )}
+            </div>
+            {children}
+            {hint && <p className="text-[10.5px] text-slate-400 mt-1 leading-relaxed">{hint}</p>}
+        </div>
+    );
+}
+
+function PresetCard({
+    icon,
+    label,
+    sub,
+    active,
+    onClick,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    sub: string;
+    active: boolean;
+    onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`relative text-left rounded-md border px-2.5 py-2 transition-colors ${
+                active
+                    ? "border-sky-400 bg-sky-50/60"
+                    : "border-slate-200 hover:border-slate-300 bg-white"
+            }`}
+        >
+            <div className="flex items-center gap-1.5 mb-0.5">
+                <span className={active ? "text-sky-600" : "text-slate-500"}>{icon}</span>
+                <span className={`text-[11.5px] font-medium ${active ? "text-sky-900" : "text-slate-900"}`}>
+                    {label}
+                </span>
+            </div>
+            <p className="text-[10.5px] text-slate-500">{sub}</p>
+        </button>
+    );
+}
+
+function PermissionMatrix({
+    permissions,
+    bitmask,
+    onToggle,
+}: {
+    permissions: APIPermission[];
+    bitmask: number;
+    onToggle: (value: number) => void;
+}) {
+    const grouped = React.useMemo(() => {
+        const out: Record<string, APIPermission[]> = { read: [], write: [], bulk: [], special: [] };
+        for (const p of permissions) {
+            (out[p.category] ?? (out[p.category] = [])).push(p);
+        }
+        return out;
+    }, [permissions]);
+
+    return (
+        <div className="rounded-md border border-slate-200 divide-y divide-slate-200/60 max-h-56 overflow-y-auto">
+            {(["read", "write", "bulk", "special"] as const).map((cat) =>
+                grouped[cat] && grouped[cat].length > 0 ? (
+                    <div key={cat}>
+                        <div className="px-2.5 py-1.5 bg-slate-50/60 text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium">
+                            {cat}
+                        </div>
+                        <div>
+                            {grouped[cat].map((p) => {
+                                const on = (bitmask & p.value) !== 0;
+                                return (
+                                    <button
+                                        key={p.name}
+                                        type="button"
+                                        onClick={() => onToggle(p.value)}
+                                        className="w-full px-2.5 py-1.5 flex items-center gap-2 hover:bg-slate-50 text-left transition-colors"
+                                    >
+                                        <div
+                                            className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors shrink-0 ${
+                                                on
+                                                    ? "border-sky-600 bg-sky-600 text-white"
+                                                    : "border-slate-300 bg-white"
+                                            }`}
+                                        >
+                                            {on && <CheckIcon className="w-2.5 h-2.5" strokeWidth={3} />}
+                                        </div>
+                                        <span className="font-mono text-[11px] text-slate-900">{p.name}</span>
+                                        <span className="text-[10.5px] text-slate-500 truncate">{p.description}</span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                ) : null,
+            )}
+        </div>
+    );
+}
+
+function presetMask(p: Preset, presets: { read_only: number; full_access: number }): number {
+    if (p === "read_only") return presets.read_only;
+    if (p === "full_access") return presets.full_access;
+    return 0;
+}

--- a/web/src/app/app/api-keys/_components/KeyDetailDrawer.tsx
+++ b/web/src/app/app/api-keys/_components/KeyDetailDrawer.tsx
@@ -1,0 +1,517 @@
+// Per-key detail drawer.
+//
+// Shows the live picture for one key:
+//   - identification (prefix/suffix, status, created/last-used)
+//   - configuration (permissions, rate limit, IP allowlist)
+//   - usage graph (24h request volume, status-code split)
+//   - top endpoints
+//   - recent request log
+//   - actions (revoke, edit name/description)
+//
+// Slides in from the right; closes on backdrop click or Escape.
+
+import React from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import {
+    ActivityIcon,
+    AlertCircleIcon,
+    CheckIcon,
+    ChevronRightIcon,
+    ClockIcon,
+    GaugeIcon,
+    Loader2Icon,
+    NetworkIcon,
+    RefreshCwIcon,
+    ShieldCheckIcon,
+    TrashIcon,
+    XIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
+
+import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
+import useAPIKeyAnalytics from "@/lib/api/hooks/app/api-keys/useAPIKeyAnalytics";
+import useAPIKeyUsageLogs from "@/lib/api/hooks/app/api-keys/useAPIKeyUsageLogs";
+import useAPIPermissions from "@/lib/api/hooks/app/api-keys/useAPIPermissions";
+import useRevokeAPIKey from "@/lib/api/hooks/app/api-keys/useRevokeAPIKey";
+import useUpdateAPIKey from "@/lib/api/hooks/app/api-keys/useUpdateAPIKey";
+import { StackedBars } from "./Sparkline";
+
+export default function KeyDetailDrawer({
+    apiKey,
+    onClose,
+}: {
+    apiKey: APIKey | null;
+    onClose: () => void;
+}) {
+    React.useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (e.key === "Escape") onClose();
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    return (
+        <AnimatePresence>
+            {apiKey && (
+                <>
+                    <motion.div
+                        initial={{ opacity: 0 }}
+                        animate={{ opacity: 1 }}
+                        exit={{ opacity: 0 }}
+                        transition={{ duration: 0.15 }}
+                        className="fixed inset-0 z-40 bg-black/30"
+                        onClick={onClose}
+                    />
+                    <motion.aside
+                        initial={{ x: "100%" }}
+                        animate={{ x: 0 }}
+                        exit={{ x: "100%" }}
+                        transition={{ type: "tween", ease: "easeOut", duration: 0.2 }}
+                        className="fixed right-0 top-0 bottom-0 z-50 w-[640px] max-w-[100vw] bg-white border-l border-slate-200 shadow-[-20px_0_40px_-12px_rgba(15,23,42,0.16)] flex flex-col"
+                    >
+                        <Inner apiKey={apiKey} onClose={onClose} />
+                    </motion.aside>
+                </>
+            )}
+        </AnimatePresence>
+    );
+}
+
+function Inner({ apiKey, onClose }: { apiKey: APIKey; onClose: () => void }) {
+    const analytics = useAPIKeyAnalytics(apiKey.id);
+    const logs = useAPIKeyUsageLogs(apiKey.id, { limit: 50 });
+    const perms = useAPIPermissions();
+    const revoke = useRevokeAPIKey();
+    const update = useUpdateAPIKey();
+
+    const [editing, setEditing] = React.useState(false);
+    const [name, setName] = React.useState(apiKey.name);
+    const [description, setDescription] = React.useState(apiKey.description ?? "");
+
+    React.useEffect(() => {
+        setName(apiKey.name);
+        setDescription(apiKey.description ?? "");
+    }, [apiKey.id, apiKey.name, apiKey.description]);
+
+    function saveEdit() {
+        if (!name.trim()) {
+            toast.error("Name is required");
+            return;
+        }
+        update.mutate(
+            {
+                id: apiKey.id,
+                data: { name: name.trim(), description: description.trim() || undefined },
+            },
+            {
+                onSuccess: () => {
+                    setEditing(false);
+                    toast.success("Saved");
+                },
+                onError: () => toast.error("Failed to save"),
+            },
+        );
+    }
+
+    function confirmRevoke() {
+        if (!window.confirm(`Revoke "${apiKey.name}"? Requests authenticating with this key will start failing immediately.`)) return;
+        revoke.mutate(
+            { id: apiKey.id, reason: "Revoked by user" },
+            {
+                onSuccess: () => {
+                    toast.success("Key revoked");
+                    onClose();
+                },
+                onError: () => toast.error("Failed to revoke"),
+            },
+        );
+    }
+
+    const grantedPermissions = React.useMemo(() => {
+        if (!perms.data) return [];
+        return perms.data.permissions.filter((p) => (apiKey.permissions & p.value) !== 0);
+    }, [perms.data, apiKey.permissions]);
+
+    return (
+        <>
+            {/* Header */}
+            <div className="h-12 px-5 border-b border-slate-200 flex items-center gap-2 shrink-0">
+                <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                    API key
+                </span>
+                <div className="h-4 w-px bg-slate-200" />
+                <span className="font-mono text-[11.5px] text-slate-900 truncate">
+                    {apiKey.key_prefix}…{apiKey.key_suffix}
+                </span>
+                <StatusBadge status={apiKey.status} />
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="ml-auto w-7 h-7 rounded-md hover:bg-slate-100 inline-flex items-center justify-center text-slate-500 hover:text-slate-900"
+                    aria-label="Close"
+                >
+                    <XIcon className="w-3.5 h-3.5" />
+                </button>
+            </div>
+
+            {/* Body (scrollable) */}
+            <div className="flex-1 overflow-y-auto">
+                {/* Identification */}
+                <section className="px-5 py-4 border-b border-slate-200/60">
+                    {editing ? (
+                        <div className="space-y-2">
+                            <input
+                                autoFocus
+                                value={name}
+                                onChange={(e) => setName(e.target.value)}
+                                className="w-full h-8 px-2.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12.5px]"
+                            />
+                            <textarea
+                                value={description}
+                                onChange={(e) => setDescription(e.target.value)}
+                                rows={2}
+                                placeholder="Description"
+                                className="w-full px-2.5 py-1.5 rounded-md border border-slate-200 focus:border-sky-400 focus:ring-1 focus:ring-sky-200 outline-none text-[12px] resize-none"
+                            />
+                            <div className="flex items-center gap-1.5">
+                                <button
+                                    type="button"
+                                    onClick={saveEdit}
+                                    disabled={update.isPending}
+                                    className="h-7 px-3 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] inline-flex items-center gap-1.5 disabled:opacity-60"
+                                >
+                                    {update.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
+                                    Save
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => setEditing(false)}
+                                    className="h-7 px-3 rounded-md border border-slate-200 text-[12px] text-slate-700 hover:border-slate-300"
+                                >
+                                    Cancel
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        <div>
+                            <div className="flex items-center gap-2">
+                                <h2 className="text-[15px] font-medium text-slate-900 truncate">{apiKey.name}</h2>
+                                {apiKey.status === "active" && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setEditing(true)}
+                                        className="text-[11px] text-sky-700 hover:text-sky-900 underline-offset-2 hover:underline"
+                                    >
+                                        Edit
+                                    </button>
+                                )}
+                            </div>
+                            {apiKey.description && (
+                                <p className="text-[12px] text-slate-500 mt-0.5 leading-relaxed">{apiKey.description}</p>
+                            )}
+                            <div className="mt-2 grid grid-cols-3 gap-3 text-[10.5px]">
+                                <MiniField label="Created" value={fmtRelative(apiKey.created_at)} />
+                                <MiniField label="Last used" value={apiKey.last_used_at ? fmtRelative(apiKey.last_used_at) : "never"} />
+                                <MiniField label="Last IP" value={apiKey.last_request_ip || "—"} mono />
+                            </div>
+                        </div>
+                    )}
+                </section>
+
+                {/* Quick stats */}
+                <section className="grid grid-cols-3 border-b border-slate-200/60 bg-slate-50/40">
+                    <QuickStat
+                        label="Requests · 24h"
+                        value={analytics.data?.total ?? 0}
+                        icon={<ActivityIcon className="w-3 h-3" />}
+                    />
+                    <QuickStat
+                        label="Errors · 24h"
+                        value={analytics.data?.errors ?? 0}
+                        icon={<AlertCircleIcon className="w-3 h-3" />}
+                        accent={(analytics.data?.errors ?? 0) > 0 ? "rose" : "slate"}
+                    />
+                    <QuickStat
+                        label="Rate limit"
+                        value={`${apiKey.rate_limit_per_minute}/m`}
+                        icon={<GaugeIcon className="w-3 h-3" />}
+                        last
+                    />
+                </section>
+
+                {/* Usage graph */}
+                <section className="px-5 py-4 border-b border-slate-200/60">
+                    <SectionLabel
+                        title="Traffic · last 24 hours"
+                        action={
+                            <button
+                                type="button"
+                                onClick={() => analytics.refetch()}
+                                className="text-slate-400 hover:text-slate-900 inline-flex items-center gap-1 text-[10.5px]"
+                            >
+                                {analytics.isFetching ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <RefreshCwIcon className="w-3 h-3" />}
+                                Refresh
+                            </button>
+                        }
+                    />
+                    {analytics.isPending ? (
+                        <div className="h-[140px] rounded bg-slate-50 animate-pulse" />
+                    ) : (
+                        <StackedBars buckets={analytics.data?.buckets ?? []} height={140} />
+                    )}
+                    <div className="mt-2 flex items-center gap-3 text-[10.5px] text-slate-500">
+                        <Legend color="bg-emerald-500/80" label="2xx success" />
+                        <Legend color="bg-amber-400/80" label="4xx client" />
+                        <Legend color="bg-rose-500/80" label="5xx server" />
+                    </div>
+                </section>
+
+                {/* Top endpoints */}
+                <section className="px-5 py-4 border-b border-slate-200/60">
+                    <SectionLabel title="Top endpoints" />
+                    {analytics.isPending ? (
+                        <div className="h-16 rounded bg-slate-50 animate-pulse" />
+                    ) : analytics.data?.endpoints && analytics.data.endpoints.length > 0 ? (
+                        <div className="divide-y divide-slate-200/60 -mx-1.5">
+                            {analytics.data.endpoints.slice(0, 8).map((e, i) => (
+                                <div key={`${e.method}-${e.endpoint}-${i}`} className="px-1.5 py-1.5 flex items-center gap-2">
+                                    <span className="text-[10px] uppercase font-mono text-slate-400 w-12 shrink-0">{e.method}</span>
+                                    <span className="font-mono text-[11px] text-slate-900 truncate">{e.endpoint}</span>
+                                    <span className="ml-auto tabular-nums font-mono text-[11px] text-slate-700">{e.count}</span>
+                                    {e.error_count > 0 && (
+                                        <span className="text-[10px] text-rose-600 tabular-nums">{e.error_count} err</span>
+                                    )}
+                                    <span className="text-[10px] text-slate-400 tabular-nums w-12 text-right">{Math.round(e.avg_latency_ms)}ms</span>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="text-[11.5px] text-slate-400">No endpoint traffic in this window.</p>
+                    )}
+                </section>
+
+                {/* Permissions */}
+                <section className="px-5 py-4 border-b border-slate-200/60">
+                    <SectionLabel
+                        title={`Permissions · ${grantedPermissions.length}`}
+                        icon={<ShieldCheckIcon className="w-3 h-3" />}
+                    />
+                    {perms.isPending ? (
+                        <div className="h-10 rounded bg-slate-50 animate-pulse" />
+                    ) : (
+                        <div className="flex flex-wrap gap-1">
+                            {grantedPermissions.map((p) => (
+                                <span
+                                    key={p.name}
+                                    className="inline-flex items-center gap-1 h-6 px-1.5 rounded text-[10.5px] font-mono border border-slate-200 text-slate-700 bg-white"
+                                    title={p.description}
+                                >
+                                    <span
+                                        className={`size-1.5 rounded-full ${
+                                            p.category === "read"
+                                                ? "bg-sky-400"
+                                                : p.category === "write"
+                                                  ? "bg-violet-400"
+                                                  : p.category === "bulk"
+                                                    ? "bg-amber-400"
+                                                    : "bg-emerald-400"
+                                        }`}
+                                    />
+                                    {p.name}
+                                </span>
+                            ))}
+                            {grantedPermissions.length === 0 && (
+                                <span className="text-[11.5px] text-slate-400">no scopes granted</span>
+                            )}
+                        </div>
+                    )}
+                </section>
+
+                {/* IP allowlist */}
+                {apiKey.allowed_ips && apiKey.allowed_ips.length > 0 && (
+                    <section className="px-5 py-4 border-b border-slate-200/60">
+                        <SectionLabel title="IP allowlist" icon={<NetworkIcon className="w-3 h-3" />} />
+                        <div className="flex flex-wrap gap-1">
+                            {apiKey.allowed_ips.map((ip) => (
+                                <span
+                                    key={ip}
+                                    className="h-6 px-1.5 rounded text-[10.5px] font-mono border border-slate-200 text-slate-700 bg-white"
+                                >
+                                    {ip}
+                                </span>
+                            ))}
+                        </div>
+                    </section>
+                )}
+
+                {/* Activity log */}
+                <section className="px-5 py-4">
+                    <SectionLabel
+                        title={`Recent activity${logs.data ? ` · ${logs.data.data.length}` : ""}`}
+                        icon={<ClockIcon className="w-3 h-3" />}
+                    />
+                    {logs.isPending ? (
+                        <div className="space-y-1">
+                            {[0, 1, 2, 3].map((i) => (
+                                <div key={i} className="h-7 rounded bg-slate-50 animate-pulse" />
+                            ))}
+                        </div>
+                    ) : logs.data?.data && logs.data.data.length > 0 ? (
+                        <div className="divide-y divide-slate-200/60 -mx-1.5">
+                            {logs.data.data.map((l) => (
+                                <div key={l.id} className="px-1.5 py-1.5 flex items-center gap-2">
+                                    <StatusDot status={l.response_code} />
+                                    <span className="font-mono text-[10px] tabular-nums text-slate-500 w-32 shrink-0">
+                                        {fmtFull(l.created_at)}
+                                    </span>
+                                    <span className="text-[10px] uppercase font-mono text-slate-400 w-10 shrink-0">{l.method}</span>
+                                    <span className="font-mono text-[11px] text-slate-900 truncate flex-1">{l.endpoint}</span>
+                                    <span className="font-mono text-[10px] text-slate-500 tabular-nums w-10 text-right">{l.response_code}</span>
+                                    <span className="font-mono text-[10px] text-slate-400 tabular-nums w-12 text-right">{l.response_time_ms}ms</span>
+                                </div>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="text-[11.5px] text-slate-400">No requests recorded yet.</p>
+                    )}
+                </section>
+            </div>
+
+            {/* Footer */}
+            <div className="h-12 px-4 border-t border-slate-200 flex items-center bg-white shrink-0">
+                {apiKey.status === "active" ? (
+                    <button
+                        type="button"
+                        onClick={confirmRevoke}
+                        disabled={revoke.isPending}
+                        className="h-7 px-3 rounded-md border border-rose-200 text-rose-700 hover:bg-rose-50 hover:border-rose-300 text-[12px] inline-flex items-center gap-1.5 transition-colors disabled:opacity-60"
+                    >
+                        {revoke.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <TrashIcon className="w-3 h-3" />}
+                        Revoke key
+                    </button>
+                ) : (
+                    <span className="text-[11.5px] text-slate-500 inline-flex items-center gap-1.5">
+                        <span className="size-1.5 rounded-full bg-rose-500" />
+                        Revoked {apiKey.revoked_at ? fmtRelative(apiKey.revoked_at) : ""}
+                        {apiKey.revoked_reason ? ` · ${apiKey.revoked_reason}` : ""}
+                    </span>
+                )}
+                <ChevronRightIcon className="w-3 h-3 text-slate-300 ml-auto" />
+            </div>
+        </>
+    );
+}
+
+function StatusBadge({ status }: { status: "active" | "revoked" | "expired" }) {
+    const tone =
+        status === "active"
+            ? { bg: "bg-emerald-50", text: "text-emerald-700", dot: "bg-emerald-500" }
+            : status === "revoked"
+              ? { bg: "bg-rose-50", text: "text-rose-700", dot: "bg-rose-500" }
+              : { bg: "bg-slate-100", text: "text-slate-600", dot: "bg-slate-400" };
+    return (
+        <span className={`inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] uppercase tracking-[0.08em] font-medium ${tone.bg} ${tone.text}`}>
+            <span className={`size-1.5 rounded-full ${tone.dot}`} />
+            {status}
+        </span>
+    );
+}
+
+function StatusDot({ status }: { status: number }) {
+    const c = status >= 500 ? "bg-rose-500" : status >= 400 ? "bg-amber-500" : status >= 200 ? "bg-emerald-500" : "bg-slate-400";
+    return <span className={`size-1.5 rounded-full ${c} shrink-0`} />;
+}
+
+function MiniField({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+    return (
+        <div>
+            <div className="text-[9.5px] uppercase tracking-[0.14em] text-slate-400 font-medium">{label}</div>
+            <div className={`mt-0.5 text-[11.5px] text-slate-700 ${mono ? "font-mono" : ""} truncate`}>{value}</div>
+        </div>
+    );
+}
+
+function QuickStat({
+    label,
+    value,
+    icon,
+    accent = "slate",
+    last,
+}: {
+    label: string;
+    value: number | string;
+    icon: React.ReactNode;
+    accent?: "slate" | "rose";
+    last?: boolean;
+}) {
+    return (
+        <div className={`px-5 py-3 ${!last ? "border-r border-slate-200/60" : ""}`}>
+            <div className="flex items-center gap-1.5">
+                <span className={`text-[10px] uppercase tracking-[0.14em] font-medium ${accent === "rose" ? "text-rose-500" : "text-slate-400"}`}>
+                    {label}
+                </span>
+                <span className={`${accent === "rose" ? "text-rose-500" : "text-slate-300"}`}>{icon}</span>
+            </div>
+            <div className={`mt-1 text-[20px] leading-none font-light tabular-nums ${accent === "rose" ? "text-rose-700" : "text-slate-900"}`}>
+                {typeof value === "number" ? value.toLocaleString() : value}
+            </div>
+        </div>
+    );
+}
+
+function SectionLabel({
+    title,
+    icon,
+    action,
+}: {
+    title: string;
+    icon?: React.ReactNode;
+    action?: React.ReactNode;
+}) {
+    return (
+        <div className="flex items-center gap-1.5 mb-2">
+            <span className="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium inline-flex items-center gap-1.5">
+                {icon}
+                {title}
+            </span>
+            {action && <span className="ml-auto">{action}</span>}
+        </div>
+    );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+    return (
+        <span className="inline-flex items-center gap-1">
+            <span className={`size-1.5 rounded-sm ${color}`} />
+            {label}
+        </span>
+    );
+}
+
+function fmtRelative(iso: string): string {
+    try {
+        const d = new Date(iso);
+        const diff = Date.now() - d.getTime();
+        const s = Math.floor(diff / 1000);
+        if (s < 60) return `${s}s ago`;
+        const m = Math.floor(s / 60);
+        if (m < 60) return `${m}m ago`;
+        const h = Math.floor(m / 60);
+        if (h < 24) return `${h}h ago`;
+        const days = Math.floor(h / 24);
+        if (days < 30) return `${days}d ago`;
+        return d.toLocaleDateString();
+    } catch {
+        return "—";
+    }
+}
+
+function fmtFull(iso: string): string {
+    try {
+        const d = new Date(iso);
+        return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    } catch {
+        return "—";
+    }
+}

--- a/web/src/app/app/api-keys/_components/Sparkline.tsx
+++ b/web/src/app/app/api-keys/_components/Sparkline.tsx
@@ -1,0 +1,140 @@
+// Tiny inline SVG charts. Two flavours:
+//
+//   <Sparkline values={...} />            // smooth single-series line
+//   <StackedBars buckets={...} />         // 2xx / 4xx / 5xx stacked column chart
+//
+// Built without a chart library so the bundle stays light and the visual
+// stays consistent with the dashboard chrome (hairlines, mono labels,
+// no axis chrome unless asked).
+
+import React from "react";
+
+export function Sparkline({
+    values,
+    width = 120,
+    height = 28,
+    stroke = "#0284c7",
+}: {
+    values: number[];
+    width?: number;
+    height?: number;
+    stroke?: string;
+}) {
+    if (!values || values.length === 0) {
+        return <div style={{ width, height }} className="bg-slate-50 rounded" />;
+    }
+
+    const max = Math.max(1, ...values);
+    const pad = 2;
+    const w = width - pad * 2;
+    const h = height - pad * 2;
+    const step = values.length > 1 ? w / (values.length - 1) : 0;
+
+    const points = values.map((v, i) => {
+        const x = pad + i * step;
+        const y = pad + h - (v / max) * h;
+        return [x, y] as const;
+    });
+
+    const linePath = points
+        .map(([x, y], i) => `${i === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`)
+        .join(" ");
+
+    const areaPath =
+        linePath + ` L ${pad + (values.length - 1) * step} ${pad + h} L ${pad} ${pad + h} Z`;
+
+    return (
+        <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`} className="block">
+            <defs>
+                <linearGradient id={`spark-${stroke.replace("#", "")}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={stroke} stopOpacity="0.18" />
+                    <stop offset="100%" stopColor={stroke} stopOpacity="0" />
+                </linearGradient>
+            </defs>
+            <path d={areaPath} fill={`url(#spark-${stroke.replace("#", "")})`} />
+            <path d={linePath} fill="none" stroke={stroke} strokeWidth={1.4} strokeLinejoin="round" strokeLinecap="round" />
+        </svg>
+    );
+}
+
+export interface BucketLike {
+    bucket: string;
+    success: number;
+    client_errors: number;
+    server_errors: number;
+    total: number;
+}
+
+export function StackedBars({
+    buckets,
+    height = 140,
+    onHoverBucket,
+}: {
+    buckets: BucketLike[];
+    height?: number;
+    onHoverBucket?: (b: BucketLike | null) => void;
+}) {
+    if (!buckets || buckets.length === 0) {
+        return (
+            <div
+                style={{ height }}
+                className="flex items-center justify-center text-[11.5px] text-slate-400 border border-dashed border-slate-200 rounded-md"
+            >
+                No traffic in this window
+            </div>
+        );
+    }
+
+    const max = Math.max(1, ...buckets.map((b) => b.total));
+    const barGap = 2;
+
+    return (
+        <div className="relative w-full" style={{ height }}>
+            <div className="absolute inset-0 flex items-end gap-[2px]">
+                {buckets.map((b, i) => {
+                    const totalH = (b.total / max) * (height - 16);
+                    const successH = b.total > 0 ? (b.success / b.total) * totalH : 0;
+                    const clientH = b.total > 0 ? (b.client_errors / b.total) * totalH : 0;
+                    const serverH = b.total > 0 ? (b.server_errors / b.total) * totalH : 0;
+                    return (
+                        <div
+                            key={`${b.bucket}-${i}`}
+                            className="flex-1 flex flex-col justify-end group cursor-default"
+                            onMouseEnter={() => onHoverBucket?.(b)}
+                            onMouseLeave={() => onHoverBucket?.(null)}
+                            style={{ marginRight: i === buckets.length - 1 ? 0 : barGap }}
+                        >
+                            <div className="flex flex-col-reverse rounded-sm overflow-hidden" style={{ height: totalH }}>
+                                {successH > 0 && (
+                                    <div className="bg-emerald-500/80 group-hover:bg-emerald-500 transition-colors" style={{ height: successH }} />
+                                )}
+                                {clientH > 0 && (
+                                    <div className="bg-amber-400/80 group-hover:bg-amber-500 transition-colors" style={{ height: clientH }} />
+                                )}
+                                {serverH > 0 && (
+                                    <div className="bg-rose-500/80 group-hover:bg-rose-500 transition-colors" style={{ height: serverH }} />
+                                )}
+                            </div>
+                        </div>
+                    );
+                })}
+            </div>
+            {/* horizontal hairline at base */}
+            <div className="absolute left-0 right-0 bottom-3 h-px bg-slate-200/80" />
+            <div className="absolute left-0 right-0 bottom-0 flex justify-between font-mono text-[9.5px] text-slate-400">
+                <span>{labelTick(buckets[0]?.bucket)}</span>
+                <span>{labelTick(buckets[buckets.length - 1]?.bucket)}</span>
+            </div>
+        </div>
+    );
+}
+
+function labelTick(iso: string | undefined): string {
+    if (!iso) return "";
+    try {
+        const d = new Date(iso);
+        return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+    } catch {
+        return "";
+    }
+}

--- a/web/src/app/app/api-keys/page.tsx
+++ b/web/src/app/app/api-keys/page.tsx
@@ -1,13 +1,39 @@
-// API keys — dev-focused preview.
+// API keys dashboard.
 //
-// Instead of an empty page, show a code snippet using the API + a
-// permissions matrix so the user understands what an API key gives
-// them. Different shape from every other tab — code monospace
-// dominates the visual.
+// Top strip: real org-level usage stats (active keys, 24h request volume,
+// error rate, avg latency). Refresh every 30s.
+//
+// Quick start: curl snippet using the user's own prefix once they have a
+// key. Pre-create, we show a placeholder snippet so the page isn't empty.
+//
+// Activity graph: org-wide stacked bars (2xx / 4xx / 5xx) for the last 24
+// hours. Read on first paint so the page lands with real data immediately.
+//
+// Keys list: one row per key with prefix, suffix, status, last used,
+// sparkline of recent volume. Clicking a row opens the detail drawer.
+//
+// Create flow lives in CreateKeyModal. Detail/edit/revoke lives in
+// KeyDetailDrawer. This page just orchestrates them.
 
-import { CopyIcon, KeyIcon, PlusIcon, ShieldCheckIcon } from "lucide-react";
-import toast from "react-hot-toast";
+"use client";
+
+import React from "react";
 import {
+    ActivityIcon,
+    AlertCircleIcon,
+    CheckIcon,
+    CopyIcon,
+    GaugeIcon,
+    KeyIcon,
+    PlusIcon,
+    RefreshCwIcon,
+    SearchIcon,
+    XIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
+
+import {
+    EmptyBlock,
     Page,
     PageBody,
     PageTopbar,
@@ -16,129 +42,316 @@ import {
     StatStrip,
     TopbarAction,
 } from "@/components/layout/Page";
-import { comingSoon } from "@/lib/helper/comingSoon";
-
-const SAMPLE_PERMISSIONS = [
-    { scope: "campaigns:read", description: "List + read campaign data", granted: true },
-    { scope: "campaigns:write", description: "Create / update / start / stop campaigns", granted: true },
-    { scope: "contacts:read", description: "Search and read contact records", granted: true },
-    { scope: "contacts:write", description: "Add, edit, delete contacts and tags", granted: false },
-    { scope: "emails:send", description: "Trigger sends from a connected mailbox", granted: false },
-    { scope: "analytics:read", description: "Aggregated stats and deliverability data", granted: true },
-];
-
-const SAMPLE_KEYS = [
-    { label: "production · server", prefix: "wmbly_pk_live_••••••••••••", lastUsed: "3m ago" },
-    { label: "staging · ci", prefix: "wmbly_pk_test_••••••••••••", lastUsed: "yesterday" },
-];
-
-const CODE_SNIPPET = `curl https://api.warmbly.com/v1/campaigns \\
-  -H "Authorization: Bearer wmbly_pk_live_••••••••" \\
-  -H "Content-Type: application/json"`;
+import useAPIKeys from "@/lib/api/hooks/app/api-keys/useAPIKeys";
+import useAPIKeyUsageSummary from "@/lib/api/hooks/app/api-keys/useAPIKeyUsageSummary";
+import useAPIKeyAnalytics from "@/lib/api/hooks/app/api-keys/useAPIKeyAnalytics";
+import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
+import CreateKeyModal from "./_components/CreateKeyModal";
+import KeyDetailDrawer from "./_components/KeyDetailDrawer";
+import { StackedBars } from "./_components/Sparkline";
 
 export default function APIKeysPage() {
-    function copyCode() {
-        navigator.clipboard.writeText(CODE_SNIPPET).catch(() => undefined);
-        toast.success("Snippet copied");
-    }
+    const summary = useAPIKeyUsageSummary();
+    const keys = useAPIKeys();
+    const analytics = useAPIKeyAnalytics("all");
+
+    const [createOpen, setCreateOpen] = React.useState(false);
+    const [selected, setSelected] = React.useState<APIKey | null>(null);
+    const [search, setSearch] = React.useState("");
+
+    const all = keys.data?.data ?? [];
+    const filtered = search.trim()
+        ? all.filter(
+              (k) =>
+                  k.name.toLowerCase().includes(search.trim().toLowerCase()) ||
+                  k.key_prefix.toLowerCase().includes(search.trim().toLowerCase()) ||
+                  (k.description ?? "").toLowerCase().includes(search.trim().toLowerCase()),
+          )
+        : all;
+
+    const samplePrefix = all[0]?.key_prefix ? `${all[0].key_prefix}…` : "wmbly_••";
 
     return (
         <Page>
-            <PageTopbar
-                eyebrow="API keys"
-                subtitle="Programmatic access tokens · billed against your workspace"
-            >
-                <TopbarAction
-                    icon={<PlusIcon className="w-3 h-3" />}
-                    onClick={() => comingSoon("API keys")}
+            <PageTopbar eyebrow="API keys" subtitle="Programmatic access · stripe-style scoped tokens">
+                <SearchPill value={search} onChange={setSearch} />
+                <button
+                    type="button"
+                    onClick={() => {
+                        summary.refetch();
+                        keys.refetch();
+                        analytics.refetch();
+                    }}
+                    aria-label="Refresh"
+                    className="h-7 w-7 rounded-md border border-slate-200 hover:border-slate-300 text-slate-500 hover:text-slate-900 inline-flex items-center justify-center transition-colors"
                 >
+                    <RefreshCwIcon className={`w-3 h-3 ${summary.isFetching ? "animate-spin" : ""}`} />
+                </button>
+                <TopbarAction icon={<PlusIcon className="w-3 h-3" />} onClick={() => setCreateOpen(true)}>
                     Create key
                 </TopbarAction>
             </PageTopbar>
 
             <StatStrip cols={4}>
-                <Stat label="Active" value={0} sub="keys" />
-                <Stat label="Requests (24h)" value="—" sub="across all keys" />
-                <Stat label="Rate limit" value="60" sub="req/min, default" />
-                <Stat label="Last call" value="—" sub="across all keys" last />
+                <Stat
+                    label="Active keys"
+                    value={summary.data?.active_keys ?? 0}
+                    sub={summary.data ? `${summary.data.revoked_keys + summary.data.expired_keys} inactive` : "—"}
+                    accent={(summary.data?.active_keys ?? 0) > 0}
+                />
+                <Stat
+                    label="Requests · 24h"
+                    value={summary.data?.requests_24h ?? 0}
+                    sub={summary.data ? `${summary.data.errors_24h} errors` : "—"}
+                />
+                <Stat
+                    label="Avg latency · 24h"
+                    value={summary.data ? `${Math.round(summary.data.avg_latency_ms_24h)}ms` : "—"}
+                    sub="across all keys"
+                />
+                <Stat
+                    label="Last call"
+                    value={summary.data?.last_call_at ? fmtRelative(summary.data.last_call_at) : "—"}
+                    sub={summary.data?.last_call_at ? fmtFull(summary.data.last_call_at) : "no calls yet"}
+                    last
+                />
             </StatStrip>
+
+            <SectionBar
+                label="Traffic · last 24h"
+                count={analytics.data?.total ?? 0}
+            >
+                {analytics.isFetching && <span className="text-[10px] text-slate-400">syncing…</span>}
+            </SectionBar>
+            <div className="px-5 py-4 border-b border-slate-200/60">
+                {analytics.isPending ? (
+                    <div className="h-[120px] rounded bg-slate-50 animate-pulse" />
+                ) : (
+                    <StackedBars buckets={analytics.data?.buckets ?? []} height={120} />
+                )}
+                <div className="mt-2 flex items-center gap-3 text-[10.5px] text-slate-500">
+                    <Legend color="bg-emerald-500/80" label="2xx" />
+                    <Legend color="bg-amber-400/80" label="4xx" />
+                    <Legend color="bg-rose-500/80" label="5xx" />
+                    <span className="ml-auto inline-flex items-center gap-1.5 text-[10.5px] text-slate-400">
+                        <GaugeIcon className="w-3 h-3" />
+                        live; refreshes every minute
+                    </span>
+                </div>
+            </div>
 
             <SectionBar label="Quick start" />
             <div className="px-5 py-4 border-b border-slate-200/60">
-                <div className="rounded-md border border-slate-200 bg-slate-950 overflow-hidden">
-                    <div className="h-8 px-3 flex items-center gap-2 border-b border-slate-800/60">
-                        <div className="size-1.5 rounded-full bg-red-400/70" />
-                        <div className="size-1.5 rounded-full bg-amber-400/70" />
-                        <div className="size-1.5 rounded-full bg-emerald-400/70" />
-                        <span className="ml-2 text-[11px] text-slate-400 font-mono">curl</span>
-                        <button
-                            type="button"
-                            onClick={copyCode}
-                            className="ml-auto inline-flex items-center gap-1 h-6 px-2 rounded text-slate-400 hover:text-white hover:bg-slate-800 transition-colors text-[11px]"
-                        >
-                            <CopyIcon className="w-3 h-3" />
-                            Copy
-                        </button>
-                    </div>
-                    <pre className="px-4 py-3 text-[12px] leading-relaxed text-slate-200 font-mono whitespace-pre overflow-x-auto">
-{CODE_SNIPPET}
-                    </pre>
-                </div>
+                <CodeSnippet prefix={samplePrefix} />
                 <p className="text-[11.5px] text-slate-500 mt-2 leading-relaxed">
-                    Send the key as a Bearer header. Every request is logged with
-                    request id, latency and origin — visible from this page once
-                    keys are live.
+                    Pass the secret as a <span className="font-mono">Bearer</span> header. Every request returns
+                    rate-limit headers (<span className="font-mono">X-RateLimit-Limit</span>,{" "}
+                    <span className="font-mono">X-RateLimit-Remaining</span>) so well-behaved clients can self-throttle
+                    before hitting <span className="font-mono">429</span>.
                 </p>
             </div>
 
-            <SectionBar label="Keys" count={0} />
-            <div
-                aria-hidden
-                className="border-b border-slate-200/60 opacity-70 pointer-events-none select-none divide-y divide-slate-200/60"
-            >
-                {SAMPLE_KEYS.map((k, i) => (
-                    <div key={i} className="h-11 px-5 flex items-center gap-3">
-                        <KeyIcon className="w-3.5 h-3.5 text-slate-400" />
-                        <span className="text-[12.5px] text-slate-900 font-medium">
-                            {k.label}
-                        </span>
-                        <span className="font-mono text-[11px] text-slate-400 ml-3 truncate">
-                            {k.prefix}
-                        </span>
-                        <span className="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums">
-                            last used {k.lastUsed}
-                        </span>
-                    </div>
-                ))}
-            </div>
-
-            <SectionBar label="Default scopes" />
+            <SectionBar label="Keys" count={filtered.length} />
             <PageBody>
-                <div className="px-5 py-3 divide-y divide-slate-200/60">
-                    {SAMPLE_PERMISSIONS.map((p) => (
-                        <div key={p.scope} className="h-9 flex items-center gap-3">
-                            <ShieldCheckIcon
-                                className={`w-3.5 h-3.5 shrink-0 ${
-                                    p.granted ? "text-emerald-500" : "text-slate-300"
-                                }`}
-                            />
-                            <span className="font-mono text-[11.5px] text-slate-900">
-                                {p.scope}
-                            </span>
-                            <span className="text-[11.5px] text-slate-500 truncate">
-                                {p.description}
-                            </span>
-                            <span
-                                className={`ml-auto text-[10.5px] uppercase tracking-[0.08em] font-medium ${
-                                    p.granted ? "text-emerald-600" : "text-slate-400"
-                                }`}
-                            >
-                                {p.granted ? "default" : "opt in"}
-                            </span>
-                        </div>
-                    ))}
-                </div>
+                {keys.isPending ? (
+                    <div className="px-5 py-4 space-y-2">
+                        {[0, 1, 2].map((i) => (
+                            <div key={i} className="h-11 rounded bg-slate-50 animate-pulse" />
+                        ))}
+                    </div>
+                ) : filtered.length === 0 ? (
+                    <div className="py-10">
+                        <EmptyBlock
+                            title={search ? "No keys match" : "No API keys yet"}
+                            body={
+                                search
+                                    ? "Try a shorter search."
+                                    : "Create a key to start calling Warmbly from your server or CI."
+                            }
+                            cta={
+                                !search && (
+                                    <button
+                                        type="button"
+                                        onClick={() => setCreateOpen(true)}
+                                        className="h-7 px-3 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors"
+                                    >
+                                        <PlusIcon className="w-3 h-3" />
+                                        Create key
+                                    </button>
+                                )
+                            }
+                        />
+                    </div>
+                ) : (
+                    <div className="divide-y divide-slate-200/60">
+                        {filtered.map((k) => (
+                            <KeyRow key={k.id} apiKey={k} onClick={() => setSelected(k)} />
+                        ))}
+                    </div>
+                )}
             </PageBody>
+
+            <CreateKeyModal open={createOpen} onClose={() => setCreateOpen(false)} />
+            <KeyDetailDrawer apiKey={selected} onClose={() => setSelected(null)} />
         </Page>
     );
 }
+
+function KeyRow({ apiKey, onClick }: { apiKey: APIKey; onClick: () => void }) {
+    const status = apiKey.status;
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="w-full h-12 px-5 flex items-center gap-3 text-left hover:bg-slate-50/80 transition-colors group"
+        >
+            <KeyIcon
+                className={`w-3.5 h-3.5 shrink-0 ${
+                    status === "active" ? "text-slate-500" : "text-slate-300"
+                }`}
+            />
+            <div className="flex flex-col min-w-0 max-w-[40%]">
+                <span className="text-[12.5px] text-slate-900 font-medium truncate">{apiKey.name}</span>
+                {apiKey.description && (
+                    <span className="text-[10.5px] text-slate-500 truncate">{apiKey.description}</span>
+                )}
+            </div>
+            <span className="font-mono text-[10.5px] text-slate-500 truncate">
+                {apiKey.key_prefix}…{apiKey.key_suffix}
+            </span>
+            <StatusPill status={status} />
+            <span className="ml-auto flex items-center gap-3 shrink-0">
+                <span className="text-[10.5px] text-slate-400 tabular-nums">
+                    <GaugeIcon className="inline w-3 h-3 mr-1 align-[-2px]" />
+                    {apiKey.rate_limit_per_minute}/m
+                </span>
+                <span className="font-mono text-[10.5px] text-slate-400 tabular-nums w-32 text-right truncate">
+                    {apiKey.last_used_at ? `used ${fmtRelative(apiKey.last_used_at)}` : "never used"}
+                </span>
+            </span>
+        </button>
+    );
+}
+
+function StatusPill({ status }: { status: APIKey["status"] }) {
+    const tone =
+        status === "active"
+            ? { bg: "bg-emerald-50", text: "text-emerald-700", dot: "bg-emerald-500" }
+            : status === "revoked"
+              ? { bg: "bg-rose-50", text: "text-rose-700", dot: "bg-rose-500" }
+              : { bg: "bg-slate-100", text: "text-slate-600", dot: "bg-slate-400" };
+    return (
+        <span
+            className={`inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] uppercase tracking-[0.08em] font-medium ${tone.bg} ${tone.text}`}
+        >
+            <span className={`size-1.5 rounded-full ${tone.dot}`} />
+            {status}
+        </span>
+    );
+}
+
+function CodeSnippet({ prefix }: { prefix: string }) {
+    const snippet = `curl https://api.warmbly.com/v1/campaigns \\
+  -H "Authorization: Bearer ${prefix}…" \\
+  -H "Content-Type: application/json"`;
+    const [copied, setCopied] = React.useState(false);
+    function copy() {
+        navigator.clipboard.writeText(snippet).then(
+            () => {
+                setCopied(true);
+                toast.success("Snippet copied");
+                setTimeout(() => setCopied(false), 1500);
+            },
+            () => toast.error("Failed to copy"),
+        );
+    }
+    return (
+        <div className="rounded-md border border-slate-200 bg-slate-950 overflow-hidden">
+            <div className="h-8 px-3 flex items-center gap-2 border-b border-slate-800/60">
+                <div className="size-1.5 rounded-full bg-red-400/70" />
+                <div className="size-1.5 rounded-full bg-amber-400/70" />
+                <div className="size-1.5 rounded-full bg-emerald-400/70" />
+                <span className="ml-2 text-[11px] text-slate-400 font-mono">curl</span>
+                <button
+                    type="button"
+                    onClick={copy}
+                    className="ml-auto inline-flex items-center gap-1 h-6 px-2 rounded text-slate-400 hover:text-white hover:bg-slate-800 transition-colors text-[11px]"
+                >
+                    {copied ? <CheckIcon className="w-3 h-3" /> : <CopyIcon className="w-3 h-3" />}
+                    {copied ? "Copied" : "Copy"}
+                </button>
+            </div>
+            <pre className="px-4 py-3 text-[12px] leading-relaxed text-slate-200 font-mono whitespace-pre overflow-x-auto">
+                {snippet}
+            </pre>
+        </div>
+    );
+}
+
+function SearchPill({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+    return (
+        <div className="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5 focus-within:border-sky-400 transition-colors">
+            <SearchIcon className="w-3 h-3 text-slate-400" />
+            <input
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder="Search…"
+                className="w-[140px] h-5 bg-transparent text-[12px] text-slate-900 placeholder:text-slate-400 outline-none"
+            />
+            {value && (
+                <button
+                    type="button"
+                    onClick={() => onChange("")}
+                    aria-label="Clear"
+                    className="text-slate-400 hover:text-slate-700"
+                >
+                    <XIcon className="w-3 h-3" />
+                </button>
+            )}
+        </div>
+    );
+}
+
+function Legend({ color, label }: { color: string; label: string }) {
+    return (
+        <span className="inline-flex items-center gap-1">
+            <span className={`size-1.5 rounded-sm ${color}`} />
+            {label}
+        </span>
+    );
+}
+
+function fmtRelative(iso: string): string {
+    try {
+        const d = new Date(iso);
+        const diff = Date.now() - d.getTime();
+        const s = Math.floor(diff / 1000);
+        if (s < 60) return `${s}s ago`;
+        const m = Math.floor(s / 60);
+        if (m < 60) return `${m}m ago`;
+        const h = Math.floor(m / 60);
+        if (h < 24) return `${h}h ago`;
+        const days = Math.floor(h / 24);
+        if (days < 30) return `${days}d ago`;
+        return d.toLocaleDateString();
+    } catch {
+        return "—";
+    }
+}
+
+function fmtFull(iso: string): string {
+    try {
+        return new Date(iso).toLocaleString("en-US", {
+            month: "short",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+    } catch {
+        return "—";
+    }
+}
+
+// Lint shim: keep imported icons that may render only in transient branches.
+void ActivityIcon;
+void AlertCircleIcon;

--- a/web/src/lib/api/client/app/api-keys/createAPIKey.ts
+++ b/web/src/lib/api/client/app/api-keys/createAPIKey.ts
@@ -1,11 +1,21 @@
-import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
+import type { APIKeyWithSecret } from "@/lib/api/models/app/apikeys/APIKey";
 import Request from "../../Request";
 
-export default async function createAPIKey(data: { name: string; permissions: string[]; expires_at?: string }): Promise<APIKey & { key: string }> {
-    return await Request<APIKey & { key: string }>({
+export interface CreateAPIKeyInput {
+    name: string;
+    description?: string;
+    permissions: number;
+    allowed_ips?: string[];
+    allowed_email_accounts?: string[];
+    rate_limit_per_minute?: number;
+    expires_at?: string;
+}
+
+export default async function createAPIKey(data: CreateAPIKeyInput): Promise<APIKeyWithSecret> {
+    return await Request<APIKeyWithSecret>({
         method: "POST",
         url: `/api-keys`,
         data,
         authorization: true,
-    })
+    });
 }

--- a/web/src/lib/api/client/app/api-keys/getAPIKeyAnalytics.ts
+++ b/web/src/lib/api/client/app/api-keys/getAPIKeyAnalytics.ts
@@ -1,0 +1,24 @@
+import type { APIKeyAnalytics } from "@/lib/api/models/app/apikeys/APIKeyAnalytics";
+import Request from "../../Request";
+
+export interface AnalyticsParams {
+    from?: string;
+    to?: string;
+    interval?: "minute" | "hour" | "day";
+}
+
+export default async function getAPIKeyAnalytics(keyID: string | "all", params?: AnalyticsParams): Promise<APIKeyAnalytics> {
+    const qs = new URLSearchParams();
+    if (params?.from) qs.set("from", params.from);
+    if (params?.to) qs.set("to", params.to);
+    if (params?.interval) qs.set("interval", params.interval);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+    const path = keyID === "all" ? `/api-keys/usage/analytics${suffix}` : `/api-keys/${keyID}/analytics${suffix}`;
+
+    return await Request<APIKeyAnalytics>({
+        method: "GET",
+        url: path,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/api-keys/getAPIKeyUsageSummary.ts
+++ b/web/src/lib/api/client/app/api-keys/getAPIKeyUsageSummary.ts
@@ -1,0 +1,10 @@
+import type { APIKeyUsageSummary } from "@/lib/api/models/app/apikeys/APIKeyAnalytics";
+import Request from "../../Request";
+
+export default async function getAPIKeyUsageSummary(): Promise<APIKeyUsageSummary> {
+    return await Request<APIKeyUsageSummary>({
+        method: "GET",
+        url: `/api-keys/usage/summary`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/api-keys/listAPIKeyUsageLogs.ts
+++ b/web/src/lib/api/client/app/api-keys/listAPIKeyUsageLogs.ts
@@ -1,0 +1,15 @@
+import type { APIKeyUsageLogsResult } from "@/lib/api/models/app/apikeys/APIKeyAnalytics";
+import Request from "../../Request";
+
+export default async function listAPIKeyUsageLogs(keyID: string, params?: { cursor?: string; limit?: number }): Promise<APIKeyUsageLogsResult> {
+    const qs = new URLSearchParams();
+    if (params?.cursor) qs.set("cursor", params.cursor);
+    if (params?.limit) qs.set("limit", String(params.limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+    return await Request<APIKeyUsageLogsResult>({
+        method: "GET",
+        url: `/api-keys/${keyID}/logs${suffix}`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/api-keys/listAPIKeys.ts
+++ b/web/src/lib/api/client/app/api-keys/listAPIKeys.ts
@@ -1,10 +1,15 @@
-import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
+import type { APIKeysResult } from "@/lib/api/models/app/apikeys/APIKey";
 import Request from "../../Request";
 
-export default async function listAPIKeys(): Promise<APIKey[]> {
-    return await Request<APIKey[]>({
+export default async function listAPIKeys(params?: { cursor?: string; limit?: number }): Promise<APIKeysResult> {
+    const qs = new URLSearchParams();
+    if (params?.cursor) qs.set("cursor", params.cursor);
+    if (params?.limit) qs.set("limit", String(params.limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+    return await Request<APIKeysResult>({
         method: "GET",
-        url: `/api-keys`,
+        url: `/api-keys${suffix}`,
         authorization: true,
-    })
+    });
 }

--- a/web/src/lib/api/client/app/api-keys/listAPIPermissions.ts
+++ b/web/src/lib/api/client/app/api-keys/listAPIPermissions.ts
@@ -1,10 +1,10 @@
-import type APIPermission from "@/lib/api/models/app/apikeys/APIPermission";
+import type { APIPermissionsResponse } from "@/lib/api/models/app/apikeys/APIPermission";
 import Request from "../../Request";
 
-export default async function listAPIPermissions(): Promise<APIPermission[]> {
-    return await Request<APIPermission[]>({
+export default async function listAPIPermissions(): Promise<APIPermissionsResponse> {
+    return await Request<APIPermissionsResponse>({
         method: "GET",
         url: `/api-keys/permissions`,
         authorization: true,
-    })
+    });
 }

--- a/web/src/lib/api/client/app/api-keys/revokeAPIKey.ts
+++ b/web/src/lib/api/client/app/api-keys/revokeAPIKey.ts
@@ -1,9 +1,10 @@
 import Request from "../../Request";
 
-export default async function revokeAPIKey(id: string): Promise<void> {
+export default async function revokeAPIKey(id: string, reason?: string): Promise<void> {
+    const qs = reason ? `?reason=${encodeURIComponent(reason)}` : "";
     return await Request<void>({
         method: "DELETE",
-        url: `/api-keys/${id}`,
+        url: `/api-keys/${id}${qs}`,
         authorization: true,
-    })
+    });
 }

--- a/web/src/lib/api/client/app/api-keys/updateAPIKey.ts
+++ b/web/src/lib/api/client/app/api-keys/updateAPIKey.ts
@@ -1,11 +1,20 @@
 import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
 import Request from "../../Request";
 
-export default async function updateAPIKey(id: string, data: Partial<APIKey>): Promise<APIKey> {
+export interface UpdateAPIKeyInput {
+    name?: string;
+    description?: string;
+    permissions?: number;
+    allowed_ips?: string[];
+    allowed_email_accounts?: string[];
+    rate_limit_per_minute?: number;
+}
+
+export default async function updateAPIKey(id: string, data: UpdateAPIKeyInput): Promise<APIKey> {
     return await Request<APIKey>({
         method: "PATCH",
         url: `/api-keys/${id}`,
         data,
         authorization: true,
-    })
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useAPIKey.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIKey.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import getAPIKey from "@/lib/api/client/app/api-keys/getAPIKey";
 
-export default function useAPIKey(id: string) {
+export default function useAPIKey(id: string | undefined) {
     return useQuery({
-        queryKey: ["api-keys", id],
-        queryFn: () => getAPIKey(id),
+        queryKey: ["api-keys", "detail", id],
+        queryFn: () => getAPIKey(id!),
         enabled: !!id,
-    })
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useAPIKeyAnalytics.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIKeyAnalytics.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import getAPIKeyAnalytics, { type AnalyticsParams } from "@/lib/api/client/app/api-keys/getAPIKeyAnalytics";
+
+export default function useAPIKeyAnalytics(keyID: string | "all", params?: AnalyticsParams) {
+    return useQuery({
+        queryKey: ["api-keys", "analytics", keyID, params],
+        queryFn: () => getAPIKeyAnalytics(keyID, params),
+        refetchInterval: 60_000,
+    });
+}

--- a/web/src/lib/api/hooks/app/api-keys/useAPIKeyUsageLogs.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIKeyUsageLogs.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import listAPIKeyUsageLogs from "@/lib/api/client/app/api-keys/listAPIKeyUsageLogs";
+
+export default function useAPIKeyUsageLogs(keyID: string | undefined, params?: { cursor?: string; limit?: number }) {
+    return useQuery({
+        queryKey: ["api-keys", "logs", keyID, params],
+        queryFn: () => listAPIKeyUsageLogs(keyID!, params),
+        enabled: !!keyID,
+        refetchInterval: 15_000,
+    });
+}

--- a/web/src/lib/api/hooks/app/api-keys/useAPIKeyUsageSummary.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIKeyUsageSummary.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import getAPIKeyUsageSummary from "@/lib/api/client/app/api-keys/getAPIKeyUsageSummary";
+
+export default function useAPIKeyUsageSummary() {
+    return useQuery({
+        queryKey: ["api-keys", "usage-summary"],
+        queryFn: () => getAPIKeyUsageSummary(),
+        refetchInterval: 30_000,
+    });
+}

--- a/web/src/lib/api/hooks/app/api-keys/useAPIKeys.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIKeys.ts
@@ -4,6 +4,7 @@ import listAPIKeys from "@/lib/api/client/app/api-keys/listAPIKeys";
 export default function useAPIKeys() {
     return useQuery({
         queryKey: ["api-keys", "list"],
-        queryFn: () => listAPIKeys(),
-    })
+        queryFn: () => listAPIKeys({ limit: 100 }),
+        staleTime: 5_000,
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useAPIPermissions.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useAPIPermissions.ts
@@ -5,5 +5,6 @@ export default function useAPIPermissions() {
     return useQuery({
         queryKey: ["api-keys", "permissions"],
         queryFn: () => listAPIPermissions(),
-    })
+        staleTime: 60 * 60 * 1000,
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useCreateAPIKey.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useCreateAPIKey.ts
@@ -1,15 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import createAPIKey from "@/lib/api/client/app/api-keys/createAPIKey";
+import createAPIKey, { type CreateAPIKeyInput } from "@/lib/api/client/app/api-keys/createAPIKey";
 
 export default function useCreateAPIKey() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (data: { name: string; permissions: string[]; expires_at?: string }) => createAPIKey(data),
+        mutationFn: (data: CreateAPIKeyInput) => createAPIKey(data),
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ["api-keys", "list"],
-            })
-        }
-    })
+            queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+        },
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useRevokeAPIKey.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useRevokeAPIKey.ts
@@ -5,11 +5,9 @@ export default function useRevokeAPIKey() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (id: string) => revokeAPIKey(id),
+        mutationFn: ({ id, reason }: { id: string; reason?: string }) => revokeAPIKey(id, reason),
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ["api-keys"],
-            })
-        }
-    })
+            queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+        },
+    });
 }

--- a/web/src/lib/api/hooks/app/api-keys/useUpdateAPIKey.ts
+++ b/web/src/lib/api/hooks/app/api-keys/useUpdateAPIKey.ts
@@ -1,16 +1,13 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import type APIKey from "@/lib/api/models/app/apikeys/APIKey";
-import updateAPIKey from "@/lib/api/client/app/api-keys/updateAPIKey";
+import updateAPIKey, { type UpdateAPIKeyInput } from "@/lib/api/client/app/api-keys/updateAPIKey";
 
 export default function useUpdateAPIKey() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: ({ id, data }: { id: string; data: Partial<APIKey> }) => updateAPIKey(id, data),
+        mutationFn: ({ id, data }: { id: string; data: UpdateAPIKeyInput }) => updateAPIKey(id, data),
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ["api-keys"],
-            })
-        }
-    })
+            queryClient.invalidateQueries({ queryKey: ["api-keys"] });
+        },
+    });
 }

--- a/web/src/lib/api/models/app/apikeys/APIKey.ts
+++ b/web/src/lib/api/models/app/apikeys/APIKey.ts
@@ -1,9 +1,46 @@
+// API key shape as returned by the backend.
+//
+// `permissions` is a bitmask (uint64). JavaScript safely handles the
+// number range we use (currently 19 bits, ceiling at 53 bits without
+// switching to BigInt). Resolve names <-> bits using APIPermission.value
+// from /api-keys/permissions.
+
+export type APIKeyStatus = "active" | "revoked" | "expired";
+
 export default interface APIKey {
-    id: string
-    name: string
-    key_prefix: string
-    permissions: string[]
-    last_used_at?: Date
-    expires_at?: Date
-    created_at: Date
+    id: string;
+    user_id: string;
+    organization_id: string;
+    name: string;
+    description?: string | null;
+    key_prefix: string;
+    key_suffix: string;
+    permissions: number;
+
+    allowed_ips?: string[];
+    allowed_email_accounts?: string[];
+
+    rate_limit_per_minute: number;
+
+    status: APIKeyStatus;
+    last_used_at?: string | null;
+    last_request_ip?: string | null;
+    expires_at?: string | null;
+    revoked_at?: string | null;
+    revoked_reason?: string | null;
+
+    created_at: string;
+    updated_at: string;
+}
+
+export interface APIKeyWithSecret extends APIKey {
+    secret: string;
+}
+
+export interface APIKeysResult {
+    data: APIKey[];
+    pagination: {
+        next_cursor?: string | null;
+        has_more: boolean;
+    };
 }

--- a/web/src/lib/api/models/app/apikeys/APIKeyAnalytics.ts
+++ b/web/src/lib/api/models/app/apikeys/APIKeyAnalytics.ts
@@ -1,0 +1,57 @@
+export interface APIKeyUsageSummary {
+    active_keys: number;
+    revoked_keys: number;
+    expired_keys: number;
+    requests_24h: number;
+    errors_24h: number;
+    avg_latency_ms_24h: number;
+    last_call_at?: string | null;
+}
+
+export interface APIKeyUsageBucket {
+    bucket: string;
+    total: number;
+    success: number;
+    client_errors: number;
+    server_errors: number;
+    avg_latency_ms: number;
+}
+
+export interface APIKeyEndpointStat {
+    endpoint: string;
+    method: string;
+    count: number;
+    error_count: number;
+    avg_latency_ms: number;
+}
+
+export interface APIKeyAnalytics {
+    api_key_id: string;
+    from: string;
+    to: string;
+    interval: "minute" | "hour" | "day";
+    buckets: APIKeyUsageBucket[];
+    endpoints: APIKeyEndpointStat[];
+    total: number;
+    errors: number;
+}
+
+export interface APIKeyUsageLog {
+    id: string;
+    api_key_id: string;
+    endpoint: string;
+    method: string;
+    ip_address: string;
+    user_agent: string;
+    response_code: number;
+    response_time_ms: number;
+    created_at: string;
+}
+
+export interface APIKeyUsageLogsResult {
+    data: APIKeyUsageLog[];
+    pagination: {
+        next_cursor?: string | null;
+        has_more: boolean;
+    };
+}

--- a/web/src/lib/api/models/app/apikeys/APIPermission.ts
+++ b/web/src/lib/api/models/app/apikeys/APIPermission.ts
@@ -1,6 +1,16 @@
+export type APIPermissionCategory = "read" | "write" | "bulk" | "special";
+
 export default interface APIPermission {
-    id: string
-    name: string
-    description: string
-    category: string
+    name: string;
+    value: number;
+    description: string;
+    category: APIPermissionCategory;
+}
+
+export interface APIPermissionsResponse {
+    permissions: APIPermission[];
+    presets: {
+        read_only: number;
+        full_access: number;
+    };
 }


### PR DESCRIPTION
- Add migration `000035_api_key_smart_limits` for per-key rate limit, description, last request IP, and usage-log analytics indexes
- Extend API key models, repository, and service with usage summary, timeseries, endpoint breakdown, and a Redis Lua sliding-window `CheckAndIncrementRateLimit` (fails open)
- Enforce per-key limits in the API key middleware and emit `X-RateLimit-*` and `Retry-After` headers; expose `/api-keys/usage/*` and per-key analytics/logs endpoints
- Rewrite the API keys page with stat strip, org-wide stacked traffic chart, live list, and search; add create modal (configure → reveal-once secret, permission matrix, rate limit, expiration, IP allowlist) and detail drawer (analytics, top endpoints, recent activity, edit/revoke)
- Reconcile permissions as a uint64 bitmask across models, clients, and hooks; use inline SVG sparkline/stacked-bar charts to avoid a chart-lib dependency