### PR TITLE
feat: refresh landing page feature showcase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ Commit hygiene:
 - when instructed to make a commit, use the subject format `feat: one line explanation`
 - commit messages on this repo do not include `Co-Authored-By:` or other AI/agent attribution footers. Keep messages to subject + body explaining the why. If a commit slips through with an attribution footer, rewrite it before opening or updating a PR.
 
+Copy / writing style:
+
+- do not lean on em dashes (`—`). Use them sparingly, only when one is genuinely the clearest option; prefer a period, comma, colon, or parentheses instead. This applies to user-facing copy and microcopy in `site/` and `web/`, and to docs. Overusing em dashes reads as machine-written.
+
 Data modeling / representation:
 
 - we are happiest with the most **type-safe** option, but the rule is: pick the **most effective option for the actual use case**, not type-safety for its own sake.

--- a/site/src/components/AIAssistantMock.astro
+++ b/site/src/components/AIAssistantMock.astro
@@ -1,0 +1,315 @@
+---
+/**
+ * Pixel-faithful mock of the Warmbly "Write with AI" assistant, shown IN
+ * CONTEXT inside the campaign Step email composer.
+ *
+ * Maps 1:1 to the real components:
+ *   - web/src/components/app/campaigns/sequences/SequenceView.tsx   the Step composer panel
+ *   - web/src/components/app/campaigns/sequences/WriteWithAI.tsx    the AI popover (the star)
+ *   - web/src/components/app/campaigns/sequences/RichTextEditor.tsx the body toolbar + editor
+ *   - web/src/lib/api/models/app/generation/Write.ts               WRITE_TONES presets
+ *   - web/src/components/ui/field.tsx                               TextInput / Label
+ *   - web/src/components/ui/popover-menu.tsx                        SelectButton / PopoverMenuContent
+ *
+ * Desktop-locked, authored at the 900px design width (FeatureSection scales it
+ * to the column). No responsive variants; always the desktop layout.
+ */
+
+// Tone presets, copied verbatim from WRITE_TONES (web/.../generation/Write.ts).
+// "Default" (empty value) is the selected tone.
+const tones = [
+  { label: "Default", selected: true },
+  { label: "Friendly", selected: false },
+  { label: "Professional", selected: false },
+  { label: "Casual", selected: false },
+  { label: "Concise", selected: false },
+  { label: "Persuasive", selected: false },
+];
+
+// The freshly generated cold-email draft that fills the body after Generate.
+// Matches SequenceView.onInsert -> setBody: each line is a <p> in the tiptap body.
+const draftLines = [
+  "Hi Alex,",
+  "Noticed Acme has been scaling fast on AWS. Teams your size are usually overpaying 30 to 40 percent on compute they spun up once and never tuned.",
+  "I help engineering teams find that spend without re-architecting anything. Worth a quick 15-minute call to walk through the three line items I'd check first?",
+  "Open to next Tuesday or Wednesday afternoon?",
+  "Best,",
+  "Jordan",
+];
+---
+<!-- Root: fills parent width, white surface. relative for cursor + reaction. -->
+<div class="w-full bg-white text-slate-900 relative" style="min-height:560px;">
+
+  <!-- Slim Step tab bar above the composer (campaign sequence builder chrome) -->
+  <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 bg-white">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Sequence</span>
+    <div class="h-4 w-px bg-slate-200"></div>
+    <div class="flex items-center gap-1.5">
+      <span class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-slate-900 text-white text-[12px] font-medium">
+        <span class="size-4 rounded-full bg-white/20 inline-flex items-center justify-center font-mono text-[10px] tabular-nums">1</span>
+        Step 1
+      </span>
+      <span class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-slate-500 text-[12px]">
+        <span class="size-4 rounded-full bg-slate-100 inline-flex items-center justify-center font-mono text-[10px] tabular-nums text-slate-500">2</span>
+        Follow-up
+        <span class="font-mono text-[10px] text-slate-400 tabular-nums">+3d</span>
+      </span>
+      <span class="inline-flex items-center gap-1.5 h-7 px-2 rounded-md text-slate-400 text-[12px]">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add step
+      </span>
+    </div>
+    <div class="ml-auto inline-flex items-center gap-1.5 text-[11px] text-emerald-600 font-medium">
+      <span class="relative flex size-1.5">
+        <span class="absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-60 animate-ping"></span>
+        <span class="relative inline-flex size-1.5 rounded-full bg-emerald-500"></span>
+      </span>
+      Draft saved
+    </div>
+  </div>
+
+  <!-- Composer body padding -->
+  <div class="p-5">
+
+    <!-- The Step composer card (SequenceView root) -->
+    <div class="rounded-md border border-slate-200 bg-white relative">
+
+      <!-- Header: Step label + subtitle (left), action buttons (right) -->
+      <div class="flex flex-row items-center justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
+        <div class="min-w-0">
+          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Step 1</div>
+          <p class="mt-0.5 truncate text-[11px] text-slate-400">Compose the email this step sends.</p>
+        </div>
+        <div class="flex flex-wrap shrink-0 items-center gap-2">
+          <!-- Templates (SelectButton) -->
+          <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium">
+            <span class="text-slate-400 shrink-0">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/></svg>
+            </span>
+            <span class="truncate max-w-[160px]">Templates</span>
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="text-slate-400 shrink-0"><path d="M6 9l6 6 6-6"/></svg>
+          </button>
+
+          <!-- Save as template -->
+          <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15.5 22v-8.4a.6.6 0 0 0-.6-.6H9.1a.6.6 0 0 0-.6.6V22l3.5-2.5z"/><path d="M4 19V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v15"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="10" y1="9" x2="14" y2="9"/></svg>
+            Save as template
+          </button>
+
+          <!-- Write with AI (highlighted, popover open) -->
+          <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-300 bg-sky-100 text-[12px] font-medium text-sky-700">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/></svg>
+            Write with AI
+          </button>
+
+          <div class="h-4 w-px bg-slate-200"></div>
+
+          <!-- Reset -->
+          <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700 opacity-40">Reset</button>
+
+          <!-- Save changes -->
+          <button type="button" class="h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 opacity-40">Save changes</button>
+        </div>
+      </div>
+
+      <!-- Composer fields -->
+      <div class="space-y-4 p-3">
+
+        <!-- Step name -->
+        <div>
+          <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block mb-1.5">Step name</label>
+          <div class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 flex items-center">Cold intro</div>
+          <p class="mt-1.5 text-[10.5px] text-slate-400">Internal label only. Recipients never see it.</p>
+        </div>
+
+        <!-- Subject -->
+        <div>
+          <div class="flex items-center justify-between gap-2 mb-1.5">
+            <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block">Subject</label>
+            <button type="button" class="h-7 px-1.5 inline-flex items-center gap-1 rounded text-slate-500">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5a2 2 0 0 0 2 2h1"/><path d="M16 21h1a2 2 0 0 0 2-2v-5a2 2 0 0 1 2-2 2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/></svg>
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            </button>
+          </div>
+          <div class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 flex items-center">
+            <span>Quick question about Acme's AWS spend, </span><span class="font-mono text-sky-700">{`{{.FirstName}}`}</span>
+          </div>
+        </div>
+
+        <!-- Body: Edit/Preview toggle + rich-text editor -->
+        <div>
+          <div class="flex items-center justify-between gap-2 mb-1.5">
+            <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block">Body</label>
+            <div class="inline-flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5">
+              <span class="h-6 px-2 inline-flex items-center gap-1 rounded text-[11.5px] font-medium bg-white text-slate-900 shadow-sm">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"/></svg>
+                Edit
+              </span>
+              <span class="h-6 px-2 inline-flex items-center gap-1 rounded text-[11.5px] font-medium text-slate-500">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/></svg>
+                Preview
+              </span>
+            </div>
+          </div>
+
+          <!-- RichTextEditor: bordered card, toolbar + body -->
+          <div class="rounded-md border border-slate-200 bg-white">
+            <!-- Toolbar (px-1.5 py-1, gap-0.5, hairline bottom border) -->
+            <div class="relative flex flex-wrap items-center gap-0.5 border-b border-slate-200/70 px-1.5 py-1">
+              <!-- Bold -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8"/></svg>
+              </span>
+              <!-- Italic -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/></svg>
+              </span>
+              <!-- Underline -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/></svg>
+              </span>
+              <!-- Strikethrough -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>
+              </span>
+              <span class="mx-0.5 h-4 w-px bg-slate-200"></span>
+              <!-- Heading 2 -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12h8"/><path d="M4 18V6"/><path d="M12 18V6"/><path d="M21 18h-4c0-4 4-3 4-6 0-1.5-2-2.5-4-1"/></svg>
+              </span>
+              <!-- Bullet list -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/></svg>
+              </span>
+              <!-- Ordered list -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 12h11"/><path d="M10 18h11"/><path d="M10 6h11"/><path d="M4 10h2"/><path d="M4 6h1v4"/><path d="M6 18H4c0-1 2-2 2-3s-1-1.5-2-1"/></svg>
+              </span>
+              <!-- Link -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" x2="16" y1="12" y2="12"/></svg>
+              </span>
+              <span class="mx-0.5 h-4 w-px bg-slate-200"></span>
+              <!-- Variables (Braces + chevron) -->
+              <span class="h-7 px-1.5 inline-flex items-center gap-1 rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5a2 2 0 0 0 2 2h1"/><path d="M16 21h1a2 2 0 0 0 2-2v-5a2 2 0 0 1 2-2 2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/></svg>
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+              </span>
+              <!-- Spintax (shuffle) -->
+              <span class="size-7 inline-flex items-center justify-center rounded text-slate-500">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg>
+              </span>
+            </div>
+
+            <!-- Body content area (empty before Generate). The reaction overlays
+                 here, so it reads as Generate -> body filled. -->
+            <div class="ai-bodyarea relative tiptap-body min-h-[228px] px-3 py-2.5 text-[13px] leading-relaxed">
+              <p class="text-slate-300 select-none">Hi {`{{.FirstName}}`}, ...</p>
+
+              <!-- REACTION: the generated draft fills the body (white bg so it
+                   cleanly covers the placeholder once revealed). -->
+              <div class="ai-react" style="position:absolute; left:12px; right:12px; top:10px; background:#ffffff;">
+                <div class="space-y-3 text-slate-800">
+                  {draftLines.map((line) => (
+                    <p>{line}</p>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ─────────────────────────────────────────────────────────────
+           THE STAR: "Write with AI" popover, open at the top-right under
+           its trigger (align="end"). PopoverMenuContent: rounded-md border
+           border-slate-200 bg-white, minWidth 320, p-3, the popover shadow.
+      ────────────────────────────────────────────────────────────── -->
+      <div
+        class="absolute z-40 rounded-md border border-slate-200 bg-white p-3 overflow-hidden"
+        style="top:48px; right:12px; min-width:336px; box-shadow:0 4px 12px -2px rgba(15,23,42,0.10),0 12px 32px -8px rgba(15,23,42,0.18);"
+      >
+        <div class="space-y-3">
+          <!-- Prompt (textarea, focused state: sky border + ring) -->
+          <div>
+            <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block mb-1.5">What should this email say?</label>
+            <div class="w-full rounded-md border border-sky-400 ring-2 ring-sky-100 bg-white px-2.5 py-2 text-[12.5px] text-slate-900 leading-relaxed">
+              A short intro asking to book a 15-min call about cutting their AWS bill.
+            </div>
+          </div>
+
+          <!-- Tone: 6 chips, Default selected -->
+          <div>
+            <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block mb-1.5">Tone</label>
+            <div class="flex flex-wrap gap-1.5">
+              {tones.map((t) => (
+                <span class={`h-6 rounded-md border px-2 inline-flex items-center text-[11.5px] font-medium ${
+                  t.selected
+                    ? "border-sky-300 bg-sky-50 text-sky-700"
+                    : "border-slate-200 bg-white text-slate-600"
+                }`}>{t.label}</span>
+              ))}
+            </div>
+          </div>
+
+          <!-- Footer: credits remaining + Generate. Credits flip to 2 + a
+               "Generated" check after the press (via the .ai-credits swap). -->
+          <div class="flex items-center justify-between gap-2 pt-0.5">
+            <span class="text-[10.5px] text-slate-400">
+              <span class="ai-credits-before">3 credits remaining</span>
+              <span class="ai-credits-after inline-flex items-center gap-1 text-emerald-600 font-medium">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                Generated. 2 credits remaining
+              </span>
+            </span>
+            <button type="button" class="ai-genbtn h-7 px-3 inline-flex items-center gap-1.5 rounded-md bg-sky-600 text-[12px] font-medium text-white">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"/><path d="m14 7 3 3"/><path d="M5 6v4"/><path d="M19 14v4"/><path d="M10 2v2"/><path d="M7 8H3"/><path d="M21 16h-4"/><path d="M11 3H9"/></svg>
+              Generate
+            </button>
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       DEMO SCENE: the cursor glides to the popover "Generate" button,
+       presses it (28%) - the button shows an active ring; the generated
+       draft fades into the composer body (~32%) and the footer flips to
+       "Generated. 2 credits remaining". The cursor then dips into the
+       body (press #2, 64%). 11s infinite loop.
+  ────────────────────────────────────────────────────────────── -->
+
+  <!-- Cursor -->
+  <div class="ai-cursor" aria-hidden="true">
+    <span class="ai-ripple"></span>
+    <svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg>
+  </div>
+
+  <style>
+    /* Reaction (generated draft) hidden until press #1, then rests. */
+    .ai-react{opacity:0;animation:ai-react 11s ease-out infinite;}
+
+    /* Credits text swap: "3 remaining" -> "Generated. 2 remaining" on press. */
+    .ai-credits-after{display:none;}
+    .ai-credits-before{animation:ai-credits-before 11s step-end infinite;}
+    .ai-credits-after{animation:ai-credits-after 11s step-end infinite;}
+
+    /* Generate button active state synced with press #1. */
+    .ai-genbtn{animation:ai-genbtn 11s ease-in-out infinite;}
+
+    .ai-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:ai-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .ai-cursor svg{display:block;transform-origin:3px 2px;animation:ai-press 11s ease-in-out infinite;}
+    .ai-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:ai-rip 11s ease-out infinite;}
+
+    @keyframes ai-move{0%{left:20%;top:15%}22%{left:88%;top:45%}32%{left:88%;top:45%}58%{left:32%;top:74%}68%{left:32%;top:74%}88%{left:32%;top:74%}100%{left:20%;top:15%}}
+    @keyframes ai-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes ai-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes ai-react{0%,29%{opacity:0;transform:translateY(8px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(8px)}100%{opacity:0;transform:translateY(8px)}}
+    @keyframes ai-genbtn{0%,27%{background-color:#0284c7;box-shadow:none}28%,31%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,1)}33%,100%{background-color:#0284c7;box-shadow:none}}
+    @keyframes ai-credits-before{0%,31.9%{display:inline}32%,100%{display:none}}
+    @keyframes ai-credits-after{0%,31.9%{display:none}32%,92%{display:inline-flex}92.1%,100%{display:none}}
+    @media (prefers-reduced-motion: reduce){.ai-cursor{display:none}.ai-react{opacity:1;transform:none;animation:none}.ai-genbtn{animation:none}.ai-credits-before{display:none;animation:none}.ai-credits-after{display:inline-flex;animation:none}}
+  </style>
+</div>

--- a/site/src/components/AIAssistantMock.astro
+++ b/site/src/components/AIAssistantMock.astro
@@ -80,9 +80,9 @@ const draftLines = [
           <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Step 1</div>
           <p class="mt-0.5 truncate text-[11px] text-slate-400">Compose the email this step sends.</p>
         </div>
-        <div class="flex flex-wrap shrink-0 items-center gap-2">
+        <div class="flex flex-nowrap shrink-0 items-center gap-2">
           <!-- Templates (SelectButton) -->
-          <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium">
+          <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium whitespace-nowrap shrink-0">
             <span class="text-slate-400 shrink-0">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/></svg>
             </span>
@@ -90,25 +90,24 @@ const draftLines = [
             <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="text-slate-400 shrink-0"><path d="M6 9l6 6 6-6"/></svg>
           </button>
 
-          <!-- Save as template -->
-          <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">
+          <!-- Save as template (icon-only at 900px to keep the row on one line) -->
+          <button type="button" aria-label="Save as template" title="Save as template" class="h-7 w-7 inline-flex items-center justify-center rounded-md border border-slate-200 bg-white text-slate-700 shrink-0">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M15.5 22v-8.4a.6.6 0 0 0-.6-.6H9.1a.6.6 0 0 0-.6.6V22l3.5-2.5z"/><path d="M4 19V4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v15"/><line x1="12" y1="7" x2="12" y2="11"/><line x1="10" y1="9" x2="14" y2="9"/></svg>
-            Save as template
           </button>
 
           <!-- Write with AI (highlighted, popover open) -->
-          <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-300 bg-sky-100 text-[12px] font-medium text-sky-700">
+          <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-300 bg-sky-100 text-[12px] font-medium text-sky-700 whitespace-nowrap shrink-0">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/></svg>
             Write with AI
           </button>
 
-          <div class="h-4 w-px bg-slate-200"></div>
+          <div class="h-4 w-px bg-slate-200 shrink-0"></div>
 
           <!-- Reset -->
-          <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700 opacity-40">Reset</button>
+          <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700 opacity-40 whitespace-nowrap shrink-0">Reset</button>
 
           <!-- Save changes -->
-          <button type="button" class="h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 opacity-40">Save changes</button>
+          <button type="button" class="h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 opacity-40 whitespace-nowrap shrink-0">Save changes</button>
         </div>
       </div>
 
@@ -227,7 +226,7 @@ const draftLines = [
       ────────────────────────────────────────────────────────────── -->
       <div
         class="absolute z-40 rounded-md border border-slate-200 bg-white p-3 overflow-hidden"
-        style="top:48px; right:12px; min-width:336px; box-shadow:0 4px 12px -2px rgba(15,23,42,0.10),0 12px 32px -8px rgba(15,23,42,0.18);"
+        style="top:48px; right:12px; min-width:408px; box-shadow:0 4px 12px -2px rgba(15,23,42,0.10),0 12px 32px -8px rgba(15,23,42,0.18);"
       >
         <div class="space-y-3">
           <!-- Prompt (textarea, focused state: sky border + ring) -->

--- a/site/src/components/AIAssistantMock.astro
+++ b/site/src/components/AIAssistantMock.astro
@@ -240,9 +240,9 @@ const draftLines = [
           <!-- Tone: 6 chips, Default selected -->
           <div>
             <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block mb-1.5">Tone</label>
-            <div class="flex flex-wrap gap-1.5">
+            <div class="flex flex-nowrap gap-1">
               {tones.map((t) => (
-                <span class={`h-6 rounded-md border px-2 inline-flex items-center text-[11.5px] font-medium ${
+                <span class={`h-6 rounded-md border px-1.5 inline-flex items-center whitespace-nowrap shrink-0 text-[11.5px] font-medium ${
                   t.selected
                     ? "border-sky-300 bg-sky-50 text-sky-700"
                     : "border-slate-200 bg-white text-slate-600"
@@ -261,7 +261,7 @@ const draftLines = [
                 Generated. 2 credits remaining
               </span>
             </span>
-            <button type="button" class="ai-genbtn h-7 px-3 inline-flex items-center gap-1.5 rounded-md bg-sky-600 text-[12px] font-medium text-white">
+            <button type="button" class="ai-genbtn h-7 px-3 inline-flex items-center gap-1.5 rounded-md bg-sky-600 text-[12px] font-medium text-white whitespace-nowrap shrink-0">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m21.64 3.64-1.28-1.28a1.21 1.21 0 0 0-1.72 0L2.36 18.64a1.21 1.21 0 0 0 0 1.72l1.28 1.28a1.2 1.2 0 0 0 1.72 0L21.64 5.36a1.2 1.2 0 0 0 0-1.72"/><path d="m14 7 3 3"/><path d="M5 6v4"/><path d="M19 14v4"/><path d="M10 2v2"/><path d="M7 8H3"/><path d="M21 16h-4"/><path d="M11 3H9"/></svg>
               Generate
             </button>
@@ -302,7 +302,7 @@ const draftLines = [
     .ai-cursor svg{display:block;transform-origin:3px 2px;animation:ai-press 11s ease-in-out infinite;}
     .ai-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:ai-rip 11s ease-out infinite;}
 
-    @keyframes ai-move{0%{left:20%;top:15%}22%{left:88%;top:45%}32%{left:88%;top:45%}58%{left:32%;top:74%}68%{left:32%;top:74%}88%{left:32%;top:74%}100%{left:20%;top:15%}}
+    @keyframes ai-move{0%{left:18%;top:14%}22%{left:89.2%;top:46.2%}32%{left:89.2%;top:46.2%}58%{left:34%;top:72%}68%{left:34%;top:72%}88%{left:34%;top:72%}100%{left:18%;top:14%}}
     @keyframes ai-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes ai-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
     @keyframes ai-react{0%,29%{opacity:0;transform:translateY(8px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(8px)}100%{opacity:0;transform:translateY(8px)}}

--- a/site/src/components/AnalyticsMock.astro
+++ b/site/src/components/AnalyticsMock.astro
@@ -101,14 +101,14 @@ const activity = [
     <span class="text-[12.5px] text-slate-600 truncate">Deliverability across the workspace</span>
     <div class="ml-auto flex items-center gap-2">
       <!-- RangeTabs -->
-      <div class="inline-flex items-center gap-0.5 rounded-md border border-slate-200 bg-white p-0.5">
-        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums bg-slate-900 text-white">7d</button>
-        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500">30d</button>
-        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500">90d</button>
+      <div class="inline-flex items-center gap-0.5 rounded-md border border-slate-200 bg-white p-0.5 shrink-0">
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums bg-slate-900 text-white whitespace-nowrap shrink-0">7d</button>
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500 whitespace-nowrap shrink-0">30d</button>
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500 whitespace-nowrap shrink-0">90d</button>
       </div>
       <!-- Share image -->
-      <button class="an-share h-7 px-2.5 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5">
-        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+      <button class="an-share h-7 px-2.5 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class="shrink-0">
           <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
         </svg>
         Share image
@@ -138,7 +138,7 @@ const activity = [
         <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Email performance</span>
         <div class="ml-auto inline-flex items-center gap-0.5 rounded-md border border-slate-200 bg-white p-0.5">
           {metricTabs.map((m) => (
-            <button class={`h-6 px-2 rounded text-[11px] font-medium ${m.active ? 'bg-slate-900 text-white' : 'text-slate-500'}`}>{m.label}</button>
+            <button class={`h-6 px-2 rounded text-[11px] font-medium whitespace-nowrap shrink-0 ${m.active ? 'bg-slate-900 text-white' : 'text-slate-500'}`}>{m.label}</button>
           ))}
         </div>
       </div>
@@ -248,10 +248,10 @@ const activity = [
       <!-- aspect preset selector -->
       <div class="px-4 pt-3 flex items-center gap-2">
         <span class="text-[11px] text-slate-500 font-medium">Aspect</span>
-        <div class="inline-flex items-center gap-1 rounded-md bg-slate-100 p-0.5">
-          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600">1:1</button>
-          <button class="h-7 px-3 rounded text-[12px] font-medium bg-sky-600 text-white shadow-sm">3:2</button>
-          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600">16:9</button>
+        <div class="inline-flex items-center gap-1 rounded-md bg-slate-100 p-0.5 shrink-0">
+          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600 whitespace-nowrap shrink-0">1:1</button>
+          <button class="h-7 px-3 rounded text-[12px] font-medium bg-sky-600 text-white shadow-sm whitespace-nowrap shrink-0">3:2</button>
+          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600 whitespace-nowrap shrink-0">16:9</button>
         </div>
       </div>
 
@@ -331,12 +331,12 @@ const activity = [
 
       <!-- modal footer: Copy + Download PNG -->
       <div class="px-4 py-3 border-t border-slate-200 flex items-center justify-end gap-2">
-        <span class="h-8 px-3 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+        <span class="h-8 px-3 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
           Copy
         </span>
-        <button class="an-dl h-8 px-3 rounded-md bg-slate-900 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+        <button class="h-8 px-3 rounded-md bg-slate-900 text-white text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
           Download PNG
         </button>
       </div>
@@ -355,16 +355,17 @@ const activity = [
     .an-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:an-rip 11s ease-out infinite;}
     .an-react{position:absolute;z-index:40;opacity:0;animation:an-react 11s ease-out infinite;}
     .an-modal{transform-origin:center;}
-    /* press #1 (~28%) flashes the topbar "Share image" button */
+    /* press #1 (~28%) flashes the topbar "Share image" button (its computed center) */
     .an-share{animation:an-share-press 11s ease-out infinite;}
-    /* press #2 (~64%) darkens the modal "Download PNG" button */
-    .an-dl{animation:an-dl-press 11s ease-out infinite;}
-    @keyframes an-move{0%{left:30%;top:80%}22%{left:88%;top:9%}32%{left:88%;top:9%}58%{left:74%;top:71%}68%{left:74%;top:71%}88%{left:74%;top:71%}100%{left:30%;top:80%}}
+    /* press #1 lands on the Share image button center (x 92%, y 4% of the mock);
+       press #2 lands on the dark scrim in the upper-left corner (x 8%, y 16%) and
+       dismisses the modal via the click-outside timeline. */
+    @keyframes an-move{0%{left:30%;top:80%}22%{left:92%;top:4%}32%{left:92%;top:4%}58%{left:8%;top:16%}68%{left:8%;top:16%}88%{left:8%;top:16%}100%{left:30%;top:80%}}
     @keyframes an-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes an-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
-    @keyframes an-react{0%,29%{opacity:0;transform:scale(.94)}33%{opacity:1;transform:scale(1)}88%{opacity:1;transform:scale(1)}95%{opacity:0;transform:scale(.94)}100%{opacity:0;transform:scale(.94)}}
+    /* dismissable popup timeline: opens after press #1, closes after press #2 */
+    @keyframes an-react{0%,29%{opacity:0;transform:scale(.94)}33%{opacity:1;transform:scale(1)}60%{opacity:1;transform:scale(1)}66%{opacity:0;transform:scale(.94)}100%{opacity:0;transform:scale(.94)}}
     @keyframes an-share-press{0%,26%{box-shadow:none;border-color:rgb(226,232,240)}28%{box-shadow:0 0 0 2px rgb(186,230,253);border-color:rgb(125,211,252)}33%,100%{box-shadow:none;border-color:rgb(226,232,240)}}
-    @keyframes an-dl-press{0%,62%{background-color:rgb(15,23,42)}64%{background-color:rgb(2,132,199);box-shadow:0 0 0 2px rgb(186,230,253)}69%,100%{background-color:rgb(15,23,42)}}
-    @media (prefers-reduced-motion: reduce){.an-cursor{display:none}.an-react{display:none}.an-share{animation:none}.an-dl{animation:none}}
+    @media (prefers-reduced-motion: reduce){.an-cursor{display:none}.an-react{display:none}.an-share{animation:none}}
   </style>
 </div>

--- a/site/src/components/AnalyticsMock.astro
+++ b/site/src/components/AnalyticsMock.astro
@@ -1,0 +1,370 @@
+---
+import Logo from '../components/Logo.astro';
+
+/**
+ * Pixel-faithful mock of the Warmbly /app/analytics screen.
+ *
+ * Maps 1:1 to the real content panel:
+ *   - web/src/app/app/analytics/page.tsx - PageTopbar / StatStrip / SectionBar / charts / rows
+ *   - web/src/components/ui/charts.tsx    - DailyBars (rounded-sm bars, baseline, font-mono ticks)
+ *   - web/src/components/app/analytics/StatsShareCard.tsx - the branded share card
+ *   - web/src/components/app/analytics/AnalyticsShareButton.tsx - the preview modal
+ *
+ * Renders only the in-app screen content + its immediate chrome (no global
+ * sidebar / app header). The marketing page wraps this in its own browser frame.
+ */
+
+// Exact StatsShareCard gradient/wash/haze (copied from the real component).
+const SKY_BASE =
+  'radial-gradient(ellipse 125% 105% at 50% -12%,' +
+  ' #9fe0fb 0%, #74cef7 30%, #4ec1f6 58%, #2fb6f2 82%, #18abed 100%)';
+const SKY_BREATHE =
+  'radial-gradient(ellipse 125% 105% at 50% -12%,' +
+  ' rgba(224,242,254,0.85) 0%, rgba(125,211,252,0.38) 24%, rgba(56,189,248,0.14) 46%, transparent 64%)';
+const HAZE_BOTTOM =
+  'linear-gradient(to top, rgba(186,230,253,0.40) 0%, rgba(125,211,252,0.16) 42%, transparent 100%)';
+
+// The card's "Sends over time" area chart, computed from the same trend the
+// dashboard shows (ShareAreaChart geometry: viewBox 0 0 1000 320, baseline y=314).
+const shareLine = 'M 4.0 76.5 L 169.3 51.5 L 334.7 95.2 L 500.0 14.0 L 665.3 39.0 L 830.7 57.8 L 996.0 84.6';
+const shareArea = `${shareLine} L 996.0 314 L 4 314 Z`;
+
+// The 4-metric divided row inside the share card (matches the StatStrip values).
+const shareMetrics = [
+  { label: 'Sent',        value: '2,847' },
+  { label: 'Open rate',   value: '31.3%' },
+  { label: 'Reply rate',  value: '2.0%'  },
+  { label: 'Bounce rate', value: '0.5%'  },
+];
+
+// daily_trend "sent" series - Dec 2 … Dec 8
+const trend = [
+  { date: 'Dec 2', sent: 380 },
+  { date: 'Dec 3', sent: 420 },
+  { date: 'Dec 4', sent: 350 },
+  { date: 'Dec 5', sent: 480 },
+  { date: 'Dec 6', sent: 440 },
+  { date: 'Dec 7', sent: 410 },
+  { date: 'Dec 8', sent: 367 },
+];
+const maxSent = Math.max(...trend.map((p) => p.sent));
+
+const statStrip = [
+  { label: 'Total sent',  value: '2,847', sub: 'in range',       accent: false, last: false },
+  { label: 'Open rate',   value: '31.3%', sub: 'after delivery', accent: true,  last: false },
+  { label: 'Reply rate',  value: '2.0%',  sub: 'incl. positive', accent: false, last: false },
+  { label: 'Bounce rate', value: '0.5%',  sub: 'hard + soft',    accent: false, last: true  },
+];
+
+const metricTabs = [
+  { label: 'Sent',    active: true  },
+  { label: 'Opens',   active: false },
+  { label: 'Clicks',  active: false },
+  { label: 'Replies', active: false },
+];
+
+const breakdown = [
+  { label: 'Sent',    value: '2,847', dot: 'bg-slate-400'   },
+  { label: 'Opens',   value: '891',   dot: 'bg-emerald-500' },
+  { label: 'Clicks',  value: '234',   dot: 'bg-violet-500'  },
+  { label: 'Replies', value: '56',    dot: 'bg-amber-500'   },
+  { label: 'Bounces', value: '14',    dot: 'bg-rose-500'    },
+];
+
+const health = [
+  { n: '6', label: 'Healthy', tone: 'text-emerald-600' },
+  { n: '1', label: 'At risk', tone: 'text-amber-600'   },
+  { n: '1', label: 'Issues',  tone: 'text-rose-600'    },
+];
+
+const campaigns = [
+  { name: 'Q4 Outreach - Tech Leaders', status: 'active', sent: '850', open: '38.5%', reply: '2.8%' },
+  { name: 'Win-back: Former Customers',  status: 'active', sent: '620', open: '26.3%', reply: '1.6%' },
+  { name: 'Product Launch Beta Access',  status: 'paused', sent: '480', open: '42.1%', reply: '3.1%' },
+];
+const statusDot = (s: string) =>
+  s === 'active' ? 'bg-emerald-500' : s === 'paused' ? 'bg-amber-500' : 'bg-slate-300';
+
+// activity icon path (lucide "activity")
+const activityPath = '<path d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"/>';
+const activity = [
+  { tone: 'text-emerald-600', verb: 'Opened by',  email: 'sarah.chen@techcorp.com',  campaign: 'Q4 Outreach',     ts: 'Dec 8, 02:32 PM' },
+  { tone: 'text-violet-600',  verb: 'Clicked by',  email: 'mark.ross@northwind.dev',  campaign: 'Win-back',        ts: 'Dec 8, 02:18 PM' },
+  { tone: 'text-amber-600',   verb: 'Reply from',  email: 'jess@helio.gen',           campaign: 'Product Launch',  ts: 'Dec 8, 01:54 PM' },
+];
+---
+<div class="relative w-full bg-white text-slate-900 min-h-[480px] flex flex-col">
+  <!-- ── PageTopbar ── -->
+  <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Analytics</span>
+    <div class="h-4 w-px bg-slate-200"></div>
+    <span class="text-[12.5px] text-slate-600 truncate">Deliverability across the workspace</span>
+    <div class="ml-auto flex items-center gap-2">
+      <!-- RangeTabs -->
+      <div class="inline-flex items-center gap-0.5 rounded-md border border-slate-200 bg-white p-0.5">
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums bg-slate-900 text-white">7d</button>
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500">30d</button>
+        <button class="h-6 px-2 rounded text-[11px] font-medium tabular-nums text-slate-500">90d</button>
+      </div>
+      <!-- Share image -->
+      <button class="an-share h-7 px-2.5 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5">
+        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"/>
+        </svg>
+        Share image
+      </button>
+    </div>
+  </div>
+
+  <!-- ── StatStrip ── -->
+  <div class="grid grid-cols-4 border-b border-slate-200 shrink-0">
+    {statStrip.map((s) => (
+      <div class={`px-5 py-4 ${!s.last ? 'border-r border-slate-200' : ''}`}>
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{s.label}</span>
+          {s.accent && <span class="size-1.5 rounded-full bg-sky-500 animate-pulse"></span>}
+        </div>
+        <div class="text-[26px] text-slate-900 font-light leading-none mt-2 tabular-nums">{s.value}</div>
+        <div class="text-[10px] text-slate-400 mt-1.5 font-mono truncate">{s.sub}</div>
+      </div>
+    ))}
+  </div>
+
+  <!-- ── Main grid: performance + sidebar ── -->
+  <div class="grid grid-cols-[1fr_300px]">
+    <!-- LEFT: Email performance -->
+    <section class="flex flex-col border-r border-slate-200">
+      <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Email performance</span>
+        <div class="ml-auto inline-flex items-center gap-0.5 rounded-md border border-slate-200 bg-white p-0.5">
+          {metricTabs.map((m) => (
+            <button class={`h-6 px-2 rounded text-[11px] font-medium ${m.active ? 'bg-slate-900 text-white' : 'text-slate-500'}`}>{m.label}</button>
+          ))}
+        </div>
+      </div>
+      <!-- Bar chart -->
+      <div class="px-5 py-4">
+        <div class="relative w-full select-none" style="height:176px;">
+          <div class="absolute inset-x-0 top-0 flex items-end gap-1.5" style="height:150px;">
+            {trend.map((p) => (
+              <div class="relative flex-1 flex items-end justify-center h-full">
+                <div class="w-full rounded-sm bg-sky-500" style={`height:${Math.max(2, (p.sent / maxSent) * 150)}px; max-width:64px;`}></div>
+              </div>
+            ))}
+          </div>
+          <!-- baseline -->
+          <div class="absolute left-0 right-0 h-px bg-slate-200/80" style="bottom:18px;"></div>
+          <!-- date ticks -->
+          <div class="absolute left-0 right-0 bottom-0 flex justify-between font-mono text-[9.5px] text-slate-400 tabular-nums">
+            <span>{trend[0].date}</span>
+            <span>{trend[trend.length - 1].date}</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- RIGHT: Breakdown + Account health -->
+    <aside class="flex flex-col bg-slate-50/40 border-slate-200">
+      <div class="h-9 px-4 border-b border-slate-200/60 flex items-center shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Breakdown</span>
+      </div>
+      <div class="divide-y divide-slate-200/60">
+        {breakdown.map((q) => (
+          <div class="h-9 px-4 flex items-center gap-2">
+            <span class={`size-1.5 rounded-full ${q.dot}`}></span>
+            <span class="text-[12px] text-slate-700">{q.label}</span>
+            <span class="ml-auto font-mono text-[11px] text-slate-500 tabular-nums">{q.value}</span>
+          </div>
+        ))}
+      </div>
+      <div class="h-9 px-4 border-y border-slate-200/60 flex items-center shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Account health</span>
+      </div>
+      <div class="px-4 py-3 grid grid-cols-3 gap-2 text-center">
+        {health.map((h) => (
+          <div>
+            <div class={`font-mono text-[18px] tabular-nums leading-none ${h.tone}`}>{h.n}</div>
+            <div class="text-[10px] uppercase tracking-[0.12em] text-slate-400 mt-1">{h.label}</div>
+          </div>
+        ))}
+      </div>
+    </aside>
+  </div>
+
+  <!-- ── Top campaigns ── -->
+  <div class="h-9 px-5 border-y border-slate-200/60 flex items-center gap-2.5 shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Top campaigns</span>
+    <span class="ml-auto inline-flex items-center gap-1 text-[11px] text-slate-500">
+      All campaigns
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 7h10v10"/><path d="M7 17 17 7"/></svg>
+    </span>
+  </div>
+  <div class="divide-y divide-slate-200/60">
+    {campaigns.map((c) => (
+      <div class="group h-11 px-5 flex items-center gap-3 hover:bg-slate-50">
+        <span class={`size-1.5 rounded-full shrink-0 ${statusDot(c.status)}`}></span>
+        <span class="text-[12.5px] font-medium text-slate-900 truncate max-w-[40%]">{c.name}</span>
+        <span class="ml-auto flex items-center gap-4 font-mono text-[11px] text-slate-500 tabular-nums shrink-0">
+          <span>{c.sent} sent</span>
+          <span class="text-emerald-600">{c.open} open</span>
+          <span class="text-amber-600">{c.reply} reply</span>
+        </span>
+      </div>
+    ))}
+  </div>
+
+  <!-- ── Recent activity ── -->
+  <div class="h-9 px-5 border-y border-slate-200/60 flex items-center shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Recent activity</span>
+  </div>
+  <div class="divide-y divide-slate-200/60">
+    {activity.map((a) => (
+      <div class="h-10 px-5 flex items-center gap-3">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" class={`shrink-0 ${a.tone}`} set:html={activityPath}></svg>
+        <span class="text-[12.5px] text-slate-900 truncate">
+          <span class={a.tone}>{a.verb}</span> {a.email}
+        </span>
+        <span class="text-[11.5px] text-slate-400 truncate inline">{a.campaign}</span>
+        <span class="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums shrink-0">{a.ts}</span>
+      </div>
+    ))}
+  </div>
+
+  <!-- ── Demo scene: cursor + Share image reaction ── -->
+  <!-- Reaction: the AnalyticsShareButton preview modal (scrim + centered card) -->
+  <div class="an-react absolute inset-0 z-40 flex items-center justify-center" aria-hidden="true">
+    <div class="absolute inset-0 bg-slate-900/30"></div>
+    <div class="an-modal relative w-full max-w-[680px] mx-6 rounded-lg bg-white border border-slate-200 shadow-xl overflow-hidden">
+      <!-- modal header -->
+      <div class="h-12 px-4 border-b border-slate-200 flex items-center gap-2 shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Share image</span>
+        <div class="h-4 w-px bg-slate-200"></div>
+        <span class="text-[12.5px] text-slate-600 truncate">Preview before download</span>
+        <span class="ml-auto size-7 rounded-md text-slate-400 inline-flex items-center justify-center">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+        </span>
+      </div>
+
+      <!-- aspect preset selector -->
+      <div class="px-4 pt-3 flex items-center gap-2">
+        <span class="text-[11px] text-slate-500 font-medium">Aspect</span>
+        <div class="inline-flex items-center gap-1 rounded-md bg-slate-100 p-0.5">
+          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600">1:1</button>
+          <button class="h-7 px-3 rounded text-[12px] font-medium bg-sky-600 text-white shadow-sm">3:2</button>
+          <button class="h-7 px-3 rounded text-[12px] font-medium text-slate-600">16:9</button>
+        </div>
+      </div>
+
+      <!-- preview: the full StatsShareCard rendered at 3:2 -->
+      <div class="px-4 py-4 bg-slate-50/40 flex justify-center">
+        <div class="relative rounded-md border border-slate-200 overflow-hidden" style="width:618px;aspect-ratio:3 / 2;">
+          <!-- card: symmetric sky base + breathe + bottom haze -->
+          <div class="absolute inset-0" style={`background:${SKY_BASE};`}></div>
+          <div class="absolute inset-0 overflow-hidden pointer-events-none">
+            <div class="absolute inset-0" style={`background:${SKY_BREATHE};opacity:0.6;`}></div>
+            <div class="absolute inset-x-0 bottom-0" style={`height:55%;background:${HAZE_BOTTOM};`}></div>
+          </div>
+
+          <!-- card content (pad scaled to the 3:2 preset, ~56 of 1620w) -->
+          <div class="relative z-10 flex flex-col h-full" style="padding:21px;">
+            <!-- logo on the sky + date -->
+            <div class="flex items-center justify-between">
+              <div class="inline-flex items-center gap-[5px]">
+                <Logo class="w-[23px] h-[23px] text-white" />
+                <span class="text-white font-extrabold tracking-tight leading-none" style="font-size:16px;">Warmbly</span>
+              </div>
+              <span class="font-mono text-[8px] tabular-nums text-white/85">Dec 8, 2025</span>
+            </div>
+
+            <!-- single white panel -->
+            <div class="mt-[10px] flex-1 flex flex-col min-h-0" style="background:#ffffff;border-radius:11px;border:1px solid rgba(255,255,255,0.85);">
+              <div class="flex flex-col h-full" style="padding:17px;">
+                <div class="text-[8px] font-semibold uppercase tracking-[0.16em] text-sky-600">Workspace performance</div>
+                <h1 class="mt-1 font-semibold leading-tight tracking-tight text-slate-900" style="font-size:17px;">Deliverability across the workspace</h1>
+
+                <!-- divided metric row -->
+                <div class="mt-3 grid grid-cols-4 divide-x divide-slate-200">
+                  {shareMetrics.map((m) => (
+                    <div class="px-3 first:pl-0 last:pr-0">
+                      <div class="text-[7px] font-medium uppercase tracking-[0.14em] text-slate-400">{m.label}</div>
+                      <div class="mt-1 font-mono leading-none tabular-nums text-slate-900" style="font-size:19px;">{m.value}</div>
+                    </div>
+                  ))}
+                </div>
+
+                <div class="mt-3 h-px bg-slate-200/70"></div>
+
+                <!-- long area chart -->
+                <div class="mt-2.5 flex items-center justify-between">
+                  <span class="text-[7px] font-medium uppercase tracking-[0.14em] text-slate-400">Sends over time</span>
+                </div>
+                <div class="mt-1.5 flex-1 min-h-0 flex flex-col">
+                  <div class="relative flex-1 min-h-0">
+                    <svg viewBox="0 0 1000 320" preserveAspectRatio="none" width="100%" height="100%" style="display:block;">
+                      <defs>
+                        <linearGradient id="anShareArea" x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="0%" stop-color="#0ea5e9" stop-opacity="0.28"/>
+                          <stop offset="100%" stop-color="#0ea5e9" stop-opacity="0"/>
+                        </linearGradient>
+                      </defs>
+                      <path d={shareArea} fill="url(#anShareArea)"/>
+                      <path d={shareLine} fill="none" stroke="#0284c7" stroke-width="3" stroke-linejoin="round" stroke-linecap="round" vector-effect="non-scaling-stroke"/>
+                      <line x1="4" y1="314" x2="996" y2="314" stroke="#cbd5e1" stroke-width="2" vector-effect="non-scaling-stroke"/>
+                    </svg>
+                  </div>
+                  <div class="mt-1 flex justify-between font-mono text-[6px] tabular-nums text-slate-400">
+                    <span>Dec 2</span>
+                    <span>Dec 8</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <!-- footer on the sky -->
+            <div class="mt-[7px] flex items-center justify-between" style="font-size:8px;">
+              <span class="text-white font-semibold">warmbly.com</span>
+              <span class="text-white/80">Cold email, warmed up.</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- modal footer: Copy + Download PNG -->
+      <div class="px-4 py-3 border-t border-slate-200 flex items-center justify-end gap-2">
+        <span class="h-8 px-3 rounded-md border border-slate-200 bg-white text-slate-700 text-[12px] font-medium inline-flex items-center gap-1.5">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+          Copy
+        </span>
+        <button class="an-dl h-8 px-3 rounded-md bg-slate-900 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+          Download PNG
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cursor -->
+  <div class="an-cursor" aria-hidden="true">
+    <span class="an-ripple"></span>
+    <svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg>
+  </div>
+
+  <style>
+    .an-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:an-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .an-cursor svg{display:block;transform-origin:3px 2px;animation:an-press 11s ease-in-out infinite;}
+    .an-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:an-rip 11s ease-out infinite;}
+    .an-react{position:absolute;z-index:40;opacity:0;animation:an-react 11s ease-out infinite;}
+    .an-modal{transform-origin:center;}
+    /* press #1 (~28%) flashes the topbar "Share image" button */
+    .an-share{animation:an-share-press 11s ease-out infinite;}
+    /* press #2 (~64%) darkens the modal "Download PNG" button */
+    .an-dl{animation:an-dl-press 11s ease-out infinite;}
+    @keyframes an-move{0%{left:30%;top:80%}22%{left:88%;top:9%}32%{left:88%;top:9%}58%{left:74%;top:71%}68%{left:74%;top:71%}88%{left:74%;top:71%}100%{left:30%;top:80%}}
+    @keyframes an-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes an-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes an-react{0%,29%{opacity:0;transform:scale(.94)}33%{opacity:1;transform:scale(1)}88%{opacity:1;transform:scale(1)}95%{opacity:0;transform:scale(.94)}100%{opacity:0;transform:scale(.94)}}
+    @keyframes an-share-press{0%,26%{box-shadow:none;border-color:rgb(226,232,240)}28%{box-shadow:0 0 0 2px rgb(186,230,253);border-color:rgb(125,211,252)}33%,100%{box-shadow:none;border-color:rgb(226,232,240)}}
+    @keyframes an-dl-press{0%,62%{background-color:rgb(15,23,42)}64%{background-color:rgb(2,132,199);box-shadow:0 0 0 2px rgb(186,230,253)}69%,100%{background-color:rgb(15,23,42)}}
+    @media (prefers-reduced-motion: reduce){.an-cursor{display:none}.an-react{display:none}.an-share{animation:none}.an-dl{animation:none}}
+  </style>
+</div>

--- a/site/src/components/CRMMock.astro
+++ b/site/src/components/CRMMock.astro
@@ -188,27 +188,27 @@ const stats = [
       <!-- pipeline picker (PipelinePicker) -->
       <button
         type="button"
-        class="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center gap-1.5"
+        class="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center gap-1.5 whitespace-nowrap shrink-0"
       >
         Sales pipeline
         <span class="text-slate-400">▾</span>
       </button>
       <!-- total-value pill -->
       <span
-        class="h-7 px-2.5 rounded-md border border-emerald-200 bg-emerald-50 text-emerald-700 text-[12px] font-mono tabular-nums inline-flex items-center gap-1.5"
+        class="h-7 px-2.5 rounded-md border border-emerald-200 bg-emerald-50 text-emerald-700 text-[12px] font-mono tabular-nums inline-flex items-center gap-1.5 whitespace-nowrap shrink-0"
       >
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/><path d="M12 18V6"/></svg>
         {money(totalValue)}
       </span>
       <!-- search pill (SearchPill) -->
-      <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5">
+      <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5 whitespace-nowrap shrink-0">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
         <span class="w-[120px] text-[12px] text-slate-400">Search deals…</span>
       </div>
-      <!-- primary action (TopbarAction, sky-600) -->
+      <!-- primary action (TopbarAction, sky-600); cr-target shows the press feedback -->
       <button
         type="button"
-        class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white"
+        class="cr-target h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white whitespace-nowrap shrink-0"
       >
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
         Add deal
@@ -381,10 +381,16 @@ const stats = [
     .cr-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:cr-rip 11s ease-out infinite;}
     .cr-react{position:absolute;z-index:40;opacity:0;animation:cr-react 11s ease-out infinite;}
     .cr-toast{position:absolute;z-index:45;opacity:0;animation:cr-react 11s ease-out infinite;}
-    @keyframes cr-move{0%{left:46%;top:62%}22%{left:84%;top:7%}32%{left:84%;top:7%}58%{left:11%;top:46%}68%{left:11%;top:46%}88%{left:46%;top:62%}100%{left:46%;top:62%}}
+    /* Press #1 (28%) lands on the "Add deal" button center (834.5px,24px on the
+       900x~522 mock => 92.4%,4.2% after the 3px/2px cursor hotspot). Press #2
+       (64%) lands on the new Beacon Labs card, which PERSISTS (shown 33%->88%). */
+    @keyframes cr-move{0%{left:46%;top:62%}22%{left:92.4%;top:4.2%}32%{left:92.4%;top:4.2%}58%{left:20%;top:43%}68%{left:20%;top:43%}88%{left:46%;top:62%}100%{left:46%;top:62%}}
     @keyframes cr-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes cr-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
     @keyframes cr-react{0%,29%{opacity:0;transform:scale(.92) translateY(-6px)}33%{opacity:1;transform:scale(1) translateY(0)}88%{opacity:1;transform:scale(1) translateY(0)}95%{opacity:0;transform:scale(.92) translateY(-6px)}100%{opacity:0;transform:scale(.92) translateY(-6px)}}
+    /* target press-feedback: the "Add deal" button dips at press #1 (28%) */
+    .cr-target{animation:cr-target 11s ease-in-out infinite;}
+    @keyframes cr-target{0%,26%{transform:scale(1);background-color:#0284c7}28%{transform:scale(.96);background-color:#0369a1}31%,100%{transform:scale(1);background-color:#0284c7}}
     @media (prefers-reduced-motion: reduce){.cr-cursor{display:none}.cr-react{display:none}.cr-toast{display:none}}
   </style>
 </div>

--- a/site/src/components/CRMMock.astro
+++ b/site/src/components/CRMMock.astro
@@ -382,15 +382,15 @@ const stats = [
     .cr-react{position:absolute;z-index:40;opacity:0;animation:cr-react 11s ease-out infinite;}
     .cr-toast{position:absolute;z-index:45;opacity:0;animation:cr-react 11s ease-out infinite;}
     /* Press #1 (28%) lands on the "Add deal" button center (834.5px,24px on the
-       900x~522 mock => 92.4%,4.2% after the 3px/2px cursor hotspot). Press #2
+       900x~522 mock => 92.5%,4.2% after the 3px/2px cursor hotspot). Press #2
        (64%) lands on the new Beacon Labs card, which PERSISTS (shown 33%->88%). */
-    @keyframes cr-move{0%{left:46%;top:62%}22%{left:92.4%;top:4.2%}32%{left:92.4%;top:4.2%}58%{left:20%;top:43%}68%{left:20%;top:43%}88%{left:46%;top:62%}100%{left:46%;top:62%}}
+    @keyframes cr-move{0%{left:46%;top:62%}22%{left:92.5%;top:4.2%}32%{left:92.5%;top:4.2%}58%{left:20%;top:43%}68%{left:20%;top:43%}88%{left:46%;top:62%}100%{left:46%;top:62%}}
     @keyframes cr-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes cr-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
     @keyframes cr-react{0%,29%{opacity:0;transform:scale(.92) translateY(-6px)}33%{opacity:1;transform:scale(1) translateY(0)}88%{opacity:1;transform:scale(1) translateY(0)}95%{opacity:0;transform:scale(.92) translateY(-6px)}100%{opacity:0;transform:scale(.92) translateY(-6px)}}
     /* target press-feedback: the "Add deal" button dips at press #1 (28%) */
     .cr-target{animation:cr-target 11s ease-in-out infinite;}
     @keyframes cr-target{0%,26%{transform:scale(1);background-color:#0284c7}28%{transform:scale(.96);background-color:#0369a1}31%,100%{transform:scale(1);background-color:#0284c7}}
-    @media (prefers-reduced-motion: reduce){.cr-cursor{display:none}.cr-react{display:none}.cr-toast{display:none}}
+    @media (prefers-reduced-motion: reduce){.cr-cursor{display:none}.cr-react{display:none}.cr-toast{display:none}.cr-target{animation:none}}
   </style>
 </div>

--- a/site/src/components/CRMMock.astro
+++ b/site/src/components/CRMMock.astro
@@ -1,0 +1,390 @@
+---
+/**
+ * Pixel-faithful mock of the Warmbly /app/crm/deals screen (the CRM kanban board).
+ *
+ * Maps 1:1 to the real components:
+ *   - web/src/app/app/crm/deals/page.tsx        (the board page: PageTopbar / StatStrip / SectionBar / Board)
+ *   - web/src/components/layout/Page.tsx          (PageTopbar h-12, StatStrip, Stat, SectionBar, TopbarAction)
+ *   - the Board / Column / DealCard primitives inside deals/page.tsx
+ *
+ * Renders only the in-app screen content (page topbar + stat strip + section bar
+ * + the horizontal kanban). The marketing page wraps this in its own browser
+ * frame, so there is no global sidebar / app header / window chrome here. The
+ * board overflows the frame on purpose; the parent crops with overflow-hidden,
+ * so the load-bearing content sits top-left.
+ *
+ * Tokens copied verbatim from the real source:
+ *   - PageTopbar:  h-12 px-5 border-b border-slate-200, eyebrow text-[10px] uppercase
+ *                  tracking-[0.14em] text-slate-400, h-4 w-px divider, subtitle text-[12.5px]
+ *   - TopbarAction: h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px]
+ *   - Stat:        label text-[10px] uppercase tracking-[0.14em], value text-[26px] font-light
+ *   - Column head: h-9 px-3, size-1.5 color dot, name text-[11px] uppercase tracking-[0.1em]
+ *                  font-semibold text-slate-700, count font-mono text-[10.5px]
+ *   - DealCard:    rounded-lg bg-white border border-slate-200, name text-[12.5px] font-medium,
+ *                  value font-mono text-[12px] text-slate-700
+ */
+
+// Money formatter, mirrors formatMoney() in deals/page.tsx.
+const money = (n: number) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(n);
+
+// ── Sample dataset: one pipeline, four stages, eight deals ─────────
+type Tag = { color: string; label: string };
+type Deal = {
+  name: string;
+  value: number;
+  contact: string;
+  owner: string; // initials for the avatar
+  gradient: string; // tailwind gradient classes for the owner avatar
+  status?: "won";
+  close?: string;
+  tags: Tag[];
+};
+
+type Stage = {
+  name: string;
+  color: string; // hex dot, mirrors STAGE_COLORS in pipelines/page.tsx
+  won?: boolean;
+  deals: Deal[];
+};
+
+const stages: Stage[] = [
+  {
+    name: "Lead",
+    color: "#94a3b8", // slate-400
+    deals: [
+      {
+        name: "Acme Co",
+        value: 12000,
+        contact: "dana@acme.co",
+        owner: "MO",
+        gradient: "from-violet-400 to-indigo-500",
+        close: "Jun 18",
+        tags: [{ color: "#3b82f6", label: "Inbound" }],
+      },
+      {
+        name: "Northwind",
+        value: 8500,
+        contact: "ravi@northwind.dev",
+        owner: "JS",
+        gradient: "from-sky-400 to-blue-500",
+        close: "Jun 21",
+        tags: [{ color: "#f59e0b", label: "Outbound" }],
+      },
+      {
+        name: "Spruce Bio",
+        value: 6200,
+        contact: "lena@sprucebio.com",
+        owner: "AM",
+        gradient: "from-rose-400 to-pink-500",
+        tags: [{ color: "#3b82f6", label: "Inbound" }],
+      },
+    ],
+  },
+  {
+    name: "Qualified",
+    color: "#0ea5e9", // sky-500
+    deals: [
+      {
+        name: "Helio",
+        value: 24000,
+        contact: "founder@helio.gen",
+        owner: "MO",
+        gradient: "from-violet-400 to-indigo-500",
+        close: "Jul 02",
+        tags: [
+          { color: "#8b5cf6", label: "Enterprise" },
+          { color: "#3b82f6", label: "Inbound" },
+        ],
+      },
+      {
+        name: "Tidewater Labs",
+        value: 15500,
+        contact: "ops@tidewater.io",
+        owner: "CR",
+        gradient: "from-teal-400 to-emerald-500",
+        close: "Jul 09",
+        tags: [{ color: "#f59e0b", label: "Outbound" }],
+      },
+    ],
+  },
+  {
+    name: "Proposal",
+    color: "#8b5cf6", // violet-500
+    deals: [
+      {
+        name: "Brightfold",
+        value: 31000,
+        contact: "priya@brightfold.com",
+        owner: "JS",
+        gradient: "from-sky-400 to-blue-500",
+        close: "Jul 15",
+        tags: [
+          { color: "#8b5cf6", label: "Enterprise" },
+          { color: "#ef4444", label: "Hot" },
+        ],
+      },
+      {
+        name: "Maple & Co",
+        value: 9800,
+        contact: "sam@mapleco.com",
+        owner: "AM",
+        gradient: "from-rose-400 to-pink-500",
+        close: "Jul 20",
+        tags: [{ color: "#3b82f6", label: "Inbound" }],
+      },
+    ],
+  },
+  {
+    name: "Won",
+    color: "#10b981", // emerald-500
+    won: true,
+    deals: [
+      {
+        name: "Cobalt Group",
+        value: 42000,
+        contact: "ceo@cobaltgroup.com",
+        owner: "MO",
+        gradient: "from-violet-400 to-indigo-500",
+        status: "won",
+        close: "Jun 03",
+        tags: [
+          { color: "#8b5cf6", label: "Enterprise" },
+          { color: "#10b981", label: "Closed" },
+        ],
+      },
+    ],
+  },
+];
+
+// ── Derived strip values, mirrors the page's reduce()s ─────────────
+const allDeals = stages.flatMap((s) => s.deals);
+const totalValue = allDeals.reduce((a, d) => a + d.value, 0);
+const openCount = allDeals.filter((d) => d.status !== "won").length;
+const wonCount = allDeals.filter((d) => d.status === "won").length;
+const stageTotal = (s: Stage) => s.deals.reduce((a, d) => a + d.value, 0);
+
+const stats = [
+  { label: "Open", value: String(openCount), sub: "active deals", last: false },
+  { label: "Pipeline value", value: money(totalValue), sub: "all filtered", last: false },
+  { label: "Won", value: String(wonCount), sub: "this view", last: false },
+  { label: "Stages", value: String(stages.length), sub: "on this pipeline", last: true },
+];
+---
+<div class="relative w-full flex flex-col bg-white text-slate-900" style="min-height:500px;">
+  <!-- ─────────────────────────────────────────────────────────────
+       1) PAGE TOPBAR (PageTopbar, h-12)
+  ────────────────────────────────────────────────────────────── -->
+  <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Deals</span>
+    <div class="h-4 w-px bg-slate-200"></div>
+    <span class="text-[12.5px] text-slate-600 truncate">8 deals on Sales pipeline</span>
+
+    <div class="ml-auto flex items-center gap-1.5">
+      <!-- pipeline picker (PipelinePicker) -->
+      <button
+        type="button"
+        class="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center gap-1.5"
+      >
+        Sales pipeline
+        <span class="text-slate-400">▾</span>
+      </button>
+      <!-- total-value pill -->
+      <span
+        class="h-7 px-2.5 rounded-md border border-emerald-200 bg-emerald-50 text-emerald-700 text-[12px] font-mono tabular-nums inline-flex items-center gap-1.5"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M16 8h-6a2 2 0 1 0 0 4h4a2 2 0 1 1 0 4H8"/><path d="M12 18V6"/></svg>
+        {money(totalValue)}
+      </span>
+      <!-- search pill (SearchPill) -->
+      <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <span class="w-[120px] text-[12px] text-slate-400">Search deals…</span>
+      </div>
+      <!-- primary action (TopbarAction, sky-600) -->
+      <button
+        type="button"
+        class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+        Add deal
+      </button>
+    </div>
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       2) STAT STRIP (StatStrip cols=4)
+  ────────────────────────────────────────────────────────────── -->
+  <div class="grid grid-cols-4 border-b border-slate-200 shrink-0 bg-white">
+    {stats.map((s, i) => (
+      <div class={`group px-5 py-4 ${!s.last ? "border-r border-slate-200" : ""}`}>
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{s.label}</span>
+          {i === 1 && <span class="size-1.5 rounded-full bg-sky-500 animate-pulse"></span>}
+        </div>
+        <div class="text-[26px] text-slate-900 font-light leading-none mt-2 tabular-nums">{s.value}</div>
+        <div class="text-[10px] text-slate-400 mt-1.5 font-mono truncate">{s.sub}</div>
+      </div>
+    ))}
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       3) SECTION BAR (SectionBar, h-9) with a live dot
+  ────────────────────────────────────────────────────────────── -->
+  <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">4 stages</span>
+    <span class="font-mono text-[10.5px] text-slate-400 tabular-nums">8</span>
+    <div class="ml-auto inline-flex items-center gap-1.5 text-[11px] text-emerald-600 font-medium">
+      <span class="relative flex size-1.5">
+        <span class="absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-60 animate-ping"></span>
+        <span class="relative inline-flex size-1.5 rounded-full bg-emerald-500"></span>
+      </span>
+      live
+    </div>
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       4) KANBAN BOARD (Board / Column / DealCard)
+       (real: grid grid-flow-col auto-cols-[280px]; here we use flex
+        gap-3 p-5 so columns sit edge to edge and the parent crops)
+  ────────────────────────────────────────────────────────────── -->
+  <div class="flex-1 min-h-0 flex gap-3 p-5 overflow-hidden">
+    {stages.map((stage) => (
+      <div
+        class={`flex flex-col rounded-md min-h-[300px] w-[280px] shrink-0 border ${
+          stage.won ? "bg-emerald-50/50 border-emerald-200" : "bg-slate-50 border-slate-200"
+        }`}
+      >
+        <!-- Column header -->
+        <div class="h-9 px-3 flex items-center gap-2 border-b border-slate-200">
+          <span class="size-1.5 rounded-full shrink-0" style={`background-color:${stage.color};`}></span>
+          <span class="text-[11px] uppercase tracking-[0.1em] font-semibold text-slate-700 truncate">{stage.name}</span>
+          <span class="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums">{stage.deals.length}</span>
+        </div>
+
+        <!-- Stage total value -->
+        <div class={`px-3 py-1 border-b ${stage.won ? "border-emerald-200/60 bg-emerald-50/40" : "border-slate-200/60 bg-white"}`}>
+          <span class="text-[10.5px] text-emerald-700 font-mono tabular-nums">{money(stageTotal(stage))} total</span>
+        </div>
+
+        <!-- Deal cards -->
+        <div class="p-2 space-y-1.5 flex-1">
+          {stage.deals.map((d) => (
+            <div class="rounded-lg bg-white border border-slate-200 hover:border-slate-300 shadow-sm transition-all p-3">
+              <!-- name + won badge -->
+              <div class="flex items-center gap-1.5 mb-1">
+                <div class="text-[12.5px] font-medium text-slate-900 truncate flex-1">{d.name}</div>
+                {d.status === "won" && (
+                  <span class="text-[9.5px] uppercase tracking-[0.08em] font-semibold text-emerald-700">Won</span>
+                )}
+              </div>
+
+              <!-- deal value -->
+              <div class="font-mono text-[12px] text-slate-700 tabular-nums mb-1.5">{money(d.value)}</div>
+
+              <!-- contact line -->
+              <div class="flex items-center gap-1 text-[10.5px] text-slate-500 truncate mb-2">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                <span class="truncate">{d.contact}</span>
+              </div>
+
+              <!-- owner avatar + tag chips -->
+              <div class="flex items-center gap-1.5 flex-wrap">
+                <span class={`size-6 rounded-full bg-gradient-to-br ${d.gradient} flex items-center justify-center shrink-0 text-[9px] font-semibold text-white`}>{d.owner}</span>
+                {d.tags.map((t) => (
+                  <span
+                    class="inline-flex items-center gap-1 h-4 pl-1 pr-1.5 rounded-sm border bg-white text-[10px] font-medium text-slate-700 truncate max-w-[110px]"
+                    style={`border-color:${t.color}60;background-color:${t.color}12;`}
+                  >
+                    <span class="block size-2 rounded-full shrink-0" style={`background-color:${t.color};`}></span>
+                    {t.label}
+                  </span>
+                ))}
+                {d.close && (
+                  <span class="ml-auto inline-flex items-center gap-1 text-[10px] text-slate-400 shrink-0">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+                    {d.close}
+                  </span>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    ))}
+
+    <!-- ghost 5th column (parent crops it) so the board reads as scrollable -->
+    <div class="flex flex-col rounded-md min-h-[300px] w-[280px] shrink-0 border border-dashed border-slate-200 bg-slate-50/40">
+      <div class="h-9 px-3 flex items-center gap-2 border-b border-slate-200/60">
+        <span class="size-1.5 rounded-full shrink-0 bg-slate-300"></span>
+        <span class="text-[11px] uppercase tracking-[0.1em] font-semibold text-slate-400 truncate">Lost</span>
+        <span class="ml-auto font-mono text-[10.5px] text-slate-300 tabular-nums">0</span>
+      </div>
+      <div class="p-2 flex-1">
+        <div class="h-20 rounded-md border border-dashed border-slate-200 flex items-center justify-center text-[10.5px] text-slate-400">
+          Drop deals here
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       DEMO SCENE: cursor glides to "Add deal", presses it, and a new
+       deal card appears at the top of the Lead column (cause → effect).
+       Static Astro only; pure CSS, 11s infinite loop.
+  ────────────────────────────────────────────────────────────── -->
+
+  <!-- (b) reaction overlay: a NEW Beacon Labs deal card near the Lead column top -->
+  <div class="cr-react" style="left:6.5%;top:33%;width:248px;">
+    <div class="rounded-lg bg-white border border-slate-200 shadow-sm p-3">
+      <div class="flex items-center gap-1.5 mb-1">
+        <div class="text-[12.5px] font-medium text-slate-900 truncate flex-1">Beacon Labs</div>
+        <span class="text-[9.5px] uppercase tracking-[0.08em] font-semibold text-sky-600">New</span>
+      </div>
+      <div class="font-mono text-[12px] text-slate-700 tabular-nums mb-1.5">$9,400</div>
+      <div class="flex items-center gap-1 text-[10.5px] text-slate-500 truncate mb-2">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+        <span class="truncate">ops@beaconlabs.io</span>
+      </div>
+      <div class="flex items-center gap-1.5 flex-wrap">
+        <span class="size-6 rounded-full bg-gradient-to-br from-sky-400 to-blue-500 flex items-center justify-center shrink-0 text-[9px] font-semibold text-white">MO</span>
+        <span class="inline-flex items-center gap-1 h-4 pl-1 pr-1.5 rounded-sm border bg-white text-[10px] font-medium text-slate-700 truncate max-w-[110px]" style="border-color:#3b82f660;background-color:#3b82f612;">
+          <span class="block size-2 rounded-full shrink-0" style="background-color:#3b82f6;"></span>
+          Inbound
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <!-- tiny "Deal added" toast, rides the same reaction reveal -->
+  <div class="cr-toast" style="left:6.5%;top:25%;">
+    <span class="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md bg-slate-900 text-white text-[11px] font-medium shadow-sm">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+      Deal added
+    </span>
+  </div>
+
+  <!-- (a) cursor -->
+  <div class="cr-cursor" aria-hidden="true">
+    <span class="cr-ripple"></span>
+    <svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg>
+  </div>
+
+  <!-- (c) one style block -->
+  <style>
+    .cr-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:cr-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .cr-cursor svg{display:block;transform-origin:3px 2px;animation:cr-press 11s ease-in-out infinite;}
+    .cr-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:cr-rip 11s ease-out infinite;}
+    .cr-react{position:absolute;z-index:40;opacity:0;animation:cr-react 11s ease-out infinite;}
+    .cr-toast{position:absolute;z-index:45;opacity:0;animation:cr-react 11s ease-out infinite;}
+    @keyframes cr-move{0%{left:46%;top:62%}22%{left:84%;top:7%}32%{left:84%;top:7%}58%{left:11%;top:46%}68%{left:11%;top:46%}88%{left:46%;top:62%}100%{left:46%;top:62%}}
+    @keyframes cr-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes cr-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes cr-react{0%,29%{opacity:0;transform:scale(.92) translateY(-6px)}33%{opacity:1;transform:scale(1) translateY(0)}88%{opacity:1;transform:scale(1) translateY(0)}95%{opacity:0;transform:scale(.92) translateY(-6px)}100%{opacity:0;transform:scale(.92) translateY(-6px)}}
+    @media (prefers-reduced-motion: reduce){.cr-cursor{display:none}.cr-react{display:none}.cr-toast{display:none}}
+  </style>
+</div>

--- a/site/src/components/CampaignBuilderMock.astro
+++ b/site/src/components/CampaignBuilderMock.astro
@@ -347,9 +347,9 @@ const chevronDownIcon = '<path d="m6 9 6 6 6-6"/>';
     .cb-react{position:absolute;z-index:40;opacity:0;animation:cb-react 11s ease-out infinite;}
     /* press #1 feedback on the First email node */
     .cb-node{animation:cb-node-press 11s ease-in-out infinite;}
-    /* press #1 lands on the First email node center (50%, 17.5%); press #2 dismisses the
-       drawer by clicking the canvas to its LEFT (40%, 60%); start/return is a neutral spot. */
-    @keyframes cb-move{0%{left:18%;top:78%}22%{left:50%;top:17.5%}32%{left:50%;top:17.5%}58%{left:40%;top:60%}68%{left:40%;top:60%}88%{left:40%;top:60%}100%{left:18%;top:78%}}
+    /* press #1 lands on the First email node center (~50%, 44%); press #2 dismisses the
+       drawer by clicking the canvas to its LEFT (34%, 62%); start/return is a neutral spot. */
+    @keyframes cb-move{0%{left:18%;top:80%}22%{left:50%;top:44%}32%{left:50%;top:44%}58%{left:34%;top:62%}68%{left:34%;top:62%}88%{left:30%;top:70%}100%{left:18%;top:80%}}
     @keyframes cb-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes cb-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
     @keyframes cb-react{0%,29%{opacity:0;transform:translateX(18px)}33%{opacity:1;transform:translateX(0)}60%{opacity:1;transform:translateX(0)}66%{opacity:0;transform:translateX(18px)}100%{opacity:0;transform:translateX(18px)}}

--- a/site/src/components/CampaignBuilderMock.astro
+++ b/site/src/components/CampaignBuilderMock.astro
@@ -349,14 +349,13 @@ const chevronDownIcon = '<path d="m6 9 6 6 6-6"/>';
     .cb-react{position:absolute;z-index:40;opacity:0;animation:cb-react 11s ease-out infinite;}
     /* press #1 feedback on the First email node */
     .cb-node{animation:cb-node-press 11s ease-in-out infinite;}
-    /* press #2 feedback on the drawer Save changes button */
-    .cb-save{animation:cb-save-press 11s ease-in-out infinite;}
-    @keyframes cb-move{0%{left:18%;top:78%}22%{left:50%;top:24%}32%{left:50%;top:24%}58%{left:90%;top:14%}68%{left:90%;top:14%}88%{left:90%;top:14%}100%{left:18%;top:78%}}
+    /* press #1 lands on the First email node center (50%, 17.5%); press #2 dismisses the
+       drawer by clicking the canvas to its LEFT (40%, 60%); start/return is a neutral spot. */
+    @keyframes cb-move{0%{left:18%;top:78%}22%{left:50%;top:17.5%}32%{left:50%;top:17.5%}58%{left:40%;top:60%}68%{left:40%;top:60%}88%{left:40%;top:60%}100%{left:18%;top:78%}}
     @keyframes cb-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes cb-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
-    @keyframes cb-react{0%,29%{opacity:0;transform:translateX(18px)}33%{opacity:1;transform:translateX(0)}88%{opacity:1;transform:translateX(0)}95%{opacity:0;transform:translateX(18px)}100%{opacity:0;transform:translateX(18px)}}
+    @keyframes cb-react{0%,29%{opacity:0;transform:translateX(18px)}33%{opacity:1;transform:translateX(0)}60%{opacity:1;transform:translateX(0)}66%{opacity:0;transform:translateX(18px)}100%{opacity:0;transform:translateX(18px)}}
     @keyframes cb-node-press{0%,26%{box-shadow:none}28%{box-shadow:0 0 0 4px rgba(186,230,253,.9)}31%,100%{box-shadow:none}}
-    @keyframes cb-save-press{0%,62%{background-color:#0284c7}64%{background-color:#075985;box-shadow:0 0 0 4px rgba(186,230,253,.9)}67%,100%{background-color:#0284c7}}
     @media (prefers-reduced-motion: reduce){.cb-cursor{display:none}.cb-react{display:none}}
   </style>
 </div>

--- a/site/src/components/CampaignBuilderMock.astro
+++ b/site/src/components/CampaignBuilderMock.astro
@@ -1,0 +1,362 @@
+---
+/**
+ * Pixel-faithful mock of the Warmbly /app/campaigns/[id]/sequences screen,
+ * the campaign SEQUENCE BUILDER (flow canvas).
+ *
+ * Maps to the real shell:
+ *   web/src/app/app/campaigns/[id]/layout.tsx (campaign header + tab bar)
+ *   web/src/components/app/campaigns/sequences/CampaignFlow.tsx (the flow canvas:
+ *   StepNode / IfNode / ActionNode / StopNode, toolbar, help panel)
+ *
+ * Flow geometry is laid out in ONE fixed 720x360 coordinate layer: the SVG edge
+ * overlay uses viewBox 0 0 720 360 at a fixed 720x360 size, and every node card
+ * is absolutely positioned in the same px space, so edges connect node ports
+ * exactly and the branch labels sit on the lines.
+ *
+ * The marketing page wraps this in its own browser frame, so this renders only
+ * the in-app screen content + its immediate chrome (header + tab bar).
+ */
+const tabs = [
+  { label: 'Overview', icon: 'barchart', active: false },
+  { label: 'Leads', icon: 'users', active: false },
+  { label: 'Steps', icon: 'listchecks', active: true },
+  { label: 'Schedule', icon: 'calendar', active: false },
+  { label: 'Settings', icon: 'settings', active: false },
+];
+
+const tabIcons: Record<string, string> = {
+  barchart: '<path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>',
+  users: '<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M22 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>',
+  listchecks: '<path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/>',
+  calendar: '<rect width="18" height="18" x="3" y="4" rx="2" ry="2"/><line x1="16" x2="16" y1="2" y2="6"/><line x1="8" x2="8" y1="2" y2="6"/><line x1="3" x2="21" y1="10" y2="10"/>',
+  settings: '<path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/>',
+};
+
+// lucide mail (step icon) + trash (node delete)
+const mailIcon = '<rect width="20" height="16" x="2" y="4" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>';
+const trashIcon = '<path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>';
+const flagIcon = '<path d="M4 22V4a2 2 0 0 1 2-2h8.5L20 7.5V22l-3-2-2 2-2-2-2 2-2-2z"/>';
+
+// lucide icons for the step composer drawer (matches SequenceView + RichTextEditor toolbar)
+const sparklesIcon = '<path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/><path d="M20 3v4"/><path d="M22 5h-4"/><path d="M4 17v2"/><path d="M5 18H3"/>';
+const bookmarkPlusIcon = '<path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h7"/><path d="M16 6h6"/><path d="M19 3v6"/>';
+const bracesIcon = '<path d="M8 3H7a2 2 0 0 0-2 2v5a2 2 0 0 1-2 2 2 2 0 0 1 2 2v5c0 1.1.9 2 2 2h1"/><path d="M16 21h1a2 2 0 0 0 2-2v-5c0-1.1.9-2 2-2a2 2 0 0 1-2-2V5a2 2 0 0 0-2-2h-1"/>';
+const pencilLineIcon = '<path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/><path d="m15 5 3 3"/>';
+const eyeIcon = '<path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0"/><circle cx="12" cy="12" r="3"/>';
+const boldIcon = '<path d="M6 12h9a4 4 0 0 1 0 8H7a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1h7a4 4 0 0 1 0 8"/>';
+const italicIcon = '<line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/>';
+const underlineIcon = '<path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/>';
+const strikeIcon = '<path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/>';
+const h2Icon = '<path d="M4 12h8"/><path d="M4 18V6"/><path d="M12 18V6"/><path d="M21 18h-4c0-4 4-3 4-6 0-1.5-2-2.5-4-1"/>';
+const listIcon = '<path d="M3 5h.01"/><path d="M3 12h.01"/><path d="M3 19h.01"/><path d="M8 5h13"/><path d="M8 12h13"/><path d="M8 19h13"/>';
+const listOrderedIcon = '<path d="M10 5h11"/><path d="M10 12h11"/><path d="M10 19h11"/><path d="M4 4h1v5"/><path d="M4 9h2"/><path d="M6 17a2 2 0 1 0-3.464 1.5"/><path d="M2 20h4"/>';
+const link2Icon = '<path d="M9 17H7A5 5 0 0 1 7 7h2"/><path d="M15 7h2a5 5 0 1 1 0 10h-2"/><line x1="8" x2="16" y1="12" y2="12"/>';
+const shuffleIcon = '<path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/>';
+const shieldCheckIcon = '<path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/>';
+const rotateIcon = '<path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/>';
+const chevronDownIcon = '<path d="m6 9 6 6 6-6"/>';
+---
+<div class="relative w-full bg-white min-h-[500px] flex flex-col">
+  <!-- Campaign header -->
+  <div class="px-5 pt-5 pb-3 flex items-start gap-3 shrink-0">
+    <div class="min-w-0">
+      <div class="flex items-center gap-2">
+        <h1 class="text-[18px] font-semibold text-slate-900 truncate">Q1 Sales Outreach</h1>
+        <span class="shrink-0 inline-flex items-center h-5 px-2 rounded-md border text-[10px] uppercase tracking-[0.12em] font-medium bg-slate-100 text-slate-600 border-slate-200">draft</span>
+      </div>
+      <p class="text-[11px] text-slate-400 font-mono mt-1 truncate">cmp_8fK2pQ7rXa19</p>
+    </div>
+    <div class="ml-auto shrink-0">
+      <button type="button" class="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polygon points="6 3 20 12 6 21 6 3"/></svg>
+        Start
+      </button>
+    </div>
+  </div>
+
+  <!-- Tab bar -->
+  <div class="shrink-0 px-3 flex items-center gap-1 border-b border-slate-200 overflow-x-auto">
+    {tabs.map((t) => (
+      <div class={`relative h-10 px-2.5 inline-flex items-center gap-1.5 text-[12.5px] ${t.active ? 'text-slate-900 font-medium' : 'text-slate-500'}`}>
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width={t.active ? 2 : 1.8} stroke-linecap="round" stroke-linejoin="round" set:html={tabIcons[t.icon]}></svg>
+        {t.label}
+        {t.active && <span class="absolute left-1.5 right-1.5 -bottom-px h-0.5 rounded-full bg-sky-600"></span>}
+      </div>
+    ))}
+  </div>
+
+  <!-- Page body -->
+  <div class="p-5 flex-1 min-h-0">
+    <div class="relative h-full min-h-[380px] w-full overflow-hidden rounded-md border border-slate-200 bg-slate-50/40">
+      <!-- dotted background -->
+      <div aria-hidden="true" class="absolute inset-0 pointer-events-none" style="background-image: radial-gradient(#e2e8f0 1px, transparent 1px); background-size: 22px 22px;"></div>
+
+      <!-- top-left toolbar -->
+      <div class="absolute left-3 top-3 z-20 flex items-center gap-1.5">
+        <button type="button" class="inline-flex h-8 items-center gap-1.5 rounded-md bg-sky-600 px-3 text-[12px] font-medium text-white shadow-sm hover:bg-sky-700 transition-colors">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Add step
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="-mr-0.5 opacity-80"><polyline points="6 9 12 15 18 9"/></svg>
+        </button>
+        <button type="button" class="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 text-[12px] font-medium text-slate-700 shadow-sm hover:border-slate-300 transition-colors">Tidy up</button>
+      </div>
+
+      <!-- top-right: stop on reply -->
+      <div class="absolute right-3 top-3 z-20 flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
+        <span class="text-[11.5px] text-slate-600">Stop on reply</span>
+        <span class="relative inline-flex h-5 w-9 shrink-0 items-center rounded-full bg-sky-600">
+          <span class="inline-block size-4 translate-x-4 rounded-full bg-white shadow-sm"></span>
+        </span>
+      </div>
+
+      <!-- fixed coordinate layer (720x360): SVG edges + node cards share these px -->
+      <div class="absolute left-1/2 top-12 -translate-x-1/2" style="width:720px; height:360px;">
+        <svg width="720" height="360" viewBox="0 0 720 360" class="absolute inset-0 pointer-events-none" aria-hidden="true">
+          <defs>
+            <marker id="cb-arrow-sky" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="#0ea5e9"/></marker>
+            <marker id="cb-arrow-slate" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="#94a3b8"/></marker>
+          </defs>
+          <!-- 1: First email -> IF (conditional spine) -->
+          <path d="M 360 78 L 360 102" fill="none" stroke="#0ea5e9" stroke-width="2" marker-end="url(#cb-arrow-sky)"/>
+          <!-- 2: IF then (right) -> Follow-up -->
+          <path d="M 434 116 C 452 150, 464 168, 464 193" fill="none" stroke="#0ea5e9" stroke-width="2" marker-end="url(#cb-arrow-sky)"/>
+          <!-- 3: IF else (bottom) -> Alternative -->
+          <path d="M 360 130 C 360 152, 180 144, 180 160" fill="none" stroke="#94a3b8" stroke-width="1.5" stroke-dasharray="4 3" marker-end="url(#cb-arrow-slate)"/>
+          <!-- 4: Follow-up -> Add engagement tag -->
+          <path d="M 588 226 L 588 268" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#cb-arrow-slate)"/>
+          <!-- 5: Alternative -> Stop -->
+          <path d="M 180 226 C 180 250, 180 258, 180 276" fill="none" stroke="#94a3b8" stroke-width="1.5" marker-end="url(#cb-arrow-slate)"/>
+        </svg>
+
+        <!-- edge labels, placed on the lines -->
+        <span class="absolute z-10 inline-flex items-center rounded border border-sky-200 bg-white px-1.5 py-px text-[10px] text-sky-700 shadow-sm" style="left:430px; top:150px;">wait 2d</span>
+        <span class="absolute z-10 inline-flex items-center rounded border border-slate-200 bg-white px-1.5 py-px text-[10px] text-slate-500 shadow-sm" style="left:243px; top:132px;">else</span>
+
+        <!-- StepNode: First email (selected) -->
+        <div class="absolute" style="left:236px; top:12px; width:248px;">
+          <div class="cb-node rounded-xl border border-sky-400 ring-2 ring-sky-100 bg-white shadow-sm">
+            <div class="flex items-center gap-2 rounded-t-xl border-b border-slate-200/70 bg-gradient-to-r from-sky-50/80 to-white px-2.5 py-1.5">
+              <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-sky-100 text-sky-600 ring-1 ring-sky-200/70"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={mailIcon}></svg></span>
+              <span class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">First email</span>
+              <span class="shrink-0 rounded bg-sky-600 px-1.5 py-px text-[9px] font-semibold uppercase tracking-[0.12em] text-white">Start</span>
+            </div>
+            <div class="px-2.5 py-2">
+              <div class="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">Email</div>
+              <div class="mt-0.5 truncate text-[11.5px] text-slate-500">Quick question, {`{{.FirstName}}`}</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- IfNode: opened within 3d -->
+        <div class="absolute" style="left:286px; top:102px; width:148px;">
+          <div class="rounded-lg border border-sky-200 bg-gradient-to-b from-sky-50 to-white px-2 py-1 shadow-sm">
+            <div class="flex items-center gap-1.5">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-sky-600"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+              <span class="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-sky-500">if</span>
+              <span class="min-w-0 flex-1 truncate text-[11px] font-medium text-sky-800">opened within 3d</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- StepNode: Follow-up -->
+        <div class="absolute" style="left:464px; top:160px; width:248px;">
+          <div class="rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div class="flex items-center gap-2 rounded-t-xl border-b border-slate-200/70 bg-gradient-to-r from-sky-50/80 to-white px-2.5 py-1.5">
+              <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-sky-100 text-sky-600 ring-1 ring-sky-200/70"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={mailIcon}></svg></span>
+              <span class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">Follow-up</span>
+            </div>
+            <div class="px-2.5 py-2">
+              <div class="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">Email</div>
+              <div class="mt-0.5 truncate text-[11.5px] text-slate-500">Following up on my message</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- StepNode: Alternative -->
+        <div class="absolute" style="left:56px; top:160px; width:248px;">
+          <div class="rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div class="flex items-center gap-2 rounded-t-xl border-b border-slate-200/70 bg-gradient-to-r from-sky-50/80 to-white px-2.5 py-1.5">
+              <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-sky-100 text-sky-600 ring-1 ring-sky-200/70"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={mailIcon}></svg></span>
+              <span class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">Alternative</span>
+            </div>
+            <div class="px-2.5 py-2">
+              <div class="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">Email</div>
+              <div class="mt-0.5 truncate text-[11.5px] text-slate-500">Trying a different angle</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- ActionNode: Add engagement tag -->
+        <div class="absolute" style="left:464px; top:268px; width:248px;">
+          <div class="rounded-xl border border-slate-200 bg-white shadow-sm">
+            <div class="flex items-center gap-2 rounded-t-xl border-b border-slate-200/70 bg-gradient-to-r from-slate-50 to-white px-2.5 py-1.5">
+              <span class="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-slate-100 ring-1 ring-slate-200/70"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-600"><path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z"/><circle cx="7.5" cy="7.5" r=".5" fill="currentColor"/></svg></span>
+              <span class="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">Add engagement tag</span>
+            </div>
+            <div class="px-2.5 py-2">
+              <div class="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">Add tag</div>
+              <div class="mt-0.5 truncate text-[11.5px] text-slate-500">engaged</div>
+            </div>
+            <div class="flex items-center gap-1 border-t border-slate-200/70 px-2.5 py-1 text-[10.5px] text-slate-400">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={flagIcon}></svg>
+              Ends here
+            </div>
+          </div>
+        </div>
+
+        <!-- StopNode -->
+        <div class="absolute" style="left:122px; top:276px;">
+          <div class="inline-flex items-center gap-1.5 rounded-md border border-rose-200 bg-rose-50 px-3 py-1.5 text-[11.5px] font-medium text-rose-600">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={flagIcon}></svg>
+            Stop
+          </div>
+        </div>
+      </div>
+
+      <!-- bottom-left zoom controls -->
+      <div class="absolute bottom-3 left-3 z-20 flex flex-col overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm">
+        <span class="inline-flex size-6 items-center justify-center border-b border-slate-100 text-slate-500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+        <span class="inline-flex size-6 items-center justify-center border-b border-slate-100 text-slate-500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="5" y1="12" x2="19" y2="12"/></svg></span>
+        <span class="inline-flex size-6 items-center justify-center text-slate-500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7V5a2 2 0 0 1 2-2h2"/><path d="M17 3h2a2 2 0 0 1 2 2v2"/><path d="M21 17v2a2 2 0 0 1-2 2h-2"/><path d="M7 21H5a2 2 0 0 1-2-2v-2"/></svg></span>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo scene: reaction drawer (the real Step composer / SequenceView sliding in from the right) -->
+  <div class="cb-react absolute right-0 top-0 bottom-0 w-[330px] bg-white border-l border-slate-200 shadow-[-8px_0_30px_-12px_rgba(15,23,42,.25)] flex flex-col overflow-hidden" aria-hidden="true">
+    <!-- Header row: Step label + subtitle + Templates / Save as template / Write with AI + Reset + Save changes -->
+    <div class="shrink-0 border-b border-slate-200 px-3 py-2.5">
+      <div class="flex items-center justify-between gap-2">
+        <div class="min-w-0">
+          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Step 1</div>
+          <p class="mt-0.5 truncate text-[11px] text-slate-400">Compose the email this step sends.</p>
+        </div>
+        <button type="button" class="cb-save h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 transition-colors">Save changes</button>
+      </div>
+      <div class="mt-2 flex flex-wrap items-center gap-1.5">
+        <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium">
+          <span class="text-slate-400 shrink-0"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={sparklesIcon}></svg></span>
+          <span class="truncate">Templates</span>
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="text-slate-400 shrink-0"><path d="M6 9l6 6 6-6"/></svg>
+        </button>
+        <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={bookmarkPlusIcon}></svg>
+          Save as template
+        </button>
+        <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-200 bg-sky-50 text-[12px] font-medium text-sky-700">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={sparklesIcon}></svg>
+          Write with AI
+        </button>
+        <div class="h-4 w-px bg-slate-200"></div>
+        <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">Reset</button>
+      </div>
+    </div>
+
+    <!-- Composer body -->
+    <div class="flex-1 min-h-0 overflow-hidden space-y-4 p-3">
+      <!-- Step name -->
+      <div>
+        <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block mb-1.5">Step name</label>
+        <div class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 inline-flex w-full items-center">First email</div>
+        <p class="mt-1.5 text-[10.5px] text-slate-400">Internal label only. Recipients never see it.</p>
+      </div>
+
+      <!-- Subject + variables insert -->
+      <div>
+        <div class="flex items-center justify-between gap-2 mb-1.5">
+          <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block">Subject</label>
+          <span class="h-7 px-1.5 inline-flex items-center gap-1 rounded text-slate-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={bracesIcon}></svg>
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={chevronDownIcon}></svg>
+          </span>
+        </div>
+        <div class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 inline-flex w-full items-center">Quick question, {`{{.FirstName}}`}</div>
+      </div>
+
+      <!-- Body: Edit/Preview pill + rich text toolbar + body -->
+      <div>
+        <div class="flex items-center justify-between gap-2 mb-1.5">
+          <label class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium block">Body</label>
+          <div class="inline-flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5">
+            <span class="h-6 px-2 inline-flex items-center gap-1 rounded text-[11.5px] font-medium bg-white text-slate-900 shadow-sm">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={pencilLineIcon}></svg>
+              Edit
+            </span>
+            <span class="h-6 px-2 inline-flex items-center gap-1 rounded text-[11.5px] font-medium text-slate-500">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={eyeIcon}></svg>
+              Preview
+            </span>
+          </div>
+        </div>
+        <div class="rounded-md border border-slate-200 bg-white">
+          <!-- Toolbar -->
+          <div class="flex flex-wrap items-center gap-0.5 border-b border-slate-200/70 px-1.5 py-1">
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={boldIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={italicIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={underlineIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={strikeIcon}></svg></span>
+            <span class="mx-0.5 h-4 w-px bg-slate-200"></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={h2Icon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={listIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={listOrderedIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={link2Icon}></svg></span>
+            <span class="mx-0.5 h-4 w-px bg-slate-200"></span>
+            <span class="h-7 px-1.5 inline-flex items-center gap-1 rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={bracesIcon}></svg><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={chevronDownIcon}></svg></span>
+            <span class="size-7 inline-flex items-center justify-center rounded text-slate-500"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={shuffleIcon}></svg></span>
+          </div>
+          <!-- Body text -->
+          <div class="px-3 py-2.5 text-[13px] leading-relaxed text-slate-800 space-y-2">
+            <p>Hi {`{{.FirstName}}`}, I noticed {`{{.Company}}`} is scaling fast.</p>
+            <p>We help teams like yours land more cold replies without burning sender reputation.</p>
+            <p>Worth a quick 15 minutes this week?</p>
+          </div>
+        </div>
+      </div>
+
+      <!-- ContentScore footer -->
+      <div class="rounded-md border border-slate-200 bg-white">
+        <div class="flex items-center justify-between gap-3 px-3 py-2.5">
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Content check</div>
+            <p class="mt-0.5 text-[11px] text-slate-400 leading-relaxed">Advisory deliverability score. Never blocks sending.</p>
+          </div>
+          <span class="h-8 px-3 rounded-md border border-slate-200 text-[12px] font-medium text-slate-700 inline-flex items-center gap-1.5 shrink-0">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={shieldCheckIcon}></svg>
+            Re-check
+          </span>
+        </div>
+        <div class="px-3 pb-3 border-t border-slate-200/60 pt-3">
+          <div class="flex items-center gap-2">
+            <span class="text-[22px] font-light leading-none tabular-nums text-emerald-600">78</span>
+            <span class="text-[11px] text-slate-400 mb-0.5">/ 100</span>
+            <span class="ml-auto text-[11px] font-medium text-emerald-600">Looks good</span>
+          </div>
+          <div class="mt-2 h-1.5 w-full rounded-full bg-slate-100 overflow-hidden">
+            <div class="h-full rounded-full bg-emerald-500" style="width:78%"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo scene: animated cursor -->
+  <div class="cb-cursor" aria-hidden="true"><span class="cb-ripple"></span><svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg></div>
+
+  <style>
+    .cb-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:cb-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .cb-cursor svg{display:block;transform-origin:3px 2px;animation:cb-press 11s ease-in-out infinite;}
+    .cb-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:cb-rip 11s ease-out infinite;}
+    .cb-react{position:absolute;z-index:40;opacity:0;animation:cb-react 11s ease-out infinite;}
+    /* press #1 feedback on the First email node */
+    .cb-node{animation:cb-node-press 11s ease-in-out infinite;}
+    /* press #2 feedback on the drawer Save changes button */
+    .cb-save{animation:cb-save-press 11s ease-in-out infinite;}
+    @keyframes cb-move{0%{left:18%;top:78%}22%{left:50%;top:24%}32%{left:50%;top:24%}58%{left:90%;top:14%}68%{left:90%;top:14%}88%{left:90%;top:14%}100%{left:18%;top:78%}}
+    @keyframes cb-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes cb-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes cb-react{0%,29%{opacity:0;transform:translateX(18px)}33%{opacity:1;transform:translateX(0)}88%{opacity:1;transform:translateX(0)}95%{opacity:0;transform:translateX(18px)}100%{opacity:0;transform:translateX(18px)}}
+    @keyframes cb-node-press{0%,26%{box-shadow:none}28%{box-shadow:0 0 0 4px rgba(186,230,253,.9)}31%,100%{box-shadow:none}}
+    @keyframes cb-save-press{0%,62%{background-color:#0284c7}64%{background-color:#075985;box-shadow:0 0 0 4px rgba(186,230,253,.9)}67%,100%{background-color:#0284c7}}
+    @media (prefers-reduced-motion: reduce){.cb-cursor{display:none}.cb-react{display:none}}
+  </style>
+</div>

--- a/site/src/components/CampaignBuilderMock.astro
+++ b/site/src/components/CampaignBuilderMock.astro
@@ -231,24 +231,22 @@ const chevronDownIcon = '<path d="m6 9 6 6 6-6"/>';
           <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Step 1</div>
           <p class="mt-0.5 truncate text-[11px] text-slate-400">Compose the email this step sends.</p>
         </div>
-        <button type="button" class="cb-save h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 transition-colors">Save changes</button>
+        <button type="button" class="h-7 px-3 rounded-md bg-sky-600 text-[12px] font-medium text-white inline-flex items-center gap-1.5 transition-colors shrink-0 whitespace-nowrap">Save changes</button>
       </div>
-      <div class="mt-2 flex flex-wrap items-center gap-1.5">
-        <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium">
+      <div class="mt-2 flex items-center gap-1.5">
+        <button type="button" aria-label="Templates" title="Templates" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1 text-[12px] font-medium shrink-0 whitespace-nowrap">
           <span class="text-slate-400 shrink-0"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={sparklesIcon}></svg></span>
-          <span class="truncate">Templates</span>
           <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="text-slate-400 shrink-0"><path d="M6 9l6 6 6-6"/></svg>
         </button>
-        <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">
+        <button type="button" aria-label="Save as template" title="Save as template" class="h-7 w-7 inline-flex items-center justify-center rounded-md border border-slate-200 bg-white text-slate-700 shrink-0">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={bookmarkPlusIcon}></svg>
-          Save as template
         </button>
-        <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-200 bg-sky-50 text-[12px] font-medium text-sky-700">
+        <button type="button" class="h-7 px-2.5 inline-flex items-center gap-1.5 rounded-md border border-sky-200 bg-sky-50 text-[12px] font-medium text-sky-700 shrink-0 whitespace-nowrap">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" set:html={sparklesIcon}></svg>
           Write with AI
         </button>
-        <div class="h-4 w-px bg-slate-200"></div>
-        <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700">Reset</button>
+        <div class="h-4 w-px bg-slate-200 shrink-0"></div>
+        <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12px] font-medium text-slate-700 shrink-0 whitespace-nowrap">Reset</button>
       </div>
     </div>
 

--- a/site/src/components/ChangelogShowcase.astro
+++ b/site/src/components/ChangelogShowcase.astro
@@ -95,7 +95,7 @@ const categoryStyle = (c: Release['category']) => {
               <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
               <span class="absolute inset-0 rounded-full bg-emerald-500/40 animate-pulse-soft"></span>
             </span>
-            Shipping weekly
+            Shipping continuously
           </span>
         </div>
         <h2 class="text-[28px] md:text-[40px] font-semibold tracking-[-0.025em] leading-[1.08] text-heading">

--- a/site/src/components/ChangelogShowcase.astro
+++ b/site/src/components/ChangelogShowcase.astro
@@ -1,0 +1,178 @@
+---
+import Icon from './Icon.astro';
+
+/**
+ * ChangelogShowcase - a landing-page CHANGELOG section.
+ *
+ * A clean vertical timeline of the latest releases. Content is grounded in the
+ * real entries on /changelog/ (versions, dates, change bullets) so the section
+ * never drifts from the actual product history. Self-contained, no props, no
+ * client JS, no app-window frame - this is a content section, not a mock.
+ *
+ * Category chips map the changelog tag vocabulary to a reader-friendly set:
+ *   shipped -> New      (sky)
+ *   changed -> Improved (emerald)
+ *   fixed   -> Fixed    (amber)
+ */
+
+interface Release {
+  version: string;
+  date: string;
+  category: 'New' | 'Improved' | 'Fixed';
+  title: string;
+  bullets: string[];
+}
+
+// Latest four releases, taken from /changelog/ and split into 2-3 bullet lines.
+const releases: Release[] = [
+  {
+    version: 'v1.9',
+    date: '2026-05-26',
+    category: 'New',
+    title: 'BYOK envelope encryption for self-host',
+    bullets: [
+      'Register your own AWS KMS key as the root of trust for the per-user DEK envelope.',
+      'Existing encrypted material is re-wrapped on first key activation.',
+      'Plaintext DEKs stay only in the Redis cache with a bounded TTL.',
+    ],
+  },
+  {
+    version: 'v1.8',
+    date: '2026-05-22',
+    category: 'New',
+    title: 'SAML SSO for Business plans',
+    bullets: [
+      'Connect Okta, Azure AD, or any SAML 2.0 identity provider.',
+      'Just-in-time provisioning is on by default.',
+      'Admins can pin a default role for new sign-ins.',
+    ],
+  },
+  {
+    version: 'v1.7',
+    date: '2026-05-20',
+    category: 'New',
+    title: 'API keys dashboard',
+    bullets: [
+      'Per-key scopes, last-used timestamps, and one-click rotation.',
+      'Existing keys auto-migrated to full-access scope.',
+    ],
+  },
+  {
+    version: 'v1.6',
+    date: '2026-05-15',
+    category: 'Improved',
+    title: 'Per-mailbox health bands',
+    bullets: [
+      'Mailboxes surface a health band: healthy, watch, quarantined, or blocked.',
+      'Bands are driven by rolling placement, complaint, and bounce signals.',
+      'Pool selection now skips anything not healthy.',
+    ],
+  },
+];
+
+const categoryStyle = (c: Release['category']) => {
+  if (c === 'New') {
+    return { chip: 'bg-sky-50 text-sky-700 ring-sky-100', dot: 'bg-sky-500', rail: 'bg-sky-500' };
+  }
+  if (c === 'Improved') {
+    return { chip: 'bg-emerald-50 text-emerald-700 ring-emerald-100', dot: 'bg-emerald-500', rail: 'bg-emerald-500' };
+  }
+  return { chip: 'bg-amber-50 text-amber-700 ring-amber-100', dot: 'bg-amber-500', rail: 'bg-amber-500' };
+};
+---
+<section class="bg-[color:var(--surface-2)] border-y border-[color:var(--border)] py-20 md:py-28">
+  <div class="container-page">
+    <!-- Header: eyebrow + heading + subcopy -->
+    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-12 md:mb-16">
+      <div class="max-w-2xl">
+        <div class="flex items-center gap-2.5 mb-4">
+          <span class="text-[11px] uppercase tracking-[0.18em] text-[color:var(--brand-strong)] font-mono">
+            Changelog
+          </span>
+          <span class="w-1 h-1 rounded-full bg-[color:var(--border-strong)]"></span>
+          <span class="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground font-mono">
+            <span class="relative inline-flex">
+              <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+              <span class="absolute inset-0 rounded-full bg-emerald-500/40 animate-pulse-soft"></span>
+            </span>
+            Shipping weekly
+          </span>
+        </div>
+        <h2 class="text-[28px] md:text-[40px] font-semibold tracking-[-0.025em] leading-[1.08] text-heading">
+          The latest from Warmbly.
+        </h2>
+        <p class="mt-4 text-[15.5px] md:text-[16.5px] text-foreground/75 leading-relaxed">
+          New features, behavioural changes, and fixes, in the order they reached production. Every entry is dated, tagged, and traceable to a commit.
+        </p>
+      </div>
+
+      <a
+        href="/changelog/"
+        class="group shrink-0 inline-flex items-center gap-1.5 h-9 px-4 rounded-[10px] text-[12.5px] font-medium bg-white ring-1 ring-[color:var(--border)] text-foreground/80 hover:text-heading hover:ring-[color:var(--brand)]/40 hover:-translate-y-0.5 transition-all"
+      >
+        View full changelog
+        <Icon name="arrowUpRight" size={13} class="text-muted-foreground group-hover:text-[color:var(--brand-strong)] transition-colors" />
+      </a>
+    </div>
+
+    <!-- Vertical timeline of releases -->
+    <ol class="relative">
+      <!-- continuous rail -->
+      <span aria-hidden="true" class="absolute left-[7px] top-2 bottom-2 w-px bg-[color:var(--border)] hidden sm:block"></span>
+
+      {releases.map((r) => {
+        const s = categoryStyle(r.category);
+        return (
+          <li class="relative sm:pl-10 mb-4 last:mb-0">
+            <!-- timeline node -->
+            <span aria-hidden="true" class="hidden sm:flex absolute left-0 top-6 w-[15px] h-[15px] items-center justify-center">
+              <span class="w-[15px] h-[15px] rounded-full bg-white ring-1 ring-[color:var(--border)] flex items-center justify-center">
+                <span class={`w-1.5 h-1.5 rounded-full ${s.dot}`}></span>
+              </span>
+            </span>
+
+            <article class="relative bg-white ring-1 ring-[color:var(--border)] rounded-[12px] p-5 md:p-6 hover:ring-[color:var(--brand)]/40 hover:shadow-[0_18px_36px_-22px_rgba(2,132,199,0.3)] transition-all overflow-hidden">
+              <!-- category accent rail -->
+              <span aria-hidden="true" class={`absolute left-0 top-0 bottom-0 w-[3px] ${s.rail}`}></span>
+
+              <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <span class="text-[12.5px] font-mono font-semibold text-heading tabular-nums">
+                  {r.version}
+                </span>
+                <span class="text-[11.5px] font-mono uppercase tracking-[0.14em] text-muted-foreground tabular-nums">
+                  {r.date}
+                </span>
+                <span class={`ml-auto inline-flex items-center gap-1.5 h-5 px-2 rounded-full ring-1 text-[10px] font-semibold uppercase tracking-[0.1em] ${s.chip}`}>
+                  <span class={`w-1 h-1 rounded-full ${s.dot}`}></span>
+                  {r.category}
+                </span>
+              </div>
+
+              <h3 class="mt-3 text-[16px] md:text-[17px] font-semibold text-heading tracking-[-0.015em] leading-[1.25]">
+                {r.title}
+              </h3>
+
+              <ul class="mt-3 space-y-1.5">
+                {r.bullets.map((b) => (
+                  <li class="flex gap-2.5 text-[12.5px] text-foreground/70 leading-relaxed">
+                    <span class={`mt-[7px] w-1 h-1 rounded-full shrink-0 ${s.dot}`}></span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          </li>
+        );
+      })}
+    </ol>
+
+    <!-- footer link -->
+    <div class="mt-10 flex flex-wrap items-center gap-x-4 gap-y-2 text-[11.5px] font-mono text-muted-foreground sm:pl-10">
+      <span>Older releases and the full history</span>
+      <span class="w-1 h-1 rounded-full bg-[color:var(--border-strong)]"></span>
+      <a href="/changelog/" class="text-[color:var(--brand-strong)] hover:text-[color:var(--brand)] transition-colors">
+        Read the full changelog
+      </a>
+    </div>
+  </div>
+</section>

--- a/site/src/components/DashboardMock.astro
+++ b/site/src/components/DashboardMock.astro
@@ -3,11 +3,11 @@
  * Pixel-faithful mock of the Warmbly /app/emails screen.
  *
  * Maps 1:1 to the real shell:
- *   - web/src/components/layout/AppShell.tsx — the outer frame
- *   - web/src/components/layout/SkyChrome.tsx — the off-white #f5f6f8 chrome
- *   - web/src/components/layout/AppHeader.tsx — top breadcrumb bar (h-14)
- *   - web/src/components/layout/AppNav.tsx — the w-64 sidebar (LivePanel + sections)
- *   - web/src/app/app/emails/page.tsx — the content panel (PageTopbar/StatStrip/SectionBar/table)
+ *   - web/src/components/layout/AppShell.tsx - the outer frame
+ *   - web/src/components/layout/SkyChrome.tsx - the off-white #f5f6f8 chrome
+ *   - web/src/components/layout/AppHeader.tsx - top breadcrumb bar (h-14)
+ *   - web/src/components/layout/AppNav.tsx - the w-64 sidebar (LivePanel + sections)
+ *   - web/src/app/app/emails/page.tsx - the content panel (PageTopbar/StatStrip/SectionBar/table)
  *
  * The white content panel meets the bottom + right edges of the frame
  * and has only its inner top-left corner rounded (rounded-tl-2xl) plus
@@ -56,7 +56,7 @@ const sidebarSections: { label: string; items: { title: string; active?: boolean
   ]},
 ];
 ---
-<!-- Outer SkyChrome — #f5f6f8 base + cloud blurs -->
+<!-- Outer SkyChrome - #f5f6f8 base + cloud blurs -->
 <div class="relative overflow-hidden text-slate-900" style="background:#f5f6f8;">
   <!-- cloud blurs (subtle, ambient) -->
   <span aria-hidden="true" class="absolute pointer-events-none" style="top:-80px; left:-60px; width:520px; height:240px; background:rgba(255,255,255,0.95); border-radius:50% 50% 18% 18%; filter:blur(60px); opacity:0.7;"></span>
@@ -65,7 +65,7 @@ const sidebarSections: { label: string; items: { title: string; active?: boolean
 
   <!-- ── AppHeader (h-14, sits over SkyChrome) ── -->
   <div class="relative z-10 h-14 flex items-center shrink-0">
-    <!-- Logo zone — sidebar-width -->
+    <!-- Logo zone - sidebar-width -->
     <div class="w-64 px-5 h-full flex items-center gap-2.5 shrink-0">
       <svg viewBox="0 0 746 764" class="w-7 h-7 text-slate-900" fill="currentColor"><path d="M222.805 644.772L186.274 108.881L704.5 451.158L484.5 451.158L245.5 196.158L444 463.5L222.805 644.772Z"/></svg>
       <span class="font-extrabold text-[15.5px] tracking-tight text-slate-900">Warmbly</span>
@@ -183,7 +183,7 @@ const sidebarSections: { label: string; items: { title: string; active?: boolean
       </div>
     </aside>
 
-    <!-- Content panel — white with rounded inner top-left corner -->
+    <!-- Content panel - white with rounded inner top-left corner -->
     <main class="flex-1 min-w-0 rounded-tl-2xl bg-white overflow-hidden border-t border-l border-slate-200/70">
       <!-- PageTopbar -->
       <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">

--- a/site/src/components/DeveloperMock.astro
+++ b/site/src/components/DeveloperMock.astro
@@ -97,16 +97,16 @@ const stats = [
         <span class="text-[12.5px] text-slate-600 truncate">Programmatic access · stripe-style scoped tokens</span>
         <div class="ml-auto flex items-center gap-1.5">
           <!-- SearchPill -->
-          <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5">
+          <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5 shrink-0">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
             <span class="text-[12px] text-slate-400 w-[140px]">Search…</span>
           </div>
           <!-- Refresh -->
-          <span class="h-7 w-7 rounded-md border border-slate-200 text-slate-500 inline-flex items-center justify-center">
+          <span class="h-7 w-7 rounded-md border border-slate-200 text-slate-500 inline-flex items-center justify-center shrink-0">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>
           </span>
           <!-- Create key (TopbarAction, sky-600). Press #1 target. -->
-          <button id="dv-create" class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white">
+          <button id="dv-create" class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white whitespace-nowrap shrink-0">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
             Create key
           </button>
@@ -385,24 +385,24 @@ const stats = [
               <span class="text-[11px] uppercase tracking-[0.14em] text-slate-500 font-medium">Expires</span>
             </div>
             <div class="flex items-center gap-1">
-              <span class="h-7 px-3 rounded-md text-[11.5px] bg-slate-900 text-white inline-flex items-center">Never</span>
-              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">30 days</span>
-              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">90 days</span>
-              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">365 days</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] bg-slate-900 text-white inline-flex items-center whitespace-nowrap shrink-0">Never</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center whitespace-nowrap shrink-0">30 days</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center whitespace-nowrap shrink-0">90 days</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center whitespace-nowrap shrink-0">365 days</span>
             </div>
           </div>
         </div>
 
         <!-- modal footer -->
         <div class="h-12 px-4 border-t border-slate-200 flex items-center gap-2 bg-slate-50/40">
-          <span class="text-[11px] text-slate-500 inline-flex items-center gap-1.5">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
-            The secret will be shown once. Save it somewhere safe.
+          <span class="text-[11px] text-slate-500 inline-flex items-center gap-1.5 min-w-0">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+            <span class="truncate">The secret will be shown once. Save it somewhere safe.</span>
           </span>
-          <div class="ml-auto flex items-center gap-1.5">
-            <span class="h-7 px-3 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center">Cancel</span>
-            <!-- modal Create key (press #2 target) -->
-            <span id="dv-modal-create" class="h-7 px-3 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+          <div class="ml-auto flex items-center gap-1.5 shrink-0">
+            <span class="h-7 px-3 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center whitespace-nowrap shrink-0">Cancel</span>
+            <!-- modal Create key -->
+            <span class="h-7 px-3 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>
               Create key
             </span>
@@ -428,14 +428,12 @@ const stats = [
     .dv-caret{display:inline-block;animation:dv-blink 1s step-end infinite;}
     /* press feedback on the two targets, synced to the cursor dips */
     #dv-create{animation:dv-btn1 11s ease-out infinite;}
-    #dv-modal-create{animation:dv-btn2 11s ease-out infinite;}
-    @keyframes dv-move{0%{left:30%;top:60%}22%{left:48%;top:4%}32%{left:48%;top:4%}58%{left:73%;top:89%}68%{left:73%;top:89%}88%{left:30%;top:60%}100%{left:30%;top:60%}}
+    @keyframes dv-move{0%{left:30%;top:60%}22%{left:47.5%;top:4.6%}32%{left:47.5%;top:4.6%}58%{left:8%;top:85%}68%{left:8%;top:85%}88%{left:30%;top:60%}100%{left:30%;top:60%}}
     @keyframes dv-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes dv-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
-    @keyframes dv-react{0%,29%{opacity:0}33%{opacity:1}88%{opacity:1}95%{opacity:0}100%{opacity:0}}
-    @keyframes dv-card{0%,29%{transform:scale(.94)}33%{transform:scale(1)}88%{transform:scale(1)}95%{transform:scale(.94)}100%{transform:scale(.94)}}
+    @keyframes dv-react{0%,29%{opacity:0}33%{opacity:1}60%{opacity:1}66%{opacity:0}100%{opacity:0}}
+    @keyframes dv-card{0%,29%{transform:scale(.94)}33%{transform:scale(1)}60%{transform:scale(1)}66%{transform:scale(.94)}100%{transform:scale(.94)}}
     @keyframes dv-btn1{0%,27%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}28%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,.9)}31%,100%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}}
-    @keyframes dv-btn2{0%,63%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}64%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,.9)}67%,100%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}}
     @keyframes dv-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
     @media (prefers-reduced-motion: reduce){.dv-cursor{display:none}.dv-react{display:none}}
   </style>

--- a/site/src/components/DeveloperMock.astro
+++ b/site/src/components/DeveloperMock.astro
@@ -275,7 +275,7 @@ const stats = [
 
   <!-- ════════════════════════════════════════════════════════════
        DEMO SCENE · cursor presses "Create key" -> CreateKeyModal opens,
-       cursor then presses the modal's "Create key" button
+       cursor then presses the dark scrim (click-outside) -> modal dismisses
   ════════════════════════════════════════════════════════════ -->
 
   <!-- (b) reaction overlay: the real CreateKeyModal -->
@@ -426,7 +426,7 @@ const stats = [
     .dv-react{position:absolute;z-index:40;opacity:0;animation:dv-react 11s ease-out infinite;}
     .dv-card{transform-origin:center;transform:scale(.94);animation:dv-card 11s ease-out infinite;}
     .dv-caret{display:inline-block;animation:dv-blink 1s step-end infinite;}
-    /* press feedback on the two targets, synced to the cursor dips */
+    /* press feedback on the trigger, synced to the press #1 cursor dip; press #2 lands on the scrim (no target highlight, the modal dismisses) */
     #dv-create{animation:dv-btn1 11s ease-out infinite;}
     @keyframes dv-move{0%{left:30%;top:60%}22%{left:47.5%;top:4.6%}32%{left:47.5%;top:4.6%}58%{left:8%;top:85%}68%{left:8%;top:85%}88%{left:30%;top:60%}100%{left:30%;top:60%}}
     @keyframes dv-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}

--- a/site/src/components/DeveloperMock.astro
+++ b/site/src/components/DeveloperMock.astro
@@ -1,0 +1,442 @@
+---
+/**
+ * Pixel-faithful mock of the Warmbly /app/api-keys screen, paired with a
+ * dark quick-start code panel. Maps 1:1 to the real source:
+ *
+ *   - web/src/app/app/api-keys/page.tsx                       PageTopbar / StatStrip / SearchPill / KeyRow / StatusPill
+ *   - web/src/app/app/api-keys/_components/CreateKeyModal.tsx the Create API key modal (the reaction)
+ *   - web/src/components/layout/Page.tsx                      PageTopbar / StatStrip / Stat / SectionBar / TopbarAction
+ *   - internal/models/api_permission.go                      the real scope names + descriptions + categories
+ *
+ * The dark code panel reuses the slate-950 idiom from the real CodeSnippet
+ * (page.tsx) and the developers/index marketing surfaces.
+ *
+ * Renders only the in-app screen content. The marketing page wraps this in
+ * its own browser frame and crops overflow.
+ */
+
+// Scope-dot tone, mirrors the category coloring used across the keys UI.
+const scopeTone: Record<string, string> = {
+  read: 'bg-sky-400',
+  write: 'bg-violet-400',
+  send: 'bg-emerald-400',
+};
+
+// One row per key, matching the real KeyRow: name+description, mono
+// prefix…suffix, status pill, rate limit, last used.
+const keys = [
+  {
+    name: 'production-server',
+    desc: 'Server-side calls from EU production',
+    prefix: 'wmbly_live_a1',
+    suffix: '4f2a',
+    scope: 'write',
+    rpm: 600,
+    last: 'used 2m ago',
+    status: 'active' as const,
+  },
+  {
+    name: 'ci-pipeline',
+    desc: 'GitHub Actions deploy step',
+    prefix: 'wmbly_live_7c',
+    suffix: '91c7',
+    scope: 'read',
+    rpm: 120,
+    last: 'used 1h ago',
+    status: 'active' as const,
+  },
+  {
+    name: 'zapier-replies',
+    desc: 'Inbound reply automation',
+    prefix: 'wmbly_live_3d',
+    suffix: '3d8e',
+    scope: 'send',
+    rpm: 300,
+    last: 'used 3d ago',
+    status: 'active' as const,
+  },
+  {
+    name: 'old-laptop',
+    desc: 'Rotated out, kept for audit',
+    prefix: 'wmbly_live_0p',
+    suffix: 'xx0p',
+    scope: 'read',
+    rpm: 120,
+    last: 'used 23d ago',
+    status: 'revoked' as const,
+  },
+];
+
+const statusTone = (s: string) =>
+  s === 'active'
+    ? { bg: 'bg-emerald-50', text: 'text-emerald-700', dot: 'bg-emerald-500' }
+    : s === 'revoked'
+      ? { bg: 'bg-rose-50', text: 'text-rose-700', dot: 'bg-rose-500' }
+      : { bg: 'bg-slate-100', text: 'text-slate-600', dot: 'bg-slate-400' };
+
+// Top StatStrip cells, mirroring useAPIKeyUsageSummary on the real page.
+const stats = [
+  { label: 'Active keys',      value: '3',       sub: '1 inactive',          accent: true,  last: false },
+  { label: 'Requests · 24h',   value: '8,241',   sub: '4 errors',            accent: false, last: false },
+  { label: 'Avg latency · 24h',value: '28ms',    sub: 'across all keys',     accent: false, last: false },
+  { label: 'Last call',        value: '14s ago', sub: 'Jun 6, 02:02 PM',     accent: false, last: true },
+];
+---
+<div class="relative w-full bg-white text-slate-900" style="min-height:520px;">
+  <div class="flex min-h-[520px]">
+
+    <!-- ════════════════════════════════════════════════════════════
+         LEFT · the API Keys screen (PageTopbar + StatStrip + Keys list)
+    ════════════════════════════════════════════════════════════ -->
+    <div class="flex-1 min-w-0 flex flex-col border-r border-slate-200">
+
+      <!-- PageTopbar (h-12) -->
+      <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">API keys</span>
+        <div class="h-4 w-px bg-slate-200"></div>
+        <span class="text-[12.5px] text-slate-600 truncate">Programmatic access · stripe-style scoped tokens</span>
+        <div class="ml-auto flex items-center gap-1.5">
+          <!-- SearchPill -->
+          <div class="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+            <span class="text-[12px] text-slate-400 w-[140px]">Search…</span>
+          </div>
+          <!-- Refresh -->
+          <span class="h-7 w-7 rounded-md border border-slate-200 text-slate-500 inline-flex items-center justify-center">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>
+          </span>
+          <!-- Create key (TopbarAction, sky-600). Press #1 target. -->
+          <button id="dv-create" class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Create key
+          </button>
+        </div>
+      </div>
+
+      <!-- StatStrip (4 cols) -->
+      <div class="grid grid-cols-4 border-b border-slate-200 shrink-0 bg-white">
+        {stats.map((s) => (
+          <div class={`px-5 py-4 ${!s.last ? 'border-r border-slate-200' : ''}`}>
+            <div class="flex items-center gap-2">
+              <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{s.label}</span>
+              {s.accent && <span class="size-1.5 rounded-full bg-sky-500 animate-pulse"></span>}
+            </div>
+            <div class="text-[26px] text-slate-900 font-light leading-none mt-2 tabular-nums">{s.value}</div>
+            <div class="text-[10px] text-slate-400 mt-1.5 font-mono truncate">{s.sub}</div>
+          </div>
+        ))}
+      </div>
+
+      <!-- SectionBar · Traffic last 24h -->
+      <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Traffic · last 24h</span>
+        <span class="font-mono text-[10.5px] text-slate-400 tabular-nums">8,241</span>
+      </div>
+
+      <!-- StackedBars activity graph (2xx / 4xx / 5xx) -->
+      <div class="px-5 py-4 border-b border-slate-200/60 shrink-0">
+        <div class="flex items-end gap-[3px] h-[80px]">
+          {[42,55,38,61,49,72,58,80,64,47,69,53,76,60,84,51,68,57,73,45,62,79,54,66].map((h, i) => (
+            <div class="flex-1 flex flex-col justify-end gap-px" style={`height:80px`}>
+              {i % 7 === 3 && <div class="w-full rounded-[1px] bg-rose-500/80" style="height:4px"></div>}
+              {i % 5 === 2 && <div class="w-full rounded-[1px] bg-amber-400/80" style="height:6px"></div>}
+              <div class="w-full rounded-[1px] bg-emerald-500/80" style={`height:${h}%`}></div>
+            </div>
+          ))}
+        </div>
+        <div class="mt-2 flex items-center gap-3 text-[10.5px] text-slate-500">
+          <span class="inline-flex items-center gap-1"><span class="size-1.5 rounded-sm bg-emerald-500/80"></span>2xx</span>
+          <span class="inline-flex items-center gap-1"><span class="size-1.5 rounded-sm bg-amber-400/80"></span>4xx</span>
+          <span class="inline-flex items-center gap-1"><span class="size-1.5 rounded-sm bg-rose-500/80"></span>5xx</span>
+          <span class="ml-auto inline-flex items-center gap-1.5 text-[10.5px] text-slate-400">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>
+            live; refreshes every minute
+          </span>
+        </div>
+      </div>
+
+      <!-- SectionBar · Keys -->
+      <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Keys</span>
+        <span class="font-mono text-[10.5px] text-slate-400 tabular-nums">4</span>
+      </div>
+
+      <!-- Keys list (KeyRow, divide-y) -->
+      <div class="divide-y divide-slate-200/60">
+        {keys.map((k) => {
+          const t = statusTone(k.status);
+          return (
+            <div class="group h-12 px-5 flex items-center gap-3 text-left hover:bg-slate-50/80">
+              <!-- KeyIcon -->
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class={`shrink-0 ${k.status === 'active' ? 'text-slate-500' : 'text-slate-300'}`} stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>
+              <!-- name + description -->
+              <div class="flex flex-col min-w-0 max-w-[40%]">
+                <span class="text-[12.5px] text-slate-900 font-medium truncate">{k.name}</span>
+                <span class="text-[10.5px] text-slate-500 truncate">{k.desc}</span>
+              </div>
+              <!-- mono prefix…suffix -->
+              <span class="font-mono text-[10.5px] text-slate-500 truncate">{k.prefix}…{k.suffix}</span>
+              <!-- StatusPill -->
+              <span class={`inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] uppercase tracking-[0.08em] font-medium ${t.bg} ${t.text}`}>
+                <span class={`size-1.5 rounded-full ${t.dot}`}></span>
+                {k.status}
+              </span>
+              <!-- right: rate limit + last used -->
+              <span class="ml-auto flex items-center gap-3 shrink-0">
+                <span class="text-[10.5px] text-slate-400 tabular-nums inline-flex items-center">
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="mr-1 align-[-2px]" stroke-linecap="round" stroke-linejoin="round"><path d="m12 14 4-4"/><path d="M3.34 19a10 10 0 1 1 17.32 0"/></svg>
+                  {k.rpm}/m
+                </span>
+                <span class="font-mono text-[10.5px] text-slate-400 tabular-nums w-32 text-right truncate">{k.last}</span>
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+
+    <!-- ════════════════════════════════════════════════════════════
+         RIGHT · Quick start (dark code panel, slate-950 idiom)
+    ════════════════════════════════════════════════════════════ -->
+    <div class="w-[400px] shrink-0 flex flex-col bg-slate-50/40">
+
+      <!-- panel topbar -->
+      <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Quick start</span>
+        <div class="h-4 w-px bg-slate-200"></div>
+        <span class="text-[12.5px] text-slate-600 truncate">Your first request</span>
+      </div>
+
+      <div class="p-4 flex flex-col gap-3">
+        <!-- dark code panel: cURL request -->
+        <div class="rounded-md border border-slate-200 bg-slate-950 overflow-hidden">
+          <div class="h-8 px-3 flex items-center gap-2 border-b border-slate-800/60">
+            <span class="size-1.5 rounded-full bg-red-400/70"></span>
+            <span class="size-1.5 rounded-full bg-amber-400/70"></span>
+            <span class="size-1.5 rounded-full bg-emerald-400/70"></span>
+            <span class="ml-2 text-[11px] text-slate-400 font-mono">curl</span>
+            <span class="ml-auto inline-flex items-center gap-1 h-6 px-2 rounded text-slate-400 text-[11px]">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>
+              Copy
+            </span>
+          </div>
+          <pre class="text-slate-200 px-4 py-3 text-[12px] leading-relaxed font-mono whitespace-pre overflow-x-auto"><code>curl <span style="color:#fde68a">https://api.warmbly.com/v1/campaigns</span> \
+  <span style="color:#f472b6">-H</span> <span style="color:#fde68a">"Authorization: Bearer wmbly_live_a1…"</span> \
+  <span style="color:#f472b6">-H</span> <span style="color:#fde68a">"Content-Type: application/json"</span></code></pre>
+        </div>
+
+        <!-- rate-limit-header note, from the page copy -->
+        <p class="text-[11.5px] text-slate-500 leading-relaxed">
+          Pass the secret as a <span class="font-mono text-slate-700">Bearer</span> header. Every request returns
+          rate-limit headers (<span class="font-mono text-slate-700">X-RateLimit-Limit</span>,
+          <span class="font-mono text-slate-700">X-RateLimit-Remaining</span>) so well-behaved clients can self-throttle
+          before hitting <span class="font-mono text-slate-700">429</span>.
+        </p>
+
+        <!-- response (200) -->
+        <div class="rounded-md border border-slate-200 bg-slate-950 overflow-hidden">
+          <div class="h-8 px-3 flex items-center gap-2 border-b border-slate-800/60">
+            <span class="text-[10px] font-mono uppercase tracking-[0.14em] text-slate-400">Response</span>
+            <span class="ml-auto inline-flex items-center gap-1.5 h-5 px-1.5 rounded text-[10px] font-mono font-medium bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-400/20">
+              <span class="size-1.5 rounded-full bg-emerald-400"></span>
+              200 OK
+            </span>
+          </div>
+          <pre class="text-slate-200 px-4 py-3 text-[12px] leading-relaxed font-mono overflow-x-auto"><code><span style="color:#94a3b8">&#123;</span>
+  <span style="color:#7dd3fc">"id"</span>: <span style="color:#fde68a">"cmp_01HQX9F7P3A8KY"</span>,
+  <span style="color:#7dd3fc">"status"</span>: <span style="color:#fde68a">"scheduled"</span>,
+  <span style="color:#7dd3fc">"daily_cap"</span>: <span style="color:#a78bfa">50</span>,
+  <span style="color:#7dd3fc">"created_at"</span>: <span style="color:#fde68a">"2026-06-06T14:02Z"</span>
+<span style="color:#94a3b8">&#125;</span></code></pre>
+        </div>
+
+        <!-- HMAC-signed webhooks note -->
+        <div class="rounded-md border border-slate-200 bg-white px-3.5 py-3">
+          <div class="flex items-center gap-1.5 mb-1.5">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-sky-600" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/></svg>
+            <span class="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium">HMAC-signed webhooks</span>
+          </div>
+          <p class="text-[11px] text-slate-500 leading-relaxed">
+            Events post to your endpoint with an <span class="font-mono text-slate-700">X-Warmbly-Signature</span> header.
+            Verify the HMAC-SHA256 digest before you trust the body.
+          </p>
+          <div class="mt-2 flex items-center gap-2">
+            <span class="inline-flex items-center gap-1.5 h-5 px-2 rounded bg-sky-50 text-sky-700 text-[10.5px] font-mono">
+              <span class="size-1.5 rounded-full bg-sky-500"></span>
+              contact.replied
+            </span>
+            <span class="font-mono text-[10px] text-slate-400 tabular-nums">delivered 4s ago</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- ════════════════════════════════════════════════════════════
+       DEMO SCENE · cursor presses "Create key" -> CreateKeyModal opens,
+       cursor then presses the modal's "Create key" button
+  ════════════════════════════════════════════════════════════ -->
+
+  <!-- (b) reaction overlay: the real CreateKeyModal -->
+  <div class="dv-react" style="left:0;top:0;right:0;bottom:0;" aria-hidden="true">
+    <div class="absolute inset-0 bg-slate-900/30"></div>
+    <div class="absolute inset-0 flex items-start justify-center pt-6 px-4">
+      <div class="dv-card w-[560px] bg-white rounded-lg border border-slate-200 shadow-[0_24px_60px_-12px_rgba(15,23,42,0.25)] overflow-hidden">
+
+        <!-- modal header -->
+        <div class="h-11 px-4 border-b border-slate-200 flex items-center gap-2">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-slate-500" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>
+          <span class="text-[12.5px] font-medium text-slate-900">Create API key</span>
+          <span class="ml-auto w-7 h-7 rounded-md inline-flex items-center justify-center text-slate-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+          </span>
+        </div>
+
+        <!-- modal body -->
+        <div class="px-5 py-3.5 space-y-3.5">
+          <!-- Name field -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-[11px] uppercase tracking-[0.14em] text-slate-500 font-medium">Name</span>
+            </div>
+            <div class="w-full h-8 px-2.5 rounded-md border border-sky-400 ring-1 ring-sky-200 bg-white flex items-center">
+              <span class="text-[12.5px] text-slate-900">Staging</span>
+              <span class="dv-caret ml-px w-px h-3.5 bg-sky-500"></span>
+            </div>
+            <p class="text-[10.5px] text-slate-400 mt-1 leading-relaxed">Shown in the dashboard. e.g. production-server, ci-pipeline.</p>
+          </div>
+
+          <!-- Permissions: preset cards + matrix -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-[11px] uppercase tracking-[0.14em] text-slate-500 font-medium">Permissions</span>
+            </div>
+            <!-- preset cards -->
+            <div class="grid grid-cols-3 gap-1.5 mb-2">
+              <div class="relative text-left rounded-md border px-2.5 py-2 border-sky-400 bg-sky-50/60">
+                <div class="flex items-center gap-1.5 mb-0.5">
+                  <span class="text-sky-600"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/></svg></span>
+                  <span class="text-[11.5px] font-medium text-sky-900">Read-only</span>
+                </div>
+                <p class="text-[10.5px] text-slate-500">View everything</p>
+              </div>
+              <div class="relative text-left rounded-md border px-2.5 py-2 border-slate-200 bg-white">
+                <div class="flex items-center gap-1.5 mb-0.5">
+                  <span class="text-slate-500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg></span>
+                  <span class="text-[11.5px] font-medium text-slate-900">Full access</span>
+                </div>
+                <p class="text-[10.5px] text-slate-500">Read + write</p>
+              </div>
+              <div class="relative text-left rounded-md border px-2.5 py-2 border-slate-200 bg-white">
+                <div class="flex items-center gap-1.5 mb-0.5">
+                  <span class="text-slate-500"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" x2="4" y1="21" y2="14"/><line x1="4" x2="4" y1="10" y2="3"/><line x1="12" x2="12" y1="21" y2="12"/><line x1="12" x2="12" y1="8" y2="3"/><line x1="20" x2="20" y1="21" y2="16"/><line x1="20" x2="20" y1="12" y2="3"/><line x1="1" x2="7" y1="14" y2="14"/><line x1="9" x2="15" y1="8" y2="8"/><line x1="17" x2="23" y1="16" y2="16"/></svg></span>
+                  <span class="text-[11.5px] font-medium text-slate-900">Custom</span>
+                </div>
+                <p class="text-[10.5px] text-slate-500">Pick scopes</p>
+              </div>
+            </div>
+            <!-- PermissionMatrix: grouped checkbox rows (read [checked], write [checked], special) -->
+            <div class="rounded-md border border-slate-200 divide-y divide-slate-200/60 max-h-[148px] overflow-hidden">
+              <!-- read group -->
+              <div>
+                <div class="px-2.5 py-1.5 bg-slate-50/60 text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium">read</div>
+                <div>
+                  <div class="w-full px-2.5 py-1.5 flex items-center gap-2 text-left">
+                    <span class="w-3.5 h-3.5 rounded border border-sky-600 bg-sky-600 text-white flex items-center justify-center shrink-0">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </span>
+                    <span class="font-mono text-[11px] text-slate-900">READ_CAMPAIGNS</span>
+                    <span class="text-[10.5px] text-slate-500 truncate">View campaigns and sequences</span>
+                  </div>
+                  <div class="w-full px-2.5 py-1.5 flex items-center gap-2 text-left">
+                    <span class="w-3.5 h-3.5 rounded border border-sky-600 bg-sky-600 text-white flex items-center justify-center shrink-0">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </span>
+                    <span class="font-mono text-[11px] text-slate-900">READ_CONTACTS</span>
+                    <span class="text-[10.5px] text-slate-500 truncate">View contact lists, notes, and activities</span>
+                  </div>
+                </div>
+              </div>
+              <!-- write group -->
+              <div>
+                <div class="px-2.5 py-1.5 bg-slate-50/60 text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium">write</div>
+                <div>
+                  <div class="w-full px-2.5 py-1.5 flex items-center gap-2 text-left">
+                    <span class="w-3.5 h-3.5 rounded border border-sky-600 bg-sky-600 text-white flex items-center justify-center shrink-0">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </span>
+                    <span class="font-mono text-[11px] text-slate-900">WRITE_CAMPAIGNS</span>
+                    <span class="text-[10.5px] text-slate-500 truncate">Create and modify campaigns and sequences</span>
+                  </div>
+                  <div class="w-full px-2.5 py-1.5 flex items-center gap-2 text-left">
+                    <span class="w-3.5 h-3.5 rounded border border-slate-300 bg-white shrink-0"></span>
+                    <span class="font-mono text-[11px] text-slate-900">SEND_CAMPAIGNS</span>
+                    <span class="text-[10.5px] text-slate-500 truncate">Start and stop campaigns (sends real mail)</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Expires pills -->
+          <div>
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-[11px] uppercase tracking-[0.14em] text-slate-500 font-medium">Expires</span>
+            </div>
+            <div class="flex items-center gap-1">
+              <span class="h-7 px-3 rounded-md text-[11.5px] bg-slate-900 text-white inline-flex items-center">Never</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">30 days</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">90 days</span>
+              <span class="h-7 px-3 rounded-md text-[11.5px] border border-slate-200 text-slate-600 inline-flex items-center">365 days</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- modal footer -->
+        <div class="h-12 px-4 border-t border-slate-200 flex items-center gap-2 bg-slate-50/40">
+          <span class="text-[11px] text-slate-500 inline-flex items-center gap-1.5">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="11" x="3" y="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+            The secret will be shown once. Save it somewhere safe.
+          </span>
+          <div class="ml-auto flex items-center gap-1.5">
+            <span class="h-7 px-3 rounded-md border border-slate-200 text-[12px] text-slate-700 inline-flex items-center">Cancel</span>
+            <!-- modal Create key (press #2 target) -->
+            <span id="dv-modal-create" class="h-7 px-3 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>
+              Create key
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- (a) cursor -->
+  <div class="dv-cursor" aria-hidden="true">
+    <span class="dv-ripple"></span>
+    <svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg>
+  </div>
+
+  <!-- (c) demo-scene styles -->
+  <style>
+    .dv-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:dv-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .dv-cursor svg{display:block;transform-origin:3px 2px;animation:dv-press 11s ease-in-out infinite;}
+    .dv-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:dv-rip 11s ease-out infinite;}
+    .dv-react{position:absolute;z-index:40;opacity:0;animation:dv-react 11s ease-out infinite;}
+    .dv-card{transform-origin:center;transform:scale(.94);animation:dv-card 11s ease-out infinite;}
+    .dv-caret{display:inline-block;animation:dv-blink 1s step-end infinite;}
+    /* press feedback on the two targets, synced to the cursor dips */
+    #dv-create{animation:dv-btn1 11s ease-out infinite;}
+    #dv-modal-create{animation:dv-btn2 11s ease-out infinite;}
+    @keyframes dv-move{0%{left:30%;top:60%}22%{left:48%;top:4%}32%{left:48%;top:4%}58%{left:73%;top:89%}68%{left:73%;top:89%}88%{left:30%;top:60%}100%{left:30%;top:60%}}
+    @keyframes dv-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes dv-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes dv-react{0%,29%{opacity:0}33%{opacity:1}88%{opacity:1}95%{opacity:0}100%{opacity:0}}
+    @keyframes dv-card{0%,29%{transform:scale(.94)}33%{transform:scale(1)}88%{transform:scale(1)}95%{transform:scale(.94)}100%{transform:scale(.94)}}
+    @keyframes dv-btn1{0%,27%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}28%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,.9)}31%,100%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}}
+    @keyframes dv-btn2{0%,63%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}64%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,.9)}67%,100%{background-color:#0284c7;box-shadow:0 0 0 0 rgba(186,230,253,0)}}
+    @keyframes dv-blink{0%,49%{opacity:1}50%,100%{opacity:0}}
+    @media (prefers-reduced-motion: reduce){.dv-cursor{display:none}.dv-react{display:none}}
+  </style>
+</div>

--- a/site/src/components/FeatureSection.astro
+++ b/site/src/components/FeatureSection.astro
@@ -1,0 +1,165 @@
+---
+import Icon from './Icon.astro';
+
+/**
+ * One feature showcase section: marketing copy on one side, a pixel-faithful
+ * product window (mock) floating on the other. Each mock is authored at a fixed
+ * DESIGN width (1080px) and uniformly scaled to fit its column by a tiny
+ * ResizeObserver, so it looks identical on every device (just smaller) with no
+ * reflow, no overlap, and the demo cursor always lands on the right control.
+ */
+interface Callout { label: string; text: string }
+interface Props {
+  eyebrow: string;
+  title: string;
+  description: string;
+  callouts?: Callout[];
+  cta?: { text: string; href: string };
+  side?: 'left' | 'right';
+  bg?: 'sky' | 'light' | 'navy' | 'wallpaper';
+  url: string;
+  cursor?: 'a' | 'b' | 'c' | 'd';
+  id?: string;
+}
+const {
+  eyebrow, title, description, callouts = [], cta,
+  side = 'right', bg = 'sky', url, id,
+} = Astro.props;
+
+const lightText = bg !== 'light';
+
+const bgStyle: Record<string, string> = {
+  sky: 'background: radial-gradient(ellipse 130% 120% at 50% -10%, #38bdf8 0%, #0ea5e9 34%, #0284c7 68%, #0369a1 100%);',
+  light: 'background: linear-gradient(180deg, #ffffff 0%, #f5f8fc 100%);',
+  navy: 'background: radial-gradient(ellipse 110% 90% at 50% -10%, #143a63 0%, #0e2545 38%, #0a1730 68%, #070d1c 100%);',
+  wallpaper: 'background: radial-gradient(78% 95% at 15% 6%, #38bdf8 0%, #1d4ed8 42%, rgba(29,78,216,0) 72%), linear-gradient(120deg, #1e40af 0%, #1d4ed8 48%, #172554 100%);',
+};
+
+const ringClass = bg === 'light' ? 'ring-slate-200/80' : 'ring-white/60';
+const frameShadow =
+  bg === 'navy'
+    ? 'box-shadow: 0 50px 100px -30px rgba(2,132,199,0.55), 0 8px 24px -12px rgba(0,0,0,0.4);'
+    : 'box-shadow: 0 44px 90px -32px rgba(2,132,199,0.45);';
+
+const eyebrowColor = lightText ? 'text-white/60' : 'text-sky-600';
+const titleColor = lightText ? 'text-white' : 'text-slate-900';
+const bodyColor = lightText ? 'text-white/75' : 'text-slate-600';
+const calloutLabel = lightText ? 'text-white' : 'text-slate-900';
+const calloutText = lightText ? 'text-white/65' : 'text-slate-500';
+
+const slash = url.indexOf('/');
+const urlDomain = slash === -1 ? url : url.slice(0, slash);
+const urlPath = slash === -1 ? '' : url.slice(slash);
+
+const copyOrder = side === 'left' ? 'lg:order-2' : 'lg:order-1';
+const mockOrder = side === 'left' ? 'lg:order-1' : 'lg:order-2';
+---
+<section id={id} class="relative isolate overflow-hidden" style={bgStyle[bg]}>
+  {bg === 'sky' && (
+    <>
+      <div class="absolute inset-0 pointer-events-none" style="opacity:0.5; background: radial-gradient(ellipse 120% 100% at 50% -10%, rgba(224,242,254,0.7) 0%, rgba(125,211,252,0.28) 30%, transparent 62%);"></div>
+      <img src="/backdrops/cloud-4.webp" alt="" aria-hidden="true" class="absolute -top-12 -left-16 w-[480px] opacity-[0.22] pointer-events-none select-none cloud-drift cloud-1" loading="lazy" decoding="async" style="mix-blend-mode: screen;" />
+    </>
+  )}
+  {bg === 'wallpaper' && (
+    <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(55% 55% at 16% 12%, rgba(255,255,255,0.22) 0%, transparent 60%), radial-gradient(50% 60% at 88% 92%, rgba(99,102,241,0.4) 0%, transparent 65%);"></div>
+  )}
+  {bg === 'navy' && (
+    <div class="absolute inset-0 pointer-events-none" style="background: radial-gradient(60% 50% at 78% 8%, rgba(56,189,248,0.16) 0%, transparent 60%);"></div>
+  )}
+
+  <div class="container-wide relative py-16 md:py-24">
+    <div class="grid lg:grid-cols-12 gap-10 lg:gap-14 items-center">
+      <!-- COPY -->
+      <div class={`lg:col-span-5 ${copyOrder}`}>
+        <div class={`text-[11px] uppercase tracking-[0.18em] font-mono mb-3 ${eyebrowColor}`}>{eyebrow}</div>
+        <h2 class={`text-[28px] md:text-[40px] font-semibold tracking-[-0.025em] leading-[1.07] ${titleColor}`}>{title}</h2>
+        <p class={`mt-5 text-[15.5px] leading-relaxed max-w-xl ${bodyColor}`}>{description}</p>
+
+        {callouts.length > 0 && (
+          <div class="mt-7 space-y-4 max-w-md">
+            {callouts.map((c) => (
+              <div class="flex gap-3">
+                <span class={`mt-[7px] h-1.5 w-1.5 rounded-full shrink-0 ${lightText ? 'bg-sky-300' : 'bg-sky-500'}`}></span>
+                <div>
+                  <div class={`text-[13px] font-semibold ${calloutLabel}`}>{c.label}</div>
+                  <div class={`text-[13px] leading-relaxed mt-0.5 ${calloutText}`}>{c.text}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {cta && (
+          <a href={cta.href}
+             class={`mt-8 inline-flex items-center gap-1.5 text-[13.5px] font-medium pb-px border-b ${lightText ? 'text-white border-white/30 hover:border-white' : 'text-slate-900 border-slate-900/30 hover:border-slate-900'}`}>
+            {cta.text}
+            <Icon name="arrowUpRight" size={13} />
+          </a>
+        )}
+      </div>
+
+      <!-- PRODUCT WINDOW -->
+      <div class={`lg:col-span-7 ${mockOrder} min-w-0`}>
+        <div class={`feature-window showcase-frame relative rounded-[14px] overflow-hidden bg-white ring-1 ${ringClass}`} style={frameShadow}>
+          <!-- browser chrome -->
+          <div class="flex items-center gap-2.5 px-3 h-11 border-b border-slate-200/80 bg-gradient-to-b from-[#f7f8fa] to-[#eceef1]">
+            <div class="flex items-center gap-2 shrink-0">
+              <span class="w-3 h-3 rounded-full bg-[#ff5f57]"></span>
+              <span class="w-3 h-3 rounded-full bg-[#febc2e]"></span>
+              <span class="w-3 h-3 rounded-full bg-[#28c840]"></span>
+            </div>
+            <div class="hidden sm:flex items-center gap-1 shrink-0 text-slate-400">
+              <span class="grid place-items-center w-6 h-6 rounded-md hover:bg-slate-200/60">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+              </span>
+              <span class="grid place-items-center w-6 h-6 rounded-md text-slate-300">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+              </span>
+            </div>
+            <div class="flex-1 min-w-0 flex items-center gap-2 h-7 px-3 rounded-lg bg-white ring-1 ring-slate-200/90 text-[12px] shadow-[inset_0_1px_2px_rgba(15,23,42,0.04)]">
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" class="text-emerald-500 shrink-0"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
+              <span class="truncate font-medium text-slate-700">{urlDomain}<span class="text-slate-400 font-normal">{urlPath}</span></span>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ml-auto shrink-0 text-slate-300"><path d="M21 12a9 9 0 1 1-2.64-6.36"/><polyline points="21 3 21 9 15 9"/></svg>
+            </div>
+            <div class="hidden sm:flex items-center gap-2.5 shrink-0 text-slate-300">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg>
+            </div>
+          </div>
+
+          <!-- scale-to-fit screen: authored at 1080px, scaled to the column on every device -->
+          <div class="feat-fit relative w-full overflow-hidden bg-white min-h-[240px]">
+            <div class="feat-screen absolute top-0 left-0 origin-top-left" style="width:900px;">
+              <slot />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<script>
+  // Uniformly scale every fixed-width mock screen to fit its column. Runs on
+  // load + resize so the showcase is correct on every device width.
+  const DESIGN = 900;
+  function fit(screen: HTMLElement) {
+    const box = screen.parentElement as HTMLElement | null;
+    if (!box) return;
+    const s = box.clientWidth / DESIGN;
+    screen.style.transform = `scale(${s})`;
+    box.style.height = `${screen.offsetHeight * s}px`;
+  }
+  function init() {
+    document.querySelectorAll<HTMLElement>('.feat-screen').forEach((screen) => {
+      const run = () => fit(screen);
+      run();
+      requestAnimationFrame(run);
+      if (screen.parentElement) new ResizeObserver(run).observe(screen.parentElement);
+    });
+    window.addEventListener('load', () =>
+      document.querySelectorAll<HTMLElement>('.feat-screen').forEach((s) => fit(s)),
+    );
+  }
+  init();
+</script>

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -82,7 +82,7 @@ function active(match?: string) {
   <div class="container-page flex h-14 items-center gap-6">
     <Wordmark size="md" />
 
-    <nav class="hidden md:flex items-center gap-1 ml-2 relative">
+    <nav class="hidden lg:flex items-center gap-1 ml-2 relative">
       {nav.map((n) => (
         n.mega ? (
           <div class="mega-wrapper relative" data-mega>
@@ -209,11 +209,12 @@ function active(match?: string) {
       <button
         id="nav-toggle"
         class={
-          'md:hidden inline-flex h-8 w-8 items-center justify-center rounded-md ' +
+          'lg:hidden inline-flex h-8 w-8 items-center justify-center rounded-md ' +
           (onSky ? 'cta-ghost' : 'text-muted-foreground hover:text-foreground hover:bg-surface-2')
         }
-        aria-label="Toggle navigation"
+        aria-label="Open navigation"
         aria-expanded="false"
+        aria-controls="mobile-nav"
       >
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
           <line x1="4" y1="7" x2="20" y2="7" />
@@ -223,28 +224,60 @@ function active(match?: string) {
       </button>
     </div>
   </div>
+</header>
 
-  <div id="mobile-nav" class="hidden md:hidden border-t border-border bg-background">
-    <div class="container-page py-3 grid gap-1">
-      {nav.map((n) => (
-        <a
-          href={n.href}
-          class={
-            'h-9 px-2 inline-flex items-center rounded-md text-sm ' +
-            (active(n.match)
-              ? 'text-foreground bg-surface-2'
-              : 'text-muted-foreground hover:text-foreground hover:bg-surface-2/60')
-          }
-        >
-          {n.label}
-        </a>
+<!-- Full-screen mobile menu (outside <header> so fixed positioning is viewport-relative,
+     not clipped by the header's backdrop-filter containing block) -->
+<div
+    id="mobile-nav"
+    class="mobile-menu fixed inset-0 z-[60] lg:hidden flex flex-col bg-white text-slate-900"
+    aria-hidden="true"
+  >
+    <div class="container-page flex h-14 items-center shrink-0 border-b border-slate-200/70">
+      <a href="/" class="inline-flex items-center gap-2.5 text-slate-900">
+        <svg viewBox="0 0 746 764" class="w-6 h-6" fill="currentColor" aria-hidden="true"><path d="M222.805 644.772L186.274 108.881L704.5 451.158L484.5 451.158L245.5 196.158L444 463.5L222.805 644.772Z"/></svg>
+        <span class="font-extrabold tracking-tight text-[15.5px]">Warmbly</span>
+      </a>
+      <button id="nav-close" class="ml-auto inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 transition-colors" aria-label="Close navigation">
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18"/><line x1="18" y1="6" x2="6" y2="18"/></svg>
+      </button>
+    </div>
+
+    <nav class="container-page flex-1 overflow-y-auto py-2">
+      {nav.map((n, i) => (
+        n.mega ? (
+          <div class="mobile-link border-b border-slate-100" style={`--i:${i}`}>
+            <button type="button" class="acc-trigger w-full flex items-center justify-between py-4 text-[19px] font-medium text-slate-900" aria-expanded="false">
+              <span>{n.label}</span>
+              <svg class="acc-caret text-slate-400" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+            </button>
+            <div class="acc-panel">
+              <div>
+                <div class="pb-3 flex flex-col">
+                  {(n.megaItems ?? []).map((it) => (
+                    <a href={it.href} class="flex flex-col py-2 pl-1 pr-2 rounded-md hover:bg-slate-50">
+                      <span class="text-[15px] font-medium text-slate-800">{it.title}</span>
+                      <span class="text-[12.5px] text-slate-400 leading-snug">{it.desc.split('.')[0]}.</span>
+                    </a>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <a href={n.href} class="mobile-link group flex items-center justify-between py-4 border-b border-slate-100 text-[19px] font-medium text-slate-900" style={`--i:${i}`}>
+            <span>{n.label}</span>
+            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-300 group-hover:text-slate-500 transition-colors"><path d="M9 18l6-6-6-6"/></svg>
+          </a>
+        )
       ))}
-      <div class="h-px bg-border my-2" />
-      <a href="https://app.warmbly.com/login" class="h-9 px-2 inline-flex items-center rounded-md text-sm text-muted-foreground hover:text-foreground hover:bg-surface-2">Log in</a>
-      <a href="https://app.warmbly.com/register" class="h-9 px-2 inline-flex items-center rounded-md text-sm font-medium text-background bg-foreground">Start free</a>
+    </nav>
+
+    <div class="container-page py-5 shrink-0 flex flex-col gap-2.5 border-t border-slate-200/70">
+      <a href="https://app.warmbly.com/login" class="h-12 inline-flex items-center justify-center rounded-[11px] border border-slate-200 text-slate-700 text-[15px] font-medium hover:bg-slate-50 transition-colors">Log in</a>
+      <a href="https://app.warmbly.com/register" class="h-12 inline-flex items-center justify-center rounded-[11px] bg-foreground text-background text-[15px] font-medium hover:bg-foreground/85 transition-colors">Start free</a>
     </div>
   </div>
-</header>
 
 <style>
   /* Mega panel: only fade opacity to keep bounds stable while open */
@@ -263,19 +296,90 @@ function active(match?: string) {
     height: 24px;
   }
   .mega-wrapper.open .mega-caret { transform: rotate(180deg); }
+
+  /* Full-screen mobile menu: animates open AND closed. Display is toggled by
+     JS via .is-visible; .is-open drives the fade + slide so both run. */
+  .mobile-menu {
+    display: none;
+    opacity: 0;
+    transform: translateY(-10px);
+    transition: opacity 220ms ease, transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+  .mobile-menu.is-visible { display: flex; }
+  .mobile-menu.is-open { opacity: 1; transform: translateY(0); }
+
+  /* staggered link entrance */
+  .mobile-menu .mobile-link { opacity: 0; transform: translateY(14px); transition: opacity 180ms ease; }
+  .mobile-menu.is-open .mobile-link {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 380ms ease, transform 460ms cubic-bezier(0.22, 1, 0.36, 1);
+    transition-delay: calc(70ms + var(--i, 0) * 48ms);
+  }
+
+  /* accordion: collapsed by default, expands on click via grid-rows */
+  .acc-panel { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 300ms cubic-bezier(0.22, 1, 0.36, 1); }
+  .acc-panel.open { grid-template-rows: 1fr; }
+  .acc-panel > div { overflow: hidden; }
+  .acc-caret { transition: transform 240ms ease; }
+  .acc-trigger[aria-expanded="true"] .acc-caret { transform: rotate(180deg); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .mobile-menu, .mobile-menu .mobile-link, .acc-panel, .acc-caret { transition: none; }
+  }
 </style>
 
 <script is:inline>
   (function () {
-    // Mobile nav toggle
+    // Full-screen mobile menu
     var toggle = document.getElementById('nav-toggle');
     var menu = document.getElementById('mobile-nav');
-    if (toggle) {
-      toggle.addEventListener('click', function () {
-        var open = menu && menu.classList.toggle('hidden') === false;
-        toggle.setAttribute('aria-expanded', String(!!open));
+    var closeBtn = document.getElementById('nav-close');
+    var closeTimer = null;
+    function openMenu() {
+      if (!menu) return;
+      if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+      menu.classList.add('is-visible');
+      void menu.offsetWidth; // reflow so the open transition runs from the hidden state
+      menu.classList.add('is-open');
+      menu.setAttribute('aria-hidden', 'false');
+      if (toggle) toggle.setAttribute('aria-expanded', 'true');
+      document.documentElement.style.overflow = 'hidden';
+    }
+    function closeMenu() {
+      if (!menu) return;
+      menu.classList.remove('is-open');
+      menu.setAttribute('aria-hidden', 'true');
+      if (toggle) toggle.setAttribute('aria-expanded', 'false');
+      document.documentElement.style.overflow = '';
+      if (closeTimer) clearTimeout(closeTimer);
+      closeTimer = setTimeout(function () {
+        menu.classList.remove('is-visible');
+        // reset accordions so the menu reopens clean
+        Array.prototype.forEach.call(menu.querySelectorAll('.acc-trigger'), function (b) { b.setAttribute('aria-expanded', 'false'); });
+        Array.prototype.forEach.call(menu.querySelectorAll('.acc-panel'), function (p) { p.classList.remove('open'); });
+      }, 340);
+    }
+    function setMenu(open) { open ? openMenu() : closeMenu(); }
+    if (toggle) toggle.addEventListener('click', function () { setMenu(!menu.classList.contains('is-open')); });
+    if (closeBtn) closeBtn.addEventListener('click', function () { setMenu(false); });
+    if (menu) {
+      // Accordion sections (Product / Use cases): collapsed by default, expand on tap.
+      Array.prototype.forEach.call(menu.querySelectorAll('.acc-trigger'), function (btn) {
+        btn.addEventListener('click', function () {
+          var panel = btn.nextElementSibling;
+          var open = btn.getAttribute('aria-expanded') === 'true';
+          btn.setAttribute('aria-expanded', String(!open));
+          if (panel) panel.classList.toggle('open', !open);
+        });
+      });
+      // Tapping a destination link closes the menu.
+      Array.prototype.forEach.call(menu.querySelectorAll('a'), function (a) {
+        a.addEventListener('click', function () { setMenu(false); });
       });
     }
+    document.addEventListener('keydown', function (e) { if (e.key === 'Escape') setMenu(false); });
+    window.addEventListener('resize', function () { if (window.innerWidth >= 1024) setMenu(false); });
 
     // Mega-menu — hover state driven by hit-testing the cursor against
     // both the trigger and the panel. Avoids the fixed-positioning

--- a/site/src/components/IntegrationsMock.astro
+++ b/site/src/components/IntegrationsMock.astro
@@ -1,0 +1,246 @@
+---
+/**
+ * Static, desktop-locked mock of the Warmbly /app/integrations screen.
+ *
+ * Faithful to the real source:
+ *   - web/src/app/app/integrations/page.tsx                       marketplace page (CatalogCard)
+ *   - web/src/components/layout/Page.tsx                          PageTopbar / StatStrip / Stat / SectionBar
+ *   - web/src/app/app/integrations/_components/ProviderGlyph.tsx  per-brand tinted glyph tile (BRAND map)
+ *   - web/src/app/app/integrations/_components/StatusPill.tsx     connected / configured pills (TONES map)
+ *   - web/src/app/app/integrations/_components/ConnectDrawer.tsx  trust copy + primary button styling
+ *   - web/src/components/ui/field.tsx                             SearchInput
+ *   - internal/app/integration/catalog.go                        provider names + taglines + auth methods
+ *
+ * Authored at a 900px design width and scaled by the page. DESKTOP-LOCKED:
+ * no responsive variants anywhere. Renders only the in-app content (no global
+ * sidebar / app header), since the marketing page wraps it in its own frame.
+ */
+
+// Per-brand glyph tints, mirroring ProviderGlyph.tsx BRAND (with mail-provider
+// + webhook + sheets tints that match the real theme tokens).
+const brand: Record<string, { bg: string; ring: string; text: string }> = {
+  gmail: { bg: 'bg-red-50', ring: 'ring-red-200', text: 'text-red-600' },
+  outlook: { bg: 'bg-sky-50', ring: 'ring-sky-200', text: 'text-sky-600' },
+  slack: { bg: 'bg-fuchsia-50', ring: 'ring-fuchsia-200', text: 'text-fuchsia-600' },
+  hubspot: { bg: 'bg-orange-50', ring: 'ring-orange-200', text: 'text-orange-600' },
+  salesforce: { bg: 'bg-sky-50', ring: 'ring-sky-200', text: 'text-sky-600' },
+  zapier: { bg: 'bg-orange-50', ring: 'ring-orange-200', text: 'text-orange-600' },
+  webhooks: { bg: 'bg-slate-100', ring: 'ring-slate-300', text: 'text-slate-700' },
+  sheets: { bg: 'bg-emerald-50', ring: 'ring-emerald-200', text: 'text-emerald-600' },
+};
+
+type Tile = {
+  key: string;
+  name: string;
+  initial: string;
+  tagline: string;
+  auth: string; // mono caption: one-click / api_key / webhook
+  state: 'connected' | 'configured' | 'connect';
+};
+
+const tiles: Tile[] = [
+  {
+    key: 'gmail', name: 'Gmail', initial: 'G',
+    tagline: 'Send and sync through your Google Workspace mailboxes.',
+    auth: 'one-click', state: 'connected',
+  },
+  {
+    key: 'outlook', name: 'Microsoft 365', initial: 'M',
+    tagline: 'Send and sync through Outlook and Exchange Online mailboxes.',
+    auth: 'one-click', state: 'connected',
+  },
+  {
+    key: 'slack', name: 'Slack', initial: 'S',
+    tagline: 'Real-time alerts for positive replies, bounces, and deliverability.',
+    auth: 'one-click', state: 'connect',
+  },
+  {
+    key: 'hubspot', name: 'HubSpot', initial: 'H',
+    tagline: 'Push positive replies and new leads straight into your CRM.',
+    auth: 'one-click', state: 'connect',
+  },
+  {
+    key: 'salesforce', name: 'Salesforce', initial: 'S',
+    tagline: 'Sync leads, contacts, and email activity to Salesforce.',
+    auth: 'one-click', state: 'connect',
+  },
+  {
+    key: 'zapier', name: 'Zapier', initial: 'Z',
+    tagline: 'Triggers and actions across 8,000+ apps.',
+    auth: 'api_key', state: 'connect',
+  },
+  {
+    key: 'webhooks', name: 'Webhooks', initial: 'W',
+    tagline: 'HMAC-signed event delivery to your own endpoint.',
+    auth: 'webhook', state: 'configured',
+  },
+  {
+    key: 'sheets', name: 'Google Sheets', initial: 'G',
+    tagline: 'On-demand lead sync from a spreadsheet into your contacts.',
+    auth: 'one-click', state: 'connect',
+  },
+];
+
+// StatStrip cells (mirror page.tsx: Available / Connected / Needs attention / Meetings).
+const stats = [
+  { label: 'Available', value: '8', sub: 'providers', accent: false, last: false },
+  { label: 'Connected', value: '3', sub: '3 total', accent: true, last: false },
+  { label: 'Needs attention', value: '0', sub: 'all healthy', accent: false, last: false },
+  { label: 'Meetings', value: '14', sub: 'booked via integrations', accent: false, last: true },
+];
+---
+<div class="relative w-full flex flex-col bg-white text-slate-900" style="min-height:500px;">
+
+  <!-- PageTopbar (h-12 px-5 border-b): eyebrow + divider + subtitle + search + refresh -->
+  <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Integrations</span>
+    <div class="h-4 w-px bg-slate-200"></div>
+    <span class="text-[12.5px] text-slate-600 truncate">
+      Connect your stack: CRMs, alerts, automation, meetings, and data
+    </span>
+    <div class="ml-auto flex items-center gap-1.5">
+      <!-- SearchInput (w-48, h-7, hairline, sky focus) -->
+      <div class="w-48 flex h-7 pl-2 pr-1 rounded-md border border-slate-200 bg-white items-center gap-1.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400 shrink-0" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <span class="flex-1 min-w-0 text-[12.5px] text-slate-400">Search integrations</span>
+      </div>
+      <!-- Refresh -->
+      <button class="h-7 w-7 rounded-md border border-slate-200 text-slate-500 inline-flex items-center justify-center" aria-label="Refresh">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M3 21v-5h5"/></svg>
+      </button>
+    </div>
+  </div>
+
+  <!-- StatStrip (4 cols, vertical-rule dividers, bottom hairline) -->
+  <div class="grid grid-cols-4 border-b border-slate-200 shrink-0 bg-white">
+    {stats.map((s) => (
+      <div class={`px-5 py-4 ${!s.last ? 'border-r border-slate-200' : ''}`}>
+        <div class="flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{s.label}</span>
+          {s.accent && <span class="size-1.5 rounded-full bg-sky-500 animate-pulse"></span>}
+        </div>
+        <div class="text-[26px] text-slate-900 font-light leading-none mt-2 tabular-nums">{s.value}</div>
+        <div class="text-[10px] text-slate-400 mt-1.5 font-mono truncate">{s.sub}</div>
+      </div>
+    ))}
+  </div>
+
+  <!-- SectionBar (h-9, lighter divider): directory label + count + trust note -->
+  <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">App directory</span>
+    <span class="font-mono text-[10.5px] text-slate-400 tabular-nums">8</span>
+    <div class="ml-auto inline-flex items-center gap-1.5 text-[10.5px] text-slate-400">
+      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/></svg>
+      <span>OAuth tokens encrypted at rest. Webhooks HMAC-signed.</span>
+    </div>
+  </div>
+
+  <!-- Tile grid (grid-cols-3 gap-3 p-5) -->
+  <div class="grid grid-cols-3 gap-3 p-5">
+    {tiles.map((t) => {
+      const b = brand[t.key] ?? { bg: 'bg-sky-50', ring: 'ring-sky-100', text: 'text-sky-700' };
+      const isSlack = t.key === 'slack';
+      return (
+        <div class={`relative rounded-lg border bg-white p-4 flex flex-col ${isSlack ? 'ig-slack-tile border-slate-200' : 'border-slate-200'}`}>
+          <!-- top row: glyph + name/auth + status -->
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex items-center gap-2.5 min-w-0">
+              <div class={`w-9 h-9 text-[13px] rounded-md ring-1 inline-flex items-center justify-center font-semibold uppercase shrink-0 ${b.bg} ${b.ring} ${b.text}`}>{t.initial}</div>
+              <div class="min-w-0">
+                <div class="text-[13px] font-semibold text-slate-900 truncate">{t.name}</div>
+                <div class="text-[10px] uppercase tracking-[0.08em] text-slate-400 font-mono">{t.auth}</div>
+              </div>
+            </div>
+            {t.state === 'connected' && (
+              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700">
+                <span class="size-1.5 rounded-full bg-emerald-500"></span>
+                connected
+              </span>
+            )}
+            {t.state === 'configured' && (
+              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-sky-50 text-sky-700">
+                <span class="size-1.5 rounded-full bg-sky-500"></span>
+                configured
+              </span>
+            )}
+          </div>
+
+          <!-- one-line tagline -->
+          <p class="mt-3 text-[12px] text-slate-600 leading-relaxed line-clamp-2">{t.tagline}</p>
+
+          <!-- bottom row: docs link + action -->
+          <div class="mt-auto pt-3 flex items-center justify-between gap-2">
+            <span class="text-[11px] text-slate-400 inline-flex items-center gap-1 underline decoration-dotted underline-offset-2">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
+              Docs
+            </span>
+
+            {t.state === 'connect' && !isSlack && (
+              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white">
+                Connect
+              </span>
+            )}
+            {t.state === 'configured' && (
+              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 text-slate-600">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
+                Manage
+              </span>
+            )}
+            {isSlack && (
+              <span class="relative inline-flex items-center justify-end" style="min-width:78px;height:28px;">
+                <!-- default Slack Connect button (presses, then fades to the pill) -->
+                <span class="ig-slack-connect absolute right-0 h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white">
+                  Connect
+                </span>
+                <!-- reaction: emerald Connected pill revealed after press #1 -->
+                <span class="ig-react absolute right-0 inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700" style="top:50%;margin-top:-10px;">
+                  <span class="size-1.5 rounded-full bg-emerald-500"></span>
+                  connected
+                </span>
+              </span>
+            )}
+          </div>
+        </div>
+      );
+    })}
+  </div>
+
+  <!-- Demo scene: cursor presses Slack Connect (press #1) then the toast area
+       (press #2). The Slack tile flips to a Connected pill and a bottom-right
+       toast confirms. 11s loop. -->
+
+  <!-- cursor -->
+  <div class="ig-cursor" aria-hidden="true">
+    <span class="ig-ripple"></span>
+    <svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg>
+  </div>
+
+  <!-- bottom-right toast (reaction) -->
+  <div class="ig-react" style="right:4%;bottom:5%;" aria-hidden="true">
+    <span class="inline-flex items-center gap-1.5 h-8 pl-2 pr-3 rounded-md bg-white border border-slate-200 shadow-md text-[12px] font-medium text-slate-700">
+      <span class="size-4 rounded-full bg-emerald-50 text-emerald-600 inline-flex items-center justify-center">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+      </span>
+      Slack connected
+    </span>
+  </div>
+
+  <style>
+    .ig-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:ig-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .ig-cursor svg{display:block;transform-origin:3px 2px;animation:ig-press 11s ease-in-out infinite;}
+    .ig-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:ig-rip 11s ease-out infinite;}
+    .ig-react{position:absolute;z-index:40;opacity:0;animation:ig-react 11s ease-out infinite;}
+    /* Slack Connect button: active dip in sync with press #1, then fade out so the pill shows through. */
+    .ig-slack-connect{animation:ig-slack-btn 11s ease-out infinite;}
+    .ig-slack-tile{animation:ig-slack-ring 11s ease-out infinite;}
+    @keyframes ig-move{0%{left:18%;top:30%}22%{left:54.5%;top:51%}32%{left:54.5%;top:51%}58%{left:86%;top:88%}68%{left:86%;top:88%}88%{left:18%;top:30%}100%{left:18%;top:30%}}
+    @keyframes ig-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes ig-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes ig-react{0%,29%{opacity:0;transform:translateY(8px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(8px)}100%{opacity:0;transform:translateY(8px)}}
+    /* Connect button darkens at the press, then disappears once the pill is revealed. */
+    @keyframes ig-slack-btn{0%,27%{background-color:#0284c7;opacity:1}28%{background-color:#0369a1;opacity:1}30%{background-color:#0369a1;opacity:1}33%{opacity:0}88%{opacity:0}95%{background-color:#0284c7;opacity:1}100%{background-color:#0284c7;opacity:1}}
+    /* Slack tile briefly rings sky at the press to sell the click. */
+    @keyframes ig-slack-ring{0%,27%{box-shadow:0 0 0 0 rgba(186,230,253,0)}28%{box-shadow:0 0 0 2px rgba(186,230,253,1)}33%{box-shadow:0 0 0 2px rgba(186,230,253,1)}40%{box-shadow:0 0 0 0 rgba(186,230,253,0)}100%{box-shadow:0 0 0 0 rgba(186,230,253,0)}}
+    @media (prefers-reduced-motion: reduce){.ig-cursor{display:none}.ig-react{opacity:1;transform:none}.ig-slack-connect{display:none}.ig-slack-tile{box-shadow:none}}
+  </style>
+</div>

--- a/site/src/components/IntegrationsMock.astro
+++ b/site/src/components/IntegrationsMock.astro
@@ -152,13 +152,13 @@ const stats = [
               </div>
             </div>
             {t.state === 'connected' && (
-              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700">
+              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700 whitespace-nowrap shrink-0">
                 <span class="size-1.5 rounded-full bg-emerald-500"></span>
                 connected
               </span>
             )}
             {t.state === 'configured' && (
-              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-sky-50 text-sky-700">
+              <span class="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-sky-50 text-sky-700 whitespace-nowrap shrink-0">
                 <span class="size-1.5 rounded-full bg-sky-500"></span>
                 configured
               </span>
@@ -176,12 +176,12 @@ const stats = [
             </span>
 
             {t.state === 'connect' && !isSlack && (
-              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white">
+              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white whitespace-nowrap shrink-0">
                 Connect
               </span>
             )}
             {t.state === 'configured' && (
-              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 text-slate-600">
+              <span class="h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 text-slate-600 whitespace-nowrap shrink-0">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/></svg>
                 Manage
               </span>
@@ -189,11 +189,11 @@ const stats = [
             {isSlack && (
               <span class="relative inline-flex items-center justify-end" style="min-width:78px;height:28px;">
                 <!-- default Slack Connect button (presses, then fades to the pill) -->
-                <span class="ig-slack-connect absolute right-0 h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white">
+                <span class="ig-slack-connect absolute right-0 h-7 px-2.5 rounded-md text-[11.5px] font-medium inline-flex items-center gap-1 bg-sky-600 text-white whitespace-nowrap shrink-0">
                   Connect
                 </span>
                 <!-- reaction: emerald Connected pill revealed after press #1 -->
-                <span class="ig-react absolute right-0 inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700" style="top:50%;margin-top:-10px;">
+                <span class="ig-react absolute right-0 inline-flex items-center gap-1 h-5 px-1.5 rounded text-[9.5px] uppercase tracking-[0.08em] font-medium bg-emerald-50 text-emerald-700 whitespace-nowrap shrink-0" style="top:50%;margin-top:-10px;">
                   <span class="size-1.5 rounded-full bg-emerald-500"></span>
                   connected
                 </span>
@@ -217,7 +217,7 @@ const stats = [
 
   <!-- bottom-right toast (reaction) -->
   <div class="ig-react" style="right:4%;bottom:5%;" aria-hidden="true">
-    <span class="inline-flex items-center gap-1.5 h-8 pl-2 pr-3 rounded-md bg-white border border-slate-200 shadow-md text-[12px] font-medium text-slate-700">
+    <span class="inline-flex items-center gap-1.5 h-8 pl-2 pr-3 rounded-md bg-white border border-slate-200 shadow-md text-[12px] font-medium text-slate-700 whitespace-nowrap shrink-0">
       <span class="size-4 rounded-full bg-emerald-50 text-emerald-600 inline-flex items-center justify-center">
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
       </span>
@@ -233,7 +233,7 @@ const stats = [
     /* Slack Connect button: active dip in sync with press #1, then fade out so the pill shows through. */
     .ig-slack-connect{animation:ig-slack-btn 11s ease-out infinite;}
     .ig-slack-tile{animation:ig-slack-ring 11s ease-out infinite;}
-    @keyframes ig-move{0%{left:18%;top:30%}22%{left:54.5%;top:51%}32%{left:54.5%;top:51%}58%{left:86%;top:88%}68%{left:86%;top:88%}88%{left:18%;top:30%}100%{left:18%;top:30%}}
+    @keyframes ig-move{0%{left:24%;top:24%}22%{left:92%;top:46%}32%{left:92%;top:46%}58%{left:82%;top:91%}68%{left:82%;top:91%}88%{left:24%;top:24%}100%{left:24%;top:24%}}
     @keyframes ig-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes ig-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
     @keyframes ig-react{0%,29%{opacity:0;transform:translateY(8px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(8px)}100%{opacity:0;transform:translateY(8px)}}

--- a/site/src/components/OpenSourceShowcase.astro
+++ b/site/src/components/OpenSourceShowcase.astro
@@ -1,0 +1,233 @@
+---
+/**
+ * Big, information-rich open-source band after the changelog. Fills the full
+ * width: a hero (copy + facts left, live self-host terminal right), a row of
+ * real info cards (the actual services in the repo, how to contribute, how to
+ * self-host), and a links row. No fabricated metrics; everything here is true.
+ */
+const gh = '<path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.8 10.9.6.1.8-.2.8-.5v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.4-2.3 1.2-3.2-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.9.1 3.1.8.8 1.2 1.9 1.2 3.2 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.5 4.6-1.5 7.8-5.8 7.8-10.9C23.5 5.7 18.3.5 12 .5z"/>';
+const arrow = '<path d="M7 17 17 7M7 7h10v10"/>';
+
+const facts = [
+  { value: '100%', label: 'Open source' },
+  { value: 'Apache 2.0', label: 'Fork it, ship it' },
+  { value: '$0', label: 'To self-host' },
+  { value: 'Public', label: 'Roadmap and issues' },
+];
+
+const lines = [
+  { kind: 'cmd', text: 'git clone https://github.com/warmbly/warmbly.git' },
+  { kind: 'cmd', text: 'cd warmbly' },
+  { kind: 'cmd', text: 'make up', note: 'build images, boot the full stack' },
+  { kind: 'ok', text: 'Warmbly is live on http://localhost:8080' },
+  { kind: 'caret' },
+];
+
+const layers = [
+  { name: 'Backend API', tag: 'Go', desc: 'Control plane and business orchestration' },
+  { name: 'Consumer', tag: 'Go', desc: 'Turns Kafka events into platform state' },
+  { name: 'Workers', tag: 'Go', desc: 'Distributed sending and mailbox sync' },
+  { name: 'Tracking', tag: 'Rust', desc: 'Open and click pixel service' },
+  { name: 'Realtime', tag: 'Elixir', desc: 'Websocket fanout for live dashboards' },
+  { name: 'Dashboard & admin', tag: 'React', desc: 'The product UI and the admin console' },
+  { name: 'Marketing site', tag: 'Astro', desc: 'This very site you are reading' },
+];
+const contribute = [
+  { label: 'Browse good first issues', href: 'https://github.com/warmbly/warmbly/labels/good%20first%20issue' },
+  { label: 'Read the contributing guide', href: 'https://github.com/warmbly/warmbly/blob/main/CONTRIBUTING.md' },
+  { label: 'Follow the public roadmap', href: '/roadmap/' },
+  { label: 'Open a discussion or RFC', href: 'https://github.com/warmbly/warmbly/discussions' },
+];
+const selfhost = [
+  'Run on your own infra: Postgres, Redis, Kafka, S3, KMS',
+  'One make up command boots the whole stack',
+  'Or skip the ops and use our managed cloud',
+  'BYOK encryption and SSO on enterprise',
+];
+const links = [
+  { label: 'Docs', href: '/developers/' },
+  { label: 'Architecture', href: '/trust/' },
+  { label: 'Roadmap', href: '/roadmap/' },
+  { label: 'Changelog', href: '/changelog/' },
+  { label: 'Apache 2.0 license', href: 'https://github.com/warmbly/warmbly/blob/main/LICENSE' },
+];
+---
+<section class="relative isolate overflow-hidden text-white"
+         style="background: radial-gradient(ellipse 130% 130% at 50% -10%, #0ea5e9 0%, #0284c7 30%, #075985 62%, #0c2f4a 100%);">
+  <img src="/backdrops/cloud-4.webp" alt="" aria-hidden="true" class="absolute -top-16 -left-20 w-[560px] opacity-[0.18] pointer-events-none select-none cloud-drift cloud-1" loading="lazy" decoding="async" style="mix-blend-mode: screen;" />
+  <img src="/backdrops/cloud-5.webp" alt="" aria-hidden="true" class="absolute top-24 -right-16 w-[520px] opacity-[0.12] pointer-events-none select-none cloud-drift cloud-2" loading="lazy" decoding="async" style="mix-blend-mode: screen;" />
+
+  <div class="container-page relative py-20 md:py-28">
+    <!-- HERO: copy + facts left, terminal right -->
+    <div class="grid lg:grid-cols-12 gap-10 lg:gap-12 items-center">
+      <div class="lg:col-span-6">
+        <a href="https://github.com/warmbly/warmbly" target="_blank" rel="noopener noreferrer"
+           class="inline-flex items-center gap-2 h-7 pl-1 pr-3 rounded-full bg-white/10 backdrop-blur text-[12px] text-white/95">
+          <span class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded-full text-[10.5px] font-semibold uppercase tracking-[0.06em] bg-white text-[color:var(--sky-6)]">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" set:html={gh}></svg>
+            Open source
+          </span>
+          Apache 2.0
+        </a>
+        <h2 class="mt-6 text-[40px] md:text-[58px] font-semibold tracking-[-0.035em] leading-[1.02] text-white">
+          Read the code. Run it yourself.
+        </h2>
+        <p class="mt-5 text-[16px] md:text-[17.5px] text-white/80 leading-relaxed max-w-xl">
+          Read exactly how warmup, sending and deliverability really work, self-host the whole platform,
+          and send a pull request. Help us build the biggest open-source cold email and warmup platform.
+        </p>
+        <div class="mt-7 flex flex-wrap items-center gap-3">
+          <a href="https://github.com/warmbly/warmbly" target="_blank" rel="noopener noreferrer"
+             class="inline-flex h-11 px-5 items-center gap-2 rounded-[10px] text-[14.5px] font-medium text-[color:var(--sky-6)] bg-white hover:bg-white/95 transition-colors whitespace-nowrap shadow-[0_12px_30px_-12px_rgba(8,47,73,0.6)]">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" class="shrink-0" set:html={gh}></svg>
+            Star on GitHub
+          </a>
+          <a href="https://github.com/warmbly/warmbly/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer"
+             class="inline-flex h-11 px-5 items-center gap-2 rounded-[10px] text-[14.5px] font-medium text-white bg-white/[0.14] backdrop-blur hover:bg-white/20 transition-colors whitespace-nowrap">
+            Contributing guide
+          </a>
+        </div>
+        <div class="mt-9 grid grid-cols-2 sm:grid-cols-4 gap-y-6 gap-x-4">
+          {facts.map((f) => (
+            <div>
+              <div class="text-[24px] md:text-[30px] font-semibold tracking-[-0.02em] leading-none text-white">{f.value}</div>
+              <div class="mt-2 text-[10.5px] uppercase tracking-[0.14em] font-mono text-white/55">{f.label}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <!-- terminal -->
+      <div class="lg:col-span-6">
+        <div class="os-term w-full text-left rounded-[14px] overflow-hidden bg-[#0a1020]"
+             style="box-shadow: 0 40px 90px -30px rgba(8,47,73,0.75), 0 0 0 1px rgba(125,211,252,0.08);">
+          <div class="flex items-center gap-2 px-4 h-9 border-b border-black/20 bg-white/[0.04]">
+            <span class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></span>
+            <span class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></span>
+            <span class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></span>
+            <span class="ml-2 text-[11px] font-mono text-white/40">warmbly · self-host</span>
+          </div>
+          <div class="px-5 py-4 font-mono text-[12.5px] md:text-[13px] leading-[1.9]">
+            {lines.map((l, i) => (
+              <div class="os-line" style={`animation-delay: ${(-3 + i * 0.7).toFixed(2)}s`}>
+                {l.kind === 'cmd' && (
+                  <span>
+                    <span class="text-sky-400">$</span>
+                    <span class="text-white/90"> {l.text}</span>
+                    {l.note && <span class="text-white/35">  # {l.note}</span>}
+                  </span>
+                )}
+                {l.kind === 'ok' && (
+                  <span class="inline-flex items-center gap-2 text-emerald-300">
+                    <span class="relative inline-flex">
+                      <span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
+                      <span class="absolute inset-0 rounded-full bg-emerald-400/50 animate-ping"></span>
+                    </span>
+                    <span>{l.text}</span>
+                  </span>
+                )}
+                {l.kind === 'caret' && (
+                  <span><span class="text-sky-400">$</span> <span class="os-caret inline-block w-[8px] h-[15px] -mb-0.5 bg-sky-300"></span></span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- INFO CARDS (full width) -->
+    <div class="mt-14 grid md:grid-cols-3 gap-4">
+      <!-- card 1: every layer -->
+      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
+        <div class="flex items-center gap-2.5 mb-4">
+          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><path d="m12 2 9 4.9-9 4.9-9-4.9z"/><path d="m3 12 9 4.9 9-4.9"/><path d="m3 17 9 4.9 9-4.9"/></svg>
+          </span>
+          <h3 class="text-[14.5px] font-semibold text-white">Every layer is open</h3>
+        </div>
+        <ul class="space-y-2.5">
+          {layers.map((s) => (
+            <li class="flex items-start gap-2.5">
+              <span class="shrink-0 mt-0.5 inline-flex items-center h-4 px-1.5 rounded text-[9.5px] font-mono font-semibold uppercase tracking-[0.06em] bg-white/12 text-white/70">{s.tag}</span>
+              <span class="min-w-0">
+                <span class="text-[13px] font-medium text-white">{s.name}</span>
+                <span class="block text-[12px] text-white/55 leading-snug">{s.desc}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <!-- card 2: contribute -->
+      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
+        <div class="flex items-center gap-2.5 mb-4">
+          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+          </span>
+          <h3 class="text-[14.5px] font-semibold text-white">Made to contribute to</h3>
+        </div>
+        <ul class="space-y-1">
+          {contribute.map((c) => (
+            <li>
+              <a href={c.href} target={c.href.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer"
+                 class="group flex items-center gap-2 -mx-2 px-2 py-2 rounded-lg text-[13px] text-white/85 hover:bg-white/10 transition-colors">
+                <span class="flex-1">{c.label}</span>
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-white/40 group-hover:text-white/80 transition-colors" set:html={arrow}></svg>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <!-- card 3: self-host -->
+      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
+        <div class="flex items-center gap-2.5 mb-4">
+          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01M6 18h.01"/></svg>
+          </span>
+          <h3 class="text-[14.5px] font-semibold text-white">Run it your way</h3>
+        </div>
+        <ul class="space-y-2.5">
+          {selfhost.map((s) => (
+            <li class="flex items-start gap-2.5 text-[13px] text-white/80 leading-snug">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 text-sky-300"><polyline points="20 6 9 17 4 12"/></svg>
+              <span>{s}</span>
+            </li>
+          ))}
+        </ul>
+        <p class="mt-4 text-[12px] text-white/60 leading-relaxed">
+          Heads up: shared warmup pools only work with a large, vetted base of mailboxes, which a single
+          self-hosted instance usually will not have, so the shared pool is really only effective on our cloud.
+          Self-hosting still gives you the full sending, inbox and CRM stack.
+        </p>
+      </div>
+    </div>
+
+    <!-- links row -->
+    <div class="mt-12 flex flex-wrap items-center gap-x-6 gap-y-3 text-[13px]">
+      <span class="text-[11px] uppercase tracking-[0.18em] font-mono text-white/45">Built with Go · Rust · Elixir · React · Astro</span>
+      <span class="ml-auto flex flex-wrap items-center gap-x-5 gap-y-2">
+        {links.map((l) => (
+          <a href={l.href} target={l.href.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer"
+             class="text-white/70 hover:text-white transition-colors whitespace-nowrap">{l.label}</a>
+        ))}
+      </span>
+    </div>
+  </div>
+
+  <style>
+    .os-line { opacity: 0; transform: translateY(4px); animation: os-line 8s ease-in-out infinite; }
+    @keyframes os-line {
+      0%, 4%   { opacity: 0; transform: translateY(4px); }
+      9%, 90%  { opacity: 1; transform: translateY(0); }
+      97%, 100%{ opacity: 0; transform: translateY(4px); }
+    }
+    .os-caret { animation: os-caret 1s step-end infinite; }
+    @keyframes os-caret { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+    @media (prefers-reduced-motion: reduce) {
+      .os-line { opacity: 1; transform: none; animation: none; }
+      .os-caret { animation: none; }
+    }
+  </style>
+</section>

--- a/site/src/components/ScheduleMock.astro
+++ b/site/src/components/ScheduleMock.astro
@@ -1,0 +1,289 @@
+---
+/**
+ * Mock of /app/campaigns/[id]/schedule - the weekly sending-window editor.
+ * Faithful to the real screen:
+ *   - web/src/app/app/campaigns/[id]/schedule/page.tsx (hero card, presets, dates, save bar)
+ *   - web/src/components/app/campaigns/schedule/WeekScheduleGrid.tsx (the week grid + drag-to-create)
+ *
+ * Authored at a DESIGN WIDTH of 900px, desktop-locked (no responsive variants).
+ * The demo reaction reproduces the real beginDraw gesture: the cursor presses an
+ * empty weekend column near the 9am line and drags down to 5pm while a sending
+ * window grows from the press point, its bottom edge following the cursor.
+ */
+const DAY = 1440;
+const HOURS = [0, 3, 6, 9, 12, 15, 18, 21, 24];
+const ABBR = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+const todayIdx = 2; // Wed - illustrative
+
+// minutes since midnight; Mon=0..Sun=6 (display order, matches the real grid)
+const windows: { start: number; end: number }[][] = [
+  [{ start: 540, end: 720 }, { start: 780, end: 1020 }], // Mon 9-12, 1-5
+  [{ start: 540, end: 1020 }],                           // Tue 9-5
+  [{ start: 510, end: 720 }, { start: 840, end: 1080 }], // Wed 8:30-12, 2-6
+  [{ start: 540, end: 1020 }],                           // Thu 9-5
+  [{ start: 540, end: 900 }],                            // Fri 9-3
+  [],                                                    // Sat (empty - the drag target)
+  [],                                                    // Sun
+];
+
+const pct = (min: number) => `${(min / DAY) * 100}%`;
+const hourLabel = (h: number) => {
+  const hh = h % 24;
+  const ampm = hh < 12 ? 'a' : 'p';
+  const h12 = hh % 12 === 0 ? 12 : hh % 12;
+  return `${h12}${ampm}`;
+};
+const fmt = (min: number) => {
+  const h = Math.floor(min / 60);
+  const m = min % 60;
+  const ampm = h < 12 ? 'am' : 'pm';
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return m === 0 ? `${h12}${ampm}` : `${h12}:${String(m).padStart(2, '0')}${ampm}`;
+};
+
+const totalWindows = windows.reduce((s, d) => s + d.length, 0);
+const activeDays = windows.filter((d) => d.length > 0).length;
+
+const GUTTER = 46; // px (matches the real grid)
+const BODY_H = 360; // px
+
+// ── Reaction geometry (computed so the cursor + growing block land exactly
+// on the Sat column between 9am and 5pm). All values in px relative to the
+// mock root, then converted to % for the absolute overlay.
+const ROOT_W = 900;
+// The grid lives inside: card px-4 (16) -> grid section px-4 (16) -> GUTTER.
+const GRID_LEFT = 16 + 16; // card pad + section pad
+const COLS_LEFT = GRID_LEFT + GUTTER; // x where the 7 columns begin
+const COLS_W = ROOT_W - COLS_LEFT - GRID_LEFT; // available width for columns
+const COL_W = (COLS_W - 6) / 7; // 7 columns, 6 x 1px gaps
+const SAT_LEFT = COLS_LEFT + 5 * (COL_W + 1); // left x of the Sat column (index 5)
+
+// Vertical: the grid body top. Header chrome above the body:
+//   card header h-14 (56) + presets row (~41) + grid section pt-4 (16)
+//   + day headers row h-9 (36) = top of the grid body.
+const BODY_TOP = 56 + 41 + 16 + 36;
+const NINE = BODY_TOP + (540 / DAY) * BODY_H; // y of the 9am line
+const FIVE = BODY_TOP + (1020 / DAY) * BODY_H; // y of the 5pm line
+
+// Cursor / reaction anchor: centre of the Sat column. The growing window is
+// drawn from this anchor; vertical values stay in px so they track the layout
+// exactly regardless of total mock height.
+const cursorX = SAT_LEFT + COL_W / 2;
+const cursorXPct = (cursorX / ROOT_W) * 100;
+---
+<div class="relative w-full bg-white">
+  <!-- ── Hero scheduler card ─────────────────────────────────────────── -->
+  <section class="rounded-lg border border-slate-200 bg-white overflow-hidden">
+    <!-- header bar (h-14) -->
+    <div class="px-4 h-14 flex items-center gap-3 border-b border-slate-200/70">
+      <span class="size-7 rounded-md bg-sky-50 text-sky-600 inline-flex items-center justify-center shrink-0">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 14v2.2l1.6 1"/><path d="M16 2v4"/><path d="M21 7.5V6a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h6.5"/><path d="M3 10h5"/><path d="M8 2v4"/><circle cx="16" cy="16" r="6"/></svg>
+      </span>
+      <div class="min-w-0">
+        <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Weekly sending windows</div>
+        <p class="text-[12.5px] text-slate-700 leading-tight mt-0.5">
+          <span class="font-medium text-slate-900">{totalWindows}</span> windows across
+          <span class="font-medium text-slate-900">{activeDays}</span> days
+        </p>
+      </div>
+      <!-- timezone SelectButton -->
+      <div class="ml-auto shrink-0">
+        <button type="button" class="h-7 px-2 rounded-md border border-slate-200 bg-white text-slate-700 inline-flex items-center gap-1.5 text-[12px] font-medium">
+          <span class="text-slate-400 shrink-0">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"/><path d="M2 12h20"/></svg>
+          </span>
+          <span class="truncate max-w-[160px]">America/New York (EST)</span>
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="text-slate-400 shrink-0"><path d="M6 9l6 6 6-6"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- presets row -->
+    <div class="px-4 py-2.5 flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-slate-200/70 bg-slate-50/30">
+      <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mr-0.5">Presets</span>
+      {['Mon–Fri 9–5', 'Every day 9–5', 'Clear'].map((p) => (
+        <button type="button" class="h-7 px-2.5 rounded-md border border-slate-200 text-[11.5px] text-slate-600 whitespace-nowrap shrink-0">{p}</button>
+      ))}
+      <span class="ml-auto text-[11px] text-slate-400 block">Drag to add &middot; drag a block to move &middot; edges to resize &middot; &#x29C9; copies a day to all</span>
+    </div>
+
+    <!-- week grid -->
+    <div class="px-4 py-4">
+      <div class="min-w-[520px]">
+        <!-- day headers -->
+        <div class="flex">
+          <div style={`width:${GUTTER}px`} class="shrink-0"></div>
+          <div class="flex flex-1 gap-px">
+            {ABBR.map((d, i) => {
+              const active = windows[i].length > 0;
+              return (
+                <div class={`group/h relative flex-1 h-9 flex items-center justify-center rounded-t-md text-[11px] ${active ? 'text-sky-700 font-semibold bg-sky-50/60' : 'text-slate-400'}`}>
+                  {d}
+                  {i === todayIdx && <span class="absolute bottom-1 size-1 rounded-full bg-sky-500"></span>}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        <!-- grid body -->
+        <div class="relative select-none" style={`height:${BODY_H}px`}>
+          {HOURS.map((h) => (
+            <span class="absolute left-0 -translate-y-1/2 text-right text-[10px] text-slate-400 tabular-nums pr-2" style={`top:${pct(h * 60)}; width:${GUTTER}px`}>
+              {hourLabel(h)}
+            </span>
+          ))}
+          {HOURS.map((h) => (
+            <div class="absolute right-0 border-t border-slate-100" style={`left:${GUTTER}px; top:${pct(h * 60)}`}></div>
+          ))}
+
+          <div class="absolute top-0 bottom-0 right-0 flex gap-px" style={`left:${GUTTER}px`}>
+            {ABBR.map((d, i) => {
+              const active = windows[i].length > 0;
+              const isToday = i === todayIdx;
+              return (
+                <div class={`relative flex-1 cursor-crosshair ${active ? 'bg-sky-50/30' : 'bg-slate-50/40'} ${isToday ? 'ring-1 ring-inset ring-sky-100' : ''}`}>
+                  {windows[i].length === 0 && (
+                    <span class="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-[9.5px] text-slate-300 leading-tight px-1">drag, or tap +</span>
+                  )}
+                  {windows[i].map((iv) => {
+                    const tall = iv.end - iv.start >= 90;
+                    return (
+                      <div class="group absolute inset-x-[3px] rounded-md border border-sky-400/60 bg-sky-500/15 overflow-hidden" style={`top:${pct(iv.start)}; height:${pct(iv.end - iv.start)}`}>
+                        <span class={`pointer-events-none absolute left-1.5 ${tall ? 'top-1' : 'top-1/2 -translate-y-1/2'} text-[9.5px] font-medium text-sky-700 tabular-nums leading-tight`}>
+                          {fmt(iv.start)}{tall ? <br /> : '–'}{fmt(iv.end)}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+      <p class="text-[11px] text-slate-400 mt-3">
+        Each day is independent. Set different windows per day, or several windows in one day. Sends are scheduled in America/New York; worker IPs spread distribution naturally.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── Campaign dates ─────────────────────────────────────────────── -->
+  <section class="rounded-lg border border-slate-200 bg-white px-4 pt-3 pb-4 mt-4">
+    <div class="flex flex-wrap items-center gap-x-2 gap-y-1 mb-2.5">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/><path d="M17 14h-6"/><path d="M13 18H7"/><path d="M7 14h.01"/><path d="M17 18h.01"/></svg>
+      <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Campaign dates</span>
+      <span class="ml-auto inline-flex items-center gap-2 text-[11px] text-slate-400">
+        <span>Jun 9 &ndash; Jul 7, 2026</span>
+        <span class="inline-flex items-center h-5 px-1.5 rounded border border-slate-200 bg-slate-50 text-slate-600 tabular-nums">28 days</span>
+      </span>
+    </div>
+    <div class="flex items-end gap-3 flex-wrap">
+      <div class="w-[170px]">
+        <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">Start date</div>
+        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 shrink-0"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+          <span class="tabular-nums">09 Jun, 2026</span>
+        </button>
+      </div>
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-300 shrink-0 self-end mb-1.5"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+      <div class="w-[170px]">
+        <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">End date</div>
+        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 shrink-0"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
+          <span class="tabular-nums">07 Jul, 2026</span>
+        </button>
+      </div>
+      <p class="text-[11px] text-slate-400 self-end mb-1 flex-1 min-w-[180px]">
+        Optional bounds for when the campaign may send. Leave both blank to run open-ended.
+      </p>
+    </div>
+  </section>
+
+  <!-- ── Save / Reset ───────────────────────────────────────────────── -->
+  <div class="flex justify-end gap-2 pt-1 mt-4">
+    <button class="h-7 px-3 text-[12px] font-medium text-slate-600 border border-slate-200 rounded-md whitespace-nowrap shrink-0">Reset</button>
+    <button class="h-7 px-3 bg-sky-600 text-white rounded-md text-[12px] font-medium min-w-[110px] inline-flex items-center justify-center whitespace-nowrap shrink-0">Save changes</button>
+  </div>
+
+  <!-- ── Demo reaction: the real drag-to-create window growing on Sat ─── -->
+  <div class="sc-react" aria-hidden="true" style={`left:${cursorXPct}%; top:${NINE}px;`}>
+    <!-- the growing sending-window block, anchored at the 9am press point -->
+    <div class="sc-grow absolute rounded-md border border-sky-400/60 bg-sky-500/15 overflow-hidden" style={`left:${-(COL_W / 2 - 3)}px; width:${COL_W - 6}px; height:${FIVE - NINE}px;`}>
+      <span class="pointer-events-none absolute left-1.5 top-1 text-[9.5px] font-medium text-sky-700 tabular-nums leading-tight">9am<br />5pm</span>
+    </div>
+    <!-- live time chip following the bottom edge -->
+    <span class="sc-chip absolute inline-flex items-center h-5 px-1.5 rounded-md border border-sky-300 bg-sky-50 text-[9px] font-medium text-sky-700 tabular-nums whitespace-nowrap shadow-sm" style={`left:${COL_W / 2 + 4}px;`}>9:00 - 17:00</span>
+  </div>
+
+  <div class="sc-cursor" aria-hidden="true"><span class="sc-ripple"></span><svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg></div>
+
+  <style define:vars={{ ninePx: `${NINE}px`, fivePx: `${FIVE}px`, cursorXPct: `${cursorXPct}%`, growH: `${FIVE - NINE}px` }}>
+    .sc-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:sc-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .sc-cursor svg{display:block;transform-origin:3px 2px;animation:sc-press 11s ease-in-out infinite;}
+    .sc-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:sc-rip 11s ease-out infinite;}
+
+    /* The reaction overlay is anchored at the 9am press point of the Sat
+       column. Its inner block grows downward (scaleY 0 -> 1) locked to the
+       drag window, then rests until the loop resets. */
+    .sc-react{position:absolute;z-index:40;}
+    .sc-grow{transform-origin:top;transform:scaleY(0);opacity:0;animation:sc-grow 11s ease-out infinite;}
+    .sc-chip{transform:translateY(-50%);opacity:0;animation:sc-chip 11s ease-out infinite;}
+
+    /* Cursor path: travels in from the top-left, presses on the Sat column at
+       the 9am line (~22-28%), then DRAGS DOWN (stationary-x, moving-y) to the
+       5pm line between 28% and 44%, holding pressed. It rests, then on the
+       second beat nudges the finished block before the loop resets. */
+    @keyframes sc-move{
+      0%{left:18%;top:18%}
+      22%{left:var(--cursorXPct);top:var(--ninePx)}
+      28%{left:var(--cursorXPct);top:var(--ninePx)}
+      44%{left:var(--cursorXPct);top:var(--fivePx)}
+      58%{left:var(--cursorXPct);top:var(--fivePx)}
+      64%{left:var(--cursorXPct);top:var(--fivePx)}
+      68%{left:var(--cursorXPct);top:var(--fivePx)}
+      88%{left:62%;top:88%}
+      100%{left:18%;top:18%}
+    }
+    /* Pressed/grabbing through the whole drag (28% -> 44%), released after. */
+    @keyframes sc-press{
+      0%,26%{transform:scale(1)}
+      28%{transform:scale(.82)}
+      44%{transform:scale(.82)}
+      48%{transform:scale(1)}
+      62%{transform:scale(1)}
+      64%{transform:scale(.82)}
+      67%,100%{transform:scale(1)}
+    }
+    /* Ripple on the initial press, and again on the second beat. */
+    @keyframes sc-rip{
+      0%,26%{transform:scale(0);opacity:0}
+      29%{transform:scale(.25);opacity:.7}
+      41%{transform:scale(1.7);opacity:0}
+      60%{transform:scale(0);opacity:0}
+      63%{transform:scale(.25);opacity:.7}
+      75%{transform:scale(1.7);opacity:0}
+      100%{transform:scale(0);opacity:0}
+    }
+    /* Block grows from 0 height at the press point to full, tracking the drag
+       window (28% -> 44%), then rests as a finished block until ~90%. */
+    @keyframes sc-grow{
+      0%,28%{opacity:0;transform:scaleY(0)}
+      30%{opacity:1;transform:scaleY(.06)}
+      44%{opacity:1;transform:scaleY(1)}
+      90%{opacity:1;transform:scaleY(1)}
+      96%{opacity:0;transform:scaleY(0)}
+      100%{opacity:0;transform:scaleY(0)}
+    }
+    /* The live time chip rides the growing bottom edge, then rests. */
+    @keyframes sc-chip{
+      0%,28%{opacity:0;transform:translateY(-50%) translateY(0)}
+      31%{opacity:1;transform:translateY(-50%) translateY(0)}
+      44%{opacity:1;transform:translateY(-50%) translateY(var(--growH))}
+      90%{opacity:1;transform:translateY(-50%) translateY(var(--growH))}
+      96%{opacity:0;transform:translateY(-50%) translateY(var(--growH))}
+      100%{opacity:0;transform:translateY(-50%) translateY(var(--growH))}
+    }
+    @media (prefers-reduced-motion: reduce){.sc-cursor{display:none}.sc-react{display:none}}
+  </style>
+</div>

--- a/site/src/components/ScheduleMock.astro
+++ b/site/src/components/ScheduleMock.astro
@@ -181,7 +181,7 @@ const cursorXPct = (cursorX / ROOT_W) * 100;
     <div class="flex items-end gap-3 flex-wrap">
       <div class="w-[170px]">
         <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">Start date</div>
-        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700">
+        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700 whitespace-nowrap">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 shrink-0"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
           <span class="tabular-nums">09 Jun, 2026</span>
         </button>
@@ -189,7 +189,7 @@ const cursorXPct = (cursorX / ROOT_W) * 100;
       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-300 shrink-0 self-end mb-1.5"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
       <div class="w-[170px]">
         <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">End date</div>
-        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700">
+        <button type="button" class="flex gap-2 items-center h-7 px-2.5 w-full rounded-md border border-slate-200 text-[12.5px] text-slate-700 whitespace-nowrap">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-400 shrink-0"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/></svg>
           <span class="tabular-nums">07 Jul, 2026</span>
         </button>

--- a/site/src/components/SequenceMock.astro
+++ b/site/src/components/SequenceMock.astro
@@ -3,7 +3,13 @@
  * Mock of /app/campaigns/[id] sequence builder — shows the multi-step
  * sequence layout with branching, A/B variants and TZ-aware delays.
  */
-const steps = [
+interface Props {
+  /** Show only the first N steps (keeps the showcase satellite compact). */
+  limit?: number;
+}
+const { limit } = Astro.props;
+
+const allSteps = [
   { n: 1, kind: 'send', title: 'Intro · plain text', meta: '2 variants', open: true },
   { n: 2, kind: 'wait', title: 'Wait · 3 business days', meta: 'if no reply' },
   { n: 3, kind: 'send', title: 'Follow-up · context line', meta: '4 variants' },
@@ -11,6 +17,7 @@ const steps = [
   { n: 5, kind: 'send', title: 'Soft close · short ask', meta: '2 variants' },
   { n: 6, kind: 'wait', title: 'Break · 7 business days', meta: 'silence' },
 ];
+const steps = limit ? allSteps.slice(0, limit) : allSteps;
 ---
 <div class="bg-white">
   <!-- Topbar -->
@@ -22,7 +29,7 @@ const steps = [
       <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>active
     </span>
     <div class="ml-auto flex items-center gap-2">
-      <span class="text-[11px] font-mono text-slate-500">6 steps · 4 mailboxes</span>
+      <span class="text-[11px] font-mono text-slate-500">{steps.length} steps · 4 mailboxes</span>
       <button class="h-7 px-2.5 rounded-md inline-flex items-center gap-1.5 text-[12px] font-medium bg-sky-600 text-white">
         <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
         Add step

--- a/site/src/components/TemplatingShowcase.astro
+++ b/site/src/components/TemplatingShowcase.astro
@@ -1,0 +1,126 @@
+---
+/**
+ * TemplatingShowcase - explains how the Go text/template subset works inside
+ * Warmbly campaign steps. Mirrors the exact send-time syntax the dashboard
+ * composer renders (web/src/components/app/campaigns/sequences/SequenceView.tsx):
+ *
+ *   - merge fields:  {{.FirstName}} {{.LastName}} {{.Company}} {{.Email}} {{.Phone}}
+ *   - conditionals:  {{if eq .role "Engineer"}} ... {{else}} ... {{end}}  + and / or
+ *   - spintax:       {Hi|Hey|Hello} {{.FirstName}}  (one variant is picked)
+ *
+ * Sample data matches the composer's SAMPLE map (Alex Rivera at Acme, role
+ * Engineer) so the before/after examples line up with the in-app preview.
+ *
+ * Self-contained, no props. Dark code style matches the campaign code block on
+ * index.astro / campaigns.astro (#0c1224 surface, white/85 text, sky/amber/
+ * violet/emerald spans). No app-window frame and no demo cursor.
+ */
+import SectionHead from './SectionHead.astro';
+
+// Merge fields, paired with their resolved value from the composer's SAMPLE.
+const fields = [
+  { token: '{{.FirstName}}', value: 'Alex' },
+  { token: '{{.LastName}}', value: 'Rivera' },
+  { token: '{{.Company}}', value: 'Acme' },
+  { token: '{{.Email}}', value: 'alex@acme.com' },
+  { token: '{{.Phone}}', value: '+1 555-0100' },
+];
+---
+<section class="border-y border-[color:var(--border)] bg-[color:var(--surface-1)]/40 py-20 md:py-28">
+  <div class="container-page">
+    <SectionHead
+      eyebrow="Personalization / Templating"
+      title="Go templating, rendered at send time"
+      description="Every step is a Go text/template. Merge fields, if/else conditionals, and spintax all resolve per recipient the moment the email goes out, and the composer previews exactly what each contact will receive."
+    />
+
+    <div class="mt-12 md:mt-14 grid gap-5 lg:grid-cols-3">
+      <!-- 1 · MERGE FIELDS -->
+      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
+        <div class="flex items-center gap-2">
+          <span class="grid place-items-center w-7 h-7 rounded-md bg-sky-50 text-sky-600 ring-1 ring-sky-100">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>
+          </span>
+          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Merge fields</h3>
+        </div>
+        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
+          Pull any contact field with a leading dot. Missing values render empty, so a blank field never breaks the line.
+        </p>
+
+        <div class="mt-4 flex flex-wrap gap-1.5">
+          {fields.map((f) => (
+            <code class="inline-flex items-center h-6 px-2 rounded-md bg-[#0c1224] text-[11.5px] font-mono text-sky-300 ring-1 ring-white/10">{f.token}</code>
+          ))}
+        </div>
+
+        <div class="mt-auto pt-5">
+          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-mono mb-2">Before / after</div>
+          <div class="rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 p-3.5 font-mono text-[12.5px] leading-[1.6] text-white/85">
+            <div>Hi <span class="text-sky-300">{`{{.FirstName}}`}</span></div>
+            <div class="mt-1.5 flex items-center gap-1.5 text-white/50">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-400"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+              <span class="text-white/85">Hi <span class="text-emerald-400">Alex</span></span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 2 · CONDITIONALS -->
+      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
+        <div class="flex items-center gap-2">
+          <span class="grid place-items-center w-7 h-7 rounded-md bg-violet-50 text-violet-600 ring-1 ring-violet-100">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+          </span>
+          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Conditionals</h3>
+        </div>
+        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
+          Branch on a contact field with <code class="kbd">if</code> / <code class="kbd">else</code> / <code class="kbd">end</code>. Compare values with <code class="kbd">eq</code>.
+        </p>
+
+        <div class="mt-4 rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 overflow-hidden">
+          <pre class="p-3.5 font-mono text-[12px] leading-[1.7] text-white/85 overflow-x-auto"><code>{`{{`}<span style="color:#c4b5fd">if eq</span> <span style="color:#7dd3fc">.role</span> <span style="color:#fde68a">"Engineer"</span>{`}}`}
+  We built this for teams like yours.
+{`{{`}<span style="color:#c4b5fd">else</span>{`}}`}
+  Thought this might be useful.
+{`{{`}<span style="color:#c4b5fd">end</span>{`}}`}</code></pre>
+        </div>
+
+        <p class="mt-auto pt-5 text-[12.5px] leading-relaxed text-foreground/60">
+          Combine checks with <code class="kbd">and</code> / <code class="kbd">or</code>, for example
+          <code class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded bg-[#0c1224] text-[11px] font-mono text-white/85 ring-1 ring-white/10">{`{{if and (eq .role "Engineer") .Company}}`}</code>.
+        </p>
+      </div>
+
+      <!-- 3 · SPINTAX -->
+      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
+        <div class="flex items-center gap-2">
+          <span class="grid place-items-center w-7 h-7 rounded-md bg-emerald-50 text-emerald-600 ring-1 ring-emerald-100">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg>
+          </span>
+          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Spintax</h3>
+        </div>
+        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
+          List variants in braces and Warmbly picks one per send, so the same step reads a little differently to every recipient.
+        </p>
+
+        <div class="mt-4 rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 overflow-hidden">
+          <pre class="p-3.5 font-mono text-[12.5px] leading-[1.7] text-white/85 overflow-x-auto"><code>{`{`}<span style="color:#6ee7b7">Hi</span>|<span style="color:#6ee7b7">Hey</span>|<span style="color:#6ee7b7">Hello</span>{`}`} <span style="color:#7dd3fc">{`{{.FirstName}}`}</span></code></pre>
+        </div>
+
+        <div class="mt-auto pt-5">
+          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-mono mb-2">Picks one variant</div>
+          <div class="flex flex-wrap gap-1.5">
+            <span class="inline-flex items-center h-6 px-2 rounded-md bg-emerald-50 text-[11.5px] font-medium text-emerald-700 ring-1 ring-emerald-100">Hey Alex</span>
+            <span class="inline-flex items-center h-6 px-2 rounded-md bg-slate-50 text-[11.5px] font-medium text-slate-400 ring-1 ring-slate-200">Hi Alex</span>
+            <span class="inline-flex items-center h-6 px-2 rounded-md bg-slate-50 text-[11.5px] font-medium text-slate-400 ring-1 ring-slate-200">Hello Alex</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <p class="mt-8 flex items-center justify-center gap-2 text-[13px] text-foreground/60">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-sky-500 shrink-0"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
+      Everything resolves at send time, and the composer previews the result against sample data before you launch.
+    </p>
+  </div>
+</section>

--- a/site/src/components/UniboxMock.astro
+++ b/site/src/components/UniboxMock.astro
@@ -422,7 +422,7 @@ const railToneClass = (tone: string, active: boolean) => {
 
     <!-- action bar -->
     <div class="px-3 py-2 border-t border-slate-200/60 flex flex-wrap items-center gap-1.5">
-      <span class="ub-send-btn h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+      <span class="h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></svg>
         Send
       </span>
@@ -452,17 +452,17 @@ const railToneClass = (tone: string, active: boolean) => {
     .ub-cursor svg{display:block;transform-origin:3px 2px;animation:ub-press 11s ease-in-out infinite;}
     .ub-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:ub-rip 11s ease-out infinite;}
     .ub-react{position:absolute;z-index:40;opacity:0;animation:ub-react 11s ease-out infinite;}
-    /* press #1 (28%) lands on Reply in the footer; press #2 (64%) lands on Send in the composer */
-    @keyframes ub-move{0%{left:30%;top:34%}22%{left:67%;top:94%}32%{left:67%;top:94%}58%{left:66%;top:92%}68%{left:66%;top:92%}88%{left:30%;top:34%}100%{left:30%;top:34%}}
+    /* press #1 (28%) lands on the Reply button center (x 626/900=70%, y 478/500=95.5%);
+       press #2 (64%) lands in the thread/messages area ABOVE the composer to dismiss it
+       (right pane center x 740/900=82%, thread-header y 65/500=13%) */
+    @keyframes ub-move{0%{left:30%;top:34%}22%{left:70%;top:95.5%}32%{left:70%;top:95.5%}58%{left:82%;top:13%}68%{left:82%;top:13%}88%{left:30%;top:34%}100%{left:30%;top:34%}}
     @keyframes ub-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
     @keyframes ub-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
-    @keyframes ub-react{0%,29%{opacity:0;transform:translateY(22px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(22px)}100%{opacity:0;transform:translateY(22px)}}
-    /* press feedback : Reply button darkens + rings on press #1 */
+    /* dismiss timeline: composer opens after press #1, closes after press #2 (click-outside) */
+    @keyframes ub-react{0%,29%{opacity:0;transform:translateY(22px)}33%{opacity:1;transform:translateY(0)}60%{opacity:1;transform:translateY(0)}66%{opacity:0;transform:translateY(22px)}100%{opacity:0;transform:translateY(22px)}}
+    /* press feedback : Reply button darkens + rings on press #1 (opens composer) */
     .ub-reply-btn{transition:none;animation:ub-reply-press 11s ease-in-out infinite;}
     @keyframes ub-reply-press{0%,27%{background-color:#0284c7;box-shadow:none}28%,31%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,1)}32%,100%{background-color:#0284c7;box-shadow:none}}
-    /* press feedback : Send button darkens + rings on press #2 */
-    .ub-send-btn{animation:ub-send-press 11s ease-in-out infinite;}
-    @keyframes ub-send-press{0%,63%{background-color:#0284c7;box-shadow:none}64%,67%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,1)}68%,100%{background-color:#0284c7;box-shadow:none}}
-    @media (prefers-reduced-motion: reduce){.ub-cursor{display:none}.ub-react{display:none}.ub-reply-btn{animation:none}.ub-send-btn{animation:none}}
+    @media (prefers-reduced-motion: reduce){.ub-cursor{display:none}.ub-react{display:none}.ub-reply-btn{animation:none}}
   </style>
 </div>

--- a/site/src/components/UniboxMock.astro
+++ b/site/src/components/UniboxMock.astro
@@ -1,0 +1,468 @@
+---
+/**
+ * Pixel-faithful mock of the Warmbly /app/unibox screen (unified inbox).
+ *
+ * Maps 1:1 to the real components:
+ *   - web/src/app/app/unibox/page.tsx          - three-pane layout
+ *   - web/src/components/app/unibox/UniboxHeader.tsx     - top metric strip (h-10)
+ *   - web/src/components/app/unibox/ScopeRail.tsx        - left scope rail (w-220)
+ *   - web/src/components/app/unibox/ConversationList.tsx - middle list (w-360)
+ *   - web/src/components/app/unibox/ConversationItem.tsx - list rows
+ *   - web/src/components/app/unibox/ThreadView.tsx       - right thread pane
+ *   - web/src/components/app/unibox/MessageBubble.tsx    - per-message article
+ *
+ * Renders only the in-app screen content. The marketing page wraps this
+ * in its own browser frame, so there is no sidebar / app header / window
+ * chrome here. The content overflows the frame on purpose; the parent
+ * crops with overflow-hidden, so the load-bearing content sits top-left.
+ */
+
+// ── Top metric strip ───────────────────────────────────────────────
+const stats = [
+  { value: '7',  label: 'unread',    tone: 'accent' as const },
+  { value: '3',  label: 'awaiting',  tone: 'default' as const },
+  { value: '24', label: 'today',     tone: 'default' as const },
+  { value: '89', label: 'week',      tone: 'default' as const },
+  { value: '2',  label: 'snoozed',   tone: 'muted' as const },
+  { value: '3',  label: 'mailboxes', tone: 'muted' as const },
+];
+
+// ── Scope rail (left) ──────────────────────────────────────────────
+const inboxScopes = [
+  { icon: 'inbox',    label: 'All',           count: '342', active: false, tone: 'muted'  },
+  { icon: 'sparkle',  label: 'Unread',        count: '7',   active: true,  tone: 'accent' },
+  { icon: 'clock',    label: 'Today',         count: '24',  active: false, tone: 'muted'  },
+  { icon: 'calendar', label: 'This week',     count: '89',  active: false, tone: 'muted'  },
+  { icon: 'reply',    label: 'Awaiting reply', count: '3',  active: false, tone: 'accent' },
+  { icon: 'moon',     label: 'Snoozed',       count: '2',   active: false, tone: 'muted'  },
+  { icon: 'send',     label: 'Scheduled',     count: '1',   active: false, tone: 'accent' },
+];
+
+const mailboxScopes = [
+  { email: 'hello@company.com',   count: '2' },
+  { email: 'support@company.com', count: '5' },
+  { email: 'sales@company.com',   count: ''  },
+];
+
+const tagScopes = [
+  { color: '#ef4444', label: 'Urgent', count: '1'  },
+  { color: '#3b82f6', label: 'Leads',  count: '12' },
+];
+
+// ── Conversation list (middle) ─────────────────────────────────────
+const conversations = [
+  {
+    initials: 'SC', hue: 14, sender: 'Sarah Chen',
+    subject: 'Follow up on Q1 proposal',
+    preview: "Thanks for sending over the docs. I've reviewed them and have a few…",
+    time: '5m', unread: true, selected: true,
+    mailbox: 'hello@company.com',
+    tags: [{ color: '#ef4444', label: 'Urgent' }, { color: '#f59e0b', label: 'Clients' }],
+  },
+  {
+    initials: 'JS', hue: 210, sender: 'Jordan Smith',
+    subject: 'Re: Dashboard integration',
+    preview: 'The API endpoint looks good. When can we expect the staging build?',
+    time: '42m', unread: false, selected: false,
+    mailbox: 'support@company.com',
+    tags: [],
+  },
+  {
+    initials: 'AM', hue: 265, sender: 'Alex Morgan',
+    subject: 'New partnership opportunity',
+    preview: "Hi there, I'm reaching out about a potential partnership between…",
+    time: '3h', unread: false, selected: false, muted: true,
+    mailbox: 'sales@company.com',
+    tags: [{ color: '#3b82f6', label: 'Leads' }],
+  },
+  {
+    initials: 'CR', hue: 150, sender: 'Casey Reynolds',
+    subject: '(no subject)',
+    preview: '(no preview)',
+    time: 'Jan 15', unread: false, selected: false, muted: true,
+    mailbox: 'hello@company.com',
+    tags: [],
+  },
+];
+
+// ── Thread (right) ─────────────────────────────────────────────────
+const messages = [
+  {
+    initials: 'SC', name: 'Sarah Chen', addr: 'sarah@acme.io',
+    to: 'hello@company.com', time: 'Jan 18, 10:32', you: false,
+    body: "Thanks for sending over the docs. I've reviewed them and have a few questions. Can we sync up tomorrow morning?",
+  },
+  {
+    initials: 'YO', name: 'You', addr: 'hello@company.com',
+    to: 'sarah@acme.io', time: '14:15', you: true,
+    body: 'Absolutely! How does 10am EST work for you?',
+  },
+  {
+    initials: 'SC', name: 'Sarah Chen', addr: 'sarah@acme.io',
+    to: 'hello@company.com', time: '14:28', you: false,
+    body: 'Perfect. See you then!',
+  },
+];
+
+const railToneClass = (tone: string, active: boolean) => {
+  if (active) return 'bg-white/80 text-sky-700';
+  if (tone === 'accent') return 'bg-sky-100 text-sky-700';
+  return 'text-slate-400';
+};
+---
+<div class="relative w-full flex flex-col bg-white text-slate-900" style="min-height:500px;">
+  <!-- ─────────────────────────────────────────────────────────────
+       1) TOP STRIP - UniboxHeader (h-10)
+  ────────────────────────────────────────────────────────────── -->
+  <header class="h-10 px-4 border-b border-slate-200 bg-white flex items-center gap-3 shrink-0">
+    <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold shrink-0">Inbox</span>
+    <div class="h-4 w-px bg-slate-200 shrink-0"></div>
+    <div class="flex items-center gap-3.5 min-w-0">
+      {stats.map((s) => (
+        <div class="inline-flex items-baseline gap-1 shrink-0">
+          <span class={`font-mono tabular-nums text-[12.5px] font-semibold ${s.tone === 'accent' ? 'text-sky-600' : s.tone === 'muted' ? 'text-slate-400' : 'text-slate-900'}`}>{s.value}</span>
+          <span class="text-[10.5px] text-slate-500">{s.label}</span>
+        </div>
+      ))}
+    </div>
+    <div class="ml-auto inline-flex items-center gap-1.5 text-[11px] text-emerald-600 font-medium shrink-0">
+      <span class="relative flex size-1.5">
+        <span class="absolute inline-flex h-full w-full rounded-full bg-emerald-500 opacity-60 animate-ping"></span>
+        <span class="relative inline-flex size-1.5 rounded-full bg-emerald-500"></span>
+      </span>
+      live
+    </div>
+  </header>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       2) MAIN ROW - rail · list · thread
+  ────────────────────────────────────────────────────────────── -->
+  <div class="flex-1 flex min-h-0">
+
+    <!-- a) LEFT SCOPE RAIL (w-220, hidden on narrower viewports) -->
+    <nav class="flex flex-col w-[220px] shrink-0 border-r border-slate-200 bg-slate-50/60 overflow-y-auto py-2">
+      <!-- Inbox section -->
+      <div class="mb-1">
+        <div class="px-3 pt-3 pb-1 flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Inbox</span>
+        </div>
+        <div class="px-1.5 space-y-px">
+          {inboxScopes.map((it) => (
+            <div class={`w-full h-7 pl-2 pr-2 rounded-md flex items-center gap-2 text-left ${it.active ? 'bg-sky-100 text-sky-900 font-medium' : 'text-slate-600'}`}>
+              <span class={`shrink-0 ${it.active ? 'text-sky-700' : 'text-slate-500'}`}>
+                {it.icon === 'inbox'    && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>}
+                {it.icon === 'sparkle'  && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .962 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.962 0z"/></svg>}
+                {it.icon === 'clock'    && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>}
+                {it.icon === 'calendar' && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v4"/><path d="M16 2v4"/><rect width="18" height="18" x="3" y="4" rx="2"/><path d="M3 10h18"/><path d="M17 14h-6"/><path d="M13 18H7"/><path d="M7 14h.01"/><path d="M17 18h.01"/></svg>}
+                {it.icon === 'reply'    && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>}
+                {it.icon === 'moon'     && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>}
+                {it.icon === 'send'     && <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></svg>}
+              </span>
+              <span class="truncate min-w-0 flex-1 text-[12px]">{it.label}</span>
+              {it.count && (
+                <span class={`shrink-0 font-mono tabular-nums text-[10.5px] px-1.5 h-4 rounded inline-flex items-center ${railToneClass(it.tone, it.active)}`}>{it.count}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <!-- Mailboxes section -->
+      <div class="mb-1">
+        <div class="w-full px-3 pt-3 pb-1 flex items-center gap-1.5">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Mailboxes</span>
+          <span class="ml-auto font-mono text-[10px] text-slate-400 tabular-nums">3</span>
+        </div>
+        <div class="px-1.5">
+          <div class="space-y-px">
+            {mailboxScopes.map((m) => (
+              <div class="w-full h-7 pl-2 pr-2 rounded-md flex items-center gap-2 text-left text-slate-600">
+                <span class="shrink-0 text-slate-500">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 17a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9.5C2 7 4 5 6.5 5H18c2.2 0 4 1.8 4 4z"/><polyline points="15,9 18,9 18,11"/><path d="M6.5 5C9 5 11 7 11 9.5V17a2 2 0 0 1-2 2"/><line x1="6" x2="7" y1="10" y2="10"/></svg>
+                </span>
+                <span class="truncate min-w-0 flex-1 font-mono text-[11.5px]">{m.email}</span>
+                {m.count && (
+                  <span class={`shrink-0 font-mono tabular-nums text-[10.5px] px-1.5 h-4 rounded inline-flex items-center ${m.count !== '' ? 'bg-sky-100 text-sky-700' : 'text-slate-400'}`}>{m.count}</span>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <!-- Tags section -->
+      <div class="mb-1">
+        <div class="w-full px-3 pt-3 pb-1 flex items-center gap-1.5">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Tags</span>
+          <span class="ml-auto font-mono text-[10px] text-slate-400 tabular-nums">2</span>
+        </div>
+        <div class="px-1.5">
+          <div class="space-y-px">
+            {tagScopes.map((t) => (
+              <div class="w-full h-7 pl-2 pr-2 rounded-md flex items-center gap-2 text-left text-slate-600">
+                <span class="shrink-0">
+                  <span class="block size-3 rounded-full ring-1 ring-black/10 shadow-sm" style={`background-color:${t.color};`}></span>
+                </span>
+                <span class="truncate min-w-0 flex-1 text-[12px]">{t.label}</span>
+                <span class="shrink-0 font-mono tabular-nums text-[10.5px] px-1.5 h-4 rounded inline-flex items-center bg-sky-100 text-sky-700">{t.count}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- b) MIDDLE LIST (w-360) -->
+    <div class="w-[360px] shrink-0 border-r border-slate-200 flex flex-col bg-white min-h-0">
+      <!-- search bar -->
+      <div class="h-9 px-2 shrink-0 border-b border-slate-200 flex items-center gap-1.5">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400 shrink-0" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <span class="flex-1 min-w-0 text-[12.5px] text-slate-400">Search inbox… (/)</span>
+        <span class="size-7 rounded text-slate-500 inline-flex items-center justify-center shrink-0">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg>
+        </span>
+      </div>
+
+      <!-- scrollable list -->
+      <div class="flex-1 overflow-y-auto">
+        <!-- sticky time-bucket header -->
+        <div class="sticky top-0 z-10 px-3 py-1 bg-slate-50/95 border-b border-slate-200/60 flex items-center gap-2">
+          <span class="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-semibold">Today</span>
+          <span class="font-mono text-[10px] text-slate-400 tabular-nums">4</span>
+        </div>
+
+        <div class="divide-y divide-slate-200/60">
+          {conversations.map((c) => (
+            <div class={`group w-full text-left px-3 py-2.5 flex items-start gap-2.5 relative ${c.selected ? 'bg-sky-50/80' : ''}`}>
+              {c.unread && (
+                <span class="absolute left-0 top-2 bottom-2 w-[3px] rounded-r bg-sky-500"></span>
+              )}
+              <div
+                class="size-7 rounded-full flex items-center justify-center shrink-0 text-[10px] font-semibold"
+                style={c.selected
+                  ? 'background-color:rgb(224 242 254);color:rgb(2 132 199);'
+                  : `background-color:hsl(${c.hue} 70% 94%);color:hsl(${c.hue} 55% 35%);`}
+              >{c.initials}</div>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2 min-w-0">
+                  <span class={`text-[12.5px] truncate min-w-0 ${c.unread ? 'text-slate-900 font-semibold' : c.muted ? 'text-slate-500 font-medium' : 'text-slate-800 font-medium'}`}>{c.sender}</span>
+                  <span class="font-mono text-[10px] text-slate-400 tabular-nums shrink-0 ml-auto">{c.time}</span>
+                </div>
+                <div class={`text-[12px] truncate mt-0.5 ${c.unread ? 'text-slate-800 font-medium' : c.muted ? 'text-slate-500' : 'text-slate-600'}`}>{c.subject}</div>
+                <div class="text-[11px] text-slate-400 truncate mt-0.5">{c.preview}</div>
+                <div class="mt-1 flex items-center gap-1 min-w-0 flex-wrap">
+                  <span class="inline-flex items-center h-4 px-1.5 rounded-sm bg-slate-100 text-slate-500 text-[9.5px] font-mono truncate max-w-[160px]">{c.mailbox}</span>
+                  {c.tags.map((t) => (
+                    <span
+                      class="inline-flex items-center gap-1 h-4 pl-1 pr-1.5 rounded-sm border bg-white text-[10px] font-medium text-slate-700 truncate max-w-[120px]"
+                      style={`border-color:${t.color}60;background-color:${t.color}12;`}
+                    >
+                      <span class="block size-2 rounded-full shrink-0" style={`background-color:${t.color};`}></span>
+                      {t.label}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+
+    <!-- c) RIGHT THREAD PANE -->
+    <div class="flex-1 min-w-0 flex flex-col bg-white min-h-0">
+      <!-- thread header (h-12) -->
+      <div class="h-12 px-5 border-b border-slate-200 flex items-center gap-3 shrink-0 bg-white">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Thread</span>
+        <div class="h-4 w-px bg-slate-200"></div>
+        <span class="text-[12.5px] text-slate-900 font-medium truncate min-w-0">Follow up on Q1 proposal</span>
+        <span class="ml-1 inline-flex items-center gap-1 h-5 px-1.5 rounded bg-slate-100 text-slate-600 text-[10.5px] font-medium font-mono shrink-0">hello@company.com</span>
+        <div class="ml-auto flex items-center gap-1">
+          <span class="h-7 px-2 rounded-md text-slate-500 border border-slate-200 inline-flex items-center gap-1 text-[12px]">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/></svg>
+            Snooze
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+          </span>
+          <span class="size-7 rounded-md inline-flex items-center justify-center text-slate-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"/><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m16 19 2 2 4-4"/></svg>
+          </span>
+          <span class="size-7 rounded-md inline-flex items-center justify-center text-slate-500">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect width="20" height="5" x="2" y="3" rx="1"/><path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8"/><path d="M10 12h4"/></svg>
+          </span>
+          <span class="size-7 rounded-md inline-flex items-center justify-center text-slate-500 hover:text-red-600 hover:bg-red-50">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>
+          </span>
+        </div>
+      </div>
+
+      <!-- SectionBar -->
+      <div class="h-9 px-5 border-b border-slate-200/60 flex items-center gap-2.5 shrink-0">
+        <span class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">3 messages</span>
+        <span class="font-mono text-[10.5px] text-slate-400 tabular-nums">2</span>
+      </div>
+
+      <!-- messages -->
+      <div class="flex-1 overflow-y-auto divide-y divide-slate-200/60">
+        {messages.map((m) => (
+          <article class="px-5 py-4">
+            <header class="flex items-start gap-3 mb-3">
+              <div class={`size-7 rounded-full flex items-center justify-center text-[10px] font-semibold shrink-0 ${m.you ? 'bg-sky-100 text-sky-700' : 'bg-slate-100 text-slate-600'}`}>{m.initials}</div>
+              <div class="min-w-0 flex-1">
+                <div class="flex items-baseline gap-2">
+                  <span class="text-[12.5px] font-semibold text-slate-900 truncate">{m.name}</span>
+                  <span class="font-mono text-[10.5px] text-slate-400 truncate">{m.addr}</span>
+                </div>
+                <div class="text-[11px] text-slate-500 mt-0.5 flex items-center gap-1.5">
+                  <span>to {m.to}</span>
+                </div>
+              </div>
+              <span class="font-mono text-[10.5px] text-slate-400 tabular-nums shrink-0">{m.time}</span>
+            </header>
+            <div class="text-[13px] text-slate-800 leading-relaxed">{m.body}</div>
+          </article>
+        ))}
+      </div>
+
+      <!-- reply rail footer -->
+      <div class="border-t border-slate-200 bg-white px-3 py-2 flex items-center gap-1.5 shrink-0">
+        <span class="ub-reply-btn h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/></svg>
+          Reply
+        </span>
+        <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1.5">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 17 20 12 15 7"/><path d="M4 18v-2a4 4 0 0 1 4-4h12"/></svg>
+          Forward
+        </span>
+        <span class="ml-auto inline text-[10.5px] text-slate-400">Hover any message to reply to it directly.</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─────────────────────────────────────────────────────────────
+       DEMO SCENE - cursor presses Reply, the real ReplyComposer
+       slides up over the bottom of the thread pane, then Send.
+       Mirrors web/src/components/app/unibox/ReplyComposer.tsx
+  ────────────────────────────────────────────────────────────── -->
+  <!-- reaction: ReplyComposer anchored to the thread (right) area -->
+  <div class="ub-react absolute left-[580px] right-0 bottom-0 bg-white border-t border-slate-200 flex flex-col shadow-[0_-6px_24px_-12px_rgba(15,23,42,.12)]" aria-hidden="true">
+    <!-- target message preview : "Replying to" strip -->
+    <div class="px-4 pt-3 pb-2 flex items-start gap-3 bg-slate-50/60 border-b border-slate-200/70">
+      <span class="size-7 rounded-full flex items-center justify-center text-[10px] font-semibold shrink-0 bg-sky-100 text-sky-700">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/></svg>
+      </span>
+      <div class="min-w-0 flex-1">
+        <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Replying to</div>
+        <div class="flex items-baseline gap-2 mt-0.5 min-w-0">
+          <span class="text-[12.5px] font-semibold text-slate-900 truncate">Sarah Chen</span>
+          <span class="font-mono text-[10.5px] text-slate-500 truncate">sarah@acme.io</span>
+        </div>
+        <div class="text-[11.5px] text-slate-500 mt-0.5 truncate">Follow up on Q1 proposal</div>
+      </div>
+      <span class="size-7 inline-flex items-center justify-center rounded-md text-slate-400 shrink-0">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+      </span>
+    </div>
+
+    <!-- header strip : From / To / Subject -->
+    <div class="px-4 py-2.5 border-b border-slate-200/70 divide-y divide-slate-200/40 bg-white">
+      <div class="flex items-start gap-3 py-1.5">
+        <span class="w-14 shrink-0 pt-[3px] text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">From</span>
+        <span class="self-stretch w-px bg-slate-200 shrink-0"></span>
+        <div class="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
+          <div class="inline-flex items-center gap-2 min-w-0">
+            <span class="text-[12.5px] text-slate-900 font-medium truncate">Company</span>
+            <span class="font-mono text-[10.5px] text-slate-500 bg-slate-50 px-1.5 h-4 inline-flex items-center rounded border border-slate-200 shrink-0">hello@company.com</span>
+          </div>
+          <div class="ml-auto flex items-center gap-1">
+            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center">+ Cc</span>
+            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center">+ Bcc</span>
+          </div>
+        </div>
+      </div>
+      <div class="flex items-start gap-3 py-1.5">
+        <span class="w-14 shrink-0 pt-[3px] text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">To</span>
+        <span class="self-stretch w-px bg-slate-200 shrink-0"></span>
+        <div class="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
+          <span class="inline-flex items-center gap-1 h-5 pl-1.5 pr-0.5 rounded-md text-[11px] font-medium shrink-0 border bg-sky-50 text-sky-800 border-sky-200">
+            <span class="font-mono">sarah@acme.io</span>
+            <span class="size-4 inline-flex items-center justify-center rounded">
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+            </span>
+          </span>
+        </div>
+      </div>
+      <div class="flex items-start gap-3 py-1.5">
+        <span class="w-14 shrink-0 pt-[3px] text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Subject</span>
+        <span class="self-stretch w-px bg-slate-200 shrink-0"></span>
+        <div class="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
+          <span class="flex-1 min-w-0 h-6 inline-flex items-center text-[12.5px] text-slate-900">Re: Follow up on Q1 proposal</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- body -->
+    <div class="w-full min-h-[120px] px-5 py-3 text-[13px] text-slate-800 leading-relaxed">
+      Tomorrow at 10am EST works great for me. I'll send a calendar invite shortly.<span class="text-slate-400"> Write your reply. ⌘ + Enter to send.</span>
+    </div>
+
+    <!-- signature preview strip -->
+    <div class="mx-5 mb-2 rounded-md border border-emerald-200/60 bg-emerald-50/40 overflow-hidden">
+      <div class="px-3 py-1.5 flex items-center gap-1.5 border-b border-emerald-200/40 bg-emerald-50/60">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-emerald-700" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
+        <span class="text-[10px] uppercase tracking-[0.14em] text-emerald-800 font-semibold">Signature appended on send</span>
+        <span class="ml-auto inline-flex items-center gap-1 text-[10px] text-emerald-700/80">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg>
+          from hello@company.com
+        </span>
+      </div>
+      <div class="px-3 py-2 font-sans text-[11.5px] text-slate-700 leading-relaxed">Best,<br />The Company Team</div>
+    </div>
+
+    <!-- action bar -->
+    <div class="px-3 py-2 border-t border-slate-200/60 flex flex-wrap items-center gap-1.5">
+      <span class="ub-send-btn h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></svg>
+        Send
+      </span>
+      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+        Schedule
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </span>
+      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
+        Template
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+      </span>
+      <span class="ml-auto inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] font-medium bg-emerald-50 text-emerald-700">
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
+        Signature on
+      </span>
+      <span class="font-mono text-[10px] text-slate-400 tabular-nums">0 / 4000</span>
+    </div>
+  </div>
+
+  <!-- cursor -->
+  <div class="ub-cursor" aria-hidden="true"><span class="ub-ripple"></span><svg width="23" height="27" viewBox="0 0 23 27" fill="none"><path d="M3 2.2 L3 20.4 L7.7 16 L10.9 23.2 L14 21.8 L10.9 14.8 L17.2 14.6 Z" fill="#ffffff" stroke="#0f172a" stroke-width="1.4" stroke-linejoin="round"/></svg></div>
+
+  <style>
+    .ub-cursor{position:absolute;z-index:50;width:23px;height:27px;pointer-events:none;filter:drop-shadow(0 4px 6px rgba(15,23,42,.4));animation:ub-move 11s cubic-bezier(.5,0,.2,1) infinite;}
+    .ub-cursor svg{display:block;transform-origin:3px 2px;animation:ub-press 11s ease-in-out infinite;}
+    .ub-ripple{position:absolute;left:-6px;top:-6px;width:32px;height:32px;border-radius:9999px;background:rgba(2,132,199,.5);transform:scale(0);opacity:0;animation:ub-rip 11s ease-out infinite;}
+    .ub-react{position:absolute;z-index:40;opacity:0;animation:ub-react 11s ease-out infinite;}
+    /* press #1 (28%) lands on Reply in the footer; press #2 (64%) lands on Send in the composer */
+    @keyframes ub-move{0%{left:30%;top:34%}22%{left:67%;top:94%}32%{left:67%;top:94%}58%{left:66%;top:92%}68%{left:66%;top:92%}88%{left:30%;top:34%}100%{left:30%;top:34%}}
+    @keyframes ub-press{0%,26%{transform:scale(1)}28%{transform:scale(.82)}31%,62%{transform:scale(1)}64%{transform:scale(.82)}67%,100%{transform:scale(1)}}
+    @keyframes ub-rip{0%,26%{transform:scale(0);opacity:0}29%{transform:scale(.25);opacity:.7}41%{transform:scale(1.9);opacity:0}60%{transform:scale(0);opacity:0}63%{transform:scale(.25);opacity:.7}75%{transform:scale(1.9);opacity:0}100%{transform:scale(0);opacity:0}}
+    @keyframes ub-react{0%,29%{opacity:0;transform:translateY(22px)}33%{opacity:1;transform:translateY(0)}88%{opacity:1;transform:translateY(0)}95%{opacity:0;transform:translateY(22px)}100%{opacity:0;transform:translateY(22px)}}
+    /* press feedback : Reply button darkens + rings on press #1 */
+    .ub-reply-btn{transition:none;animation:ub-reply-press 11s ease-in-out infinite;}
+    @keyframes ub-reply-press{0%,27%{background-color:#0284c7;box-shadow:none}28%,31%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,1)}32%,100%{background-color:#0284c7;box-shadow:none}}
+    /* press feedback : Send button darkens + rings on press #2 */
+    .ub-send-btn{animation:ub-send-press 11s ease-in-out infinite;}
+    @keyframes ub-send-press{0%,63%{background-color:#0284c7;box-shadow:none}64%,67%{background-color:#0369a1;box-shadow:0 0 0 2px rgba(186,230,253,1)}68%,100%{background-color:#0284c7;box-shadow:none}}
+    @media (prefers-reduced-motion: reduce){.ub-cursor{display:none}.ub-react{display:none}.ub-reply-btn{animation:none}.ub-send-btn{animation:none}}
+  </style>
+</div>

--- a/site/src/components/UniboxMock.astro
+++ b/site/src/components/UniboxMock.astro
@@ -327,15 +327,15 @@ const railToneClass = (tone: string, active: boolean) => {
 
       <!-- reply rail footer -->
       <div class="border-t border-slate-200 bg-white px-3 py-2 flex items-center gap-1.5 shrink-0">
-        <span class="ub-reply-btn h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5">
+        <span class="ub-reply-btn h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 14 4 9 9 4"/><path d="M20 20v-7a4 4 0 0 0-4-4H4"/></svg>
           Reply
         </span>
-        <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1.5">
+        <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 17 20 12 15 7"/><path d="M4 18v-2a4 4 0 0 1 4-4h12"/></svg>
           Forward
         </span>
-        <span class="ml-auto inline text-[10.5px] text-slate-400">Hover any message to reply to it directly.</span>
+        <span class="ml-auto min-w-0 truncate text-[10.5px] text-slate-400">Hover any message to reply to it directly.</span>
       </div>
     </div>
   </div>
@@ -373,11 +373,11 @@ const railToneClass = (tone: string, active: boolean) => {
         <div class="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
           <div class="inline-flex items-center gap-2 min-w-0">
             <span class="text-[12.5px] text-slate-900 font-medium truncate">Company</span>
-            <span class="font-mono text-[10.5px] text-slate-500 bg-slate-50 px-1.5 h-4 inline-flex items-center rounded border border-slate-200 shrink-0">hello@company.com</span>
+            <span class="font-mono text-[10.5px] text-slate-500 bg-slate-50 px-1.5 h-4 inline-flex items-center rounded border border-slate-200 shrink-0 whitespace-nowrap">hello@company.com</span>
           </div>
-          <div class="ml-auto flex items-center gap-1">
-            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center">+ Cc</span>
-            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center">+ Bcc</span>
+          <div class="ml-auto flex items-center gap-1 shrink-0">
+            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center whitespace-nowrap shrink-0">+ Cc</span>
+            <span class="h-5 px-1.5 rounded text-[10.5px] text-slate-500 inline-flex items-center whitespace-nowrap shrink-0">+ Bcc</span>
           </div>
         </div>
       </div>
@@ -385,7 +385,7 @@ const railToneClass = (tone: string, active: boolean) => {
         <span class="w-14 shrink-0 pt-[3px] text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">To</span>
         <span class="self-stretch w-px bg-slate-200 shrink-0"></span>
         <div class="flex-1 min-w-0 flex flex-wrap items-center gap-1.5">
-          <span class="inline-flex items-center gap-1 h-5 pl-1.5 pr-0.5 rounded-md text-[11px] font-medium shrink-0 border bg-sky-50 text-sky-800 border-sky-200">
+          <span class="inline-flex items-center gap-1 h-5 pl-1.5 pr-0.5 rounded-md text-[11px] font-medium shrink-0 whitespace-nowrap border bg-sky-50 text-sky-800 border-sky-200">
             <span class="font-mono">sarah@acme.io</span>
             <span class="size-4 inline-flex items-center justify-center rounded">
               <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
@@ -420,27 +420,23 @@ const railToneClass = (tone: string, active: boolean) => {
       <div class="px-3 py-2 font-sans text-[11.5px] text-slate-700 leading-relaxed">Best,<br />The Company Team</div>
     </div>
 
-    <!-- action bar -->
-    <div class="px-3 py-2 border-t border-slate-200/60 flex flex-wrap items-center gap-1.5">
+    <!-- action bar : single row, no wrap at the 320px composer width -->
+    <div class="px-3 py-2 border-t border-slate-200/60 flex flex-nowrap items-center gap-1.5">
       <span class="h-7 px-2.5 rounded-md bg-sky-600 text-white text-[12px] font-medium inline-flex items-center gap-1.5 whitespace-nowrap shrink-0">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/><path d="m21.854 2.147-10.94 10.939"/></svg>
         Send
       </span>
-      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1">
+      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1 whitespace-nowrap shrink-0">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
         Schedule
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
       </span>
-      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1">
+      <span class="h-7 px-2 rounded-md border border-slate-200 text-slate-700 text-[12px] inline-flex items-center gap-1 whitespace-nowrap shrink-0">
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M10 9H8"/><path d="M16 13H8"/><path d="M16 17H8"/></svg>
         Template
         <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-slate-400" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
       </span>
-      <span class="ml-auto inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] font-medium bg-emerald-50 text-emerald-700">
-        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.376 3.622a1 1 0 0 1 3.002 3.002L7.368 18.635a2 2 0 0 1-.855.506l-2.872.838a.5.5 0 0 1-.62-.62l.838-2.872a2 2 0 0 1 .506-.854z"/></svg>
-        Signature on
-      </span>
-      <span class="font-mono text-[10px] text-slate-400 tabular-nums">0 / 4000</span>
+      <span class="ml-auto font-mono text-[10px] text-slate-400 tabular-nums shrink-0">0 / 4000</span>
     </div>
   </div>
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -795,30 +795,6 @@ const softwareJsonLd = {
       }
     }
 
-    /* Schedule grid — window blocks grow up once their feature frame enters
-       view. JS-gated (html.js-ready) so blocks stay visible if JS never runs;
-       reduced-motion shows them in their final state. */
-    html.js-ready .showcase-frame .sched-block {
-      transform: scaleY(0);
-      transform-origin: top;
-      opacity: 0;
-    }
-    html.js-ready .showcase-frame.is-in .sched-block {
-      animation: sched-grow 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
-    }
-    @keyframes sched-grow {
-      from { transform: scaleY(0); opacity: 0; }
-      to   { transform: scaleY(1); opacity: 1; }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      html.js-ready .showcase-frame .sched-block,
-      html.js-ready .showcase-frame.is-in .sched-block {
-        transform: none;
-        opacity: 1;
-        animation: none;
-      }
-    }
-
     /* Pause the demo cursor while a visitor is inspecting a feature window. */
     .feature-window:hover .demo-cursor,
     .feature-window:hover .demo-cursor-ripple {
@@ -870,7 +846,6 @@ const softwareJsonLd = {
     tag('.feature-card',    0.10);
     tag('.metric-cell',     0.06);
     tag('.bento-card',      0.06);
-    tag('.showcase-frame',  0.12);
 
     // ── Bar grow on scroll ──────────────────────────────────────────
     document.querySelectorAll('.bar-fill').forEach((el) => {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -447,11 +447,13 @@ const softwareJsonLd = {
           </p>
           <div class="mt-auto pt-5 grid grid-cols-4 gap-1.5">
             {['Healthy','Watch','Quarantined','Blocked'].map((b, i) => (
-              <div class={`rounded-md px-1.5 py-1 text-center text-[10px] font-semibold tracking-wider ring-1 ${
+              <div class={`bento-band rounded-md px-1.5 py-1 text-center text-[10px] font-semibold tracking-wider ring-1 ${
                 i === 0 ? 'ring-emerald-200 text-emerald-700 bg-emerald-50' :
                 i === 1 ? 'ring-amber-200 text-amber-700 bg-amber-50' :
                 i === 2 ? 'ring-orange-200 text-orange-700 bg-orange-50' :
-                          'ring-rose-200 text-rose-700 bg-rose-50'}`}>{b}</div>
+                          'ring-rose-200 text-rose-700 bg-rose-50'}`}>
+                {i === 0 && <span class="inline-block w-1 h-1 rounded-full bg-emerald-500 align-middle mr-1 animate-pulse-soft"></span>}{b}
+              </div>
             ))}
           </div>
         </div>
@@ -466,7 +468,7 @@ const softwareJsonLd = {
             <div class="relative w-28 h-28">
               <svg viewBox="0 0 36 36" class="w-full h-full -rotate-90">
                 <circle cx="18" cy="18" r="15.9" fill="none" stroke="#e2e8f0" stroke-width="2.6"></circle>
-                <circle cx="18" cy="18" r="15.9" fill="none" stroke="var(--brand)" stroke-width="2.6" stroke-dasharray="96 100" stroke-linecap="round" class="animate-ring-fill"></circle>
+                <circle cx="18" cy="18" r="15.9" fill="none" stroke="var(--brand)" stroke-width="2.6" stroke-dasharray="96 100" stroke-linecap="round" class="animate-ring-fill bento-ring"></circle>
               </svg>
               <div class="absolute inset-0 flex flex-col items-center justify-center">
                 <span class="text-xl font-semibold tracking-tight text-heading">96%</span>
@@ -493,7 +495,7 @@ const softwareJsonLd = {
                   <span>{w.name}</span><span>{w.pct}%</span>
                 </div>
                 <div class="h-1.5 rounded-full bg-[color:var(--surface-2)] overflow-hidden">
-                  <div class="h-full rounded-full bg-[color:var(--brand)] animate-bar-grow" style={`--target:${w.pct}%`}></div>
+                  <div class="h-full rounded-full bg-[color:var(--brand)] animate-bar-grow bento-bar" style={`--target:${w.pct}%`}></div>
                 </div>
               </div>
             ))}
@@ -513,7 +515,7 @@ const softwareJsonLd = {
               { n: 'Step 3', t: 'Follow-up · context', m: '4 variants' },
               { n: 'Step 4', t: 'Soft break · 7 days', m: 'if no open' },
             ].map((s) => (
-              <div class="rounded-[10px] ring-1 ring-[color:var(--border)] p-2.5">
+              <div class="bento-step rounded-[10px] ring-1 ring-[color:var(--border)] p-2.5">
                 <div class="flex items-center justify-between text-[9.5px] font-mono text-muted-foreground uppercase tracking-wider">
                   <span>{s.n}</span><span class="text-foreground/60">{s.m}</span>
                 </div>
@@ -801,6 +803,42 @@ const softwareJsonLd = {
     .feature-window:hover .demo-cursor,
     .feature-window:hover .demo-cursor-ripple {
       animation-play-state: paused;
+    }
+
+    /* "One platform" bento: continuous, living data viz. */
+    @media (prefers-reduced-motion: no-preference) {
+      /* health states: a highlight walks Healthy -> Blocked on a loop */
+      .bento-band { animation: bento-band 5s ease-in-out infinite; }
+      .bento-band:nth-child(1) { animation-delay: 0s; }
+      .bento-band:nth-child(2) { animation-delay: -3.75s; }
+      .bento-band:nth-child(3) { animation-delay: -2.5s; }
+      .bento-band:nth-child(4) { animation-delay: -1.25s; }
+      @keyframes bento-band {
+        0%, 16%, 100% { transform: translateY(0); filter: none; }
+        8%            { transform: translateY(-3px); filter: brightness(1.07); }
+      }
+      /* worker bars: a shimmer sweeps the filled bar (live sending) */
+      .bento-bar { position: relative; overflow: hidden; }
+      .bento-bar::after {
+        content: ''; position: absolute; inset: 0;
+        background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.6) 50%, transparent 100%);
+        transform: translateX(-130%);
+        animation: bento-shimmer 3.4s ease-in-out infinite;
+      }
+      @keyframes bento-shimmer { 0% { transform: translateX(-130%); } 55%, 100% { transform: translateX(260%); } }
+      /* sequence steps: a sky highlight steps through 1 -> 4 */
+      .bento-step { animation: bento-step 5.6s ease-in-out infinite; }
+      .bento-step:nth-child(1) { animation-delay: 0s; }
+      .bento-step:nth-child(2) { animation-delay: -4.2s; }
+      .bento-step:nth-child(3) { animation-delay: -2.8s; }
+      .bento-step:nth-child(4) { animation-delay: -1.4s; }
+      @keyframes bento-step {
+        0%, 16%, 100% { box-shadow: none; }
+        8%            { box-shadow: 0 0 0 2px var(--brand-soft); }
+      }
+    }
+    @media (hover: hover) and (prefers-reduced-motion: no-preference) {
+      .bento-card:hover .bento-ring { animation: ring-fill 1.1s cubic-bezier(0.22, 1, 0.36, 1) both; }
     }
   </style>
   <script is:inline>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -590,9 +590,9 @@ const softwareJsonLd = {
 
         <!-- Edge-to-edge grid: cards share borders via gap-px, no per-card ring.
              The whole grid sits inside a single rounded ring. -->
-        <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-px bg-[color:var(--border)] ring-1 ring-[color:var(--border)] rounded-[10px] overflow-hidden">
+        <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ring-1 ring-[color:var(--border-strong)] rounded-[10px] overflow-hidden">
           {plans.map((p, idx) => (
-            <div class="pricing-card relative flex flex-col bg-white p-7" data-card-idx={idx}>
+            <div class={`pricing-card relative flex flex-col bg-white p-7 border-[color:var(--border-strong)] ${idx === 0 ? '' : idx === 1 ? 'border-t sm:border-t-0 sm:border-l' : idx === 2 ? 'border-t lg:border-t-0 lg:border-l' : 'border-t lg:border-t-0 sm:border-l'}`} data-card-idx={idx}>
               <div class="relative flex flex-col h-full">
                 {p.highlight && (
                   <span class="absolute -top-2 right-0 inline-flex items-center h-6 px-2.5 rounded-full text-[10px] font-semibold uppercase tracking-[0.10em] bg-[color:var(--brand)] text-white shadow-[0_4px_12px_-2px_rgba(2,132,199,0.55)]">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -14,6 +14,7 @@ import DeveloperMock from '../components/DeveloperMock.astro';
 import CRMMock from '../components/CRMMock.astro';
 import TemplatingShowcase from '../components/TemplatingShowcase.astro';
 import ChangelogShowcase from '../components/ChangelogShowcase.astro';
+import OpenSourceShowcase from '../components/OpenSourceShowcase.astro';
 
 const compare = [
   ['Per-mailbox cold cap',     '50 / day default',                 '200 / day if you ask for it'],
@@ -370,8 +371,9 @@ const softwareJsonLd = {
       <CRMMock />
     </FeatureSection>
 
-    <!-- Changelog + Go templating: useful content sections after the feature showcase -->
+    <!-- Changelog, open-source CTA, and Go templating sections after the feature showcase -->
     <ChangelogShowcase />
+    <OpenSourceShowcase />
     <TemplatingShowcase />
 
     <!-- ============================================================

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -2,11 +2,18 @@
 import Layout from '../layouts/Layout.astro';
 import Icon from '../components/Icon.astro';
 import DashboardMock from '../components/DashboardMock.astro';
-import InboxMock from '../components/InboxMock.astro';
-import WarmupMock from '../components/WarmupMock.astro';
 import HeroAtmosphere from '../components/HeroAtmosphere.astro';
-import SequenceMock from '../components/SequenceMock.astro';
-import SectionSky from '../components/SectionSky.astro';
+import FeatureSection from '../components/FeatureSection.astro';
+import CampaignBuilderMock from '../components/CampaignBuilderMock.astro';
+import ScheduleMock from '../components/ScheduleMock.astro';
+import UniboxMock from '../components/UniboxMock.astro';
+import AnalyticsMock from '../components/AnalyticsMock.astro';
+import AIAssistantMock from '../components/AIAssistantMock.astro';
+import IntegrationsMock from '../components/IntegrationsMock.astro';
+import DeveloperMock from '../components/DeveloperMock.astro';
+import CRMMock from '../components/CRMMock.astro';
+import TemplatingShowcase from '../components/TemplatingShowcase.astro';
+import ChangelogShowcase from '../components/ChangelogShowcase.astro';
 
 const compare = [
   ['Per-mailbox cold cap',     '50 / day default',                 '200 / day if you ask for it'],
@@ -214,406 +221,158 @@ const softwareJsonLd = {
     </section>
 
     <!-- ============================================================
-         WARMUP — dark sky panel · real-looking product detail screen
+         FEATURE SHOWCASE — one section per feature, each on its own
+         background, with a pixel-faithful product window + an auto-playing
+         demo cursor. (Replaces the old warmup + abstract inbox/campaign bands.)
     ============================================================ -->
-    <section class="relative isolate overflow-hidden text-white" style="background: radial-gradient(ellipse 130% 140% at 72% 28%, #0284c7 0%, #0369a1 25%, #075985 50%, #0c4a6e 80%, #0a3d5c 100%);">
-      <img src="/backdrops/cloud-3.webp" alt="" aria-hidden="true" class="absolute -top-10 -left-10 w-[460px] opacity-30 pointer-events-none select-none cloud-drift cloud-1" loading="lazy" decoding="async" style="mix-blend-mode: screen;"/>
-      <img src="/backdrops/cloud-5.webp" alt="" aria-hidden="true" class="absolute top-10 right-0 w-[520px] opacity-22 pointer-events-none select-none cloud-drift cloud-2" loading="lazy" decoding="async" style="mix-blend-mode: screen;"/>
-      <img src="/backdrops/cloud-4.webp" alt="" aria-hidden="true" class="absolute -bottom-12 left-1/4 w-[420px] opacity-18 pointer-events-none select-none cloud-drift cloud-3" loading="lazy" decoding="async" style="mix-blend-mode: screen;"/>
 
-      <div class="container-page py-20 md:py-28 relative">
-        <div class="grid lg:grid-cols-12 gap-10 items-end mb-12">
-          <div class="lg:col-span-7">
-            <div class="text-[11px] uppercase tracking-[0.18em] text-white/55 font-mono mb-3">Warmup</div>
-            <h2 class="text-[34px] md:text-[52px] font-semibold tracking-[-0.025em] leading-[1.04]">
-              Mailbox warmup, built&nbsp;in.
-            </h2>
-          </div>
-          <div class="lg:col-span-5">
-            <p class="text-[15.5px] text-white/75 leading-relaxed">
-              Pool placement, daily ramps, conversational replies, and per-mailbox health monitoring run automatically on every paid mailbox. The same code that warms also quarantines.
-            </p>
-            <a href="/warmup/" class="mt-5 inline-flex items-center gap-1.5 text-[13.5px] font-medium text-white border-b border-white/30 hover:border-white pb-px">
-              Read the full doc
-              <Icon name="arrowUpRight" size={13} />
-            </a>
-          </div>
-        </div>
+    <FeatureSection
+      eyebrow="Campaigns"
+      title="Sequences that branch on real behavior."
+      description="Build a multi-step flow on the canvas, then drag a connector from any step to fork on opens, clicks, and replies. It's the exact builder you'll use in the app."
+      side="right"
+      bg="sky"
+      url="app.warmbly.com/campaigns/q1-sales/sequences"
+      cursor="a"
+      callouts={[
+        { label: 'Drag to branch', text: 'Pull a link from a step to add an “if opened / clicked / replied” path. No match just stops.' },
+        { label: 'A/B at every step', text: 'Weighted subject + body variants; the stronger one keeps sending.' },
+        { label: 'Threaded follow-ups', text: 'Follow-ups reply on the previous subject, so they land in the same conversation.' },
+      ]}
+      cta={{ text: 'Explore campaigns', href: '/campaigns/' }}
+    >
+      <CampaignBuilderMock />
+    </FeatureSection>
 
-        <!-- Clean warmup visual: row of mailbox rings up top, live activity
-             stream below. No big chart, no panels, no white borders.
-             Everything sits directly on the sky background. -->
-        <div class="relative">
+    <FeatureSection
+      eyebrow="Scheduling"
+      title="Send only inside their working hours."
+      description="A calendar-style editor with full per-day control. Draw a sending window on any weekday, drag to move it, grab an edge to resize. Everything snaps to 30 minutes."
+      side="left"
+      bg="light"
+      url="app.warmbly.com/campaigns/q1-sales/schedule"
+      cursor="b"
+      callouts={[
+        { label: 'Per-day windows', text: 'Independent windows for each day: mornings only, or split shifts. Several per day is fine.' },
+        { label: 'Timezone-aware', text: 'Sends follow the chosen timezone; worker IPs spread the volume naturally.' },
+        { label: 'One-click presets', text: 'Mon–Fri 9–5 in a tap, then fine-tune by dragging the blocks.' },
+      ]}
+      cta={{ text: 'See sending controls', href: '/sending/' }}
+    >
+      <ScheduleMock />
+    </FeatureSection>
 
-          <!-- Mailbox warmup rings · each mailbox shown as a circular ramp
-               with email + day count. Hovering brightens the ring. -->
-          <div class="flex items-baseline justify-between flex-wrap gap-3 mb-6">
-            <span class="text-[10.5px] uppercase tracking-[0.22em] font-mono text-white/55">Mailboxes in warmup · acme.co</span>
-            <span class="text-[10.5px] uppercase tracking-[0.22em] font-mono text-emerald-300/80 inline-flex items-center gap-1.5">
-              <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse-soft"></span>
-              pool active
-            </span>
-          </div>
+    <FeatureSection
+      eyebrow="Unified inbox"
+      title="Every reply, triaged the moment it lands."
+      description="Replies from every connected mailbox stream into one searchable queue. The classifier tags each one on arrival so you act on the labels that matter."
+      side="right"
+      bg="navy"
+      url="app.warmbly.com/unibox"
+      cursor="c"
+      callouts={[
+        { label: 'One queue, every mailbox', text: 'Scope by inbox, tag, or status: unread, awaiting reply, snoozed, scheduled.' },
+        { label: 'Classified on arrival', text: 'Positive, out-of-office, unsubscribe and bounce are labeled before you open them.' },
+        { label: 'Reply in place', text: 'Snooze, schedule, and send from the same pane, keyboard-first.' },
+      ]}
+      cta={{ text: 'Tour the inbox', href: '/inbox/' }}
+    >
+      <UniboxMock />
+    </FeatureSection>
 
-          <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-y-8 gap-x-6">
-            {[
-              { e: 'founder',      day: 28 },
-              { e: 'hello',        day: 22 },
-              { e: 'team',         day: 16 },
-              { e: 'intro',        day: 11 },
-              { e: 'partnerships', day:  7 },
-              { e: 'support',      day:  3 },
-            ].map((m) => {
-              const r = 26;
-              const C = 2 * Math.PI * r;
-              const pct = Math.min(1, m.day / 30);
-              const dash = (C * pct).toFixed(2);
-              const gap  = (C - C * pct).toFixed(2);
-              return (
-                <div class="flex flex-col items-center text-center group">
-                  <svg viewBox="0 0 64 64" class="w-[68px] h-[68px] -rotate-90 transition-transform duration-300 group-hover:scale-[1.05]" role="img" aria-label={`${m.e} warmup day ${m.day} of 30`}>
-                    <circle cx="32" cy="32" r={r} fill="none" stroke="rgba(186,230,253,0.12)" stroke-width="3" />
-                    <circle
-                      cx="32" cy="32" r={r}
-                      fill="none"
-                      stroke="url(#ringStroke)"
-                      stroke-width="3"
-                      stroke-linecap="round"
-                      stroke-dasharray={`${dash} ${gap}`}
-                    />
-                  </svg>
-                  <div class="-mt-[46px] mb-[20px] text-[15px] font-semibold text-white tabular-nums">{m.day}</div>
-                  <div class="font-mono text-[12px] text-white/85">{m.e}<span class="text-white/40">@acme.co</span></div>
-                  <div class="mt-1 font-mono text-[10.5px] text-white/40 uppercase tracking-[0.16em]">day {m.day} / 30</div>
-                </div>
-              );
-            })}
-          </div>
+    <FeatureSection
+      eyebrow="Analytics"
+      title="Proof of what actually landed."
+      description="Deliverability across the whole workspace: sent, opens, clicks, replies and bounces, with per-campaign breakdowns and account health on one screen."
+      side="left"
+      bg="wallpaper"
+      url="app.warmbly.com/analytics"
+      cursor="d"
+      callouts={[
+        { label: 'Placement, not vanity', text: 'Track the metrics that move reputation, over 7, 30 or 90 days.' },
+        { label: 'Best performers, surfaced', text: 'Top campaigns and account health rank themselves as sends roll in.' },
+        { label: 'Shareable report card', text: 'Export a branded image of any range in a single tap.' },
+      ]}
+      cta={{ text: 'View analytics', href: '/analytics/' }}
+    >
+      <AnalyticsMock />
+    </FeatureSection>
 
-          <!-- Shared gradient for all rings -->
-          <svg width="0" height="0" class="absolute" aria-hidden="true">
-            <defs>
-              <linearGradient id="ringStroke" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="#bae6fd" />
-                <stop offset="100%" stop-color="#0ea5e9" />
-              </linearGradient>
-            </defs>
-          </svg>
+    <FeatureSection
+      eyebrow="AI assistant"
+      title="Draft the whole email from one line."
+      description="Describe what the email should do and the assistant writes it in your voice, merge fields and tone already in place. Edit inline, regenerate, or keep what works."
+      side="right"
+      bg="sky"
+      url="app.warmbly.com/campaigns/q1-sales/steps"
+      cursor="a"
+      callouts={[
+        { label: 'One-line briefs', text: 'Tell it the goal; get back a ready-to-send draft with variables filled in.' },
+        { label: 'Tone presets', text: 'Friendly, professional, concise, persuasive. Switch and regenerate in a click.' },
+        { label: 'Credits, no surprises', text: 'Each draft uses one writing credit, shown before you generate.' },
+      ]}
+      cta={{ text: 'Try the assistant', href: '/campaigns/' }}
+    >
+      <AIAssistantMock />
+    </FeatureSection>
 
-          <!-- Subtle horizontal divider made of the sky color, not white -->
-          <div class="mt-14 h-px" style="background: linear-gradient(90deg, transparent 0%, rgba(186,230,253,0.22) 50%, transparent 100%);"></div>
+    <FeatureSection
+      eyebrow="Integrations"
+      title="Plug into the stack you already run."
+      description="Connect Gmail, Microsoft 365, your CRM, Slack and Zapier over OAuth. Tokens are encrypted at rest and every webhook is HMAC-signed."
+      side="left"
+      bg="light"
+      url="app.warmbly.com/integrations"
+      cursor="b"
+      callouts={[
+        { label: 'OAuth in two clicks', text: 'Authorize a provider and Warmbly handles the rest. Revoke anytime.' },
+        { label: 'Signed webhooks', text: 'Every event is HMAC-signed and HTTPS by default, with SSRF protection.' },
+        { label: 'Encrypted at rest', text: 'Secrets are sealed with your data key, never stored in plaintext.' },
+      ]}
+      cta={{ text: 'Browse integrations', href: '/integrations/' }}
+    >
+      <IntegrationsMock />
+    </FeatureSection>
 
-          <!-- KPI row directly below divider, clean and short -->
-          <div class="mt-10 grid grid-cols-2 md:grid-cols-4 gap-y-6 gap-x-10">
-            {[
-              { k: 'Peers',   v: '142',    sub: 'active last 24h' },
-              { k: 'Replies', v: '11',     sub: 'reply rate 34%' },
-              { k: 'Inbox',   v: '96.4%',  sub: 'rolling 14 day' },
-              { k: 'Spam',    v: '1.8%',   sub: 'well under 10%' },
-            ].map((s) => (
-              <div>
-                <div class="text-[10.5px] uppercase tracking-[0.22em] text-white/45 font-mono">{s.k}</div>
-                <div class="mt-2 text-[32px] md:text-[36px] font-semibold tracking-[-0.025em] text-white leading-none tabular-nums">{s.v}</div>
-                <div class="mt-1.5 text-[11.5px] text-white/45 font-mono">{s.sub}</div>
-              </div>
-            ))}
-          </div>
+    <FeatureSection
+      eyebrow="Developers"
+      title="An API you can build a product on."
+      description="Everything in the dashboard is a REST endpoint: scoped API keys, idempotent writes, opaque cursors, and HMAC-signed webhooks."
+      side="right"
+      bg="navy"
+      url="app.warmbly.com/api-keys"
+      cursor="c"
+      callouts={[
+        { label: 'Scoped keys', text: 'Mint read, write, or send-only keys per environment and rotate without downtime.' },
+        { label: 'Idempotent by default', text: 'Send an Idempotency-Key and retries are always safe.' },
+        { label: 'Webhooks that verify', text: 'Subscribe to events like contact.replied with signed payloads.' },
+      ]}
+      cta={{ text: 'Read the API docs', href: '/developers/' }}
+    >
+      <DeveloperMock />
+    </FeatureSection>
 
-          <!-- Pool composition strip, quiet, no box -->
-          <div class="mt-10 flex flex-wrap items-center gap-x-5 gap-y-2 text-[11.5px]">
-            <span class="text-[10.5px] uppercase tracking-[0.22em] text-white/45 font-mono mr-2">Pool</span>
-            <span class="inline-flex items-center gap-1.5 text-white/70"><span class="w-1.5 h-1.5 rounded-full bg-rose-400"></span>Gmail <span class="font-mono text-white/45">46%</span></span>
-            <span class="inline-flex items-center gap-1.5 text-white/70"><span class="w-1.5 h-1.5 rounded-full bg-sky-400"></span>Outlook <span class="font-mono text-white/45">24%</span></span>
-            <span class="inline-flex items-center gap-1.5 text-white/70"><span class="w-1.5 h-1.5 rounded-full bg-violet-400"></span>Yahoo <span class="font-mono text-white/45">12%</span></span>
-            <span class="inline-flex items-center gap-1.5 text-white/70"><span class="w-1.5 h-1.5 rounded-full bg-zinc-300"></span>iCloud <span class="font-mono text-white/45">9%</span></span>
-            <span class="inline-flex items-center gap-1.5 text-white/70"><span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>Self-IMAP <span class="font-mono text-white/45">9%</span></span>
-          </div>
-        </div>
-      </div>
-    </section>
+    <FeatureSection
+      eyebrow="CRM"
+      title="Replies become a pipeline, not a pile."
+      description="A positive reply can open a deal. Drag it across stages, assign an owner, and keep tasks and notes right next to the conversation that started it."
+      side="left"
+      bg="wallpaper"
+      url="app.warmbly.com/crm/deals"
+      cursor="d"
+      callouts={[
+        { label: 'Visual pipelines', text: 'Drag deals across stages; stage totals update as you go.' },
+        { label: 'Owners and tasks', text: 'Assign teammates, set follow-up tasks, and never drop a thread.' },
+        { label: 'Tied to the inbox', text: 'Each deal links back to the reply that created it.' },
+      ]}
+      cta={{ text: 'See the CRM', href: '/crm/' }}
+    >
+      <CRMMock />
+    </FeatureSection>
 
-    <!-- ============================================================
-         INBOX — architecture flow diagram (many mailboxes → 1 triage)
-    ============================================================ -->
-    <section class="relative bg-white border-t border-[color:var(--border)] overflow-hidden">
-      <div class="container-page py-20 md:py-28">
-        <div class="grid lg:grid-cols-12 gap-10 items-end">
-          <div class="lg:col-span-7">
-            <div class="text-[11px] uppercase tracking-[0.18em] text-muted-foreground font-mono mb-3">Inbox</div>
-            <h2 class="text-[34px] md:text-[48px] font-semibold tracking-[-0.025em] leading-[1.06] text-heading">
-              Every reply, one queue, five labels.
-            </h2>
-            <p class="mt-5 text-[15.5px] text-foreground/75 leading-relaxed max-w-lg">
-              Replies stream in from every connected mailbox. The classifier tags each one before it lands so triage stays on the labels you care about.
-            </p>
-          </div>
-
-          <!-- Stats fills the empty top-right space -->
-          <div class="lg:col-span-5">
-            <div class="grid grid-cols-3 gap-px bg-[color:var(--border)] ring-1 ring-[color:var(--border)] rounded-[10px] overflow-hidden">
-              {[
-                { v: '5', l: 'labels' },
-                { v: '< 1s', l: 'tag latency' },
-                { v: '∞', l: 'mailboxes per queue' },
-              ].map((s) => (
-                <div class="bg-white px-4 py-4">
-                  <div class="text-[26px] font-semibold tracking-[-0.025em] text-heading leading-none">{s.v}</div>
-                  <div class="mt-1.5 text-[11px] uppercase tracking-[0.14em] font-mono text-muted-foreground">{s.l}</div>
-                </div>
-              ))}
-            </div>
-            <div class="mt-3 flex items-center justify-between text-[12px] text-muted-foreground">
-              <span>Quoted-text aware. OOO + unsubscribe auto-handled.</span>
-              <a href="/inbox/" class="font-medium text-foreground border-b border-foreground/30 hover:border-foreground pb-px inline-flex items-center gap-1">See more <Icon name="arrowUpRight" size={11} /></a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Flow diagram — pure SVG so dots track lines perfectly -->
-        <div class="mt-12 relative rounded-[14px] ring-1 ring-[color:var(--border)] bg-[color:var(--surface-2)]/30 px-4 py-6 md:px-10 md:py-10 overflow-hidden">
-          <!-- Subtle background grid -->
-          <div class="absolute inset-0 pointer-events-none opacity-[0.6]" style="background-image: linear-gradient(rgba(15,23,42,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(15,23,42,0.05) 1px, transparent 1px); background-size: 32px 32px;"></div>
-
-          <svg viewBox="0 0 1400 540" class="relative w-full h-auto" preserveAspectRatio="xMidYMid meet">
-            <defs>
-              <linearGradient id="flow-in" x1="360" y1="0" x2="620" y2="0" gradientUnits="userSpaceOnUse">
-                <stop offset="0%" stop-color="#7dd3fc"/>
-                <stop offset="100%" stop-color="#0284c7"/>
-              </linearGradient>
-              <linearGradient id="flow-out" x1="840" y1="0" x2="1080" y2="0" gradientUnits="userSpaceOnUse">
-                <stop offset="0%" stop-color="#0284c7"/>
-                <stop offset="100%" stop-color="#7dd3fc"/>
-              </linearGradient>
-              <filter id="card-shadow" x="-10%" y="-30%" width="120%" height="160%">
-                <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#0f172a" flood-opacity="0.07"/>
-              </filter>
-              <filter id="classifier-shadow" x="-25%" y="-25%" width="150%" height="150%">
-                <feDropShadow dx="0" dy="20" stdDeviation="28" flood-color="#0f172a" flood-opacity="0.30"/>
-              </filter>
-              <filter id="dot-glow" x="-100%" y="-100%" width="300%" height="300%">
-                <feGaussianBlur stdDeviation="3" result="blur"/>
-                <feMerge>
-                  <feMergeNode in="blur"/>
-                  <feMergeNode in="SourceGraphic"/>
-                </feMerge>
-              </filter>
-            </defs>
-
-            <!-- Connector paths (IDs for animateMotion mpath) -->
-            <path id="in-1" d="M 360 60  C 500 60,  560 270, 620 270" stroke="url(#flow-in)" stroke-width="2" fill="none"/>
-            <path id="in-2" d="M 360 165 C 500 165, 560 270, 620 270" stroke="url(#flow-in)" stroke-width="2" fill="none"/>
-            <path id="in-4" d="M 360 375 C 500 375, 560 270, 620 270" stroke="url(#flow-in)" stroke-width="2" fill="none"/>
-            <path id="in-5" d="M 360 480 C 500 480, 560 270, 620 270" stroke="url(#flow-in)" stroke-width="2" fill="none"/>
-            <path id="in-3" d="M 360 270 L 620 270" stroke="url(#flow-in)" stroke-width="2" fill="none"/>
-
-            <path id="out-1" d="M 840 270 C 900 270, 940 60,  1080 60"  stroke="url(#flow-out)" stroke-width="2" fill="none"/>
-            <path id="out-2" d="M 840 270 C 900 270, 940 165, 1080 165" stroke="url(#flow-out)" stroke-width="2" fill="none"/>
-            <path id="out-4" d="M 840 270 C 900 270, 940 375, 1080 375" stroke="url(#flow-out)" stroke-width="2" fill="none"/>
-            <path id="out-5" d="M 840 270 C 900 270, 940 480, 1080 480" stroke="url(#flow-out)" stroke-width="2" fill="none"/>
-            <path id="out-3" d="M 840 270 L 1080 270" stroke="url(#flow-out)" stroke-width="2" fill="none"/>
-
-            <!-- Mailbox pills (left) -->
-            {(() => {
-              const mb = [
-                { e: 'founder@acme.co',     y: 60 },
-                { e: 'team@northwind.dev',  y: 165 },
-                { e: 'hello@spruce.bio',    y: 270 },
-                { e: 'intro@helio.gen',     y: 375 },
-                { e: 'maya@cinder.app',     y: 480 },
-              ];
-              return mb.map((m) => (
-                <g filter="url(#card-shadow)">
-                  <rect x="20" y={m.y - 22} rx="22" ry="22" width="340" height="44" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
-                  <rect x="32" y={m.y - 12} rx="6" ry="6" width="24" height="24" fill="#e0f2fe"/>
-                  <text x="44" y={m.y + 4} font-family="ui-sans-serif, system-ui" font-size="11" font-weight="700" fill="#0369a1" text-anchor="middle">{m.e.slice(0, 2).toUpperCase()}</text>
-                  <text x="68" y={m.y + 5} font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="14" fill="#0f172a">{m.e}</text>
-                </g>
-              ));
-            })()}
-
-            <!-- Classifier card (center, larger + more prominent) -->
-            <g filter="url(#classifier-shadow)">
-              <rect x="620" y="150" rx="16" ry="16" width="220" height="240" fill="#0f172a"/>
-              <!-- Top status row -->
-              <circle cx="644" cy="184" r="5" fill="#34d399">
-                <animate attributeName="opacity" values="1;0.3;1" dur="2s" repeatCount="indefinite"/>
-              </circle>
-              <text x="660" y="189" font-family="ui-monospace" font-size="11" font-weight="600" letter-spacing="2" fill="#cbd5e1">CLASSIFIER</text>
-              <!-- Headline -->
-              <text x="644" y="232" font-family="ui-sans-serif, system-ui" font-size="18" font-weight="600" fill="#ffffff" letter-spacing="-0.4">Tags every reply</text>
-              <text x="644" y="254" font-family="ui-sans-serif, system-ui" font-size="18" font-weight="600" fill="#ffffff" letter-spacing="-0.4">on arrival.</text>
-              <!-- Divider line -->
-              <line x1="644" y1="280" x2="816" y2="280" stroke="#1e293b" stroke-width="1"/>
-              <!-- Capability list -->
-              <text x="644" y="304" font-family="ui-monospace" font-size="11.5" fill="#94a3b8">quoted-text aware</text>
-              <text x="644" y="324" font-family="ui-monospace" font-size="11.5" fill="#94a3b8">OOO detection</text>
-              <text x="644" y="344" font-family="ui-monospace" font-size="11.5" fill="#94a3b8">auto-suppress</text>
-              <text x="644" y="364" font-family="ui-monospace" font-size="11.5" fill="#94a3b8">round-robin assign</text>
-            </g>
-
-            <!-- Label pills (right) -->
-            {(() => {
-              const lb = [
-                { t: 'Positive',     dot: '#10b981', y: 60 },
-                { t: 'Negative',     dot: '#f43f5e', y: 165 },
-                { t: 'Out of office',dot: '#f59e0b', y: 270 },
-                { t: 'Unsubscribe',  dot: '#64748b', y: 375 },
-                { t: 'Bounce',       dot: '#fb923c', y: 480 },
-              ];
-              return lb.map((l) => (
-                <g filter="url(#card-shadow)">
-                  <rect x="1080" y={l.y - 22} rx="22" ry="22" width="300" height="44" fill="#ffffff" stroke="#e2e8f0" stroke-width="1"/>
-                  <circle cx="1100" cy={l.y} r="4.5" fill={l.dot}/>
-                  <text x="1116" y={l.y + 5} font-family="ui-sans-serif, system-ui" font-size="14" font-weight="500" fill="#0f172a">{l.t}</text>
-                </g>
-              ));
-            })()}
-
-            <!-- Traveling dots — bigger, glowing, on every path -->
-            {[
-              { id: 'in-1',  dur: '3.2s', begin: '0s',   color: '#0ea5e9' },
-              { id: 'in-2',  dur: '3.6s', begin: '0.5s', color: '#0ea5e9' },
-              { id: 'in-3',  dur: '3.0s', begin: '1.0s', color: '#0ea5e9' },
-              { id: 'in-4',  dur: '3.8s', begin: '1.5s', color: '#0ea5e9' },
-              { id: 'in-5',  dur: '3.4s', begin: '2.0s', color: '#0ea5e9' },
-              { id: 'out-1', dur: '3.2s', begin: '2.6s', color: '#10b981' },
-              { id: 'out-2', dur: '3.6s', begin: '3.0s', color: '#f43f5e' },
-              { id: 'out-3', dur: '3.0s', begin: '3.4s', color: '#f59e0b' },
-              { id: 'out-4', dur: '3.8s', begin: '3.8s', color: '#64748b' },
-              { id: 'out-5', dur: '3.4s', begin: '4.2s', color: '#fb923c' },
-            ].map((d) => (
-              <circle r="6" fill={d.color} filter="url(#dot-glow)">
-                <animateMotion dur={d.dur} repeatCount="indefinite" begin={d.begin}><mpath href={`#${d.id}`}/></animateMotion>
-              </circle>
-            ))}
-          </svg>
-        </div>
-
-        <div class="mt-12 flex items-center gap-3">
-          <a href="/inbox/" class="inline-flex items-center gap-1.5 text-[13.5px] font-medium text-foreground border-b border-foreground/30 hover:border-foreground pb-px">
-            See the inbox
-            <Icon name="arrowUpRight" size={13} />
-          </a>
-          <span class="text-[12.5px] text-muted-foreground">Cross-mailbox search, snooze with reminders, round-robin assignment.</span>
-        </div>
-      </div>
-    </section>
-
-    <!-- ============================================================
-         CAMPAIGNS — code config + horizontal timeline of steps
-    ============================================================ -->
-    <section class="relative overflow-hidden border-t border-[color:var(--border)]" style="background: #fafafa;">
-      <div class="container-page py-20 md:py-28 relative">
-        <div class="grid lg:grid-cols-12 gap-12 lg:gap-16 mb-12">
-          <div class="lg:col-span-5">
-            <div class="text-[11px] uppercase tracking-[0.18em] text-muted-foreground font-mono mb-3">Campaigns</div>
-            <h2 class="text-[34px] md:text-[44px] font-semibold tracking-[-0.025em] leading-[1.08] text-heading">
-              Sequences as configuration, not click-and-drag prison.
-            </h2>
-          </div>
-          <div class="lg:col-span-7">
-            <p class="text-[15.5px] text-foreground/75 leading-relaxed">
-              Build a sequence in the UI or import one as YAML through the API. Up to 12 steps with A/B variants, business-hour delays, and conditions that branch on opens, replies and bounces.
-            </p>
-          </div>
-        </div>
-
-        <!-- Auto-scrolling step timeline (no scrollbar, loops forever) -->
-        <div class="relative marquee-mask overflow-hidden">
-          <!-- Faint connecting rail behind the cards -->
-          <div class="pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 h-px bg-gradient-to-r from-transparent via-[color:var(--border-strong)] to-transparent opacity-60"></div>
-
-          <ol class="relative flex items-stretch gap-0 w-max marquee-track-slow py-1">
-            {Array.from({ length: 2 }).map(() => (
-              <>
-                {[
-                  { n: 1, k: 'SEND',   t: 'Intro · plain text',            m: '2 variants',  icon: 'send' },
-                  { n: 2, k: 'WAIT',   t: '3 business days',                m: 'if no reply', icon: 'clock' },
-                  { n: 3, k: 'SEND',   t: 'Follow-up · context line',       m: '4 variants',  icon: 'send' },
-                  { n: 4, k: 'BRANCH', t: 'If opened twice',                m: 'send earlier',icon: 'workflow' },
-                  { n: 5, k: 'SEND',   t: 'Soft close · short ask',          m: '2 variants',  icon: 'send' },
-                  { n: 6, k: 'WAIT',   t: '7 business days',                m: 'silence',     icon: 'clock' },
-                  { n: 7, k: 'SEND',   t: 'Final · breakup note',           m: '1 variant',   icon: 'send' },
-                  { n: 8, k: 'END',    t: 'Stop · mark contact done',       m: 'sequence done', icon: 'check' },
-                ].map((s) => {
-                  const tone = s.k === 'SEND'  ? { bg: 'bg-sky-50',    text: 'text-sky-700',     dot: 'bg-sky-500' } :
-                              s.k === 'WAIT'   ? { bg: 'bg-slate-50',  text: 'text-slate-500',   dot: 'bg-slate-400' } :
-                              s.k === 'BRANCH' ? { bg: 'bg-violet-50', text: 'text-violet-700',  dot: 'bg-violet-500' } :
-                                                  { bg: 'bg-emerald-50',text: 'text-emerald-700', dot: 'bg-emerald-500' };
-                  return (
-                    <li class="shrink-0 flex items-center">
-                      <!-- step card -->
-                      <div class="w-[260px] rounded-[12px] bg-white ring-1 ring-[color:var(--border)] overflow-hidden" style="box-shadow: var(--shadow-sm);">
-                        <div class={`flex items-center gap-2 px-4 h-8 ${tone.bg}`}>
-                          <span class={`w-1.5 h-1.5 rounded-full ${tone.dot}`}></span>
-                          <span class={`text-[10px] font-mono font-semibold uppercase tracking-[0.16em] ${tone.text}`}>{s.k}</span>
-                          <span class="ml-auto text-[10px] font-mono text-muted-foreground">{String(s.n).padStart(2, '0')}</span>
-                        </div>
-                        <div class="px-4 py-3.5">
-                          <div class="flex items-start gap-2.5">
-                            <Icon name={s.icon} size={15} class="text-foreground/55 mt-0.5 shrink-0" />
-                            <div class="min-w-0">
-                              <div class="text-[13.5px] font-medium text-heading leading-snug">{s.t}</div>
-                              <div class="mt-1 text-[11px] font-mono text-muted-foreground">{s.m}</div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <!-- connector arrow -->
-                      <div class="shrink-0 px-2.5 text-[color:var(--border-strong)]" aria-hidden="true">
-                        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"><path d="M3 7h8M7.5 3.5L11 7l-3.5 3.5"/></svg>
-                      </div>
-                    </li>
-                  );
-                })}
-              </>
-            ))}
-          </ol>
-        </div>
-
-        <!-- Config block -->
-        <div class="mt-12 grid lg:grid-cols-12 gap-8 items-start">
-          <div class="lg:col-span-7">
-            <div class="rounded-[10px] overflow-hidden ring-1 ring-[color:var(--border)] bg-[#0c1224]"
-                 style="box-shadow: var(--shadow-md);">
-              <div class="flex items-center gap-2 px-4 h-9 border-b border-white/10 bg-[#0a0f1e]">
-                <div class="flex items-center gap-1.5">
-                  <span class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></span>
-                  <span class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></span>
-                  <span class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></span>
-                </div>
-                <span class="ml-3 text-[11px] font-mono text-white/45">campaign.q2-outbound.yaml</span>
-              </div>
-              <pre class="text-[12.5px] leading-[1.7] font-mono text-white/85 p-5 overflow-x-auto"><code><span style="color:#7dd3fc">name</span>: <span style="color:#fcd34d">Q2 outbound · enterprise</span>
-<span style="color:#7dd3fc">mailboxes</span>: <span style="color:#fcd34d">[founder@acme.co, team@acme.co]</span>
-<span style="color:#7dd3fc">steps</span>:
-  <span style="color:#a78bfa">- type</span>: <span style="color:#86efac">send</span>
-    <span style="color:#a78bfa">subject</span>: <span style="color:#fcd34d">Re: {`{{news.summary}}`}</span>
-    <span style="color:#a78bfa">variants</span>: <span style="color:#fcd34d">2</span>
-  <span style="color:#a78bfa">- type</span>: <span style="color:#86efac">wait</span>
-    <span style="color:#a78bfa">days</span>: <span style="color:#fcd34d">3</span>
-    <span style="color:#a78bfa">unless</span>: <span style="color:#fcd34d">replied</span>
-  <span style="color:#a78bfa">- type</span>: <span style="color:#86efac">send</span>
-    <span style="color:#a78bfa">subject</span>: <span style="color:#fcd34d">Quick context on {`{{custom.pain}}`}</span>
-    <span style="color:#a78bfa">variants</span>: <span style="color:#fcd34d">4</span>
-  <span style="color:#a78bfa">- type</span>: <span style="color:#86efac">branch</span>
-    <span style="color:#a78bfa">if</span>: <span style="color:#fcd34d">opens &gt;= 2</span>
-    <span style="color:#a78bfa">jump</span>: <span style="color:#fcd34d">step.5</span></code></pre>
-            </div>
-          </div>
-          <div class="lg:col-span-5">
-            <h3 class="text-[18px] font-semibold tracking-[-0.015em] text-heading">Built around an API, not against one.</h3>
-            <p class="mt-3 text-[14px] text-foreground/75 leading-relaxed">
-              Every sequence built in the UI is the same object the API returns. Version-control campaigns, branch them in code, deploy with a webhook.
-            </p>
-            <a href="/developers/" class="mt-5 inline-flex items-center gap-1.5 text-[13.5px] font-medium text-foreground border-b border-foreground/30 hover:border-foreground pb-px">
-              API reference
-              <Icon name="arrowUpRight" size={13} />
-            </a>
-          </div>
-        </div>
-      </div>
-    </section>
+    <!-- Changelog + Go templating: useful content sections after the feature showcase -->
+    <ChangelogShowcase />
+    <TemplatingShowcase />
 
     <!-- ============================================================
          COMPARE — serious data table
@@ -1035,6 +794,36 @@ const softwareJsonLd = {
         transition: none;
       }
     }
+
+    /* Schedule grid — window blocks grow up once their feature frame enters
+       view. JS-gated (html.js-ready) so blocks stay visible if JS never runs;
+       reduced-motion shows them in their final state. */
+    html.js-ready .showcase-frame .sched-block {
+      transform: scaleY(0);
+      transform-origin: top;
+      opacity: 0;
+    }
+    html.js-ready .showcase-frame.is-in .sched-block {
+      animation: sched-grow 0.55s cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    @keyframes sched-grow {
+      from { transform: scaleY(0); opacity: 0; }
+      to   { transform: scaleY(1); opacity: 1; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      html.js-ready .showcase-frame .sched-block,
+      html.js-ready .showcase-frame.is-in .sched-block {
+        transform: none;
+        opacity: 1;
+        animation: none;
+      }
+    }
+
+    /* Pause the demo cursor while a visitor is inspecting a feature window. */
+    .feature-window:hover .demo-cursor,
+    .feature-window:hover .demo-cursor-ripple {
+      animation-play-state: paused;
+    }
   </style>
   <script is:inline>
     // Tag the document so the CSS above can hide fade-in targets only when JS is alive.
@@ -1076,11 +865,12 @@ const softwareJsonLd = {
         }, { amount: 0.12 });
       });
     };
-    tag('.pricing-card', 0.10);
-    tag('.step-card',    0.10);
-    tag('.feature-card', 0.10);
-    tag('.metric-cell',  0.06);
-    tag('.bento-card',   0.06);
+    tag('.pricing-card',    0.10);
+    tag('.step-card',       0.10);
+    tag('.feature-card',    0.10);
+    tag('.metric-cell',     0.06);
+    tag('.bento-card',      0.06);
+    tag('.showcase-frame',  0.12);
 
     // ── Bar grow on scroll ──────────────────────────────────────────
     document.querySelectorAll('.bar-fill').forEach((el) => {

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -167,12 +167,23 @@ body {
    Reusable patterns
 ---------------------------------------------------------------- */
 
+/* Site-wide content width. Widened to 90rem so the header, hero, footer
+   and every section share the same generous width as the feature showcase. */
 @utility container-page {
   width: 100%;
   margin-inline: auto;
   padding-inline: 1.25rem;
-  max-width: 80rem;
-  @media (min-width: 768px) { padding-inline: 2rem; }
+  max-width: 90rem;
+  @media (min-width: 768px) { padding-inline: 2.5rem; }
+}
+
+/* Alias kept for the feature showcase; same width as container-page. */
+@utility container-wide {
+  width: 100%;
+  margin-inline: auto;
+  padding-inline: 1.25rem;
+  max-width: 90rem;
+  @media (min-width: 768px) { padding-inline: 2.5rem; }
 }
 
 @utility prose-warmbly {


### PR DESCRIPTION
## Summary
- Reworks the landing page around reusable feature showcase sections with product-style mocks for campaigns, scheduling, inbox, analytics, AI, integrations, developer APIs, and CRM.
- Adds changelog, templating, and open-source showcase sections, plus animated bento/pricing polish.
- Adds a fullscreen mobile site menu with accordion support and scroll locking.

## Verification
- Not run: `site/package.json` does not define `typecheck` or `lint` scripts.