### PR TITLE
feat: add unibox conversation labels

### DIFF
--- a/internal/api/handler/unibox.go
+++ b/internal/api/handler/unibox.go
@@ -133,6 +133,21 @@ func (h *Handler) GetUniboxIncoming(c *gin.Context) {
 		collectAccountIDs(v)
 	}
 
+	// Conversation-label filter: category_ids=<uuid>,<uuid>. A thread
+	// matches if it carries any of the listed labels. Invalid UUIDs are
+	// dropped, matching the email_ids behaviour.
+	if v := c.Query("category_ids"); v != "" {
+		for _, s := range strings.Split(v, ",") {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			if id, err := uuid.Parse(s); err == nil {
+				params.CategoryIDs = append(params.CategoryIDs, id)
+			}
+		}
+	}
+
 	resp, xerr := h.UniboxService.Search(c.Request.Context(), uid, params)
 	if xerr != nil {
 		errx.Handle(c, xerr)
@@ -240,6 +255,73 @@ func (h *Handler) GetUniboxThread(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// GetUniboxThreadLabels returns the conversation labels on a thread.
+// GET /unibox/thread/labels?thread_id=<id>
+func (h *Handler) GetUniboxThreadLabels(c *gin.Context) {
+	if !h.gateUnibox(c) {
+		return
+	}
+	userID := middleware.GetUserID(c)
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		errx.Handle(c, errx.ErrUser)
+		return
+	}
+
+	threadID := c.Query("thread_id")
+	if threadID == "" {
+		threadID = c.Query("id")
+	}
+	if threadID == "" {
+		errx.Handle(c, errx.New(errx.BadRequest, "thread_id is required"))
+		return
+	}
+
+	labels, xerr := h.UniboxService.ListThreadLabels(c.Request.Context(), uid, threadID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": labels})
+}
+
+// SetUniboxThreadLabels replaces the full conversation-label set on a
+// thread. Idempotent (PUT semantics): the body's category_ids is the
+// desired set, so retries are naturally safe. Only the user's own
+// categories are attached.
+// PUT /unibox/thread/labels
+func (h *Handler) SetUniboxThreadLabels(c *gin.Context) {
+	if !h.gateUnibox(c) {
+		return
+	}
+	userID := middleware.GetUserID(c)
+	uid, err := uuid.Parse(userID)
+	if err != nil {
+		errx.Handle(c, errx.ErrUser)
+		return
+	}
+
+	var req models.UniboxThreadLabels
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	labels, xerr := h.UniboxService.SetThreadLabels(c.Request.Context(), uid, req.ThreadID, req.CategoryIDs)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	h.auditOrg(c, models.AuditActionUpdate, models.AuditEntityUnibox, nil, nil, map[string]string{
+		"action":    "set_labels",
+		"thread_id": req.ThreadID,
+		"labels":    strconv.Itoa(len(labels)),
+	})
+
+	c.JSON(http.StatusOK, gin.H{"data": labels})
 }
 
 func (h *Handler) UniboxMarkSeen(c *gin.Context) {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -336,6 +336,13 @@ func Run(
 			unibox.GET("/count", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUnseenCount)
 			unibox.GET("/overview", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxOverview)
 			unibox.GET("/thread", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxThread)
+
+			// Conversation labels — read the set on a thread, or replace
+			// it wholesale (idempotent PUT). Registered before /:id so the
+			// fixed path wins over the catch-all.
+			unibox.GET("/thread/labels", m.RequireAccess(models.PermAccessUnibox, models.APIPermReadUnibox), h.GetUniboxThreadLabels)
+			unibox.PUT("/thread/labels", m.RequireAccess(models.PermAccessUnibox, models.APIPermWriteUnibox), h.SetUniboxThreadLabels)
+
 			unibox.PATCH("/seen", m.RequireAccess(models.PermAccessUnibox, models.APIPermWriteUnibox), h.UniboxMarkSeen)
 			unibox.POST("/reply", m.RequireOrganization(), m.RequireAccess(models.PermAccessUnibox, models.APIPermWriteUnibox), h.UniboxReply)
 

--- a/internal/app/unibox/labels.go
+++ b/internal/app/unibox/labels.go
@@ -1,0 +1,38 @@
+package unibox
+
+import (
+	"context"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// SetThreadLabels replaces the conversation's label set with the given
+// categories. The repository only attaches categories the user actually
+// owns, so callers can pass the picker's selection straight through.
+func (s *uniboxService) SetThreadLabels(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) ([]models.MiniCategory, *errx.Error) {
+	if threadID == "" {
+		return nil, errx.New(errx.BadRequest, "thread_id is required")
+	}
+	labels, err := s.uniboxRepository.SetThreadLabels(ctx, userID, threadID, categoryIDs)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	return labels, nil
+}
+
+// ListThreadLabels returns the conversation's current labels.
+func (s *uniboxService) ListThreadLabels(ctx context.Context, userID uuid.UUID, threadID string) ([]models.MiniCategory, *errx.Error) {
+	if threadID == "" {
+		return nil, errx.New(errx.BadRequest, "thread_id is required")
+	}
+	labels, err := s.uniboxRepository.ListThreadLabels(ctx, userID, threadID)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	return labels, nil
+}

--- a/internal/app/unibox/search.go
+++ b/internal/app/unibox/search.go
@@ -23,18 +23,11 @@ func (s *uniboxService) Search(
 		params.PageSize = LimitMax
 	}
 
-	// If only sender filter is used, delegate to optimized method
-	if params.Sender != nil && *params.Sender != "" &&
-		params.Subject == nil && params.Since == nil &&
-		params.Until == nil && params.Unseen == nil {
-		resp, err := s.uniboxRepository.GetBySender(ctx, userID, *params.Sender, params.PageSize, params.Cursor)
-		if err != nil {
-			sentry.CaptureException(err)
-			return nil, errx.InternalError()
-		}
-		return resp, nil
-	}
-
+	// Everything goes through Search: it collapses messages into one row
+	// per thread and attaches per-thread counts + labels. The old
+	// sender-only fast path (GetBySender) returned un-collapsed,
+	// label-less rows, so it can't serve the stacked list anymore — the
+	// sender filter is handled inside Search via params.Sender.
 	resp, err := s.uniboxRepository.Search(ctx, userID, params)
 	if err != nil {
 		sentry.CaptureException(err)

--- a/internal/app/unibox/service.go
+++ b/internal/app/unibox/service.go
@@ -49,6 +49,11 @@ type UniboxService interface {
 	// Overview powers the scope rail + top metric strip in one call.
 	Overview(ctx context.Context, userID uuid.UUID) (*models.UniboxOverview, *errx.Error)
 
+	// Conversation labels. SetThreadLabels replaces a thread's full
+	// label set (idempotent); ListThreadLabels reads the current set.
+	SetThreadLabels(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) ([]models.MiniCategory, *errx.Error)
+	ListThreadLabels(ctx context.Context, userID uuid.UUID, threadID string) ([]models.MiniCategory, *errx.Error)
+
 	// Scheduled-sends review + cancel. CancelScheduled is DB-only: we
 	// flip status to 'cancelled' and let the queued Cloud Task fire as
 	// a no-op (handler short-circuits on non-pending status). Avoids

--- a/internal/infrastructure/db/migrations/000021_unibox_thread_labels.down.sql
+++ b/internal/infrastructure/db/migrations/000021_unibox_thread_labels.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS public.idx_unibox_emails_user_thread_date;
+DROP INDEX IF EXISTS public.idx_unibox_thread_labels_thread;
+DROP INDEX IF EXISTS public.idx_unibox_thread_labels_category;
+DROP TABLE IF EXISTS public.unibox_thread_labels;

--- a/internal/infrastructure/db/migrations/000021_unibox_thread_labels.up.sql
+++ b/internal/infrastructure/db/migrations/000021_unibox_thread_labels.up.sql
@@ -1,0 +1,30 @@
+-- Conversation labels for the Unibox.
+--
+-- Inbox "categories" reuse the existing per-user `categories` registry
+-- (the same generic group table that backs contact categories) but are
+-- attached at the CONVERSATION (thread) level rather than per message —
+-- so a label tags a whole thread, which lines up with the thread-stacked
+-- inbox list. Assignment is independent from contact categorisation: the
+-- vocabulary is shared, the join is inbox-specific.
+CREATE TABLE IF NOT EXISTS public.unibox_thread_labels (
+    user_id     uuid NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+    thread_id   text NOT NULL,
+    category_id uuid NOT NULL REFERENCES public.categories(id) ON DELETE CASCADE,
+    created_at  timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (user_id, thread_id, category_id)
+);
+
+-- Counting threads per label (scope rail) reads by category.
+CREATE INDEX IF NOT EXISTS idx_unibox_thread_labels_category
+    ON public.unibox_thread_labels USING btree (category_id);
+
+-- Aggregating a thread's labels into a list row reads by (user, thread).
+CREATE INDEX IF NOT EXISTS idx_unibox_thread_labels_thread
+    ON public.unibox_thread_labels USING btree (user_id, thread_id);
+
+-- Thread-collapse query: pick the newest message per thread across every
+-- mailbox a user owns. The existing idx_unibox_emails_thread leads with
+-- (user_id, email_id, thread_id) which doesn't serve the cross-mailbox
+-- "latest per thread" window; this one does.
+CREATE INDEX IF NOT EXISTS idx_unibox_emails_user_thread_date
+    ON public.unibox_emails USING btree (user_id, thread_id, internal_date DESC);

--- a/internal/models/unibox.go
+++ b/internal/models/unibox.go
@@ -119,6 +119,24 @@ type EmailMessageStoreDataPreview struct {
 	Snippet      string    `json:"snippet"`
 	InternalDate time.Time `json:"internal_date"`
 	Seen         bool      `json:"seen"`
+
+	// Thread-stacking fields. The inbox list collapses to one row per
+	// thread (the newest message), so these summarise the whole
+	// conversation behind the row:
+	//   MessageCount — number of messages in the thread (within the
+	//                  current filter scope); 1 for a singleton.
+	//   HasUnread    — true if any message in the thread is unseen, so
+	//                  the row can bold the whole conversation Gmail-style
+	//                  rather than only when the latest message is unread.
+	// Both are zero-valued on the message-level paths (GetByThread /
+	// GetBySender / GetIncoming) that don't collapse.
+	MessageCount int64 `json:"message_count"`
+	HasUnread    bool  `json:"has_unread"`
+
+	// Labels are the conversation's assigned categories (denormalised
+	// id/title/color so the row renders chips without a second lookup).
+	// Always non-nil so it marshals to [] not null.
+	Labels []MiniCategory `json:"labels"`
 }
 
 type EmailParent struct { // used to get information from the parent email
@@ -157,8 +175,11 @@ type MailSearchParams struct {
 	// message in the thread was sent by the user (i.e. the recipient
 	// hasn't replied yet). nil = no filter.
 	AwaitingReply *bool
-	PageSize      int
-	Cursor        string
+	// CategoryIDs restricts results to threads carrying at least one of
+	// these conversation labels. Empty = no category filter.
+	CategoryIDs []uuid.UUID
+	PageSize    int
+	Cursor      string
 }
 
 type MarkSeen struct {
@@ -199,6 +220,18 @@ type UniboxTagOverview struct {
 	Total  int64     `json:"total"`
 }
 
+// UniboxCategoryOverview gives the rail per-conversation-label counts.
+// Resolved by joining threads through unibox_thread_labels. Unread/Total
+// are counted as THREADS (matching the thread-stacked list), not
+// messages.
+type UniboxCategoryOverview struct {
+	ID     uuid.UUID `json:"id"`
+	Title  string    `json:"title"`
+	Color  string    `json:"color"`
+	Unread int64     `json:"unread"`
+	Total  int64     `json:"total"`
+}
+
 // UniboxOverview powers the scope rail + top metric strip in one
 // request. Computed at /unibox/overview.
 type UniboxOverview struct {
@@ -212,12 +245,21 @@ type UniboxOverview struct {
 	// ScheduledPendingMax is the hard cap on pending scheduled email
 	// tasks per user. The dashboard shows current/max so the user
 	// sees how close they are to the limit before hitting it.
-	ScheduledPendingMax int64                   `json:"scheduled_pending_max"`
-	Mailboxes           []UniboxMailboxOverview `json:"mailboxes"`
-	Tags                []UniboxTagOverview     `json:"tags"`
-	GeneratedAt         time.Time               `json:"generated_at"`
-	WindowTodayStart    time.Time               `json:"window_today_start"`
-	WindowWeekStart     time.Time               `json:"window_week_start"`
+	ScheduledPendingMax int64                    `json:"scheduled_pending_max"`
+	Mailboxes           []UniboxMailboxOverview  `json:"mailboxes"`
+	Tags                []UniboxTagOverview      `json:"tags"`
+	Categories          []UniboxCategoryOverview `json:"categories"`
+	GeneratedAt         time.Time                `json:"generated_at"`
+	WindowTodayStart    time.Time                `json:"window_today_start"`
+	WindowWeekStart     time.Time                `json:"window_week_start"`
+}
+
+// UniboxThreadLabels is the assign/replace payload for a conversation's
+// labels. CategoryIDs is the full desired set — the handler diffs it
+// against what's stored, so a PUT-style replace is idempotent.
+type UniboxThreadLabels struct {
+	ThreadID    string      `json:"thread_id" binding:"required"`
+	CategoryIDs []uuid.UUID `json:"category_ids"`
 }
 
 // UniboxScheduledItem describes one queued outbound message the user

--- a/internal/repository/pg_unibox.go
+++ b/internal/repository/pg_unibox.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -44,6 +45,13 @@ type UniboxRepository interface {
 	// Overview powers the scope rail + top metric strip. Single call
 	// so the client doesn't fan out N+M queries for each mailbox/tag.
 	Overview(ctx context.Context, userID uuid.UUID) (*models.UniboxOverview, error)
+
+	// Conversation labels. SetThreadLabels replaces the full label set
+	// on a thread (idempotent PUT semantics, only the user's own
+	// categories are attached). ListThreadLabels returns the current
+	// set for one thread.
+	SetThreadLabels(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) ([]models.MiniCategory, error)
+	ListThreadLabels(ctx context.Context, userID uuid.UUID, threadID string) ([]models.MiniCategory, error)
 }
 
 type uniboxRepository struct {
@@ -261,96 +269,138 @@ func (r *uniboxRepository) GetBySender(ctx context.Context, userID uuid.UUID, se
 	return r.queryPreviewList(ctx, query, args, limit)
 }
 
+// Search is the main inbox list. It collapses every message sharing a
+// thread_id into a single row — the newest message represents the
+// conversation (Gmail-style stacking) — and annotates it with the
+// thread's message count, an aggregate unread flag, and its assigned
+// conversation labels.
+//
+// Filter altitude:
+//   - row-level filters (snooze scope, unseen, date window, subject,
+//     sender, mailbox) run inside the windowed subquery, so the
+//     representative + counts reflect the matched messages; with no
+//     content filter (the default inbox) that's the whole thread.
+//   - thread/representative-level filters (awaiting reply, category)
+//     and keyset pagination run on the collapsed row.
 func (r *uniboxRepository) Search(ctx context.Context, userID uuid.UUID, params *models.MailSearchParams) (*models.MailSearchResult, error) {
-	// Build a list of `ue.<col>` references so we can table-alias the
-	// rows when we join in snoozes / awaiting-reply scopes.
 	previewCols := make([]string, len(mailFieldsPreview))
 	for i, c := range mailFieldsPreview {
 		previewCols[i] = "ue." + c
 	}
 
-	query := fmt.Sprintf(`
-		SELECT %s
-		FROM unibox_emails ue
-		WHERE ue.user_id = $1
-	`, strings.Join(previewCols, ", "))
-
 	args := []any{userID}
 	argPos := 2
 
+	// ── Inner windowed subquery: row-level filters + per-thread aggs ──
+	// Partition by the thread, but treat an empty thread_id (the column
+	// default for mail with no usable threading headers) as its own
+	// singleton keyed by row id — otherwise every unthreaded message
+	// would collapse into one bogus "conversation".
+	inner := fmt.Sprintf(`
+		SELECT %s,
+			ROW_NUMBER() OVER (PARTITION BY COALESCE(NULLIF(ue.thread_id, ''), ue.id::text) ORDER BY ue.internal_date DESC, ue.id DESC) AS rn,
+			COUNT(*)              OVER (PARTITION BY COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) AS message_count,
+			bool_or(NOT ue.seen)  OVER (PARTITION BY COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) AS has_unread
+		FROM unibox_emails ue
+		WHERE ue.user_id = $1`, strings.Join(previewCols, ", "))
+
 	// Snooze handling. nil = exclude snoozed (the inbox default), so
-	// rows whose thread has an active snooze never appear unless the
-	// caller asks for them explicitly.
+	// threads with an active snooze never appear unless asked for.
 	switch {
 	case params.Snoozed == nil:
-		query += fmt.Sprintf(`
+		inner += `
 			AND NOT EXISTS (
 				SELECT 1 FROM unibox_snoozes s
 				WHERE s.user_id = ue.user_id
 				  AND s.thread_id = ue.thread_id
 				  AND s.snoozed_until > NOW()
-			)`)
+			)`
 	case params.Snoozed != nil && *params.Snoozed:
-		query += fmt.Sprintf(`
+		inner += `
 			AND EXISTS (
 				SELECT 1 FROM unibox_snoozes s
 				WHERE s.user_id = ue.user_id
 				  AND s.thread_id = ue.thread_id
 				  AND s.snoozed_until > NOW()
-			)`)
-	}
-
-	// Awaiting reply: latest message in this thread (for this user)
-	// was sent by one of the user's own mailboxes. We join the
-	// mailbox emails to scope the "from us" check correctly.
-	if params.AwaitingReply != nil && *params.AwaitingReply {
-		query += fmt.Sprintf(`
-			AND ue.id IN (
-				SELECT DISTINCT ON (latest.thread_id) latest.id
-				FROM unibox_emails latest
-				WHERE latest.user_id = $1
-				ORDER BY latest.thread_id, latest.internal_date DESC
-			)
-			AND EXISTS (
-				SELECT 1 FROM email_accounts ea
-				WHERE ea.user_id = $1
-				  AND ea.email = ANY(ue.from_addr)
-			)`)
+			)`
 	}
 
 	if params.Unseen != nil && *params.Unseen {
-		query += fmt.Sprintf(` AND ue.seen = $%d`, argPos)
+		inner += fmt.Sprintf(` AND ue.seen = $%d`, argPos)
 		args = append(args, false)
 		argPos++
 	}
 
 	if params.Since != nil {
-		query += fmt.Sprintf(` AND ue.internal_date >= $%d`, argPos)
+		inner += fmt.Sprintf(` AND ue.internal_date >= $%d`, argPos)
 		args = append(args, *params.Since)
 		argPos++
 	}
 
 	if params.Until != nil {
-		query += fmt.Sprintf(` AND ue.internal_date <= $%d`, argPos)
+		inner += fmt.Sprintf(` AND ue.internal_date <= $%d`, argPos)
 		args = append(args, *params.Until)
 		argPos++
 	}
 
 	if params.Subject != nil && *params.Subject != "" {
-		query += fmt.Sprintf(` AND ue.search_tsv @@ plainto_tsquery('english', $%d)`, argPos)
+		inner += fmt.Sprintf(` AND ue.search_tsv @@ plainto_tsquery('english', $%d)`, argPos)
 		args = append(args, *params.Subject)
 		argPos++
 	}
 
 	if params.Sender != nil && *params.Sender != "" {
-		query += fmt.Sprintf(` AND $%d = ANY(ue.from_addr)`, argPos)
+		inner += fmt.Sprintf(` AND $%d = ANY(ue.from_addr)`, argPos)
 		args = append(args, *params.Sender)
 		argPos++
 	}
 
 	if len(params.EmailAccountIDs) > 0 {
-		query += fmt.Sprintf(` AND ue.email_id = ANY($%d)`, argPos)
+		inner += fmt.Sprintf(` AND ue.email_id = ANY($%d)`, argPos)
 		args = append(args, params.EmailAccountIDs)
+		argPos++
+	}
+
+	// ── Outer: pick the representative row + thread-level filters ─────
+	// b.<col> exposes the preview columns; labels are aggregated per
+	// thread so the row renders its chips without a second round trip.
+	outerCols := make([]string, len(mailFieldsPreview))
+	for i, c := range mailFieldsPreview {
+		outerCols[i] = "b." + c
+	}
+	query := fmt.Sprintf(`
+		SELECT %s, b.message_count, b.has_unread,
+			COALESCE(
+				(
+					SELECT json_agg(json_build_object('id', c.id, 'title', c.title, 'color', c.color) ORDER BY c.position ASC, c.title ASC)
+					FROM unibox_thread_labels utl
+					JOIN categories c ON c.id = utl.category_id
+					WHERE utl.user_id = $1 AND utl.thread_id = b.thread_id
+				), '[]'::json
+			) AS labels
+		FROM (%s) b
+		WHERE b.rn = 1`, strings.Join(outerCols, ", "), inner)
+
+	// Awaiting reply: the representative (latest) message is from one of
+	// the user's own mailboxes — i.e. they're waiting on the recipient.
+	if params.AwaitingReply != nil && *params.AwaitingReply {
+		query += `
+			AND EXISTS (
+				SELECT 1 FROM email_accounts ea
+				WHERE ea.user_id = $1
+				  AND ea.email = ANY(b.from_addr)
+			)`
+	}
+
+	if len(params.CategoryIDs) > 0 {
+		query += fmt.Sprintf(`
+			AND EXISTS (
+				SELECT 1 FROM unibox_thread_labels utl
+				WHERE utl.user_id = $1
+				  AND utl.thread_id = b.thread_id
+				  AND utl.category_id = ANY($%d)
+			)`, argPos)
+		args = append(args, params.CategoryIDs)
 		argPos++
 	}
 
@@ -358,7 +408,7 @@ func (r *uniboxRepository) Search(ctx context.Context, userID uuid.UUID, params 
 		cursorID, err := uuid.Parse(params.Cursor)
 		if err == nil {
 			query += fmt.Sprintf(`
-				AND (ue.internal_date, ue.id) < (
+				AND (b.internal_date, b.id) < (
 					SELECT internal_date, id FROM unibox_emails WHERE id = $%d
 				)`, argPos)
 			args = append(args, cursorID)
@@ -366,25 +416,29 @@ func (r *uniboxRepository) Search(ctx context.Context, userID uuid.UUID, params 
 		}
 	}
 
-	query += fmt.Sprintf(` ORDER BY ue.internal_date DESC, ue.id DESC LIMIT $%d`, argPos)
+	query += fmt.Sprintf(` ORDER BY b.internal_date DESC, b.id DESC LIMIT $%d`, argPos)
 	args = append(args, params.PageSize+1)
 
-	return r.queryPreviewList(ctx, query, args, params.PageSize)
+	return r.queryThreadList(ctx, query, args, params.PageSize)
 }
 
 func (r *uniboxRepository) GetUnseenCount(ctx context.Context, userID uuid.UUID, emailAccountID *uuid.UUID) (int64, error) {
 	var count int64
 
+	// Count unread THREADS (distinct, empty-thread-safe), not messages,
+	// so the badge agrees with the collapsed list + Overview.Unread.
 	if emailAccountID != nil {
 		err := r.db.QueryRow(ctx,
-			`SELECT COUNT(*) FROM unibox_emails WHERE user_id = $1 AND email_id = $2 AND seen = FALSE`,
+			`SELECT COUNT(DISTINCT COALESCE(NULLIF(thread_id, ''), id::text))
+			 FROM unibox_emails WHERE user_id = $1 AND email_id = $2 AND seen = FALSE`,
 			userID, *emailAccountID,
 		).Scan(&count)
 		return count, err
 	}
 
 	err := r.db.QueryRow(ctx,
-		`SELECT COUNT(*) FROM unibox_emails WHERE user_id = $1 AND seen = FALSE`,
+		`SELECT COUNT(DISTINCT COALESCE(NULLIF(thread_id, ''), id::text))
+		 FROM unibox_emails WHERE user_id = $1 AND seen = FALSE`,
 		userID,
 	).Scan(&count)
 	return count, err
@@ -438,6 +492,9 @@ func (r *uniboxRepository) queryPreviewList(ctx context.Context, query string, a
 		); err != nil {
 			return nil, err
 		}
+		// Message-level paths (thread detail / by-sender) don't collapse,
+		// so there are no per-thread aggregates; keep labels [] not null.
+		e.Labels = []models.MiniCategory{}
 		emails = append(emails, e)
 	}
 
@@ -457,6 +514,132 @@ func (r *uniboxRepository) queryPreviewList(ctx context.Context, query string, a
 			NextCursor: nextCursor,
 		},
 	}, nil
+}
+
+// queryThreadList executes a thread-collapsed query. Each row is the
+// representative (newest) message of a thread plus the per-thread
+// message_count, has_unread flag, and aggregated labels json. Mirrors
+// queryPreviewList's limit+1 keyset pagination.
+func (r *uniboxRepository) queryThreadList(ctx context.Context, query string, args []any, limit int) (*models.MailSearchResult, error) {
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	emails := make([]models.EmailMessageStoreDataPreview, 0, limit)
+	for rows.Next() {
+		var e models.EmailMessageStoreDataPreview
+		var labelsJSON []byte
+		if err := rows.Scan(
+			&e.ID, &e.EmailID, &e.ThreadID, &e.FromAddr, &e.ToAddr,
+			&e.Subject, &e.Snippet, &e.InternalDate, &e.Seen,
+			&e.MessageCount, &e.HasUnread, &labelsJSON,
+		); err != nil {
+			return nil, err
+		}
+		// Always non-nil so the API marshals labels to [] not null.
+		e.Labels = []models.MiniCategory{}
+		if len(labelsJSON) > 0 {
+			if err := json.Unmarshal(labelsJSON, &e.Labels); err != nil {
+				return nil, err
+			}
+		}
+		emails = append(emails, e)
+	}
+
+	var hasMore bool
+	var nextCursor *string
+	if len(emails) > limit {
+		hasMore = true
+		cursor := emails[limit].ID.String()
+		nextCursor = &cursor
+		emails = emails[:limit]
+	}
+
+	return &models.MailSearchResult{
+		Data: emails,
+		Pagination: models.CPagination{
+			HasMore:    hasMore,
+			NextCursor: nextCursor,
+		},
+	}, nil
+}
+
+// ── Conversation labels ─────────────────────────────────────────────────
+
+// SetThreadLabels replaces the full label set on a thread. Only the
+// user's own categories are attached (a SELECT-guarded insert), so a
+// bogus or someone else's category_id is silently dropped rather than
+// trusted. Idempotent: re-sending the same set is a no-op.
+func (r *uniboxRepository) SetThreadLabels(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) ([]models.MiniCategory, error) {
+	if threadID == "" {
+		return nil, errors.New("threadID required")
+	}
+	if categoryIDs == nil {
+		categoryIDs = []uuid.UUID{}
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	// Drop labels no longer in the desired set. With an empty set this
+	// clears every label (category_id = ANY('{}') is false → NOT false).
+	if _, err := tx.Exec(ctx, `
+		DELETE FROM unibox_thread_labels
+		WHERE user_id = $1 AND thread_id = $2 AND NOT (category_id = ANY($3))
+	`, userID, threadID, categoryIDs); err != nil {
+		return nil, err
+	}
+
+	// Add the rest, but only categories that actually belong to the
+	// user. ON CONFLICT keeps the upsert idempotent.
+	if len(categoryIDs) > 0 {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO unibox_thread_labels (user_id, thread_id, category_id)
+			SELECT $1, $2, c.id
+			FROM categories c
+			WHERE c.user_id = $1 AND c.id = ANY($3)
+			ON CONFLICT (user_id, thread_id, category_id) DO NOTHING
+		`, userID, threadID, categoryIDs); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	return r.ListThreadLabels(ctx, userID, threadID)
+}
+
+// ListThreadLabels returns the conversation's current labels, ordered to
+// match the category palette ordering used everywhere else.
+func (r *uniboxRepository) ListThreadLabels(ctx context.Context, userID uuid.UUID, threadID string) ([]models.MiniCategory, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT c.id, c.title, c.color
+		FROM unibox_thread_labels utl
+		JOIN categories c ON c.id = utl.category_id
+		WHERE utl.user_id = $1 AND utl.thread_id = $2
+		ORDER BY c.position ASC, c.title ASC
+	`, userID, threadID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]models.MiniCategory, 0)
+	for rows.Next() {
+		var mc models.MiniCategory
+		if err := rows.Scan(&mc.ID, &mc.Title, &mc.Color); err != nil {
+			return nil, err
+		}
+		out = append(out, mc)
+	}
+	return out, nil
 }
 
 // ── Snoozes ────────────────────────────────────────────────────────────
@@ -529,12 +712,15 @@ func (r *uniboxRepository) Overview(ctx context.Context, userID uuid.UUID) (*mod
 		WindowWeekStart:  weekStart,
 	}
 
-	// Single aggregate over unibox_emails — cheap.
+	// Single aggregate over unibox_emails — cheap. Counts are per
+	// THREAD (matching the thread-collapsed list), not per message, so
+	// the rail numbers line up with the rows the user sees. Empty
+	// thread_ids fall back to row id so unthreaded mail counts as its
+	// own conversation.
 	err := r.db.QueryRow(ctx, `
 		WITH ue AS (
 			SELECT
-				e.thread_id,
-				e.email_id,
+				COALESCE(NULLIF(e.thread_id, ''), e.id::text) AS tkey,
 				e.from_addr,
 				e.internal_date,
 				e.seen,
@@ -547,24 +733,33 @@ func (r *uniboxRepository) Overview(ctx context.Context, userID uuid.UUID) (*mod
 			FROM unibox_emails e
 			WHERE e.user_id = $1
 		),
+		threads AS (
+			SELECT
+				tkey,
+				bool_or(is_snoozed) AS is_snoozed,
+				bool_or(NOT seen)   AS has_unread,
+				max(internal_date)  AS last_date
+			FROM ue
+			GROUP BY tkey
+		),
 		latest_per_thread AS (
-			SELECT DISTINCT ON (thread_id) thread_id, from_addr
+			SELECT DISTINCT ON (tkey) tkey, from_addr
 			FROM ue
 			WHERE NOT is_snoozed
-			ORDER BY thread_id, internal_date DESC
+			ORDER BY tkey, internal_date DESC
 		),
 		user_mailbox_emails AS (
 			SELECT email FROM email_accounts WHERE user_id = $1
 		)
 		SELECT
-			COUNT(*) FILTER (WHERE NOT is_snoozed)                                                               AS total,
-			COUNT(*) FILTER (WHERE NOT is_snoozed AND NOT seen)                                                  AS unread,
-			COUNT(*) FILTER (WHERE NOT is_snoozed AND internal_date >= $2)                                       AS today,
-			COUNT(*) FILTER (WHERE NOT is_snoozed AND internal_date >= $3)                                       AS week,
-			COUNT(*) FILTER (WHERE is_snoozed)                                                                   AS snoozed,
+			COUNT(*) FILTER (WHERE NOT t.is_snoozed)                            AS total,
+			COUNT(*) FILTER (WHERE NOT t.is_snoozed AND t.has_unread)           AS unread,
+			COUNT(*) FILTER (WHERE NOT t.is_snoozed AND t.last_date >= $2)      AS today,
+			COUNT(*) FILTER (WHERE NOT t.is_snoozed AND t.last_date >= $3)      AS week,
+			COUNT(*) FILTER (WHERE t.is_snoozed)                                AS snoozed,
 			(SELECT COUNT(*) FROM latest_per_thread l
 				WHERE EXISTS (SELECT 1 FROM user_mailbox_emails u WHERE u.email = ANY(l.from_addr)))             AS awaiting
-		FROM ue
+		FROM threads t
 	`, userID, todayStart, weekStart).Scan(
 		&overview.Total,
 		&overview.Unread,
@@ -578,18 +773,20 @@ func (r *uniboxRepository) Overview(ctx context.Context, userID uuid.UUID) (*mod
 	}
 
 	// Per-mailbox counters. LEFT JOIN against unibox_emails so empty
-	// mailboxes still show up in the rail with a zero count.
+	// mailboxes still show up in the rail with a zero count. Counts are
+	// per THREAD (distinct thread key, empty-thread-safe) to match the
+	// collapsed list, not per message.
 	mailboxRows, err := r.db.Query(ctx, `
 		SELECT
 			ea.id,
 			ea.email,
 			ea.name,
-			COUNT(ue.id) FILTER (WHERE ue.id IS NOT NULL AND NOT ue.seen
+			COUNT(DISTINCT COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) FILTER (WHERE ue.id IS NOT NULL AND NOT ue.seen
 				AND NOT EXISTS (
 					SELECT 1 FROM unibox_snoozes s
 					WHERE s.user_id = ea.user_id AND s.thread_id = ue.thread_id AND s.snoozed_until > NOW()
 				)) AS unread,
-			COUNT(ue.id) FILTER (WHERE ue.id IS NOT NULL
+			COUNT(DISTINCT COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) FILTER (WHERE ue.id IS NOT NULL
 				AND NOT EXISTS (
 					SELECT 1 FROM unibox_snoozes s
 					WHERE s.user_id = ea.user_id AND s.thread_id = ue.thread_id AND s.snoozed_until > NOW()
@@ -615,17 +812,19 @@ func (r *uniboxRepository) Overview(ctx context.Context, userID uuid.UUID) (*mod
 	}
 
 	// Per-tag counters. Mailbox tags live in `tags` + `email_tags`.
+	// Per THREAD (distinct thread key) so threads aren't over-counted by
+	// message multiplicity or the email_tags fan-out.
 	tagRows, err := r.db.Query(ctx, `
 		SELECT
 			t.id,
 			t.title,
 			t.color,
-			COUNT(ue.id) FILTER (WHERE ue.id IS NOT NULL AND NOT ue.seen
+			COUNT(DISTINCT COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) FILTER (WHERE ue.id IS NOT NULL AND NOT ue.seen
 				AND NOT EXISTS (
 					SELECT 1 FROM unibox_snoozes s
 					WHERE s.user_id = t.user_id AND s.thread_id = ue.thread_id AND s.snoozed_until > NOW()
 				)) AS unread,
-			COUNT(ue.id) FILTER (WHERE ue.id IS NOT NULL
+			COUNT(DISTINCT COALESCE(NULLIF(ue.thread_id, ''), ue.id::text)) FILTER (WHERE ue.id IS NOT NULL
 				AND NOT EXISTS (
 					SELECT 1 FROM unibox_snoozes s
 					WHERE s.user_id = t.user_id AND s.thread_id = ue.thread_id AND s.snoozed_until > NOW()
@@ -653,6 +852,47 @@ func (r *uniboxRepository) Overview(ctx context.Context, userID uuid.UUID) (*mod
 			return nil, err
 		}
 		overview.Tags = append(overview.Tags, t)
+	}
+
+	// Per-conversation-label counters. total / unread count THREADS (one
+	// row per (thread,category) in unibox_thread_labels), restricted to
+	// threads that still have a non-snoozed message. unread = the thread
+	// has any unseen message. Like tags, labels are optional — never let
+	// the join fail the whole overview.
+	overview.Categories = make([]models.UniboxCategoryOverview, 0)
+	catRows, err := r.db.Query(ctx, `
+		WITH thread_state AS (
+			SELECT e.user_id, e.thread_id, bool_or(NOT e.seen) AS has_unread
+			FROM unibox_emails e
+			WHERE e.user_id = $1
+			  AND NOT EXISTS (
+				SELECT 1 FROM unibox_snoozes s
+				WHERE s.user_id = e.user_id AND s.thread_id = e.thread_id AND s.snoozed_until > NOW()
+			  )
+			GROUP BY e.user_id, e.thread_id
+		)
+		SELECT
+			c.id, c.title, c.color,
+			COUNT(*) FILTER (WHERE ts.thread_id IS NOT NULL AND ts.has_unread) AS unread,
+			COUNT(*) FILTER (WHERE ts.thread_id IS NOT NULL)                   AS total
+		FROM categories c
+		LEFT JOIN unibox_thread_labels utl ON utl.category_id = c.id AND utl.user_id = c.user_id
+		LEFT JOIN thread_state ts ON ts.user_id = utl.user_id AND ts.thread_id = utl.thread_id
+		WHERE c.user_id = $1
+		GROUP BY c.id, c.title, c.color, c.position
+		ORDER BY c.position ASC, c.title ASC
+	`, userID)
+	if err != nil {
+		return overview, nil
+	}
+	defer catRows.Close()
+
+	for catRows.Next() {
+		var cat models.UniboxCategoryOverview
+		if err := catRows.Scan(&cat.ID, &cat.Title, &cat.Color, &cat.Unread, &cat.Total); err != nil {
+			return overview, nil
+		}
+		overview.Categories = append(overview.Categories, cat)
 	}
 
 	return overview, nil

--- a/web/src/app/app/unibox/page.tsx
+++ b/web/src/app/app/unibox/page.tsx
@@ -30,277 +30,310 @@ import { cn } from "@/lib/utils";
 import type { UniboxSearchParams } from "@/lib/api/models/app/unibox/UniboxSearch";
 
 function startOfToday(): Date {
-    const d = new Date();
-    d.setHours(0, 0, 0, 0);
-    return d;
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
 }
 
 function startOfWeek(): Date {
-    const d = startOfToday();
-    d.setDate(d.getDate() - 6);
-    return d;
+  const d = startOfToday();
+  d.setDate(d.getDate() - 6);
+  return d;
 }
 
 export default function UniboxPage() {
-    const access = useFeatureAccess();
-    const overview = useUniboxOverview();
-    const [searchParams, setSearchParams] = useSearchParams();
-    const [scopeSheetOpen, setScopeSheetOpen] = React.useState(false);
+  const access = useFeatureAccess();
+  const overview = useUniboxOverview();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [scopeSheetOpen, setScopeSheetOpen] = React.useState(false);
 
-    // ── URL state (deep-linkable threads + scope) ──────────────────
-    const urlThread = searchParams.get("thread");
-    const urlAccount = searchParams.get("account");
-    const urlScope = searchParams.get("scope") ?? "all";
-    const urlScopeRef = searchParams.get("ref");
+  // ── URL state (deep-linkable threads + scope) ──────────────────
+  const urlThread = searchParams.get("thread");
+  const urlAccount = searchParams.get("account");
+  const urlScope = searchParams.get("scope") ?? "all";
+  const urlScopeRef = searchParams.get("ref");
 
-    const setUrl = React.useCallback(
-        (next: { thread?: string | null; account?: string | null; scope?: string | null; ref?: string | null }) => {
-            setSearchParams(
-                (prev) => {
-                    const sp = new URLSearchParams(prev);
-                    for (const [k, v] of Object.entries(next)) {
-                        if (v === null || v === undefined || v === "") sp.delete(k);
-                        else sp.set(k, v);
-                    }
-                    return sp;
-                },
-                { replace: true },
-            );
+  const setUrl = React.useCallback(
+    (next: {
+      thread?: string | null;
+      account?: string | null;
+      scope?: string | null;
+      ref?: string | null;
+    }) => {
+      setSearchParams(
+        (prev) => {
+          const sp = new URLSearchParams(prev);
+          for (const [k, v] of Object.entries(next)) {
+            if (v === null || v === undefined || v === "") sp.delete(k);
+            else sp.set(k, v);
+          }
+          return sp;
         },
-        [setSearchParams],
-    );
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
 
-    // Mirror URL ↔ store so ConversationItem clicks update the URL.
-    const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
-    const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
-    React.useEffect(() => {
-        setSelectedThreadId(urlThread);
-        setSelectedAccountId(urlAccount);
-    }, [urlThread, urlAccount, setSelectedThreadId, setSelectedAccountId]);
+  // Mirror URL ↔ store so ConversationItem clicks update the URL.
+  const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
+  const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
+  React.useEffect(() => {
+    setSelectedThreadId(urlThread);
+    setSelectedAccountId(urlAccount);
+  }, [urlThread, urlAccount, setSelectedThreadId, setSelectedAccountId]);
 
-    const storeThread = useAppStore((s) => s.selectedThreadId);
-    const storeAccount = useAppStore((s) => s.selectedAccountId);
-    React.useEffect(() => {
-        if (storeThread !== urlThread || storeAccount !== urlAccount) {
-            setUrl({ thread: storeThread, account: storeAccount });
+  const storeThread = useAppStore((s) => s.selectedThreadId);
+  const storeAccount = useAppStore((s) => s.selectedAccountId);
+  React.useEffect(() => {
+    if (storeThread !== urlThread || storeAccount !== urlAccount) {
+      setUrl({ thread: storeThread, account: storeAccount });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storeThread, storeAccount]);
+
+  // ── Scope (derived from URL + ref) ─────────────────────────────
+  const scope: UniboxScope = React.useMemo(() => {
+    switch (urlScope) {
+      case "unread":
+        return { kind: "unread" };
+      case "today":
+        return { kind: "today" };
+      case "week":
+        return { kind: "week" };
+      case "awaiting":
+        return { kind: "awaiting" };
+      case "snoozed":
+        return { kind: "snoozed" };
+      case "scheduled":
+        return { kind: "scheduled" };
+      case "mailbox":
+        return urlScopeRef
+          ? { kind: "mailbox", mailboxId: urlScopeRef }
+          : { kind: "all" };
+      case "tag":
+        return urlScopeRef
+          ? { kind: "tag", tagId: urlScopeRef }
+          : { kind: "all" };
+      case "category":
+        return urlScopeRef
+          ? { kind: "category", categoryId: urlScopeRef }
+          : { kind: "all" };
+      default:
+        return { kind: "all" };
+    }
+  }, [urlScope, urlScopeRef]);
+
+  const setScope = React.useCallback(
+    (s: UniboxScope) => {
+      switch (s.kind) {
+        case "mailbox":
+          setUrl({ scope: "mailbox", ref: s.mailboxId });
+          return;
+        case "tag":
+          setUrl({ scope: "tag", ref: s.tagId });
+          return;
+        case "category":
+          setUrl({ scope: "category", ref: s.categoryId });
+          return;
+        case "all":
+          setUrl({ scope: null, ref: null });
+          return;
+        default:
+          setUrl({ scope: s.kind, ref: null });
+      }
+    },
+    [setUrl],
+  );
+
+  // ── Scope → server search params ───────────────────────────────
+  // Mailboxes/tags come from the same overview payload so we don't
+  // race a separate /emails fetch when resolving a tag.
+  const [params, setParams] = React.useState<UniboxSearchParams>({
+    sortBy: "newest",
+  });
+  const overviewData = overview.data;
+  React.useEffect(() => {
+    setParams((prev) => {
+      const next: UniboxSearchParams = { sortBy: prev.sortBy ?? "newest" };
+      switch (scope.kind) {
+        case "unread":
+          next.unseen = true;
+          break;
+        case "today":
+          next.since = startOfToday();
+          break;
+        case "week":
+          next.since = startOfWeek();
+          break;
+        case "awaiting":
+          next.awaitingReply = true;
+          break;
+        case "snoozed":
+          next.snoozed = true;
+          break;
+        case "mailbox":
+          next.accountIds = [scope.mailboxId];
+          break;
+        case "tag": {
+          // Tag-scoped account resolution: overview already lists
+          // the user's mailboxes, but tag→mailbox membership is
+          // not in the overview payload. We fall back to the
+          // dataSlice's emails, which the existing user-profile
+          // bootstrap populates.
+          const ids = useAppStore
+            .getState()
+            .emails.filter((m) => (m.tags ?? []).includes(scope.tagId))
+            .map((m) => m.id);
+          next.accountIds = ids;
+          next.tagId = scope.tagId;
+          break;
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [storeThread, storeAccount]);
+        case "category":
+          // Conversation-label scope resolves to a server-side
+          // category filter (category_ids); no client resolution
+          // needed since labels live on the thread, not the
+          // mailbox.
+          next.categoryIds = [scope.categoryId];
+          break;
+        default:
+          break;
+      }
+      return next;
+    });
+  }, [scope, overviewData]);
 
-    // ── Scope (derived from URL + ref) ─────────────────────────────
-    const scope: UniboxScope = React.useMemo(() => {
-        switch (urlScope) {
-            case "unread":
-                return { kind: "unread" };
-            case "today":
-                return { kind: "today" };
-            case "week":
-                return { kind: "week" };
-            case "awaiting":
-                return { kind: "awaiting" };
-            case "snoozed":
-                return { kind: "snoozed" };
-            case "scheduled":
-                return { kind: "scheduled" };
-            case "mailbox":
-                return urlScopeRef ? { kind: "mailbox", mailboxId: urlScopeRef } : { kind: "all" };
-            case "tag":
-                return urlScopeRef ? { kind: "tag", tagId: urlScopeRef } : { kind: "all" };
-            default:
-                return { kind: "all" };
-        }
-    }, [urlScope, urlScopeRef]);
+  // ── Scope label for header chip ────────────────────────────────
+  const scopeLabel = React.useMemo(() => {
+    switch (scope.kind) {
+      case "unread":
+        return "Unread";
+      case "today":
+        return "Today";
+      case "week":
+        return "This week";
+      case "awaiting":
+        return "Awaiting reply";
+      case "snoozed":
+        return "Snoozed";
+      case "scheduled":
+        return "Scheduled";
+      case "mailbox": {
+        const m = overviewData?.mailboxes.find((x) => x.id === scope.mailboxId);
+        return m ? m.email : "Mailbox";
+      }
+      case "tag": {
+        const t = overviewData?.tags.find((x) => x.id === scope.tagId);
+        return t ? `Tag · ${t.title}` : "Tag";
+      }
+      case "category": {
+        const c = overviewData?.categories?.find(
+          (x) => x.id === scope.categoryId,
+        );
+        return c ? `Label · ${c.title}` : "Label";
+      }
+      default:
+        return "All";
+    }
+  }, [scope, overviewData]);
 
-    const setScope = React.useCallback(
-        (s: UniboxScope) => {
-            switch (s.kind) {
-                case "mailbox":
-                    setUrl({ scope: "mailbox", ref: s.mailboxId });
-                    return;
-                case "tag":
-                    setUrl({ scope: "tag", ref: s.tagId });
-                    return;
-                case "all":
-                    setUrl({ scope: null, ref: null });
-                    return;
-                default:
-                    setUrl({ scope: s.kind, ref: null });
-            }
-        },
-        [setUrl],
-    );
+  return (
+    <LockedSurface
+      locked={!access.loading && !access.hasInbox}
+      feature="Unified inbox"
+      blurb="Read and reply to every inbound message across every connected mailbox from one place — searchable, filterable, with realtime updates."
+      minPlan="starter"
+      bullets={[
+        "Live overview: unread, awaiting reply, snoozed, today, week",
+        "Scope rail with per-mailbox + per-tag unread counts",
+        "Deep-linkable threads via ?thread= in the URL",
+        "Snooze any thread to clear it from the inbox until later",
+      ]}
+    >
+      <div className="flex flex-col h-full bg-white">
+        <UniboxHeader
+          scopeLabel={scopeLabel}
+          onClearScope={() => setScope({ kind: "all" })}
+          onOpenScopeSheet={() => setScopeSheetOpen(true)}
+        />
 
-    // ── Scope → server search params ───────────────────────────────
-    // Mailboxes/tags come from the same overview payload so we don't
-    // race a separate /emails fetch when resolving a tag.
-    const [params, setParams] = React.useState<UniboxSearchParams>({ sortBy: "newest" });
-    const overviewData = overview.data;
-    React.useEffect(() => {
-        setParams((prev) => {
-            const next: UniboxSearchParams = { sortBy: prev.sortBy ?? "newest" };
-            switch (scope.kind) {
-                case "unread":
-                    next.unseen = true;
-                    break;
-                case "today":
-                    next.since = startOfToday();
-                    break;
-                case "week":
-                    next.since = startOfWeek();
-                    break;
-                case "awaiting":
-                    next.awaitingReply = true;
-                    break;
-                case "snoozed":
-                    next.snoozed = true;
-                    break;
-                case "mailbox":
-                    next.accountIds = [scope.mailboxId];
-                    break;
-                case "tag": {
-                    // Tag-scoped account resolution: overview already lists
-                    // the user's mailboxes, but tag→mailbox membership is
-                    // not in the overview payload. We fall back to the
-                    // dataSlice's emails, which the existing user-profile
-                    // bootstrap populates.
-                    const ids = useAppStore.getState().emails
-                        .filter((m) => (m.tags ?? []).includes(scope.tagId))
-                        .map((m) => m.id);
-                    next.accountIds = ids;
-                    next.tagId = scope.tagId;
-                    break;
-                }
-                default:
-                    break;
-            }
-            return next;
-        });
-    }, [scope, overviewData]);
+        <ScopeSheet
+          open={scopeSheetOpen}
+          setOpen={setScopeSheetOpen}
+          scope={scope}
+          onChange={setScope}
+        />
 
-    // ── Scope label for header chip ────────────────────────────────
-    const scopeLabel = React.useMemo(() => {
-        switch (scope.kind) {
-            case "unread":
-                return "Unread";
-            case "today":
-                return "Today";
-            case "week":
-                return "This week";
-            case "awaiting":
-                return "Awaiting reply";
-            case "snoozed":
-                return "Snoozed";
-            case "scheduled":
-                return "Scheduled";
-            case "mailbox": {
-                const m = overviewData?.mailboxes.find((x) => x.id === scope.mailboxId);
-                return m ? m.email : "Mailbox";
-            }
-            case "tag": {
-                const t = overviewData?.tags.find((x) => x.id === scope.tagId);
-                return t ? `Tag · ${t.title}` : "Tag";
-            }
-            default:
-                return "All";
-        }
-    }, [scope, overviewData]);
+        <div className="flex-1 min-h-0 flex">
+          <aside className="hidden lg:flex w-[220px] shrink-0 h-full">
+            <ScopeRail scope={scope} onChange={setScope} />
+          </aside>
 
-    return (
-        <LockedSurface
-            locked={!access.loading && !access.hasInbox}
-            feature="Unified inbox"
-            blurb="Read and reply to every inbound message across every connected mailbox from one place — searchable, filterable, with realtime updates."
-            minPlan="starter"
-            bullets={[
-                "Live overview: unread, awaiting reply, snoozed, today, week",
-                "Scope rail with per-mailbox + per-tag unread counts",
-                "Deep-linkable threads via ?thread= in the URL",
-                "Snooze any thread to clear it from the inbox until later",
-            ]}
-        >
-            <div className="flex flex-col h-full bg-white">
-                <UniboxHeader
-                    scopeLabel={scopeLabel}
-                    onClearScope={() => setScope({ kind: "all" })}
-                    onOpenScopeSheet={() => setScopeSheetOpen(true)}
-                />
-
-                <ScopeSheet
-                    open={scopeSheetOpen}
-                    setOpen={setScopeSheetOpen}
-                    scope={scope}
-                    onChange={setScope}
-                />
-
-                <div className="flex-1 min-h-0 flex">
-                    <aside className="hidden lg:flex w-[220px] shrink-0 h-full">
-                        <ScopeRail scope={scope} onChange={setScope} />
-                    </aside>
-
-                    {scope.kind === "scheduled" ? (
-                        // Scheduled scope takes the full right side — a
-                        // queued send has no thread context to load.
-                        <div className="flex-1 min-w-0 flex flex-col overflow-hidden border-l border-slate-200">
-                            <ScheduledList />
-                        </div>
-                    ) : (
-                    <>
-                    <div
-                        className={cn(
-                            "w-full md:w-[360px] shrink-0 border-r border-slate-200 overflow-hidden flex-col",
-                            urlThread ? "hidden md:flex" : "flex",
-                        )}
-                    >
-                        <ConversationList
-                            scopeLabel={scopeLabel}
-                            params={params}
-                            setParams={setParams}
-                        />
-                    </div>
-
-                    <div
-                        className={cn(
-                            "flex-1 min-w-0 overflow-hidden flex-col",
-                            urlThread ? "flex" : "hidden md:flex",
-                        )}
-                    >
-                        {urlThread ? (
-                            <>
-                                <button
-                                    type="button"
-                                    onClick={() => setUrl({ thread: null, account: null })}
-                                    className="md:hidden flex items-center gap-1 px-3 h-10 shrink-0 border-b border-slate-200 text-[13px] font-medium text-slate-600 hover:text-slate-900 active:bg-slate-50"
-                                >
-                                    <ChevronLeftIcon className="w-4 h-4" />
-                                    Inbox
-                                </button>
-                                <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                                    <ThreadView
-                                        threadId={urlThread}
-                                        emailId={urlAccount ?? undefined}
-                                    />
-                                </div>
-                            </>
-                        ) : (
-                            <div className="flex-1 flex items-center justify-center">
-                                <div className="text-center px-5">
-                                    <div className="w-8 h-8 rounded-md bg-slate-100 flex items-center justify-center mx-auto mb-3 text-slate-400">
-                                        <InboxIcon className="w-4 h-4" />
-                                    </div>
-                                    <p className="text-[12.5px] font-medium text-slate-700">
-                                        Select a conversation
-                                    </p>
-                                    <p className="text-[11.5px] text-slate-400 mt-1 max-w-[34ch] leading-relaxed">
-                                        Pick a thread from the list — its id will appear in the URL so you can share or refresh.
-                                    </p>
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                    </>
-                    )}
-                </div>
+          {scope.kind === "scheduled" ? (
+            // Scheduled scope takes the full right side — a
+            // queued send has no thread context to load.
+            <div className="flex-1 min-w-0 flex flex-col overflow-hidden border-l border-slate-200">
+              <ScheduledList />
             </div>
-        </LockedSurface>
-    );
+          ) : (
+            <>
+              <div
+                className={cn(
+                  "w-full md:w-[360px] shrink-0 border-r border-slate-200 overflow-hidden flex-col",
+                  urlThread ? "hidden md:flex" : "flex",
+                )}
+              >
+                <ConversationList
+                  scopeLabel={scopeLabel}
+                  params={params}
+                  setParams={setParams}
+                />
+              </div>
+
+              <div
+                className={cn(
+                  "flex-1 min-w-0 overflow-hidden flex-col",
+                  urlThread ? "flex" : "hidden md:flex",
+                )}
+              >
+                {urlThread ? (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => setUrl({ thread: null, account: null })}
+                      className="md:hidden flex items-center gap-1 px-3 h-10 shrink-0 border-b border-slate-200 text-[13px] font-medium text-slate-600 hover:text-slate-900 active:bg-slate-50"
+                    >
+                      <ChevronLeftIcon className="w-4 h-4" />
+                      Inbox
+                    </button>
+                    <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+                      <ThreadView
+                        threadId={urlThread}
+                        emailId={urlAccount ?? undefined}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex-1 flex items-center justify-center">
+                    <div className="text-center px-5">
+                      <div className="w-8 h-8 rounded-md bg-slate-100 flex items-center justify-center mx-auto mb-3 text-slate-400">
+                        <InboxIcon className="w-4 h-4" />
+                      </div>
+                      <p className="text-[12.5px] font-medium text-slate-700">
+                        Select a conversation
+                      </p>
+                      <p className="text-[11.5px] text-slate-400 mt-1 max-w-[34ch] leading-relaxed">
+                        Pick a thread from the list — its id will appear in the
+                        URL so you can share or refresh.
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </LockedSurface>
+  );
 }

--- a/web/src/components/app/unibox/ConversationItem.tsx
+++ b/web/src/components/app/unibox/ConversationItem.tsx
@@ -7,178 +7,186 @@
 
 import type UniboxEmail from "@/lib/api/models/app/unibox/UniboxEmail";
 import { useAppStore } from "@/stores";
-import { useUserProfile } from "@/hooks/context/user";
 import { cn } from "@/lib/utils";
 
 function relative(d: Date): string {
-    const diff = Date.now() - d.getTime();
-    const m = Math.floor(diff / 60_000);
-    if (m < 1) return "now";
-    if (m < 60) return `${m}m`;
-    const h = Math.floor(m / 60);
-    if (h < 24) return `${h}h`;
-    const days = Math.floor(h / 24);
-    if (days < 7) return `${days}d`;
-    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  const diff = Date.now() - d.getTime();
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return "now";
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  const days = Math.floor(h / 24);
+  if (days < 7) return `${days}d`;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }
 
 function fromName(s: string): string {
-    if (!s) return "Unknown sender";
-    const m = s.match(/^"?([^"<]+)"?\s*<.+>$/);
-    if (m) return m[1].trim();
-    return s.replace(/<.+>/, "").trim() || s;
+  if (!s) return "Unknown sender";
+  const m = s.match(/^"?([^"<]+)"?\s*<.+>$/);
+  if (m) return m[1].trim();
+  return s.replace(/<.+>/, "").trim() || s;
 }
 
 function initials(s: string): string {
-    const name = fromName(s);
-    const parts = name.split(/\s+/).filter(Boolean);
-    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
-    return (parts[0]?.slice(0, 2) ?? "??").toUpperCase();
+  const name = fromName(s);
+  const parts = name.split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return (parts[0]?.slice(0, 2) ?? "??").toUpperCase();
 }
 
 // Stable colour per sender so the eye learns to spot them.
 function hueFor(s: string): number {
-    let h = 0;
-    for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
-    return h % 360;
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return h % 360;
 }
 
 interface ConversationItemProps {
-    email: UniboxEmail;
+  email: UniboxEmail;
 }
 
 export function ConversationItem({ email }: ConversationItemProps) {
-    const selectedThreadId = useAppStore((s) => s.selectedThreadId);
-    const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
-    const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
-    const accounts = useAppStore((s) => s.emails);
-    const profile = useUserProfile();
-    const tagCatalog = profile.user.tags ?? [];
+  const selectedThreadId = useAppStore((s) => s.selectedThreadId);
+  const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
+  const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
+  const accounts = useAppStore((s) => s.emails);
 
-    const threadId = email.thread_id || email.id;
-    const isSelected = selectedThreadId === threadId;
-    const date = new Date(email.date);
-    const unread = !email.is_seen;
-    const preview = email.body.replace(/<[^>]*>/g, "").replace(/\s+/g, " ").slice(0, 140);
+  const threadId = email.thread_id || email.id;
+  const isSelected = selectedThreadId === threadId;
+  const date = new Date(email.date);
+  const unread = !email.is_seen;
+  const preview = email.body
+    .replace(/<[^>]*>/g, "")
+    .replace(/\s+/g, " ")
+    .slice(0, 140);
 
-    const mailbox = accounts.find((a) => a.id === email.account_id);
-    const sender = fromName(email.from);
-    const hue = hueFor(sender);
+  const mailbox = accounts.find((a) => a.id === email.account_id);
+  const sender = fromName(email.from);
+  const hue = hueFor(sender);
 
-    // Resolve mailbox tag IDs → catalog entries so we can show the
-    // real colour dot per tag (no more abstract "2 tags" badge).
-    const tagsOnMailbox = (mailbox?.tags ?? [])
-        .map((id) => tagCatalog.find((t) => t.id === id))
-        .filter((t): t is NonNullable<typeof t> => Boolean(t));
+  // Thread-stacking: count of messages in the conversation behind this
+  // row, and the conversation's assigned labels (categories).
+  const messageCount = email.message_count ?? 1;
+  const labels = email.labels ?? [];
 
-    return (
-        <button
-            onClick={() => {
-                setSelectedThreadId(threadId);
-                setSelectedAccountId(email.account_id ?? null);
-            }}
+  return (
+    <button
+      onClick={() => {
+        setSelectedThreadId(threadId);
+        setSelectedAccountId(email.account_id ?? null);
+      }}
+      className={cn(
+        "group w-full text-left px-3 py-2 transition-colors flex items-start gap-2.5 relative",
+        isSelected ? "bg-sky-50/80" : "hover:bg-slate-50/80",
+      )}
+    >
+      {unread && (
+        <span
+          aria-hidden
+          className="absolute left-0 top-2 bottom-2 w-[3px] rounded-r bg-sky-500"
+        />
+      )}
+      <div
+        className={cn(
+          "size-7 rounded-full flex items-center justify-center shrink-0 text-[10px] font-semibold",
+        )}
+        style={
+          isSelected
+            ? { backgroundColor: "rgb(224 242 254)", color: "rgb(2 132 199)" }
+            : {
+                backgroundColor: `hsl(${hue} 70% 94%)`,
+                color: `hsl(${hue} 55% 35%)`,
+              }
+        }
+      >
+        {initials(email.from)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
             className={cn(
-                "group w-full text-left px-3 py-2 transition-colors flex items-start gap-2.5 relative",
-                isSelected ? "bg-sky-50/80" : "hover:bg-slate-50/80",
+              "text-[12.5px] truncate min-w-0",
+              unread
+                ? "text-slate-900 font-semibold"
+                : "text-slate-800 font-medium",
             )}
-        >
-            {unread && (
-                <span
-                    aria-hidden
-                    className="absolute left-0 top-2 bottom-2 w-[3px] rounded-r bg-sky-500"
-                />
-            )}
-            <div
-                className={cn(
-                    "size-7 rounded-full flex items-center justify-center shrink-0 text-[10px] font-semibold",
-                )}
-                style={
-                    isSelected
-                        ? { backgroundColor: "rgb(224 242 254)", color: "rgb(2 132 199)" }
-                        : {
-                              backgroundColor: `hsl(${hue} 70% 94%)`,
-                              color: `hsl(${hue} 55% 35%)`,
-                          }
-                }
+          >
+            {sender}
+          </span>
+          {messageCount > 1 && (
+            <span
+              className="shrink-0 font-mono tabular-nums text-[10px] text-slate-500 bg-slate-100 rounded-full px-1.5 h-4 inline-flex items-center"
+              title={`${messageCount} messages in this conversation`}
             >
-                {initials(email.from)}
-            </div>
-            <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2 min-w-0">
-                    <span
-                        className={cn(
-                            "text-[12.5px] truncate min-w-0",
-                            unread ? "text-slate-900 font-semibold" : "text-slate-800 font-medium",
-                        )}
-                    >
-                        {sender}
-                    </span>
-                    <span className="font-mono text-[10px] text-slate-400 tabular-nums shrink-0 ml-auto">
-                        {relative(date)}
-                    </span>
-                </div>
-                <div
-                    className={cn(
-                        "text-[12px] truncate mt-0.5",
-                        unread ? "text-slate-800 font-medium" : "text-slate-600",
-                    )}
-                >
-                    {email.subject || "(no subject)"}
-                </div>
-                <div className="text-[11px] text-slate-400 truncate mt-0.5">
-                    {preview || "(no preview)"}
-                </div>
-                {(mailbox || tagsOnMailbox.length > 0) && (
-                    <div className="mt-1 flex items-center gap-1 min-w-0 flex-wrap">
-                        {mailbox && (
-                            <span className="inline-flex items-center h-4 px-1.5 rounded-sm bg-slate-100 text-slate-500 text-[9.5px] font-mono truncate max-w-[160px]">
-                                {mailbox.email}
-                            </span>
-                        )}
-                        {/* Real tag chips: colored dot + name, so the user
-                            sees exactly which tags this conversation
-                            inherits from its mailbox. */}
-                        {tagsOnMailbox.slice(0, 3).map((t) => (
-                            <TagChip key={t.id} title={t.title} color={t.color} />
-                        ))}
-                        {tagsOnMailbox.length > 3 && (
-                            <span
-                                className="text-[9.5px] text-slate-400 font-mono"
-                                title={tagsOnMailbox
-                                    .slice(3)
-                                    .map((t) => t.title)
-                                    .join(", ")}
-                            >
-                                +{tagsOnMailbox.length - 3}
-                            </span>
-                        )}
-                    </div>
-                )}
-            </div>
-        </button>
-    );
+              {messageCount}
+            </span>
+          )}
+          <span className="font-mono text-[10px] text-slate-400 tabular-nums shrink-0 ml-auto">
+            {relative(date)}
+          </span>
+        </div>
+        <div
+          className={cn(
+            "text-[12px] truncate mt-0.5",
+            unread ? "text-slate-800 font-medium" : "text-slate-600",
+          )}
+        >
+          {email.subject || "(no subject)"}
+        </div>
+        <div className="text-[11px] text-slate-400 truncate mt-0.5">
+          {preview || "(no preview)"}
+        </div>
+        {(mailbox || labels.length > 0) && (
+          <div className="mt-1 flex items-center gap-1 min-w-0 flex-wrap">
+            {/* Conversation labels: colored dot + name chips, the
+                            per-thread categories the user assigned. */}
+            {labels.slice(0, 3).map((l) => (
+              <TagChip key={l.id} title={l.title} color={l.color} />
+            ))}
+            {labels.length > 3 && (
+              <span
+                className="text-[9.5px] text-slate-400 font-mono"
+                title={labels
+                  .slice(3)
+                  .map((l) => l.title)
+                  .join(", ")}
+              >
+                +{labels.length - 3}
+              </span>
+            )}
+            {mailbox && (
+              <span className="inline-flex items-center h-4 px-1.5 rounded-sm bg-slate-100 text-slate-500 text-[9.5px] font-mono truncate max-w-[160px]">
+                {mailbox.email}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+    </button>
+  );
 }
 
 function TagChip({ title, color }: { title: string; color: string }) {
-    // Tint a slim chip background from the tag's own color so two
-    // chips read as visually distinct without needing to read the
-    // text. We don't render solid coloured chips (too loud); the dot
-    // carries the colour, the chip carries the name.
-    return (
-        <span
-            className="inline-flex items-center gap-1 h-4 pl-1 pr-1.5 rounded-sm border bg-white text-[10px] font-medium text-slate-700 truncate max-w-[120px]"
-            style={{
-                borderColor: color ? `${color}60` : "rgb(226 232 240)",
-                backgroundColor: color ? `${color}12` : "white",
-            }}
-            title={title}
-        >
-            <span
-                aria-hidden
-                className="block size-2 rounded-full shrink-0"
-                style={{ backgroundColor: color || "#94a3b8" }}
-            />
-            {title}
-        </span>
-    );
+  // Tint a slim chip background from the tag's own color so two
+  // chips read as visually distinct without needing to read the
+  // text. We don't render solid coloured chips (too loud); the dot
+  // carries the colour, the chip carries the name.
+  return (
+    <span
+      className="inline-flex items-center gap-1 h-4 pl-1 pr-1.5 rounded-sm border bg-white text-[10px] font-medium text-slate-700 truncate max-w-[120px]"
+      style={{
+        borderColor: color ? `${color}60` : "rgb(226 232 240)",
+        backgroundColor: color ? `${color}12` : "white",
+      }}
+      title={title}
+    >
+      <span
+        aria-hidden
+        className="block size-2 rounded-full shrink-0"
+        style={{ backgroundColor: color || "#94a3b8" }}
+      />
+      {title}
+    </span>
+  );
 }

--- a/web/src/components/app/unibox/ConversationList.tsx
+++ b/web/src/components/app/unibox/ConversationList.tsx
@@ -13,11 +13,7 @@
 // component owns only its own search box + focused row.
 
 import React from "react";
-import {
-    Loader2Icon,
-    SearchIcon,
-    Settings2Icon,
-} from "lucide-react";
+import { Loader2Icon, SearchIcon, Settings2Icon } from "lucide-react";
 import { ConversationItem } from "./ConversationItem";
 import useUniboxSearch from "@/lib/api/hooks/app/unibox/useUniboxSearch";
 import { useAppStore } from "@/stores";
@@ -27,316 +23,336 @@ import type { UniboxSearchParams } from "@/lib/api/models/app/unibox/UniboxSearc
 type Bucket = "today" | "yesterday" | "week" | "earlier";
 
 const BUCKET_LABELS: Record<Bucket, string> = {
-    today: "Today",
-    yesterday: "Yesterday",
-    week: "This week",
-    earlier: "Earlier",
+  today: "Today",
+  yesterday: "Yesterday",
+  week: "This week",
+  earlier: "Earlier",
 };
 
 function bucketFor(d: Date): Bucket {
-    const now = new Date();
-    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
-    const yesterday = today - 24 * 60 * 60 * 1000;
-    const weekStart = today - 6 * 24 * 60 * 60 * 1000;
-    const t = d.getTime();
-    if (t >= today) return "today";
-    if (t >= yesterday) return "yesterday";
-    if (t >= weekStart) return "week";
-    return "earlier";
+  const now = new Date();
+  const today = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+  ).getTime();
+  const yesterday = today - 24 * 60 * 60 * 1000;
+  const weekStart = today - 6 * 24 * 60 * 60 * 1000;
+  const t = d.getTime();
+  if (t >= today) return "today";
+  if (t >= yesterday) return "yesterday";
+  if (t >= weekStart) return "week";
+  return "earlier";
 }
 
 interface ConversationListProps {
-    scopeLabel: string;
-    params: UniboxSearchParams;
-    setParams: React.Dispatch<React.SetStateAction<UniboxSearchParams>>;
+  scopeLabel: string;
+  params: UniboxSearchParams;
+  setParams: React.Dispatch<React.SetStateAction<UniboxSearchParams>>;
 }
 
 export function ConversationList({
-    scopeLabel,
-    params,
-    setParams,
+  scopeLabel,
+  params,
+  setParams,
 }: ConversationListProps) {
-    const [search, setSearch] = React.useState("");
-    const [sheetOpen, setSheetOpen] = React.useState(false);
-    const searchRef = React.useRef<HTMLInputElement>(null);
-    const listRef = React.useRef<HTMLDivElement>(null);
-    const selectedThreadId = useAppStore((s) => s.selectedThreadId);
-    const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
-    const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
+  const [search, setSearch] = React.useState("");
+  const [sheetOpen, setSheetOpen] = React.useState(false);
+  const searchRef = React.useRef<HTMLInputElement>(null);
+  const listRef = React.useRef<HTMLDivElement>(null);
+  const selectedThreadId = useAppStore((s) => s.selectedThreadId);
+  const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
+  const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
 
-    const merged: UniboxSearchParams = React.useMemo(() => {
-        const next: UniboxSearchParams = { ...params };
-        if (search.trim()) next.query = search.trim();
-        return next;
-    }, [params, search]);
+  const merged: UniboxSearchParams = React.useMemo(() => {
+    const next: UniboxSearchParams = { ...params };
+    if (search.trim()) next.query = search.trim();
+    return next;
+  }, [params, search]);
 
-    const q = useUniboxSearch(merged);
-    const emails = q.emails;
-    const totalShown = emails.length;
+  const q = useUniboxSearch(merged);
+  const emails = q.emails;
+  const totalShown = emails.length;
 
-    // Group rows by time bucket. The server already orders newest →
-    // oldest so a single pass preserves both global order and group
-    // adjacency.
-    const grouped = React.useMemo(() => {
-        const groups: { bucket: Bucket; rows: typeof emails }[] = [];
-        for (const e of emails) {
-            const b = bucketFor(new Date(e.internal_date));
-            const tail = groups[groups.length - 1];
-            if (tail && tail.bucket === b) tail.rows.push(e);
-            else groups.push({ bucket: b, rows: [e] });
+  // Group rows by time bucket. The server already orders newest →
+  // oldest so a single pass preserves both global order and group
+  // adjacency.
+  const grouped = React.useMemo(() => {
+    const groups: { bucket: Bucket; rows: typeof emails }[] = [];
+    for (const e of emails) {
+      const b = bucketFor(new Date(e.internal_date));
+      const tail = groups[groups.length - 1];
+      if (tail && tail.bucket === b) tail.rows.push(e);
+      else groups.push({ bucket: b, rows: [e] });
+    }
+    return groups;
+  }, [emails]);
+
+  // Keyboard navigation. We work off `emails` (flat order) so j/k
+  // moves across bucket boundaries naturally. Ignoring shortcuts
+  // while typing into any input/textarea, and while the filter
+  // sheet is open, keeps the bindings out of the user's way.
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (sheetOpen) return;
+      const target = e.target as HTMLElement | null;
+      if (target) {
+        const tag = target.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
+          // Allow Escape from search to deselect.
+          if (e.key === "Escape" && target === searchRef.current) {
+            searchRef.current?.blur();
+          }
+          return;
         }
-        return groups;
-    }, [emails]);
+      }
 
-    // Keyboard navigation. We work off `emails` (flat order) so j/k
-    // moves across bucket boundaries naturally. Ignoring shortcuts
-    // while typing into any input/textarea, and while the filter
-    // sheet is open, keeps the bindings out of the user's way.
-    React.useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if (sheetOpen) return;
-            const target = e.target as HTMLElement | null;
-            if (target) {
-                const tag = target.tagName;
-                if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable) {
-                    // Allow Escape from search to deselect.
-                    if (e.key === "Escape" && target === searchRef.current) {
-                        searchRef.current?.blur();
-                    }
-                    return;
-                }
-            }
+      const currentIdx = selectedThreadId
+        ? emails.findIndex(
+            (row) => (row.thread_id || row.id) === selectedThreadId,
+          )
+        : -1;
 
-            const currentIdx = selectedThreadId
-                ? emails.findIndex((row) => (row.thread_id || row.id) === selectedThreadId)
-                : -1;
+      const move = (delta: number) => {
+        if (emails.length === 0) return;
+        const next = Math.max(
+          0,
+          Math.min(
+            emails.length - 1,
+            (currentIdx < 0 ? 0 : currentIdx) + delta,
+          ),
+        );
+        const row = emails[next];
+        if (!row) return;
+        setSelectedThreadId(row.thread_id || row.id);
+        setSelectedAccountId(row.email_id ?? null);
+        // Bring the focused row into view if the list scrolled.
+        requestAnimationFrame(() => {
+          const el = listRef.current?.querySelector<HTMLElement>(
+            `[data-thread-id="${row.thread_id || row.id}"]`,
+          );
+          el?.scrollIntoView({ block: "nearest" });
+        });
+        e.preventDefault();
+      };
 
-            const move = (delta: number) => {
-                if (emails.length === 0) return;
-                const next = Math.max(0, Math.min(emails.length - 1, (currentIdx < 0 ? 0 : currentIdx) + delta));
-                const row = emails[next];
-                if (!row) return;
-                setSelectedThreadId(row.thread_id || row.id);
-                setSelectedAccountId(row.email_id ?? null);
-                // Bring the focused row into view if the list scrolled.
-                requestAnimationFrame(() => {
-                    const el = listRef.current?.querySelector<HTMLElement>(
-                        `[data-thread-id="${row.thread_id || row.id}"]`,
-                    );
-                    el?.scrollIntoView({ block: "nearest" });
-                });
-                e.preventDefault();
-            };
+      switch (e.key) {
+        case "j":
+          move(1);
+          return;
+        case "k":
+          move(-1);
+          return;
+        case "Enter":
+          if (currentIdx < 0 && emails[0]) {
+            const row = emails[0];
+            setSelectedThreadId(row.thread_id || row.id);
+            setSelectedAccountId(row.email_id ?? null);
+            e.preventDefault();
+          }
+          return;
+        case "Escape":
+          if (selectedThreadId) {
+            setSelectedThreadId(null);
+            setSelectedAccountId(null);
+            e.preventDefault();
+          }
+          return;
+        case "/":
+          searchRef.current?.focus();
+          e.preventDefault();
+          return;
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [
+    emails,
+    selectedThreadId,
+    sheetOpen,
+    setSelectedThreadId,
+    setSelectedAccountId,
+  ]);
 
-            switch (e.key) {
-                case "j":
-                    move(1);
-                    return;
-                case "k":
-                    move(-1);
-                    return;
-                case "Enter":
-                    if (currentIdx < 0 && emails[0]) {
-                        const row = emails[0];
-                        setSelectedThreadId(row.thread_id || row.id);
-                        setSelectedAccountId(row.email_id ?? null);
-                        e.preventDefault();
-                    }
-                    return;
-                case "Escape":
-                    if (selectedThreadId) {
-                        setSelectedThreadId(null);
-                        setSelectedAccountId(null);
-                        e.preventDefault();
-                    }
-                    return;
-                case "/":
-                    searchRef.current?.focus();
-                    e.preventDefault();
-                    return;
-            }
-        };
-        document.addEventListener("keydown", handler);
-        return () => document.removeEventListener("keydown", handler);
-    }, [emails, selectedThreadId, sheetOpen, setSelectedThreadId, setSelectedAccountId]);
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <div className="h-9 px-2 shrink-0 border-b border-slate-200 flex items-center gap-1.5">
+        <SearchIcon className="w-3.5 h-3.5 text-slate-400 shrink-0" />
+        <input
+          ref={searchRef}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder={`Search ${scopeLabel.toLowerCase()}… (/)`}
+          className="flex-1 min-w-0 h-7 bg-transparent text-[12.5px] text-slate-900 placeholder:text-slate-400 outline-none"
+        />
+        {totalShown > 0 && (
+          <span className="font-mono tabular-nums text-[10.5px] text-slate-400 shrink-0">
+            {totalShown}
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => setSheetOpen(true)}
+          className="size-7 rounded text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-colors shrink-0"
+          aria-label="Advanced filters"
+        >
+          <Settings2Icon className="w-3.5 h-3.5" />
+        </button>
+      </div>
 
-    return (
-        <div className="flex flex-col h-full bg-white">
-            <div className="h-9 px-2 shrink-0 border-b border-slate-200 flex items-center gap-1.5">
-                <SearchIcon className="w-3.5 h-3.5 text-slate-400 shrink-0" />
-                <input
-                    ref={searchRef}
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    placeholder={`Search ${scopeLabel.toLowerCase()}… (/)`}
-                    className="flex-1 min-w-0 h-7 bg-transparent text-[12.5px] text-slate-900 placeholder:text-slate-400 outline-none"
-                />
-                {totalShown > 0 && (
-                    <span className="font-mono tabular-nums text-[10.5px] text-slate-400 shrink-0">
-                        {totalShown}
-                    </span>
-                )}
+      <div ref={listRef} className="flex-1 overflow-y-auto">
+        {q.isPending ? (
+          <SkeletonRows />
+        ) : q.isError ? (
+          <div className="px-5 py-12 text-center">
+            <p className="text-[12.5px] text-slate-900 font-medium mb-1">
+              Couldn't load inbox
+            </p>
+            <p className="text-[11.5px] text-slate-500 mb-3">
+              {q.error?.message ?? "Request failed"}
+            </p>
+            <button
+              type="button"
+              onClick={() => q.refetch()}
+              className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium transition-colors"
+            >
+              Try again
+            </button>
+          </div>
+        ) : emails.length === 0 ? (
+          <div className="px-5 py-16 text-center">
+            <p className="text-[12.5px] text-slate-700 font-medium mb-1">
+              {hasActiveFilters(merged) || search.trim()
+                ? "No matches"
+                : "Nothing here yet"}
+            </p>
+            <p className="text-[11.5px] text-slate-400 max-w-[28ch] mx-auto leading-relaxed">
+              {hasActiveFilters(merged) || search.trim()
+                ? "Try a different scope or clear the filters."
+                : "Pick a different scope from the rail, or wait for new mail."}
+            </p>
+          </div>
+        ) : (
+          <>
+            {grouped.map((g) => (
+              <section key={g.bucket}>
+                <div className="sticky top-0 z-10 px-3 py-1 bg-slate-50/95 backdrop-blur-sm border-b border-slate-200/60 flex items-center gap-2">
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-semibold">
+                    {BUCKET_LABELS[g.bucket]}
+                  </span>
+                  <span className="font-mono text-[10px] text-slate-400 tabular-nums">
+                    {g.rows.length}
+                  </span>
+                </div>
+                <div className="divide-y divide-slate-200/60">
+                  {g.rows.map((e) => (
+                    <div key={e.id} data-thread-id={e.thread_id || e.id}>
+                      <ConversationItem
+                        email={{
+                          id: e.id,
+                          from: e.from_addr?.[0] ?? "",
+                          to: e.to_addr?.[0] ?? "",
+                          subject: e.subject,
+                          body: e.snippet,
+                          date: new Date(e.internal_date),
+                          // Bold the whole conversation when any
+                          // message in the thread is unread.
+                          is_seen: !e.has_unread,
+                          thread_id: e.thread_id,
+                          account_id: e.email_id,
+                          message_count: e.message_count,
+                          labels: e.labels,
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+            {q.hasNextPage && (
+              <div className="px-3 py-3 flex justify-center border-t border-slate-200/60">
                 <button
-                    type="button"
-                    onClick={() => setSheetOpen(true)}
-                    className="size-7 rounded text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-colors shrink-0"
-                    aria-label="Advanced filters"
+                  onClick={() => q.fetchNextPage()}
+                  disabled={q.isFetchingNextPage}
+                  className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
                 >
-                    <Settings2Icon className="w-3.5 h-3.5" />
-                </button>
-            </div>
-
-            <div ref={listRef} className="flex-1 overflow-y-auto">
-                {q.isPending ? (
-                    <SkeletonRows />
-                ) : q.isError ? (
-                    <div className="px-5 py-12 text-center">
-                        <p className="text-[12.5px] text-slate-900 font-medium mb-1">
-                            Couldn't load inbox
-                        </p>
-                        <p className="text-[11.5px] text-slate-500 mb-3">
-                            {q.error?.message ?? "Request failed"}
-                        </p>
-                        <button
-                            type="button"
-                            onClick={() => q.refetch()}
-                            className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium transition-colors"
-                        >
-                            Try again
-                        </button>
-                    </div>
-                ) : emails.length === 0 ? (
-                    <div className="px-5 py-16 text-center">
-                        <p className="text-[12.5px] text-slate-700 font-medium mb-1">
-                            {hasActiveFilters(merged) || search.trim()
-                                ? "No matches"
-                                : "Nothing here yet"}
-                        </p>
-                        <p className="text-[11.5px] text-slate-400 max-w-[28ch] mx-auto leading-relaxed">
-                            {hasActiveFilters(merged) || search.trim()
-                                ? "Try a different scope or clear the filters."
-                                : "Pick a different scope from the rail, or wait for new mail."}
-                        </p>
-                    </div>
-                ) : (
+                  {q.isFetchingNextPage ? (
                     <>
-                        {grouped.map((g) => (
-                            <section key={g.bucket}>
-                                <div className="sticky top-0 z-10 px-3 py-1 bg-slate-50/95 backdrop-blur-sm border-b border-slate-200/60 flex items-center gap-2">
-                                    <span className="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-semibold">
-                                        {BUCKET_LABELS[g.bucket]}
-                                    </span>
-                                    <span className="font-mono text-[10px] text-slate-400 tabular-nums">
-                                        {g.rows.length}
-                                    </span>
-                                </div>
-                                <div className="divide-y divide-slate-200/60">
-                                    {g.rows.map((e) => (
-                                        <div
-                                            key={e.id}
-                                            data-thread-id={e.thread_id || e.id}
-                                        >
-                                            <ConversationItem
-                                                email={{
-                                                    id: e.id,
-                                                    from: e.from_addr?.[0] ?? "",
-                                                    to: e.to_addr?.[0] ?? "",
-                                                    subject: e.subject,
-                                                    body: e.snippet,
-                                                    date: new Date(e.internal_date),
-                                                    is_seen: e.seen,
-                                                    thread_id: e.thread_id,
-                                                    account_id: e.email_id,
-                                                }}
-                                            />
-                                        </div>
-                                    ))}
-                                </div>
-                            </section>
-                        ))}
-                        {q.hasNextPage && (
-                            <div className="px-3 py-3 flex justify-center border-t border-slate-200/60">
-                                <button
-                                    onClick={() => q.fetchNextPage()}
-                                    disabled={q.isFetchingNextPage}
-                                    className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
-                                >
-                                    {q.isFetchingNextPage ? (
-                                        <>
-                                            <Loader2Icon className="w-3 h-3 animate-spin" />
-                                            Loading…
-                                        </>
-                                    ) : (
-                                        `Load more · ${totalShown} shown`
-                                    )}
-                                </button>
-                            </div>
-                        )}
+                      <Loader2Icon className="w-3 h-3 animate-spin" />
+                      Loading…
                     </>
-                )}
-            </div>
+                  ) : (
+                    `Load more · ${totalShown} shown`
+                  )}
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
 
-            {/* Keyboard cheat-sheet footer. Slim and unobtrusive but
+      {/* Keyboard cheat-sheet footer. Slim and unobtrusive but
                 makes the shortcuts discoverable without a help menu. */}
-            <div className="h-6 px-2 shrink-0 border-t border-slate-200/80 bg-slate-50/60 flex items-center gap-2 text-[10px] text-slate-500 overflow-x-auto">
-                <Kbd>j</Kbd>/<Kbd>k</Kbd>
-                <span className="text-slate-400">move</span>
-                <Kbd>↵</Kbd>
-                <span className="text-slate-400">open</span>
-                <Kbd>esc</Kbd>
-                <span className="text-slate-400">close</span>
-                <Kbd>/</Kbd>
-                <span className="text-slate-400">search</span>
-            </div>
+      <div className="h-6 px-2 shrink-0 border-t border-slate-200/80 bg-slate-50/60 flex items-center gap-2 text-[10px] text-slate-500 overflow-x-auto">
+        <Kbd>j</Kbd>/<Kbd>k</Kbd>
+        <span className="text-slate-400">move</span>
+        <Kbd>↵</Kbd>
+        <span className="text-slate-400">open</span>
+        <Kbd>esc</Kbd>
+        <span className="text-slate-400">close</span>
+        <Kbd>/</Kbd>
+        <span className="text-slate-400">search</span>
+      </div>
 
-            <UniboxFilterSheet
-                open={sheetOpen}
-                setOpen={setSheetOpen}
-                filters={params}
-                setFilters={setParams}
-                loading={q.isFetching}
-            />
-        </div>
-    );
+      <UniboxFilterSheet
+        open={sheetOpen}
+        setOpen={setSheetOpen}
+        filters={params}
+        setFilters={setParams}
+        loading={q.isFetching}
+      />
+    </div>
+  );
 }
 
 function Kbd({ children }: { children: React.ReactNode }) {
-    return (
-        <kbd className="px-1 h-3.5 rounded-sm bg-white border border-slate-200 text-slate-600 font-mono text-[9px] inline-flex items-center shrink-0">
-            {children}
-        </kbd>
-    );
+  return (
+    <kbd className="px-1 h-3.5 rounded-sm bg-white border border-slate-200 text-slate-600 font-mono text-[9px] inline-flex items-center shrink-0">
+      {children}
+    </kbd>
+  );
 }
 
 function hasActiveFilters(p: UniboxSearchParams): boolean {
-    return Boolean(
-        p.from ||
-            (p.accountIds && p.accountIds.length > 0) ||
-            p.tagId ||
-            p.unseen !== undefined ||
-            p.since ||
-            p.until ||
-            p.snoozed ||
-            p.awaitingReply,
-    );
+  return Boolean(
+    p.from ||
+    (p.accountIds && p.accountIds.length > 0) ||
+    p.tagId ||
+    (p.categoryIds && p.categoryIds.length > 0) ||
+    p.unseen !== undefined ||
+    p.since ||
+    p.until ||
+    p.snoozed ||
+    p.awaitingReply,
+  );
 }
 
 function SkeletonRows() {
-    return (
-        <div className="divide-y divide-slate-200/60">
-            {Array.from({ length: 8 }).map((_, i) => (
-                <div key={i} className="px-3 py-2.5 flex items-center gap-2.5">
-                    <div className="size-7 rounded-full bg-slate-100 shrink-0" />
-                    <div className="min-w-0 flex-1 space-y-1.5">
-                        <div className="flex items-center gap-2">
-                            <div className="h-2.5 w-32 bg-slate-100 rounded animate-pulse" />
-                            <div className="ml-auto h-2.5 w-8 bg-slate-100 rounded animate-pulse" />
-                        </div>
-                        <div className="h-2.5 w-44 bg-slate-100 rounded animate-pulse" />
-                        <div className="h-2.5 w-56 bg-slate-100 rounded animate-pulse" />
-                    </div>
-                </div>
-            ))}
+  return (
+    <div className="divide-y divide-slate-200/60">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="px-3 py-2.5 flex items-center gap-2.5">
+          <div className="size-7 rounded-full bg-slate-100 shrink-0" />
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="flex items-center gap-2">
+              <div className="h-2.5 w-32 bg-slate-100 rounded animate-pulse" />
+              <div className="ml-auto h-2.5 w-8 bg-slate-100 rounded animate-pulse" />
+            </div>
+            <div className="h-2.5 w-44 bg-slate-100 rounded animate-pulse" />
+            <div className="h-2.5 w-56 bg-slate-100 rounded animate-pulse" />
+          </div>
         </div>
-    );
+      ))}
+    </div>
+  );
 }

--- a/web/src/components/app/unibox/ScopeRail.tsx
+++ b/web/src/components/app/unibox/ScopeRail.tsx
@@ -12,280 +12,315 @@
 
 import React from "react";
 import {
-    CalendarRangeIcon,
-    ChevronDownIcon,
-    ChevronRightIcon,
-    ClockIcon,
-    InboxIcon,
-    MailboxIcon,
-    MoonIcon,
-    ReplyIcon,
-    SearchIcon,
-    SendIcon,
-    SparkleIcon,
+  CalendarRangeIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  ClockIcon,
+  InboxIcon,
+  MailboxIcon,
+  MoonIcon,
+  ReplyIcon,
+  SearchIcon,
+  SendIcon,
+  SparkleIcon,
 } from "lucide-react";
 import useUniboxOverview from "@/lib/api/hooks/app/unibox/useUniboxOverview";
 import { cn } from "@/lib/utils";
 
 export type UniboxScope =
-    | { kind: "all" }
-    | { kind: "unread" }
-    | { kind: "today" }
-    | { kind: "week" }
-    | { kind: "awaiting" }
-    | { kind: "snoozed" }
-    | { kind: "scheduled" }
-    | { kind: "mailbox"; mailboxId: string }
-    | { kind: "tag"; tagId: string };
+  | { kind: "all" }
+  | { kind: "unread" }
+  | { kind: "today" }
+  | { kind: "week" }
+  | { kind: "awaiting" }
+  | { kind: "snoozed" }
+  | { kind: "scheduled" }
+  | { kind: "mailbox"; mailboxId: string }
+  | { kind: "tag"; tagId: string }
+  | { kind: "category"; categoryId: string };
 
 export function scopeKey(s: UniboxScope): string {
-    switch (s.kind) {
-        case "mailbox":
-            return `mailbox:${s.mailboxId}`;
-        case "tag":
-            return `tag:${s.tagId}`;
-        default:
-            return s.kind;
-    }
+  switch (s.kind) {
+    case "mailbox":
+      return `mailbox:${s.mailboxId}`;
+    case "tag":
+      return `tag:${s.tagId}`;
+    case "category":
+      return `category:${s.categoryId}`;
+    default:
+      return s.kind;
+  }
 }
 
 const COLLAPSE_THRESHOLD = 8;
 const COLLAPSED_VISIBLE = 6;
 
 interface ScopeRailProps {
-    scope: UniboxScope;
-    onChange: (s: UniboxScope) => void;
+  scope: UniboxScope;
+  onChange: (s: UniboxScope) => void;
 }
 
 export function ScopeRail({ scope, onChange }: ScopeRailProps) {
-    const overview = useUniboxOverview();
-    const data = overview.data;
+  const overview = useUniboxOverview();
+  const data = overview.data;
 
-    const active = scopeKey(scope);
+  const active = scopeKey(scope);
 
-    return (
-        <nav className="h-full bg-slate-50/60 border-r border-slate-200 overflow-y-auto py-2">
-            <Section label="Inbox">
-                <Item
-                    icon={<InboxIcon className="w-3.5 h-3.5" />}
-                    label="All"
-                    count={data?.total}
-                    active={active === "all"}
-                    onClick={() => onChange({ kind: "all" })}
-                />
-                <Item
-                    icon={<SparkleIcon className="w-3.5 h-3.5" />}
-                    label="Unread"
-                    count={data?.unread}
-                    countTone={data?.unread ? "accent" : "muted"}
-                    active={active === "unread"}
-                    onClick={() => onChange({ kind: "unread" })}
-                />
-                <Item
-                    icon={<ClockIcon className="w-3.5 h-3.5" />}
-                    label="Today"
-                    count={data?.today}
-                    active={active === "today"}
-                    onClick={() => onChange({ kind: "today" })}
-                />
-                <Item
-                    icon={<CalendarRangeIcon className="w-3.5 h-3.5" />}
-                    label="This week"
-                    count={data?.week}
-                    active={active === "week"}
-                    onClick={() => onChange({ kind: "week" })}
-                />
-                <Item
-                    icon={<ReplyIcon className="w-3.5 h-3.5" />}
-                    label="Awaiting reply"
-                    count={data?.awaiting_reply}
-                    countTone={data?.awaiting_reply ? "accent" : "muted"}
-                    active={active === "awaiting"}
-                    onClick={() => onChange({ kind: "awaiting" })}
-                />
-                <Item
-                    icon={<MoonIcon className="w-3.5 h-3.5" />}
-                    label="Snoozed"
-                    count={data?.snoozed}
-                    active={active === "snoozed"}
-                    onClick={() => onChange({ kind: "snoozed" })}
-                />
-                <Item
-                    icon={<SendIcon className="w-3.5 h-3.5" />}
-                    label="Scheduled"
-                    count={data?.scheduled_pending}
-                    countTone={data?.scheduled_pending ? "accent" : "muted"}
-                    active={active === "scheduled"}
-                    onClick={() => onChange({ kind: "scheduled" })}
-                />
-                {/* Cap meter — only when the user is materially through the
+  return (
+    <nav className="h-full bg-slate-50/60 border-r border-slate-200 overflow-y-auto py-2">
+      <Section label="Inbox">
+        <Item
+          icon={<InboxIcon className="w-3.5 h-3.5" />}
+          label="All"
+          count={data?.total}
+          active={active === "all"}
+          onClick={() => onChange({ kind: "all" })}
+        />
+        <Item
+          icon={<SparkleIcon className="w-3.5 h-3.5" />}
+          label="Unread"
+          count={data?.unread}
+          countTone={data?.unread ? "accent" : "muted"}
+          active={active === "unread"}
+          onClick={() => onChange({ kind: "unread" })}
+        />
+        <Item
+          icon={<ClockIcon className="w-3.5 h-3.5" />}
+          label="Today"
+          count={data?.today}
+          active={active === "today"}
+          onClick={() => onChange({ kind: "today" })}
+        />
+        <Item
+          icon={<CalendarRangeIcon className="w-3.5 h-3.5" />}
+          label="This week"
+          count={data?.week}
+          active={active === "week"}
+          onClick={() => onChange({ kind: "week" })}
+        />
+        <Item
+          icon={<ReplyIcon className="w-3.5 h-3.5" />}
+          label="Awaiting reply"
+          count={data?.awaiting_reply}
+          countTone={data?.awaiting_reply ? "accent" : "muted"}
+          active={active === "awaiting"}
+          onClick={() => onChange({ kind: "awaiting" })}
+        />
+        <Item
+          icon={<MoonIcon className="w-3.5 h-3.5" />}
+          label="Snoozed"
+          count={data?.snoozed}
+          active={active === "snoozed"}
+          onClick={() => onChange({ kind: "snoozed" })}
+        />
+        <Item
+          icon={<SendIcon className="w-3.5 h-3.5" />}
+          label="Scheduled"
+          count={data?.scheduled_pending}
+          countTone={data?.scheduled_pending ? "accent" : "muted"}
+          active={active === "scheduled"}
+          onClick={() => onChange({ kind: "scheduled" })}
+        />
+        {/* Cap meter — only when the user is materially through the
                     allowance, so the rail stays calm for the 99% case. */}
-                {data &&
-                    data.scheduled_pending_max > 0 &&
-                    data.scheduled_pending / data.scheduled_pending_max >= 0.7 && (
-                        <div className="px-2 pt-1 pb-1.5">
-                            <ScheduledMeter
-                                used={data.scheduled_pending}
-                                cap={data.scheduled_pending_max}
-                            />
-                        </div>
-                    )}
-            </Section>
+        {data &&
+          data.scheduled_pending_max > 0 &&
+          data.scheduled_pending / data.scheduled_pending_max >= 0.7 && (
+            <div className="px-2 pt-1 pb-1.5">
+              <ScheduledMeter
+                used={data.scheduled_pending}
+                cap={data.scheduled_pending_max}
+              />
+            </div>
+          )}
+      </Section>
 
-            <CollapsibleSection
-                label="Mailboxes"
-                items={data?.mailboxes ?? []}
-                emptyText={overview.isPending ? "Loading…" : "No mailboxes connected."}
-                searchPlaceholder="Filter mailboxes…"
-                getSearchKey={(m) => `${m.email} ${m.name}`}
-                renderItem={(m) => (
-                    <Item
-                        key={m.id}
-                        icon={<MailboxIcon className="w-3.5 h-3.5" />}
-                        label={m.email}
-                        mono
-                        count={m.unread || undefined}
-                        countTone={m.unread > 0 ? "accent" : "muted"}
-                        active={active === `mailbox:${m.id}`}
-                        onClick={() => onChange({ kind: "mailbox", mailboxId: m.id })}
-                    />
-                )}
-            />
+      <CollapsibleSection
+        label="Mailboxes"
+        items={data?.mailboxes ?? []}
+        emptyText={overview.isPending ? "Loading…" : "No mailboxes connected."}
+        searchPlaceholder="Filter mailboxes…"
+        getSearchKey={(m) => `${m.email} ${m.name}`}
+        renderItem={(m) => (
+          <Item
+            key={m.id}
+            icon={<MailboxIcon className="w-3.5 h-3.5" />}
+            label={m.email}
+            mono
+            count={m.unread || undefined}
+            countTone={m.unread > 0 ? "accent" : "muted"}
+            active={active === `mailbox:${m.id}`}
+            onClick={() => onChange({ kind: "mailbox", mailboxId: m.id })}
+          />
+        )}
+      />
 
-            {data && data.tags.length > 0 && (
-                <CollapsibleSection
-                    label="Tags"
-                    items={data.tags}
-                    emptyText="No tags yet."
-                    searchPlaceholder="Filter tags…"
-                    getSearchKey={(t) => t.title}
-                    renderItem={(t) => (
-                        <Item
-                            key={t.id}
-                            icon={
-                                <span
-                                    aria-hidden
-                                    className="block size-3 rounded-full ring-1 ring-black/10 shadow-sm"
-                                    style={{ backgroundColor: t.color || "#94a3b8" }}
-                                />
-                            }
-                            label={t.title}
-                            count={t.unread || t.total || undefined}
-                            countTone={t.unread > 0 ? "accent" : "muted"}
-                            active={active === `tag:${t.id}`}
-                            onClick={() => onChange({ kind: "tag", tagId: t.id })}
-                        />
-                    )}
+      {data && data.categories && data.categories.length > 0 && (
+        <CollapsibleSection
+          label="Categories"
+          items={data.categories}
+          emptyText="No categories yet."
+          searchPlaceholder="Filter categories…"
+          getSearchKey={(c) => c.title}
+          renderItem={(c) => (
+            <Item
+              key={c.id}
+              icon={
+                <span
+                  aria-hidden
+                  className="block size-3 rounded-full ring-1 ring-black/10 shadow-sm"
+                  style={{ backgroundColor: c.color || "#94a3b8" }}
                 />
-            )}
-        </nav>
-    );
+              }
+              label={c.title}
+              count={c.unread || c.total || undefined}
+              countTone={c.unread > 0 ? "accent" : "muted"}
+              active={active === `category:${c.id}`}
+              onClick={() => onChange({ kind: "category", categoryId: c.id })}
+            />
+          )}
+        />
+      )}
+
+      {data && data.tags.length > 0 && (
+        <CollapsibleSection
+          label="Tags"
+          items={data.tags}
+          emptyText="No tags yet."
+          searchPlaceholder="Filter tags…"
+          getSearchKey={(t) => t.title}
+          renderItem={(t) => (
+            <Item
+              key={t.id}
+              icon={
+                <span
+                  aria-hidden
+                  className="block size-3 rounded-full ring-1 ring-black/10 shadow-sm"
+                  style={{ backgroundColor: t.color || "#94a3b8" }}
+                />
+              }
+              label={t.title}
+              count={t.unread || t.total || undefined}
+              countTone={t.unread > 0 ? "accent" : "muted"}
+              active={active === `tag:${t.id}`}
+              onClick={() => onChange({ kind: "tag", tagId: t.id })}
+            />
+          )}
+        />
+      )}
+    </nav>
+  );
 }
 
 function CollapsibleSection<T extends { id: string }>({
-    label,
-    items,
-    emptyText,
-    searchPlaceholder,
-    getSearchKey,
-    renderItem,
+  label,
+  items,
+  emptyText,
+  searchPlaceholder,
+  getSearchKey,
+  renderItem,
 }: {
-    label: string;
-    items: T[];
-    emptyText: string;
-    searchPlaceholder: string;
-    getSearchKey: (item: T) => string;
-    renderItem: (item: T) => React.ReactNode;
+  label: string;
+  items: T[];
+  emptyText: string;
+  searchPlaceholder: string;
+  getSearchKey: (item: T) => string;
+  renderItem: (item: T) => React.ReactNode;
 }) {
-    const [search, setSearch] = React.useState("");
-    const [expanded, setExpanded] = React.useState(false);
-    const [sectionOpen, setSectionOpen] = React.useState(true);
+  const [search, setSearch] = React.useState("");
+  const [expanded, setExpanded] = React.useState(false);
+  const [sectionOpen, setSectionOpen] = React.useState(true);
 
-    const filtered = React.useMemo(() => {
-        const q = search.trim().toLowerCase();
-        if (!q) return items;
-        return items.filter((it) => getSearchKey(it).toLowerCase().includes(q));
-    }, [items, search, getSearchKey]);
+  const filtered = React.useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((it) => getSearchKey(it).toLowerCase().includes(q));
+  }, [items, search, getSearchKey]);
 
-    const showSearch = items.length > COLLAPSE_THRESHOLD;
-    const showCollapse = filtered.length > COLLAPSE_THRESHOLD;
-    const visible = showCollapse && !expanded ? filtered.slice(0, COLLAPSED_VISIBLE) : filtered;
-    const hidden = filtered.length - visible.length;
+  const showSearch = items.length > COLLAPSE_THRESHOLD;
+  const showCollapse = filtered.length > COLLAPSE_THRESHOLD;
+  const visible =
+    showCollapse && !expanded ? filtered.slice(0, COLLAPSED_VISIBLE) : filtered;
+  const hidden = filtered.length - visible.length;
 
-    return (
-        <div className="mb-1">
+  return (
+    <div className="mb-1">
+      <button
+        type="button"
+        onClick={() => setSectionOpen((v) => !v)}
+        className="w-full px-3 pt-3 pb-1 flex items-center gap-1.5 text-left"
+      >
+        {sectionOpen ? (
+          <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+        ) : (
+          <ChevronRightIcon className="w-3 h-3 text-slate-400" />
+        )}
+        <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">
+          {label}
+        </span>
+        <span className="ml-auto font-mono text-[10px] text-slate-400 tabular-nums">
+          {items.length}
+        </span>
+      </button>
+
+      {sectionOpen && (
+        <div className="px-1.5">
+          {showSearch && (
+            <div className="flex items-center gap-1.5 px-2 py-1 mb-1 rounded-md border border-slate-200 bg-white">
+              <SearchIcon className="w-3 h-3 text-slate-400 shrink-0" />
+              <input
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={searchPlaceholder}
+                className="flex-1 min-w-0 h-5 bg-transparent text-[11.5px] text-slate-900 placeholder:text-slate-400 outline-none"
+              />
+              {search && (
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="text-[10px] text-slate-400 hover:text-slate-600 shrink-0"
+                  aria-label="Clear filter"
+                >
+                  clear
+                </button>
+              )}
+            </div>
+          )}
+
+          {items.length === 0 ? (
+            <div className="px-2 py-2 text-[11px] text-slate-400">
+              {emptyText}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="px-2 py-2 text-[11px] text-slate-400">
+              No matches.
+            </div>
+          ) : (
+            <div className="space-y-px">{visible.map(renderItem)}</div>
+          )}
+
+          {hidden > 0 && (
             <button
-                type="button"
-                onClick={() => setSectionOpen((v) => !v)}
-                className="w-full px-3 pt-3 pb-1 flex items-center gap-1.5 text-left"
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="w-full h-7 px-2 mt-1 rounded-md text-[11.5px] text-slate-500 hover:text-slate-900 hover:bg-white/70 transition-colors text-left"
             >
-                {sectionOpen ? (
-                    <ChevronDownIcon className="w-3 h-3 text-slate-400" />
-                ) : (
-                    <ChevronRightIcon className="w-3 h-3 text-slate-400" />
-                )}
-                <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">
-                    {label}
-                </span>
-                <span className="ml-auto font-mono text-[10px] text-slate-400 tabular-nums">
-                    {items.length}
-                </span>
+              Show all ({hidden} more)
             </button>
-
-            {sectionOpen && (
-                <div className="px-1.5">
-                    {showSearch && (
-                        <div className="flex items-center gap-1.5 px-2 py-1 mb-1 rounded-md border border-slate-200 bg-white">
-                            <SearchIcon className="w-3 h-3 text-slate-400 shrink-0" />
-                            <input
-                                value={search}
-                                onChange={(e) => setSearch(e.target.value)}
-                                placeholder={searchPlaceholder}
-                                className="flex-1 min-w-0 h-5 bg-transparent text-[11.5px] text-slate-900 placeholder:text-slate-400 outline-none"
-                            />
-                            {search && (
-                                <button
-                                    type="button"
-                                    onClick={() => setSearch("")}
-                                    className="text-[10px] text-slate-400 hover:text-slate-600 shrink-0"
-                                    aria-label="Clear filter"
-                                >
-                                    clear
-                                </button>
-                            )}
-                        </div>
-                    )}
-
-                    {items.length === 0 ? (
-                        <div className="px-2 py-2 text-[11px] text-slate-400">{emptyText}</div>
-                    ) : filtered.length === 0 ? (
-                        <div className="px-2 py-2 text-[11px] text-slate-400">No matches.</div>
-                    ) : (
-                        <div className="space-y-px">{visible.map(renderItem)}</div>
-                    )}
-
-                    {hidden > 0 && (
-                        <button
-                            type="button"
-                            onClick={() => setExpanded(true)}
-                            className="w-full h-7 px-2 mt-1 rounded-md text-[11.5px] text-slate-500 hover:text-slate-900 hover:bg-white/70 transition-colors text-left"
-                        >
-                            Show all ({hidden} more)
-                        </button>
-                    )}
-                    {expanded && filtered.length > COLLAPSED_VISIBLE && (
-                        <button
-                            type="button"
-                            onClick={() => setExpanded(false)}
-                            className="w-full h-7 px-2 mt-1 rounded-md text-[11.5px] text-slate-400 hover:text-slate-700 hover:bg-white/70 transition-colors text-left"
-                        >
-                            Show less
-                        </button>
-                    )}
-                </div>
-            )}
+          )}
+          {expanded && filtered.length > COLLAPSED_VISIBLE && (
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              className="w-full h-7 px-2 mt-1 rounded-md text-[11.5px] text-slate-400 hover:text-slate-700 hover:bg-white/70 transition-colors text-left"
+            >
+              Show less
+            </button>
+          )}
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
 // ScheduledMeter — slim usage bar that surfaces the pending-cap. Stays
@@ -293,123 +328,129 @@ function CollapsibleSection<T extends { id: string }>({
 // common case where the cap is irrelevant. Shifts to amber/red as the
 // cap gets close so the user gets unmissable warning before sends fail.
 function ScheduledMeter({ used, cap }: { used: number; cap: number }) {
-    const ratio = Math.min(1, used / cap);
-    const pct = Math.round(ratio * 100);
-    const tone =
-        ratio >= 0.95 ? "rose" : ratio >= 0.85 ? "amber" : "sky";
+  const ratio = Math.min(1, used / cap);
+  const pct = Math.round(ratio * 100);
+  const tone = ratio >= 0.95 ? "rose" : ratio >= 0.85 ? "amber" : "sky";
 
-    const barClasses =
-        tone === "rose"
-            ? "bg-rose-500"
-            : tone === "amber"
-                ? "bg-amber-500"
-                : "bg-sky-500";
-    const textClasses =
-        tone === "rose"
-            ? "text-rose-700"
-            : tone === "amber"
-                ? "text-amber-700"
-                : "text-slate-500";
+  const barClasses =
+    tone === "rose"
+      ? "bg-rose-500"
+      : tone === "amber"
+        ? "bg-amber-500"
+        : "bg-sky-500";
+  const textClasses =
+    tone === "rose"
+      ? "text-rose-700"
+      : tone === "amber"
+        ? "text-amber-700"
+        : "text-slate-500";
 
-    return (
-        <div className="px-1">
-            <div className={cn("flex items-center justify-between text-[10px] mb-1", textClasses)}>
-                <span className="uppercase tracking-[0.14em] font-medium">Queue</span>
-                <span className="font-mono tabular-nums">
-                    {used}/{cap}
-                </span>
-            </div>
-            <div className="h-1 rounded-full bg-slate-200 overflow-hidden">
-                <div
-                    className={cn("h-full transition-all", barClasses)}
-                    style={{ width: `${pct}%` }}
-                />
-            </div>
-            {ratio >= 0.95 && (
-                <p className="mt-1 text-[10px] text-rose-600 leading-snug">
-                    Near the limit — cancel a few sends to free up space.
-                </p>
-            )}
-        </div>
-    );
+  return (
+    <div className="px-1">
+      <div
+        className={cn(
+          "flex items-center justify-between text-[10px] mb-1",
+          textClasses,
+        )}
+      >
+        <span className="uppercase tracking-[0.14em] font-medium">Queue</span>
+        <span className="font-mono tabular-nums">
+          {used}/{cap}
+        </span>
+      </div>
+      <div className="h-1 rounded-full bg-slate-200 overflow-hidden">
+        <div
+          className={cn("h-full transition-all", barClasses)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      {ratio >= 0.95 && (
+        <p className="mt-1 text-[10px] text-rose-600 leading-snug">
+          Near the limit — cancel a few sends to free up space.
+        </p>
+      )}
+    </div>
+  );
 }
 
 function Section({
-    label,
-    children,
+  label,
+  children,
 }: {
-    label: string;
-    children: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
 }) {
-    return (
-        <div className="mb-1">
-            <div className="px-3 pt-3 pb-1 flex items-center gap-2">
-                <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">
-                    {label}
-                </span>
-            </div>
-            <div className="px-1.5 space-y-px">{children}</div>
-        </div>
-    );
+  return (
+    <div className="mb-1">
+      <div className="px-3 pt-3 pb-1 flex items-center gap-2">
+        <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-semibold">
+          {label}
+        </span>
+      </div>
+      <div className="px-1.5 space-y-px">{children}</div>
+    </div>
+  );
 }
 
 function Item({
-    icon,
-    label,
-    count,
-    countTone = "muted",
-    active,
-    mono,
-    onClick,
+  icon,
+  label,
+  count,
+  countTone = "muted",
+  active,
+  mono,
+  onClick,
 }: {
-    icon: React.ReactNode;
-    label: string;
-    count?: number;
-    countTone?: "muted" | "accent";
-    active?: boolean;
-    mono?: boolean;
-    onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  count?: number;
+  countTone?: "muted" | "accent";
+  active?: boolean;
+  mono?: boolean;
+  onClick: () => void;
 }) {
-    // Active = sky-100 (clearly distinct from the slate-50 rail bg).
-    // Hover = slate-200/70 so it reads as "pressable" on the muted rail
-    // — the previous white-on-slate combo was invisible.
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className={cn(
-                "w-full h-7 pl-2 pr-2 rounded-md flex items-center gap-2 transition-colors text-left",
-                active
-                    ? "bg-sky-100 text-sky-900 font-medium"
-                    : "text-slate-600 hover:bg-slate-200/70 hover:text-slate-900",
-            )}
-            title={label}
+  // Active = sky-100 (clearly distinct from the slate-50 rail bg).
+  // Hover = slate-200/70 so it reads as "pressable" on the muted rail
+  // — the previous white-on-slate combo was invisible.
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "w-full h-7 pl-2 pr-2 rounded-md flex items-center gap-2 transition-colors text-left",
+        active
+          ? "bg-sky-100 text-sky-900 font-medium"
+          : "text-slate-600 hover:bg-slate-200/70 hover:text-slate-900",
+      )}
+      title={label}
+    >
+      <span
+        className={cn("shrink-0", active ? "text-sky-700" : "text-slate-500")}
+      >
+        {icon}
+      </span>
+      <span
+        className={cn(
+          "truncate min-w-0 flex-1 text-[12px]",
+          mono && "font-mono text-[11.5px]",
+        )}
+      >
+        {label}
+      </span>
+      {count !== undefined && count !== null && (
+        <span
+          className={cn(
+            "shrink-0 font-mono tabular-nums text-[10.5px] px-1.5 h-4 rounded inline-flex items-center",
+            active
+              ? "bg-white/80 text-sky-700"
+              : countTone === "accent"
+                ? "bg-sky-100 text-sky-700"
+                : "text-slate-400",
+          )}
         >
-            <span className={cn("shrink-0", active ? "text-sky-700" : "text-slate-500")}>
-                {icon}
-            </span>
-            <span
-                className={cn(
-                    "truncate min-w-0 flex-1 text-[12px]",
-                    mono && "font-mono text-[11.5px]",
-                )}
-            >
-                {label}
-            </span>
-            {count !== undefined && count !== null && (
-                <span
-                    className={cn(
-                        "shrink-0 font-mono tabular-nums text-[10.5px] px-1.5 h-4 rounded inline-flex items-center",
-                        active
-                            ? "bg-white/80 text-sky-700"
-                            : countTone === "accent"
-                                ? "bg-sky-100 text-sky-700"
-                                : "text-slate-400",
-                    )}
-                >
-                    {count}
-                </span>
-            )}
-        </button>
-    );
+          {count}
+        </span>
+      )}
+    </button>
+  );
 }

--- a/web/src/components/app/unibox/ThreadLabelMenu.tsx
+++ b/web/src/components/app/unibox/ThreadLabelMenu.tsx
@@ -1,0 +1,168 @@
+// Label menu for a conversation. Lives in the ThreadView header and
+// also opens via the `c` shortcut. Reuses the shared category registry
+// (user.categories) and the same search-or-create pattern as the
+// contacts CategoryPicker, but assigns at the thread level via
+// PUT /unibox/thread/labels.
+
+import React from "react";
+import { CheckIcon, Loader2Icon, PlusIcon, TagIcon } from "lucide-react";
+import toast from "react-hot-toast";
+
+import {
+  PopoverMenu,
+  PopoverMenuContent,
+  PopoverMenuLabel,
+  PopoverMenuTrigger,
+} from "@/components/ui/popover-menu";
+import { useUserProfile } from "@/hooks/context/user";
+import useCreateCategory from "@/lib/api/hooks/app/categories/useCreateCategory";
+import useThreadLabels from "@/lib/api/hooks/app/unibox/useThreadLabels";
+import useSetThreadLabels from "@/lib/api/hooks/app/unibox/useSetThreadLabels";
+
+interface Props {
+  threadId: string;
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+}
+
+export function ThreadLabelMenu({ threadId, open, onOpenChange }: Props) {
+  const { user } = useUserProfile();
+  const categories = React.useMemo(
+    () => user.categories ?? [],
+    [user.categories],
+  );
+  const labelsQ = useThreadLabels(threadId);
+  const setLabels = useSetThreadLabels(threadId);
+  const createCategory = useCreateCategory();
+  const [query, setQuery] = React.useState("");
+
+  const current = React.useMemo(() => labelsQ.data ?? [], [labelsQ.data]);
+  const currentIds = React.useMemo(
+    () => new Set(current.map((c) => c.id)),
+    [current],
+  );
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return categories;
+    return categories.filter((c) => c.title.toLowerCase().includes(q));
+  }, [categories, query]);
+
+  const queryMatchesExisting = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return true;
+    return categories.some((c) => c.title.toLowerCase() === q);
+  }, [categories, query]);
+
+  const toggle = (id: string) => {
+    const next = new Set(currentIds);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    setLabels.mutate(Array.from(next));
+  };
+
+  const createAndAdd = async () => {
+    const title = query.trim();
+    if (!title) return;
+    try {
+      const c = await createCategory.mutateAsync(title);
+      setLabels.mutate([...Array.from(currentIds), c.id]);
+      setQuery("");
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to create category",
+      );
+    }
+  };
+
+  return (
+    <PopoverMenu
+      align="end"
+      side="bottom"
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <PopoverMenuTrigger asChild>
+        <button
+          aria-label="Label this conversation (press c)"
+          className="h-7 px-2 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center gap-1 transition-colors text-[12px]"
+        >
+          {setLabels.isPending ? (
+            <Loader2Icon className="w-3 h-3 animate-spin" />
+          ) : (
+            <TagIcon className="w-3.5 h-3.5" />
+          )}
+          Label
+          {current.length > 0 && (
+            <span className="font-mono tabular-nums text-[10px] text-slate-400">
+              {current.length}
+            </span>
+          )}
+        </button>
+      </PopoverMenuTrigger>
+      <PopoverMenuContent>
+        <div className="w-[240px]">
+          <PopoverMenuLabel>Label conversation</PopoverMenuLabel>
+          <div className="px-1 pb-1">
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search or create…"
+              autoFocus
+              className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] text-slate-900 placeholder:text-slate-400 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
+            />
+          </div>
+          <div className="max-h-56 overflow-y-auto py-0.5">
+            {categories.length === 0 && !query.trim() && (
+              <div className="px-2.5 py-3 text-[11.5px] text-slate-400 text-center">
+                No categories yet. Type to create one.
+              </div>
+            )}
+            {filtered.map((c) => {
+              const checked = currentIds.has(c.id);
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => toggle(c.id)}
+                  disabled={setLabels.isPending}
+                  className="w-full px-2.5 h-7 flex items-center gap-2 text-[12px] text-slate-700 hover:bg-slate-100 transition-colors disabled:opacity-60"
+                >
+                  <span
+                    className={`size-3.5 rounded border flex items-center justify-center shrink-0 ${
+                      checked
+                        ? "border-slate-900 bg-slate-900"
+                        : "border-slate-300 bg-white"
+                    }`}
+                  >
+                    {checked && <CheckIcon className="w-2 h-2 text-white" />}
+                  </span>
+                  <span
+                    className="size-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: c.color }}
+                  />
+                  <span className="truncate">{c.title}</span>
+                </button>
+              );
+            })}
+            {query.trim() && !queryMatchesExisting && (
+              <button
+                type="button"
+                onClick={createAndAdd}
+                disabled={createCategory.isPending}
+                className="w-full px-2.5 h-7 flex items-center gap-2 text-[12px] text-slate-900 font-medium hover:bg-sky-50 border-t border-slate-100 transition-colors"
+              >
+                {createCategory.isPending ? (
+                  <Loader2Icon className="w-3 h-3 animate-spin text-slate-400" />
+                ) : (
+                  <PlusIcon className="w-3 h-3 text-sky-600" />
+                )}
+                Create "{query.trim()}"
+              </button>
+            )}
+          </div>
+        </div>
+      </PopoverMenuContent>
+    </PopoverMenu>
+  );
+}

--- a/web/src/components/app/unibox/ThreadView.tsx
+++ b/web/src/components/app/unibox/ThreadView.tsx
@@ -10,519 +10,576 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import {
-    AlertCircleIcon,
-    ArchiveIcon,
-    CheckIcon,
-    ChevronDownIcon,
-    ClockIcon,
-    CornerUpLeftIcon,
-    ForwardIcon,
-    Loader2Icon,
-    MailCheckIcon,
-    MoonIcon,
-    SendIcon,
-    TrashIcon,
-    XIcon,
+  AlertCircleIcon,
+  ArchiveIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ClockIcon,
+  CornerUpLeftIcon,
+  ForwardIcon,
+  Loader2Icon,
+  MailCheckIcon,
+  MoonIcon,
+  SendIcon,
+  TrashIcon,
+  XIcon,
 } from "lucide-react";
 
 import { MessageBubble } from "./MessageBubble";
 import { ReplyComposer, type ReplyMode } from "./ReplyComposer";
+import { ThreadLabelMenu } from "./ThreadLabelMenu";
+import { CategoryChip } from "@/components/app/contacts/CategoryPicker";
 import { SectionBar } from "@/components/layout/Page";
 import useThread from "@/lib/api/hooks/app/unibox/useThread";
+import useThreadLabels from "@/lib/api/hooks/app/unibox/useThreadLabels";
 import useThreadScheduled from "@/lib/api/hooks/app/unibox/useThreadScheduled";
 import cancelScheduled from "@/lib/api/client/app/unibox/cancelScheduled";
 import { useAppStore } from "@/stores";
 import {
-    PopoverMenu,
-    PopoverMenuContent,
-    PopoverMenuItem,
-    PopoverMenuLabel,
-    PopoverMenuTrigger,
+  PopoverMenu,
+  PopoverMenuContent,
+  PopoverMenuItem,
+  PopoverMenuLabel,
+  PopoverMenuTrigger,
 } from "@/components/ui/popover-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { snoozeThread, unsnoozeThread } from "@/lib/api/client/app/unibox/snoozeThread";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
+  snoozeThread,
+  unsnoozeThread,
+} from "@/lib/api/client/app/unibox/snoozeThread";
 import type UniboxEmail from "@/lib/api/models/app/unibox/UniboxEmail";
 import type UniboxScheduledItem from "@/lib/api/models/app/unibox/UniboxScheduled";
 import type { UniboxThreadMessage } from "@/lib/api/models/app/unibox/UniboxThread";
 
 interface ThreadViewProps {
-    threadId: string;
-    emailId?: string;
+  threadId: string;
+  emailId?: string;
 }
 
 function toUniboxEmail(m: UniboxThreadMessage): UniboxEmail {
-    return {
-        id: m.id,
-        from: m.from_addr?.[0] ?? "",
-        to: m.to_addr?.[0] ?? "",
-        subject: m.subject,
-        body: m.snippet ? `<p>${escapeHtml(m.snippet)}</p>` : "",
-        date: new Date(m.internal_date),
-        is_seen: m.seen,
-        thread_id: m.thread_id,
-        account_id: m.email_id,
-    };
+  return {
+    id: m.id,
+    from: m.from_addr?.[0] ?? "",
+    to: m.to_addr?.[0] ?? "",
+    subject: m.subject,
+    body: m.snippet ? `<p>${escapeHtml(m.snippet)}</p>` : "",
+    date: new Date(m.internal_date),
+    is_seen: m.seen,
+    thread_id: m.thread_id,
+    account_id: m.email_id,
+  };
 }
 
 function escapeHtml(s: string): string {
-    return s
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }
 
 const SNOOZE_PRESETS: { label: string; until: () => Date }[] = [
-    { label: "In 1 hour", until: () => offsetHours(1) },
-    { label: "In 3 hours", until: () => offsetHours(3) },
-    { label: "Tomorrow 9:00", until: () => atHour(1, 9) },
-    { label: "Monday 9:00", until: () => nextMonday9() },
-    { label: "Next week", until: () => offsetDays(7) },
+  { label: "In 1 hour", until: () => offsetHours(1) },
+  { label: "In 3 hours", until: () => offsetHours(3) },
+  { label: "Tomorrow 9:00", until: () => atHour(1, 9) },
+  { label: "Monday 9:00", until: () => nextMonday9() },
+  { label: "Next week", until: () => offsetDays(7) },
 ];
 
 function offsetHours(h: number): Date {
-    const d = new Date();
-    d.setHours(d.getHours() + h);
-    return d;
+  const d = new Date();
+  d.setHours(d.getHours() + h);
+  return d;
 }
 function offsetDays(d: number): Date {
-    const x = new Date();
-    x.setDate(x.getDate() + d);
-    return x;
+  const x = new Date();
+  x.setDate(x.getDate() + d);
+  return x;
 }
 function atHour(dayOffset: number, hour: number): Date {
-    const d = new Date();
-    d.setDate(d.getDate() + dayOffset);
-    d.setHours(hour, 0, 0, 0);
-    return d;
+  const d = new Date();
+  d.setDate(d.getDate() + dayOffset);
+  d.setHours(hour, 0, 0, 0);
+  return d;
 }
 function nextMonday9(): Date {
-    const d = new Date();
-    const dow = d.getDay();
-    const delta = ((1 - dow + 7) % 7) || 7;
-    d.setDate(d.getDate() + delta);
-    d.setHours(9, 0, 0, 0);
-    return d;
+  const d = new Date();
+  const dow = d.getDay();
+  const delta = (1 - dow + 7) % 7 || 7;
+  d.setDate(d.getDate() + delta);
+  d.setHours(9, 0, 0, 0);
+  return d;
 }
 
 // Local datetime → ISO string. The native <input type="datetime-local">
 // hands back "YYYY-MM-DDTHH:mm" (no zone), interpreted as the user's
 // local clock : perfectly fine here since we round-trip to UTC on send.
 function toLocalInput(d: Date): string {
-    const pad = (n: number) => String(n).padStart(2, "0");
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 function defaultCustomSnoozeValue(): string {
-    return toLocalInput(offsetHours(2));
+  return toLocalInput(offsetHours(2));
 }
 
 export function ThreadView({ threadId, emailId }: ThreadViewProps) {
-    const q = useThread(threadId, emailId);
-    const scheduledQ = useThreadScheduled(threadId);
-    const accounts = useAppStore((s) => s.emails);
-    const queryClient = useQueryClient();
+  const q = useThread(threadId, emailId);
+  const scheduledQ = useThreadScheduled(threadId);
+  const accounts = useAppStore((s) => s.emails);
+  const queryClient = useQueryClient();
 
-    const cancel = useMutation({
-        mutationFn: (taskId: string) => cancelScheduled(taskId),
-        onSuccess: () => {
-            toast.success("Scheduled send cancelled");
-            // Three caches to refresh: the per-thread list (this view),
-            // the global scheduled list (Scheduled scope), and the
-            // overview that powers the scope-rail counter.
-            queryClient.invalidateQueries({
-                queryKey: ["unibox", "scheduled", "thread", threadId],
-            });
-            queryClient.invalidateQueries({ queryKey: ["unibox", "scheduled"] });
-            queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
-        },
-        onError: () => toast.error("Couldn't cancel that send"),
-    });
+  const cancel = useMutation({
+    mutationFn: (taskId: string) => cancelScheduled(taskId),
+    onSuccess: () => {
+      toast.success("Scheduled send cancelled");
+      // Three caches to refresh: the per-thread list (this view),
+      // the global scheduled list (Scheduled scope), and the
+      // overview that powers the scope-rail counter.
+      queryClient.invalidateQueries({
+        queryKey: ["unibox", "scheduled", "thread", threadId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "scheduled"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
+    },
+    onError: () => toast.error("Couldn't cancel that send"),
+  });
 
-    const [snoozeOpen, setSnoozeOpen] = React.useState(false);
-    const [customValue, setCustomValue] = React.useState(defaultCustomSnoozeValue);
-    const [customMode, setCustomMode] = React.useState(false);
+  const [snoozeOpen, setSnoozeOpen] = React.useState(false);
+  const [customValue, setCustomValue] = React.useState(
+    defaultCustomSnoozeValue,
+  );
+  const [customMode, setCustomMode] = React.useState(false);
 
-    // Composer is opt-in. Default: no reply UI mounted. The user has
-    // to click Reply (per-message or the footer CTA) before any blank
-    // composer appears. Cleared on thread change so navigating to a
-    // different conversation doesn't carry a half-written reply with
-    // it.
-    const [replyState, setReplyState] = React.useState<{
-        messageId: string;
-        mode: ReplyMode;
-    } | null>(null);
-    React.useEffect(() => {
-        setReplyState(null);
-    }, [threadId]);
+  // Conversation labels (read for the header chips; the menu writes).
+  const threadLabels = useThreadLabels(threadId);
+  const [labelMenuOpen, setLabelMenuOpen] = React.useState(false);
 
-    const snooze = useMutation({
-        mutationFn: (until: Date) =>
-            snoozeThread({ thread_id: threadId, snoozed_until: until.toISOString() }),
-        onSuccess: () => {
-            toast.success("Snoozed");
-            queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
-            queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
-            queryClient.invalidateQueries({ queryKey: ["unibox", "count"] });
-            setSnoozeOpen(false);
-            setCustomMode(false);
-        },
-        onError: () => toast.error("Couldn't snooze this thread"),
-    });
-
-    const unsnooze = useMutation({
-        mutationFn: () => unsnoozeThread(threadId),
-        onSuccess: () => {
-            toast.success("Un-snoozed");
-            queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
-            queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
-            setSnoozeOpen(false);
-        },
-        onError: () => toast.error("Couldn't un-snooze"),
-    });
-
-    if (q.isPending) {
-        return (
-            <div className="flex-1 flex items-center justify-center gap-2 text-[12px] text-slate-400">
-                <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
-                Loading thread…
-            </div>
-        );
-    }
-
-    if (q.isError) {
-        return (
-            <div className="flex-1 flex items-center justify-center px-6">
-                <div className="text-center max-w-sm">
-                    <AlertCircleIcon className="w-5 h-5 text-rose-500 mx-auto mb-2" />
-                    <p className="text-[12.5px] font-medium text-slate-900 mb-1">
-                        Couldn't load this thread
-                    </p>
-                    <p className="text-[11.5px] text-slate-500 mb-3">
-                        {q.error?.message ?? "Request failed"}
-                    </p>
-                    <button
-                        type="button"
-                        onClick={() => q.refetch()}
-                        className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium transition-colors"
-                    >
-                        Try again
-                    </button>
-                </div>
-            </div>
-        );
-    }
-
-    const messages = (q.data?.data ?? []).map(toUniboxEmail);
-
-    if (messages.length === 0) {
-        return (
-            <div className="flex-1 flex items-center justify-center text-[12px] text-slate-400">
-                This thread is empty.
-            </div>
-        );
-    }
-
-    const subject = messages[0]?.subject || "(no subject)";
-    const participants = new Set(
-        messages.map((m) => m.from).filter((f): f is string => Boolean(f)),
-    );
-    const mailbox = accounts.find((a) => a.id === messages[0]?.account_id);
-
-    const submitCustomSnooze = () => {
-        if (!customValue) return;
-        const d = new Date(customValue);
-        // Server caps at 90 days for snooze (matches SnoozeMaxHorizon
-        // in internal/app/unibox/config.go). Reject early with a
-        // useful message instead of letting the API 400.
-        const MAX_SNOOZE_MS = 90 * 24 * 60 * 60 * 1000;
-        if (Number.isNaN(d.getTime()) || d.getTime() <= Date.now() + 5_000) {
-            toast.error("Pick a future time (a few seconds out, please)");
-            return;
-        }
-        if (d.getTime() - Date.now() > MAX_SNOOZE_MS) {
-            toast.error("Snooze can't be more than 90 days out");
-            return;
-        }
-        snooze.mutate(d);
+  // `c` opens the label menu while a thread is open — ignored while
+  // typing into the composer / any input so it never eats keystrokes.
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const t = e.target as HTMLElement | null;
+      if (t) {
+        const tag = t.tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable)
+          return;
+      }
+      if (e.key === "c") {
+        setLabelMenuOpen(true);
+        e.preventDefault();
+      }
     };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, []);
 
+  // Composer is opt-in. Default: no reply UI mounted. The user has
+  // to click Reply (per-message or the footer CTA) before any blank
+  // composer appears. Cleared on thread change so navigating to a
+  // different conversation doesn't carry a half-written reply with
+  // it.
+  const [replyState, setReplyState] = React.useState<{
+    messageId: string;
+    mode: ReplyMode;
+  } | null>(null);
+  React.useEffect(() => {
+    setReplyState(null);
+  }, [threadId]);
+
+  const snooze = useMutation({
+    mutationFn: (until: Date) =>
+      snoozeThread({ thread_id: threadId, snoozed_until: until.toISOString() }),
+    onSuccess: () => {
+      toast.success("Snoozed");
+      queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "count"] });
+      setSnoozeOpen(false);
+      setCustomMode(false);
+    },
+    onError: () => toast.error("Couldn't snooze this thread"),
+  });
+
+  const unsnooze = useMutation({
+    mutationFn: () => unsnoozeThread(threadId),
+    onSuccess: () => {
+      toast.success("Un-snoozed");
+      queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
+      setSnoozeOpen(false);
+    },
+    onError: () => toast.error("Couldn't un-snooze"),
+  });
+
+  if (q.isPending) {
     return (
-        <div className="flex flex-col h-full bg-white">
-            <div className="h-12 px-3 sm:px-5 border-b border-slate-200 flex items-center gap-2 sm:gap-3 shrink-0 bg-white">
-                <span className="hidden sm:inline text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
-                    Thread
-                </span>
-                <div className="hidden sm:block h-4 w-px bg-slate-200" />
-                <span className="text-[12.5px] text-slate-900 font-medium truncate min-w-0">
-                    {subject}
-                </span>
-                {mailbox && (
-                    <span className="ml-1 hidden md:inline-flex items-center gap-1 h-5 px-1.5 rounded bg-slate-100 text-slate-600 text-[10.5px] font-medium font-mono shrink-0">
-                        {mailbox.email}
-                    </span>
-                )}
-                <div className="ml-auto flex items-center gap-1">
-                    <PopoverMenu
-                        align="end"
-                        side="bottom"
-                        open={snoozeOpen}
-                        onOpenChange={(o) => {
-                            setSnoozeOpen(o);
-                            if (!o) setCustomMode(false);
-                        }}
-                    >
-                        <PopoverMenuTrigger asChild>
-                            <button
-                                aria-label="Snooze this thread"
-                                className="h-7 px-2 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center gap-1 transition-colors text-[12px]"
-                                disabled={snooze.isPending || unsnooze.isPending}
-                            >
-                                {snooze.isPending || unsnooze.isPending ? (
-                                    <Loader2Icon className="w-3 h-3 animate-spin" />
-                                ) : (
-                                    <MoonIcon className="w-3.5 h-3.5" />
-                                )}
-                                Snooze
-                                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
-                            </button>
-                        </PopoverMenuTrigger>
-                        <PopoverMenuContent>
-                            <AnimatePresence mode="wait" initial={false}>
-                                {customMode ? (
-                                    <motion.div
-                                        key="custom"
-                                        initial={{ opacity: 0 }}
-                                        animate={{ opacity: 1 }}
-                                        exit={{ opacity: 0 }}
-                                        transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
-                                        className="px-1 py-1 w-[240px]"
-                                    >
-                                        <PopoverMenuLabel>Pick a date &amp; time</PopoverMenuLabel>
-                                        <input
-                                            type="datetime-local"
-                                            value={customValue}
-                                            onChange={(e) => setCustomValue(e.target.value)}
-                                            min={toLocalInput(new Date(Date.now() + 60_000))}
-                                            max={toLocalInput(new Date(Date.now() + 90 * 24 * 60 * 60 * 1000))}
-                                            autoFocus
-                                            className="w-full h-8 px-2 mt-1 rounded-md border border-slate-200 text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100 tabular-nums"
-                                        />
-                                        <div className="mt-2 flex items-center gap-1.5">
-                                            <button
-                                                type="button"
-                                                onClick={submitCustomSnooze}
-                                                className="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1 transition-colors"
-                                            >
-                                                <CheckIcon className="w-3 h-3" />
-                                                Snooze
-                                            </button>
-                                            <button
-                                                type="button"
-                                                onClick={() => setCustomMode(false)}
-                                                className="h-7 px-2 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 text-[12px] transition-colors"
-                                            >
-                                                Back
-                                            </button>
-                                        </div>
-                                    </motion.div>
-                                ) : (
-                                    <motion.div
-                                        key="presets"
-                                        initial={{ opacity: 0 }}
-                                        animate={{ opacity: 1 }}
-                                        exit={{ opacity: 0 }}
-                                        transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
-                                    >
-                                        <PopoverMenuLabel>Snooze until</PopoverMenuLabel>
-                                        {SNOOZE_PRESETS.map((p) => (
-                                            <PopoverMenuItem
-                                                key={p.label}
-                                                onSelect={() => snooze.mutate(p.until())}
-                                            >
-                                                {p.label}
-                                            </PopoverMenuItem>
-                                        ))}
-                                        <PopoverMenuItem
-                                            onSelect={() => setCustomMode(true)}
-                                            closeOnSelect={false}
-                                        >
-                                            Pick a time…
-                                        </PopoverMenuItem>
-                                        <PopoverMenuItem onSelect={() => unsnooze.mutate()}>
-                                            Un-snooze now
-                                        </PopoverMenuItem>
-                                    </motion.div>
-                                )}
-                            </AnimatePresence>
-                        </PopoverMenuContent>
-                    </PopoverMenu>
-
-                    <IconAction
-                        label="Mark as unread"
-                        icon={<MailCheckIcon className="w-3.5 h-3.5" />}
-                    />
-                    <IconAction
-                        label="Archive thread"
-                        icon={<ArchiveIcon className="w-3.5 h-3.5" />}
-                    />
-                    <IconAction
-                        label="Delete thread"
-                        danger
-                        icon={<TrashIcon className="w-3.5 h-3.5" />}
-                    />
-                </div>
-            </div>
-
-            <SectionBar
-                label={`${messages.length} ${messages.length === 1 ? "message" : "messages"}`}
-                count={participants.size}
-            />
-
-            <div className="flex-1 overflow-y-auto divide-y divide-slate-200/60">
-                {messages.map((email) => (
-                    <MessageBubble
-                        key={email.id}
-                        email={email}
-                        onReply={() => setReplyState({ messageId: email.id, mode: "reply" })}
-                        onForward={() => setReplyState({ messageId: email.id, mode: "forward" })}
-                    />
-                ))}
-                {(scheduledQ.data?.data ?? []).map((item) => (
-                    <ScheduledMessageBubble
-                        key={item.task_id}
-                        item={item}
-                        cancelling={cancel.isPending && cancel.variables === item.task_id}
-                        onCancel={() => cancel.mutate(item.task_id)}
-                    />
-                ))}
-            </div>
-
-            <AnimatePresence mode="wait" initial={false}>
-                {replyState ? (
-                    (() => {
-                        const target =
-                            messages.find((m) => m.id === replyState.messageId) ??
-                            messages[messages.length - 1];
-                        return target ? (
-                            <ReplyComposer
-                                key={`${replyState.messageId}-${replyState.mode}`}
-                                threadId={threadId}
-                                replyTo={target}
-                                mode={replyState.mode}
-                                onClose={() => setReplyState(null)}
-                            />
-                        ) : null;
-                    })()
-                ) : (
-                    <motion.div
-                        key="reply-rail"
-                        initial={{ opacity: 0, y: 6 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: 6 }}
-                        transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
-                        className="border-t border-slate-200 bg-white px-3 py-2 flex items-center gap-1.5 shrink-0"
-                    >
-                        <button
-                            type="button"
-                            onClick={() => {
-                                const last = messages[messages.length - 1];
-                                if (!last) return;
-                                setReplyState({ messageId: last.id, mode: "reply" });
-                            }}
-                            className="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors"
-                        >
-                            <CornerUpLeftIcon className="w-3 h-3" />
-                            Reply
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => {
-                                const last = messages[messages.length - 1];
-                                if (!last) return;
-                                setReplyState({ messageId: last.id, mode: "forward" });
-                            }}
-                            className="h-7 px-2 rounded-md border border-slate-200 hover:border-slate-300 text-slate-700 hover:text-slate-900 text-[12px] inline-flex items-center gap-1.5 transition-colors"
-                        >
-                            <ForwardIcon className="w-3 h-3" />
-                            Forward
-                        </button>
-                        <span className="ml-auto hidden md:inline text-[10.5px] text-slate-400">
-                            Hover any message to reply to it directly.
-                        </span>
-                    </motion.div>
-                )}
-            </AnimatePresence>
-        </div>
+      <div className="flex-1 flex items-center justify-center gap-2 text-[12px] text-slate-400">
+        <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
+        Loading thread…
+      </div>
     );
+  }
+
+  if (q.isError) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="text-center max-w-sm">
+          <AlertCircleIcon className="w-5 h-5 text-rose-500 mx-auto mb-2" />
+          <p className="text-[12.5px] font-medium text-slate-900 mb-1">
+            Couldn't load this thread
+          </p>
+          <p className="text-[11.5px] text-slate-500 mb-3">
+            {q.error?.message ?? "Request failed"}
+          </p>
+          <button
+            type="button"
+            onClick={() => q.refetch()}
+            className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium transition-colors"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const messages = (q.data?.data ?? []).map(toUniboxEmail);
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center text-[12px] text-slate-400">
+        This thread is empty.
+      </div>
+    );
+  }
+
+  const subject = messages[0]?.subject || "(no subject)";
+  const participants = new Set(
+    messages.map((m) => m.from).filter((f): f is string => Boolean(f)),
+  );
+  const mailbox = accounts.find((a) => a.id === messages[0]?.account_id);
+
+  const submitCustomSnooze = () => {
+    if (!customValue) return;
+    const d = new Date(customValue);
+    // Server caps at 90 days for snooze (matches SnoozeMaxHorizon
+    // in internal/app/unibox/config.go). Reject early with a
+    // useful message instead of letting the API 400.
+    const MAX_SNOOZE_MS = 90 * 24 * 60 * 60 * 1000;
+    if (Number.isNaN(d.getTime()) || d.getTime() <= Date.now() + 5_000) {
+      toast.error("Pick a future time (a few seconds out, please)");
+      return;
+    }
+    if (d.getTime() - Date.now() > MAX_SNOOZE_MS) {
+      toast.error("Snooze can't be more than 90 days out");
+      return;
+    }
+    snooze.mutate(d);
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <div className="h-12 px-3 sm:px-5 border-b border-slate-200 flex items-center gap-2 sm:gap-3 shrink-0 bg-white">
+        <span className="hidden sm:inline text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+          Thread
+        </span>
+        <div className="hidden sm:block h-4 w-px bg-slate-200" />
+        <span className="text-[12.5px] text-slate-900 font-medium truncate min-w-0">
+          {subject}
+        </span>
+        {mailbox && (
+          <span className="ml-1 hidden md:inline-flex items-center gap-1 h-5 px-1.5 rounded bg-slate-100 text-slate-600 text-[10.5px] font-medium font-mono shrink-0">
+            {mailbox.email}
+          </span>
+        )}
+        {(threadLabels.data ?? []).length > 0 && (
+          <span className="hidden md:inline-flex items-center gap-1 shrink-0">
+            {(threadLabels.data ?? []).slice(0, 3).map((c) => (
+              <CategoryChip key={c.id} category={c} compact />
+            ))}
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          <ThreadLabelMenu
+            threadId={threadId}
+            open={labelMenuOpen}
+            onOpenChange={setLabelMenuOpen}
+          />
+          <PopoverMenu
+            align="end"
+            side="bottom"
+            open={snoozeOpen}
+            onOpenChange={(o) => {
+              setSnoozeOpen(o);
+              if (!o) setCustomMode(false);
+            }}
+          >
+            <PopoverMenuTrigger asChild>
+              <button
+                aria-label="Snooze this thread"
+                className="h-7 px-2 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center gap-1 transition-colors text-[12px]"
+                disabled={snooze.isPending || unsnooze.isPending}
+              >
+                {snooze.isPending || unsnooze.isPending ? (
+                  <Loader2Icon className="w-3 h-3 animate-spin" />
+                ) : (
+                  <MoonIcon className="w-3.5 h-3.5" />
+                )}
+                Snooze
+                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+              </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent>
+              <AnimatePresence mode="wait" initial={false}>
+                {customMode ? (
+                  <motion.div
+                    key="custom"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
+                    className="px-1 py-1 w-[240px]"
+                  >
+                    <PopoverMenuLabel>Pick a date &amp; time</PopoverMenuLabel>
+                    <input
+                      type="datetime-local"
+                      value={customValue}
+                      onChange={(e) => setCustomValue(e.target.value)}
+                      min={toLocalInput(new Date(Date.now() + 60_000))}
+                      max={toLocalInput(
+                        new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+                      )}
+                      autoFocus
+                      className="w-full h-8 px-2 mt-1 rounded-md border border-slate-200 text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100 tabular-nums"
+                    />
+                    <div className="mt-2 flex items-center gap-1.5">
+                      <button
+                        type="button"
+                        onClick={submitCustomSnooze}
+                        className="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1 transition-colors"
+                      >
+                        <CheckIcon className="w-3 h-3" />
+                        Snooze
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setCustomMode(false)}
+                        className="h-7 px-2 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 text-[12px] transition-colors"
+                      >
+                        Back
+                      </button>
+                    </div>
+                  </motion.div>
+                ) : (
+                  <motion.div
+                    key="presets"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.12, ease: [0.16, 1, 0.3, 1] }}
+                  >
+                    <PopoverMenuLabel>Snooze until</PopoverMenuLabel>
+                    {SNOOZE_PRESETS.map((p) => (
+                      <PopoverMenuItem
+                        key={p.label}
+                        onSelect={() => snooze.mutate(p.until())}
+                      >
+                        {p.label}
+                      </PopoverMenuItem>
+                    ))}
+                    <PopoverMenuItem
+                      onSelect={() => setCustomMode(true)}
+                      closeOnSelect={false}
+                    >
+                      Pick a time…
+                    </PopoverMenuItem>
+                    <PopoverMenuItem onSelect={() => unsnooze.mutate()}>
+                      Un-snooze now
+                    </PopoverMenuItem>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </PopoverMenuContent>
+          </PopoverMenu>
+
+          <IconAction
+            label="Mark as unread"
+            icon={<MailCheckIcon className="w-3.5 h-3.5" />}
+          />
+          <IconAction
+            label="Archive thread"
+            icon={<ArchiveIcon className="w-3.5 h-3.5" />}
+          />
+          <IconAction
+            label="Delete thread"
+            danger
+            icon={<TrashIcon className="w-3.5 h-3.5" />}
+          />
+        </div>
+      </div>
+
+      <SectionBar
+        label={`${messages.length} ${messages.length === 1 ? "message" : "messages"}`}
+        count={participants.size}
+      />
+
+      <div className="flex-1 overflow-y-auto divide-y divide-slate-200/60">
+        {messages.map((email) => (
+          <MessageBubble
+            key={email.id}
+            email={email}
+            onReply={() =>
+              setReplyState({ messageId: email.id, mode: "reply" })
+            }
+            onForward={() =>
+              setReplyState({ messageId: email.id, mode: "forward" })
+            }
+          />
+        ))}
+        {(scheduledQ.data?.data ?? []).map((item) => (
+          <ScheduledMessageBubble
+            key={item.task_id}
+            item={item}
+            cancelling={cancel.isPending && cancel.variables === item.task_id}
+            onCancel={() => cancel.mutate(item.task_id)}
+          />
+        ))}
+      </div>
+
+      <AnimatePresence mode="wait" initial={false}>
+        {replyState ? (
+          (() => {
+            const target =
+              messages.find((m) => m.id === replyState.messageId) ??
+              messages[messages.length - 1];
+            return target ? (
+              <ReplyComposer
+                key={`${replyState.messageId}-${replyState.mode}`}
+                threadId={threadId}
+                replyTo={target}
+                mode={replyState.mode}
+                onClose={() => setReplyState(null)}
+              />
+            ) : null;
+          })()
+        ) : (
+          <motion.div
+            key="reply-rail"
+            initial={{ opacity: 0, y: 6 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 6 }}
+            transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+            className="border-t border-slate-200 bg-white px-3 py-2 flex items-center gap-1.5 shrink-0"
+          >
+            <button
+              type="button"
+              onClick={() => {
+                const last = messages[messages.length - 1];
+                if (!last) return;
+                setReplyState({ messageId: last.id, mode: "reply" });
+              }}
+              className="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors"
+            >
+              <CornerUpLeftIcon className="w-3 h-3" />
+              Reply
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const last = messages[messages.length - 1];
+                if (!last) return;
+                setReplyState({ messageId: last.id, mode: "forward" });
+              }}
+              className="h-7 px-2 rounded-md border border-slate-200 hover:border-slate-300 text-slate-700 hover:text-slate-900 text-[12px] inline-flex items-center gap-1.5 transition-colors"
+            >
+              <ForwardIcon className="w-3 h-3" />
+              Forward
+            </button>
+            <span className="ml-auto hidden md:inline text-[10.5px] text-slate-400">
+              Hover any message to reply to it directly.
+            </span>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
 }
 
 function IconAction({
-    label,
-    icon,
-    danger,
-    onClick,
+  label,
+  icon,
+  danger,
+  onClick,
 }: {
-    label: string;
-    icon: React.ReactNode;
-    danger?: boolean;
-    onClick?: () => void;
+  label: string;
+  icon: React.ReactNode;
+  danger?: boolean;
+  onClick?: () => void;
 }) {
-    return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <button
-                    type="button"
-                    onClick={onClick}
-                    aria-label={label}
-                    className={
-                        "size-7 rounded-md inline-flex items-center justify-center transition-colors " +
-                        (danger
-                            ? "text-slate-500 hover:text-red-600 hover:bg-red-50"
-                            : "text-slate-500 hover:text-slate-900 hover:bg-slate-100")
-                    }
-                >
-                    {icon}
-                </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{label}</TooltipContent>
-        </Tooltip>
-    );
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          onClick={onClick}
+          aria-label={label}
+          className={
+            "size-7 rounded-md inline-flex items-center justify-center transition-colors " +
+            (danger
+              ? "text-slate-500 hover:text-red-600 hover:bg-red-50"
+              : "text-slate-500 hover:text-slate-900 hover:bg-slate-100")
+          }
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 // Friendly relative-or-absolute time used for scheduled cards.
 // Examples: "in 12 min", "in 3 h", "tomorrow, 09:00", "Mar 5, 17:00".
 function formatScheduled(iso: string): string {
-    const d = new Date(iso);
-    if (!Number.isFinite(d.getTime())) return iso;
-    const now = new Date();
-    const diffMs = d.getTime() - now.getTime();
-    const diffMin = Math.round(diffMs / 60_000);
-    const timeStr = d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) return iso;
+  const now = new Date();
+  const diffMs = d.getTime() - now.getTime();
+  const diffMin = Math.round(diffMs / 60_000);
+  const timeStr = d.toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
-    if (diffMin > 0 && diffMin < 60) {
-        return `in ${diffMin} min`;
-    }
-    const sameDay =
-        d.getFullYear() === now.getFullYear() &&
-        d.getMonth() === now.getMonth() &&
-        d.getDate() === now.getDate();
-    if (sameDay) return `today, ${timeStr}`;
+  if (diffMin > 0 && diffMin < 60) {
+    return `in ${diffMin} min`;
+  }
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) return `today, ${timeStr}`;
 
-    const tomorrow = new Date(now);
-    tomorrow.setDate(now.getDate() + 1);
-    const isTomorrow =
-        d.getFullYear() === tomorrow.getFullYear() &&
-        d.getMonth() === tomorrow.getMonth() &&
-        d.getDate() === tomorrow.getDate();
-    if (isTomorrow) return `tomorrow, ${timeStr}`;
+  const tomorrow = new Date(now);
+  tomorrow.setDate(now.getDate() + 1);
+  const isTomorrow =
+    d.getFullYear() === tomorrow.getFullYear() &&
+    d.getMonth() === tomorrow.getMonth() &&
+    d.getDate() === tomorrow.getDate();
+  if (isTomorrow) return `tomorrow, ${timeStr}`;
 
-    return d.toLocaleString(undefined, {
-        month: "short",
-        day: "numeric",
-        hour: "2-digit",
-        minute: "2-digit",
-    });
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 // ScheduledMessageBubble : a queued send rendered inline at the
@@ -533,81 +590,78 @@ function formatScheduled(iso: string): string {
 // best-effort DeleteTask or fires as a no-op (the worker handler
 // short-circuits on non-pending status).
 function ScheduledMessageBubble({
-    item,
-    cancelling,
-    onCancel,
+  item,
+  cancelling,
+  onCancel,
 }: {
-    item: UniboxScheduledItem;
-    cancelling: boolean;
-    onCancel: () => void;
+  item: UniboxScheduledItem;
+  cancelling: boolean;
+  onCancel: () => void;
 }) {
-    const when = formatScheduled(item.scheduled_at);
-    const recipients = [
-        ...item.to,
-        ...(item.cc ?? []),
-        ...(item.bcc ?? []),
-    ];
-    const recipientLine = recipients.slice(0, 3).join(", ") +
-        (recipients.length > 3 ? ` +${recipients.length - 3}` : "");
+  const when = formatScheduled(item.scheduled_at);
+  const recipients = [...item.to, ...(item.cc ?? []), ...(item.bcc ?? [])];
+  const recipientLine =
+    recipients.slice(0, 3).join(", ") +
+    (recipients.length > 3 ? ` +${recipients.length - 3}` : "");
 
-    return (
-        <article className="px-3 sm:px-5 py-3">
-            <div className="rounded-lg border border-dashed border-sky-300 bg-sky-50/40 px-3 sm:px-4 py-3">
-                <header className="flex items-start gap-3">
-                    <div className="size-7 rounded-full bg-sky-100 text-sky-700 flex items-center justify-center shrink-0">
-                        <ClockIcon className="w-3.5 h-3.5" />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                        <div className="flex items-baseline gap-2 flex-wrap">
-                            <span className="text-[10px] uppercase tracking-[0.14em] text-sky-700 font-semibold">
-                                Scheduled
-                            </span>
-                            <span className="text-[12.5px] font-semibold text-slate-900">
-                                {when}
-                            </span>
-                        </div>
-                        <div className="text-[11px] text-slate-500 mt-0.5 flex items-center gap-1.5 min-w-0">
-                            <span className="truncate">
-                                from {item.account_email}
-                            </span>
-                            <span aria-hidden className="text-slate-300">
-                                &middot;
-                            </span>
-                            <span className="truncate">to {recipientLine || "(no recipient)"}</span>
-                        </div>
-                    </div>
-                    <button
-                        type="button"
-                        onClick={onCancel}
-                        disabled={cancelling}
-                        title="Cancel this scheduled send"
-                        className="shrink-0 inline-flex items-center gap-1 h-6 px-1.5 rounded-md border border-sky-200 bg-white text-sky-700 hover:text-rose-700 hover:border-rose-300 hover:bg-rose-50 text-[11px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                        {cancelling ? (
-                            <Loader2Icon className="w-3 h-3 animate-spin" />
-                        ) : (
-                            <XIcon className="w-3 h-3" />
-                        )}
-                        {cancelling ? "Cancelling" : "Cancel"}
-                    </button>
-                </header>
-                <div className="mt-2.5 ml-10">
-                    {item.subject && (
-                        <div className="text-[12.5px] font-medium text-slate-900 truncate">
-                            {item.subject}
-                        </div>
-                    )}
-                    {item.snippet && (
-                        <p className="text-[12px] text-slate-600 mt-1 leading-relaxed line-clamp-3">
-                            {item.snippet}
-                        </p>
-                    )}
-                    <div className="mt-2 inline-flex items-center gap-1 h-5 px-1.5 rounded bg-white border border-sky-200 text-[10px] text-sky-700 font-medium">
-                        <SendIcon className="w-2.5 h-2.5" />
-                        Will send {when}
-                    </div>
-                </div>
+  return (
+    <article className="px-3 sm:px-5 py-3">
+      <div className="rounded-lg border border-dashed border-sky-300 bg-sky-50/40 px-3 sm:px-4 py-3">
+        <header className="flex items-start gap-3">
+          <div className="size-7 rounded-full bg-sky-100 text-sky-700 flex items-center justify-center shrink-0">
+            <ClockIcon className="w-3.5 h-3.5" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-baseline gap-2 flex-wrap">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-sky-700 font-semibold">
+                Scheduled
+              </span>
+              <span className="text-[12.5px] font-semibold text-slate-900">
+                {when}
+              </span>
             </div>
-        </article>
-    );
+            <div className="text-[11px] text-slate-500 mt-0.5 flex items-center gap-1.5 min-w-0">
+              <span className="truncate">from {item.account_email}</span>
+              <span aria-hidden className="text-slate-300">
+                &middot;
+              </span>
+              <span className="truncate">
+                to {recipientLine || "(no recipient)"}
+              </span>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={cancelling}
+            title="Cancel this scheduled send"
+            className="shrink-0 inline-flex items-center gap-1 h-6 px-1.5 rounded-md border border-sky-200 bg-white text-sky-700 hover:text-rose-700 hover:border-rose-300 hover:bg-rose-50 text-[11px] font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {cancelling ? (
+              <Loader2Icon className="w-3 h-3 animate-spin" />
+            ) : (
+              <XIcon className="w-3 h-3" />
+            )}
+            {cancelling ? "Cancelling" : "Cancel"}
+          </button>
+        </header>
+        <div className="mt-2.5 ml-10">
+          {item.subject && (
+            <div className="text-[12.5px] font-medium text-slate-900 truncate">
+              {item.subject}
+            </div>
+          )}
+          {item.snippet && (
+            <p className="text-[12px] text-slate-600 mt-1 leading-relaxed line-clamp-3">
+              {item.snippet}
+            </p>
+          )}
+          <div className="mt-2 inline-flex items-center gap-1 h-5 px-1.5 rounded bg-white border border-sky-200 text-[10px] text-sky-700 font-medium">
+            <SendIcon className="w-2.5 h-2.5" />
+            Will send {when}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
 }

--- a/web/src/components/app/unibox/UniboxFilterSheet.tsx
+++ b/web/src/components/app/unibox/UniboxFilterSheet.tsx
@@ -15,454 +15,559 @@
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-    CheckIcon,
-    Loader2Icon,
-    MailIcon,
-    RotateCcwIcon,
-    SearchIcon,
-    TagIcon,
-    XIcon,
+  CheckIcon,
+  Loader2Icon,
+  MailIcon,
+  RotateCcwIcon,
+  SearchIcon,
+  TagIcon,
+  XIcon,
 } from "lucide-react";
 import { SearchInput, TextInput } from "@/components/ui/field";
 import { SectionBar } from "@/components/layout/Page";
 import { useAppStore } from "@/stores";
 import { useUserProfile } from "@/hooks/context/user";
+import useUniboxOverview from "@/lib/api/hooks/app/unibox/useUniboxOverview";
 import type { UniboxSearchParams } from "@/lib/api/models/app/unibox/UniboxSearch";
 
 interface Props {
-    open: boolean;
-    setOpen: (o: boolean) => void;
-    filters: UniboxSearchParams;
-    setFilters: React.Dispatch<React.SetStateAction<UniboxSearchParams>>;
-    loading?: boolean;
+  open: boolean;
+  setOpen: (o: boolean) => void;
+  filters: UniboxSearchParams;
+  setFilters: React.Dispatch<React.SetStateAction<UniboxSearchParams>>;
+  loading?: boolean;
 }
 
-export function UniboxFilterSheet({ open, setOpen, filters, setFilters, loading }: Props) {
-    const [draft, setDraft] = React.useState<UniboxSearchParams>(filters);
-    const emails = useAppStore((s) => s.emails);
-    const p = useUserProfile();
-    const tags = p.user.tags ?? [];
+export function UniboxFilterSheet({
+  open,
+  setOpen,
+  filters,
+  setFilters,
+  loading,
+}: Props) {
+  const [draft, setDraft] = React.useState<UniboxSearchParams>(filters);
+  const emails = useAppStore((s) => s.emails);
+  const p = useUserProfile();
+  const tags = p.user.tags ?? [];
+  const categories = p.user.categories ?? [];
+  // Per-category thread totals for the chip badges (server truth).
+  const overview = useUniboxOverview();
+  const categoryTotals = React.useMemo(() => {
+    const m = new Map<string, number>();
+    for (const c of overview.data?.categories ?? []) m.set(c.id, c.total);
+    return m;
+  }, [overview.data]);
 
-    React.useEffect(() => {
-        if (open) setDraft(filters);
-    }, [open, filters]);
+  React.useEffect(() => {
+    if (open) setDraft(filters);
+  }, [open, filters]);
 
-    const accountIds = React.useMemo(() => new Set(draft.accountIds ?? []), [draft.accountIds]);
-    const selectedTagId = draft.tagId;
+  const accountIds = React.useMemo(
+    () => new Set(draft.accountIds ?? []),
+    [draft.accountIds],
+  );
+  const selectedTagId = draft.tagId;
 
-    // Accounts that carry the currently-selected tag. Used to compute
-    // whether the chip should show as "all picked" and to resolve to
-    // concrete IDs at apply time.
-    const accountsByTag = React.useMemo(() => {
-        if (!selectedTagId) return null;
-        return emails.filter((e) => (e.tags ?? []).includes(selectedTagId));
-    }, [emails, selectedTagId]);
+  // Accounts that carry the currently-selected tag. Used to compute
+  // whether the chip should show as "all picked" and to resolve to
+  // concrete IDs at apply time.
+  const accountsByTag = React.useMemo(() => {
+    if (!selectedTagId) return null;
+    return emails.filter((e) => (e.tags ?? []).includes(selectedTagId));
+  }, [emails, selectedTagId]);
 
-    function toggleAccount(id: string) {
-        setDraft((s) => {
-            const next = new Set(s.accountIds ?? []);
-            if (next.has(id)) next.delete(id);
-            else next.add(id);
-            return { ...s, accountIds: Array.from(next) };
-        });
+  function toggleAccount(id: string) {
+    setDraft((s) => {
+      const next = new Set(s.accountIds ?? []);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { ...s, accountIds: Array.from(next) };
+    });
+  }
+  function selectTag(tagId: string) {
+    setDraft((s) => {
+      if (s.tagId === tagId) {
+        // Clicking the active tag clears it.
+        return { ...s, tagId: undefined };
+      }
+      return { ...s, tagId };
+    });
+  }
+  function selectAllAccounts() {
+    setDraft((s) => ({
+      ...s,
+      accountIds: emails.map((e) => e.id),
+      tagId: undefined,
+    }));
+  }
+  function clearAccounts() {
+    setDraft((s) => ({ ...s, accountIds: [], tagId: undefined }));
+  }
+
+  // Conversation-label filter. Multi-select: a thread matches if it
+  // carries any of the chosen labels. Passed straight to the server as
+  // categoryIds → category_ids (no client-side resolution).
+  const selectedCategoryIds = React.useMemo(
+    () => new Set(draft.categoryIds ?? []),
+    [draft.categoryIds],
+  );
+  function toggleCategory(id: string) {
+    setDraft((s) => {
+      const next = new Set(s.categoryIds ?? []);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return { ...s, categoryIds: Array.from(next) };
+    });
+  }
+
+  const activeCount = countActive(draft);
+
+  const apply = () => {
+    // If a tag is selected, resolve it to the underlying account
+    // IDs before committing — the server only knows about
+    // accountIds. We keep tagId in the draft for UI display but
+    // strip it before passing up.
+    let resolvedIds = draft.accountIds ?? [];
+    if (draft.tagId) {
+      const tagAccountIds = emails
+        .filter((e) => (e.tags ?? []).includes(draft.tagId!))
+        .map((e) => e.id);
+      // Tag selection replaces manual picks — simpler mental model.
+      resolvedIds = tagAccountIds;
     }
-    function selectTag(tagId: string) {
-        setDraft((s) => {
-            if (s.tagId === tagId) {
-                // Clicking the active tag clears it.
-                return { ...s, tagId: undefined };
-            }
-            return { ...s, tagId };
-        });
-    }
-    function selectAllAccounts() {
-        setDraft((s) => ({ ...s, accountIds: emails.map((e) => e.id), tagId: undefined }));
-    }
-    function clearAccounts() {
-        setDraft((s) => ({ ...s, accountIds: [], tagId: undefined }));
-    }
+    setFilters({ ...draft, accountIds: resolvedIds });
+    setOpen(false);
+  };
 
-    const activeCount = countActive(draft);
+  const reset = () => {
+    setDraft({ sortBy: "newest" });
+  };
 
-    const apply = () => {
-        // If a tag is selected, resolve it to the underlying account
-        // IDs before committing — the server only knows about
-        // accountIds. We keep tagId in the draft for UI display but
-        // strip it before passing up.
-        let resolvedIds = draft.accountIds ?? [];
-        if (draft.tagId) {
-            const tagAccountIds = emails
-                .filter((e) => (e.tags ?? []).includes(draft.tagId!))
-                .map((e) => e.id);
-            // Tag selection replaces manual picks — simpler mental model.
-            resolvedIds = tagAccountIds;
-        }
-        setFilters({ ...draft, accountIds: resolvedIds });
-        setOpen(false);
-    };
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          key="overlay"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          onClick={() => setOpen(false)}
+          className="fixed inset-0 z-[100] flex justify-end bg-slate-900/30 backdrop-blur-[2px]"
+        >
+          <motion.aside
+            key="panel"
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "spring", stiffness: 300, damping: 32 }}
+            onClick={(e) => e.stopPropagation()}
+            className="flex flex-col bg-white w-[420px] max-w-[95%] h-full border-l border-slate-200 shadow-[-8px_0_24px_-12px_rgba(15,23,42,0.12)]"
+          >
+            <div className="h-12 px-4 border-b border-slate-200 flex items-center gap-3 shrink-0">
+              <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                Filters
+              </span>
+              <div className="h-4 w-px bg-slate-200" />
+              <span className="text-[12.5px] text-slate-700">
+                {activeCount === 0
+                  ? "No filters applied"
+                  : `${activeCount} ${activeCount === 1 ? "filter" : "filters"} active`}
+              </span>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                aria-label="Close"
+                className="ml-auto size-7 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-colors"
+              >
+                <XIcon className="w-3.5 h-3.5" />
+              </button>
+            </div>
 
-    const reset = () => {
-        setDraft({ sortBy: "newest" });
-    };
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              <SectionBar label="Search" />
+              <div className="px-4 py-3 space-y-2">
+                <SearchInput
+                  value={draft.query ?? ""}
+                  onChange={(v) =>
+                    setDraft((s) => ({ ...s, query: v || undefined }))
+                  }
+                  placeholder="Subject, snippet, contents…"
+                />
+              </div>
 
-    return (
-        <AnimatePresence>
-            {open && (
-                <motion.div
-                    key="overlay"
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    exit={{ opacity: 0 }}
-                    transition={{ duration: 0.18 }}
-                    onClick={() => setOpen(false)}
-                    className="fixed inset-0 z-[100] flex justify-end bg-slate-900/30 backdrop-blur-[2px]"
-                >
-                    <motion.aside
-                        key="panel"
-                        initial={{ x: "100%" }}
-                        animate={{ x: 0 }}
-                        exit={{ x: "100%" }}
-                        transition={{ type: "spring", stiffness: 300, damping: 32 }}
-                        onClick={(e) => e.stopPropagation()}
-                        className="flex flex-col bg-white w-[420px] max-w-[95%] h-full border-l border-slate-200 shadow-[-8px_0_24px_-12px_rgba(15,23,42,0.12)]"
-                    >
-                        <div className="h-12 px-4 border-b border-slate-200 flex items-center gap-3 shrink-0">
-                            <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
-                                Filters
-                            </span>
-                            <div className="h-4 w-px bg-slate-200" />
-                            <span className="text-[12.5px] text-slate-700">
-                                {activeCount === 0
-                                    ? "No filters applied"
-                                    : `${activeCount} ${activeCount === 1 ? "filter" : "filters"} active`}
-                            </span>
-                            <button
-                                type="button"
-                                onClick={() => setOpen(false)}
-                                aria-label="Close"
-                                className="ml-auto size-7 rounded-md text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-colors"
-                            >
-                                <XIcon className="w-3.5 h-3.5" />
-                            </button>
-                        </div>
+              <SectionBar label="Sender" />
+              <div className="px-4 py-3 space-y-2">
+                <TextInput
+                  value={draft.from ?? ""}
+                  onChange={(v) =>
+                    setDraft((s) => ({ ...s, from: v || undefined }))
+                  }
+                  placeholder="name@company.com or substring"
+                  className="w-full"
+                />
+              </div>
 
-                        <div className="flex-1 min-h-0 overflow-y-auto">
-                            <SectionBar label="Search" />
-                            <div className="px-4 py-3 space-y-2">
-                                <SearchInput
-                                    value={draft.query ?? ""}
-                                    onChange={(v) => setDraft((s) => ({ ...s, query: v || undefined }))}
-                                    placeholder="Subject, snippet, contents…"
-                                />
-                            </div>
+              <SectionBar
+                label="Accounts"
+                count={
+                  selectedTagId
+                    ? accountsByTag?.length
+                    : draft.accountIds?.length || undefined
+                }
+              >
+                {draft.accountIds?.length || draft.tagId ? (
+                  <button
+                    type="button"
+                    onClick={clearAccounts}
+                    className="text-[11px] text-slate-500 hover:text-slate-900 transition-colors"
+                  >
+                    Clear
+                  </button>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={selectAllAccounts}
+                    className="text-[11px] text-slate-500 hover:text-slate-900 transition-colors"
+                  >
+                    Select all
+                  </button>
+                )}
+              </SectionBar>
 
-                            <SectionBar label="Sender" />
-                            <div className="px-4 py-3 space-y-2">
-                                <TextInput
-                                    value={draft.from ?? ""}
-                                    onChange={(v) => setDraft((s) => ({ ...s, from: v || undefined }))}
-                                    placeholder="name@company.com or substring"
-                                    className="w-full"
-                                />
-                            </div>
-
-                            <SectionBar
-                                label="Accounts"
-                                count={
-                                    selectedTagId
-                                        ? accountsByTag?.length
-                                        : draft.accountIds?.length || undefined
-                                }
-                            >
-                                {(draft.accountIds?.length || draft.tagId) ? (
-                                    <button
-                                        type="button"
-                                        onClick={clearAccounts}
-                                        className="text-[11px] text-slate-500 hover:text-slate-900 transition-colors"
-                                    >
-                                        Clear
-                                    </button>
-                                ) : (
-                                    <button
-                                        type="button"
-                                        onClick={selectAllAccounts}
-                                        className="text-[11px] text-slate-500 hover:text-slate-900 transition-colors"
-                                    >
-                                        Select all
-                                    </button>
-                                )}
-                            </SectionBar>
-
-                            {/* Tag chips — fastest way to scope to a group of mailboxes.
+              {/* Tag chips — fastest way to scope to a group of mailboxes.
                                 Picking a tag visually expands the selection: every
                                 account that carries the tag is included at Apply time. */}
-                            {tags.length > 0 && (
-                                <div className="px-4 pt-3">
-                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5 flex items-center gap-1.5">
-                                        <TagIcon className="w-3 h-3" />
-                                        Tags
-                                    </div>
-                                    <div className="flex flex-wrap gap-1.5">
-                                        {tags.map((t) => {
-                                            const active = selectedTagId === t.id;
-                                            const count = emails.filter((e) => (e.tags ?? []).includes(t.id)).length;
-                                            return (
-                                                <button
-                                                    key={t.id}
-                                                    type="button"
-                                                    onClick={() => selectTag(t.id)}
-                                                    className={`group h-6 pl-1.5 pr-2 rounded-full inline-flex items-center gap-1.5 text-[11.5px] font-medium border transition-colors ${
-                                                        active
-                                                            ? "bg-slate-900 text-white border-slate-900"
-                                                            : "bg-white text-slate-700 border-slate-200 hover:border-slate-300"
-                                                    }`}
-                                                >
-                                                    <span
-                                                        aria-hidden
-                                                        className="size-2 rounded-full"
-                                                        style={{ backgroundColor: t.color }}
-                                                    />
-                                                    <span className="truncate max-w-[120px]">{t.title}</span>
-                                                    <span
-                                                        className={`font-mono tabular-nums text-[10px] ${
-                                                            active ? "text-white/80" : "text-slate-400"
-                                                        }`}
-                                                    >
-                                                        {count}
-                                                    </span>
-                                                </button>
-                                            );
-                                        })}
-                                    </div>
-                                </div>
-                            )}
+              {tags.length > 0 && (
+                <div className="px-4 pt-3">
+                  <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5 flex items-center gap-1.5">
+                    <TagIcon className="w-3 h-3" />
+                    Tags
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {tags.map((t) => {
+                      const active = selectedTagId === t.id;
+                      const count = emails.filter((e) =>
+                        (e.tags ?? []).includes(t.id),
+                      ).length;
+                      return (
+                        <button
+                          key={t.id}
+                          type="button"
+                          onClick={() => selectTag(t.id)}
+                          className={`group h-6 pl-1.5 pr-2 rounded-full inline-flex items-center gap-1.5 text-[11.5px] font-medium border transition-colors ${
+                            active
+                              ? "bg-slate-900 text-white border-slate-900"
+                              : "bg-white text-slate-700 border-slate-200 hover:border-slate-300"
+                          }`}
+                        >
+                          <span
+                            aria-hidden
+                            className="size-2 rounded-full"
+                            style={{ backgroundColor: t.color }}
+                          />
+                          <span className="truncate max-w-[120px]">
+                            {t.title}
+                          </span>
+                          <span
+                            className={`font-mono tabular-nums text-[10px] ${
+                              active ? "text-white/80" : "text-slate-400"
+                            }`}
+                          >
+                            {count}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
 
-                            {/* Individual account chips with avatars. Multi-select.
+              {/* Conversation labels — filter the list to threads
+                                carrying any of the picked categories. Multi-select. */}
+              {categories.length > 0 && (
+                <div className="px-4 pt-3">
+                  <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5 flex items-center gap-1.5">
+                    <TagIcon className="w-3 h-3" />
+                    Categories
+                  </div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {categories.map((c) => {
+                      const cActive = selectedCategoryIds.has(c.id);
+                      const total = categoryTotals.get(c.id) ?? 0;
+                      return (
+                        <button
+                          key={c.id}
+                          type="button"
+                          onClick={() => toggleCategory(c.id)}
+                          className={`group h-6 pl-1.5 pr-2 rounded-full inline-flex items-center gap-1.5 text-[11.5px] font-medium border transition-colors ${
+                            cActive
+                              ? "bg-slate-900 text-white border-slate-900"
+                              : "bg-white text-slate-700 border-slate-200 hover:border-slate-300"
+                          }`}
+                        >
+                          <span
+                            aria-hidden
+                            className="size-2 rounded-full"
+                            style={{ backgroundColor: c.color }}
+                          />
+                          <span className="truncate max-w-[120px]">
+                            {c.title}
+                          </span>
+                          {total > 0 && (
+                            <span
+                              className={`font-mono tabular-nums text-[10px] ${
+                                cActive ? "text-white/80" : "text-slate-400"
+                              }`}
+                            >
+                              {total}
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Individual account chips with avatars. Multi-select.
                                 When a tag is active, accounts that belong to it get
                                 a subtle ring so the relationship is visible. */}
-                            <div className="px-4 py-3">
-                                <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5 flex items-center gap-1.5">
-                                    <MailIcon className="w-3 h-3" />
-                                    Mailboxes
-                                </div>
-                                {emails.length === 0 ? (
-                                    <p className="text-[11.5px] text-slate-400 py-2">
-                                        No mailboxes connected yet.
-                                    </p>
-                                ) : (
-                                    <div className="space-y-1">
-                                        {emails.map((e) => {
-                                            const checked = accountIds.has(e.id);
-                                            const tagMatch =
-                                                selectedTagId &&
-                                                (e.tags ?? []).includes(selectedTagId);
-                                            return (
-                                                <button
-                                                    key={e.id}
-                                                    type="button"
-                                                    onClick={() => toggleAccount(e.id)}
-                                                    className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md transition-colors text-left ${
-                                                        checked
-                                                            ? "bg-sky-50/80 hover:bg-sky-50"
-                                                            : tagMatch
-                                                                ? "bg-slate-50 hover:bg-slate-100"
-                                                                : "hover:bg-slate-50"
-                                                    }`}
-                                                >
-                                                    <span
-                                                        className={`size-4 rounded border flex items-center justify-center transition-colors shrink-0 ${
-                                                            checked
-                                                                ? "bg-slate-900 border-slate-900 text-white"
-                                                                : "bg-white border-slate-300"
-                                                        }`}
-                                                    >
-                                                        {checked && <CheckIcon className="w-2.5 h-2.5" />}
-                                                    </span>
-                                                    <span className="size-5 rounded-full bg-slate-100 text-slate-600 flex items-center justify-center text-[9px] font-semibold shrink-0">
-                                                        {e.email.slice(0, 2).toUpperCase()}
-                                                    </span>
-                                                    <span className="text-[12px] text-slate-900 truncate flex-1">
-                                                        {e.email}
-                                                    </span>
-                                                    {tagMatch && !checked && (
-                                                        <span className="text-[10px] text-slate-400 font-mono">
-                                                            via tag
-                                                        </span>
-                                                    )}
-                                                </button>
-                                            );
-                                        })}
-                                    </div>
-                                )}
-                            </div>
+              <div className="px-4 py-3">
+                <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5 flex items-center gap-1.5">
+                  <MailIcon className="w-3 h-3" />
+                  Mailboxes
+                </div>
+                {emails.length === 0 ? (
+                  <p className="text-[11.5px] text-slate-400 py-2">
+                    No mailboxes connected yet.
+                  </p>
+                ) : (
+                  <div className="space-y-1">
+                    {emails.map((e) => {
+                      const checked = accountIds.has(e.id);
+                      const tagMatch =
+                        selectedTagId && (e.tags ?? []).includes(selectedTagId);
+                      return (
+                        <button
+                          key={e.id}
+                          type="button"
+                          onClick={() => toggleAccount(e.id)}
+                          className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded-md transition-colors text-left ${
+                            checked
+                              ? "bg-sky-50/80 hover:bg-sky-50"
+                              : tagMatch
+                                ? "bg-slate-50 hover:bg-slate-100"
+                                : "hover:bg-slate-50"
+                          }`}
+                        >
+                          <span
+                            className={`size-4 rounded border flex items-center justify-center transition-colors shrink-0 ${
+                              checked
+                                ? "bg-slate-900 border-slate-900 text-white"
+                                : "bg-white border-slate-300"
+                            }`}
+                          >
+                            {checked && <CheckIcon className="w-2.5 h-2.5" />}
+                          </span>
+                          <span className="size-5 rounded-full bg-slate-100 text-slate-600 flex items-center justify-center text-[9px] font-semibold shrink-0">
+                            {e.email.slice(0, 2).toUpperCase()}
+                          </span>
+                          <span className="text-[12px] text-slate-900 truncate flex-1">
+                            {e.email}
+                          </span>
+                          {tagMatch && !checked && (
+                            <span className="text-[10px] text-slate-400 font-mono">
+                              via tag
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
 
-                            <SectionBar label="Status" />
-                            <div className="px-4 py-3">
-                                <Toggle3
-                                    value={draft.unseen ?? undefined}
-                                    onChange={(v) => setDraft((s) => ({ ...s, unseen: v }))}
-                                    options={[
-                                        { id: undefined, label: "Any" },
-                                        { id: true, label: "Unread" },
-                                        { id: false, label: "Read" },
-                                    ]}
-                                />
-                            </div>
+              <SectionBar label="Status" />
+              <div className="px-4 py-3">
+                <Toggle3
+                  value={draft.unseen ?? undefined}
+                  onChange={(v) => setDraft((s) => ({ ...s, unseen: v }))}
+                  options={[
+                    { id: undefined, label: "Any" },
+                    { id: true, label: "Unread" },
+                    { id: false, label: "Read" },
+                  ]}
+                />
+              </div>
 
-                            <SectionBar label="Dates" />
-                            <div className="px-4 py-3 space-y-2">
-                                <DateRow
-                                    label="Since"
-                                    value={draft.since}
-                                    onChange={(v) => setDraft((s) => ({ ...s, since: v }))}
-                                />
-                                <DateRow
-                                    label="Until"
-                                    value={draft.until}
-                                    onChange={(v) => setDraft((s) => ({ ...s, until: v }))}
-                                />
-                            </div>
+              <SectionBar label="Dates" />
+              <div className="px-4 py-3 space-y-2">
+                <DateRow
+                  label="Since"
+                  value={draft.since}
+                  onChange={(v) => setDraft((s) => ({ ...s, since: v }))}
+                />
+                <DateRow
+                  label="Until"
+                  value={draft.until}
+                  onChange={(v) => setDraft((s) => ({ ...s, until: v }))}
+                />
+              </div>
 
-                            <SectionBar label="Sort" />
-                            <div className="px-4 py-3 space-y-2">
-                                <Toggle3
-                                    value={draft.sortBy ?? "newest"}
-                                    onChange={(v) =>
-                                        setDraft((s) => ({ ...s, sortBy: (v as "newest" | "oldest") ?? "newest" }))
-                                    }
-                                    options={[
-                                        { id: "newest" as const, label: "Newest" },
-                                        { id: "oldest" as const, label: "Oldest" },
-                                    ]}
-                                />
-                            </div>
-                        </div>
+              <SectionBar label="Sort" />
+              <div className="px-4 py-3 space-y-2">
+                <Toggle3
+                  value={draft.sortBy ?? "newest"}
+                  onChange={(v) =>
+                    setDraft((s) => ({
+                      ...s,
+                      sortBy: (v as "newest" | "oldest") ?? "newest",
+                    }))
+                  }
+                  options={[
+                    { id: "newest" as const, label: "Newest" },
+                    { id: "oldest" as const, label: "Oldest" },
+                  ]}
+                />
+              </div>
+            </div>
 
-                        <div className="px-4 h-12 border-t border-slate-200 flex items-center gap-1.5 shrink-0">
-                            <button
-                                type="button"
-                                onClick={reset}
-                                className="h-7 px-2.5 rounded-md text-[12px] text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center gap-1.5 transition-colors"
-                            >
-                                <RotateCcwIcon className="w-3 h-3" />
-                                Reset
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => setOpen(false)}
-                                className="ml-auto h-7 px-2.5 rounded-md text-[12px] text-slate-700 hover:text-slate-900 hover:bg-slate-100 transition-colors"
-                            >
-                                Cancel
-                            </button>
-                            <button
-                                type="button"
-                                onClick={apply}
-                                disabled={loading}
-                                className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60"
-                            >
-                                {loading ? (
-                                    <Loader2Icon className="w-3 h-3 animate-spin" />
-                                ) : (
-                                    <SearchIcon className="w-3 h-3" />
-                                )}
-                                Apply
-                            </button>
-                        </div>
-                    </motion.aside>
-                </motion.div>
-            )}
-        </AnimatePresence>
-    );
+            <div className="px-4 h-12 border-t border-slate-200 flex items-center gap-1.5 shrink-0">
+              <button
+                type="button"
+                onClick={reset}
+                className="h-7 px-2.5 rounded-md text-[12px] text-slate-500 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center gap-1.5 transition-colors"
+              >
+                <RotateCcwIcon className="w-3 h-3" />
+                Reset
+              </button>
+              <button
+                type="button"
+                onClick={() => setOpen(false)}
+                className="ml-auto h-7 px-2.5 rounded-md text-[12px] text-slate-700 hover:text-slate-900 hover:bg-slate-100 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={apply}
+                disabled={loading}
+                className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60"
+              >
+                {loading ? (
+                  <Loader2Icon className="w-3 h-3 animate-spin" />
+                ) : (
+                  <SearchIcon className="w-3 h-3" />
+                )}
+                Apply
+              </button>
+            </div>
+          </motion.aside>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
 }
 
 function Toggle3<T extends string | boolean | undefined>({
-    value,
-    onChange,
-    options,
+  value,
+  onChange,
+  options,
 }: {
-    value: T;
-    onChange: (v: T) => void;
-    options: { id: T; label: string }[];
+  value: T;
+  onChange: (v: T) => void;
+  options: { id: T; label: string }[];
 }) {
-    return (
-        <div className="inline-flex items-center rounded-md border border-slate-200 bg-white p-0.5">
-            {options.map((o) => (
-                <button
-                    key={String(o.id)}
-                    type="button"
-                    onClick={() => onChange(o.id)}
-                    className={`h-6 px-2.5 rounded text-[11.5px] font-medium transition-colors ${
-                        value === o.id ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-900"
-                    }`}
-                >
-                    {o.label}
-                </button>
-            ))}
-        </div>
-    );
+  return (
+    <div className="inline-flex items-center rounded-md border border-slate-200 bg-white p-0.5">
+      {options.map((o) => (
+        <button
+          key={String(o.id)}
+          type="button"
+          onClick={() => onChange(o.id)}
+          className={`h-6 px-2.5 rounded text-[11.5px] font-medium transition-colors ${
+            value === o.id
+              ? "bg-slate-900 text-white"
+              : "text-slate-500 hover:text-slate-900"
+          }`}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
+  );
 }
 
 function DateRow({
-    label,
-    value,
-    onChange,
+  label,
+  value,
+  onChange,
 }: {
-    label: string;
-    value?: Date;
-    onChange: (v: Date | undefined) => void;
+  label: string;
+  value?: Date;
+  onChange: (v: Date | undefined) => void;
 }) {
-    const enabled = value !== undefined;
-    const dateStr = value ? toIsoDate(value) : "";
-    return (
-        <div className="flex items-center gap-2">
-            <button
-                type="button"
-                onClick={() => onChange(enabled ? undefined : new Date())}
-                className={`size-4 rounded border flex items-center justify-center transition-colors shrink-0 ${
-                    enabled
-                        ? "bg-slate-900 border-slate-900 text-white"
-                        : "border-slate-300 hover:border-slate-400"
-                }`}
-                aria-pressed={enabled}
-                aria-label={`Toggle ${label}`}
-            >
-                {enabled && (
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3">
-                        <path d="M5 12l5 5L20 7" />
-                    </svg>
-                )}
-            </button>
-            <span className="text-[12px] text-slate-700 w-12 shrink-0">{label}</span>
-            <input
-                type="date"
-                value={dateStr}
-                onChange={(e) => {
-                    const v = e.target.value;
-                    if (!v) onChange(undefined);
-                    else onChange(new Date(v));
-                }}
-                disabled={!enabled}
-                className="flex-1 h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100 disabled:bg-slate-50 disabled:text-slate-400 tabular-nums"
-            />
-        </div>
-    );
+  const enabled = value !== undefined;
+  const dateStr = value ? toIsoDate(value) : "";
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={() => onChange(enabled ? undefined : new Date())}
+        className={`size-4 rounded border flex items-center justify-center transition-colors shrink-0 ${
+          enabled
+            ? "bg-slate-900 border-slate-900 text-white"
+            : "border-slate-300 hover:border-slate-400"
+        }`}
+        aria-pressed={enabled}
+        aria-label={`Toggle ${label}`}
+      >
+        {enabled && (
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+          >
+            <path d="M5 12l5 5L20 7" />
+          </svg>
+        )}
+      </button>
+      <span className="text-[12px] text-slate-700 w-12 shrink-0">{label}</span>
+      <input
+        type="date"
+        value={dateStr}
+        onChange={(e) => {
+          const v = e.target.value;
+          if (!v) onChange(undefined);
+          else onChange(new Date(v));
+        }}
+        disabled={!enabled}
+        className="flex-1 h-7 px-2.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100 disabled:bg-slate-50 disabled:text-slate-400 tabular-nums"
+      />
+    </div>
+  );
 }
 
 function toIsoDate(d: Date): string {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 function countActive(f: UniboxSearchParams): number {
-    let n = 0;
-    if (f.query) n++;
-    if (f.from) n++;
-    if (f.tagId) n++;
-    if (f.accountIds && f.accountIds.length > 0) n++;
-    if (f.unseen !== undefined) n++;
-    if (f.since) n++;
-    if (f.until) n++;
-    return n;
+  let n = 0;
+  if (f.query) n++;
+  if (f.from) n++;
+  if (f.tagId) n++;
+  if (f.categoryIds && f.categoryIds.length > 0) n++;
+  if (f.accountIds && f.accountIds.length > 0) n++;
+  if (f.unseen !== undefined) n++;
+  if (f.since) n++;
+  if (f.until) n++;
+  return n;
 }

--- a/web/src/lib/api/client/app/unibox/getThreadLabels.ts
+++ b/web/src/lib/api/client/app/unibox/getThreadLabels.ts
@@ -1,0 +1,20 @@
+// Reads the conversation labels assigned to a thread.
+// GET /unibox/thread/labels?thread_id=<id>
+
+import Request from "../../Request";
+import type MiniCategory from "@/lib/api/models/app/contacts/MiniCategory";
+
+interface Response {
+  data: MiniCategory[];
+}
+
+export default async function getThreadLabels(
+  threadId: string,
+): Promise<MiniCategory[]> {
+  const res = await Request<Response>({
+    method: "GET",
+    url: `/unibox/thread/labels?thread_id=${encodeURIComponent(threadId)}`,
+    authorization: true,
+  });
+  return res.data ?? [];
+}

--- a/web/src/lib/api/client/app/unibox/searchIncoming.ts
+++ b/web/src/lib/api/client/app/unibox/searchIncoming.ts
@@ -7,59 +7,68 @@ import Request from "../../Request";
 import type { UniboxSearchParams } from "@/lib/api/models/app/unibox/UniboxSearch";
 
 export interface UniboxListRow {
-    id: string;
-    email_id: string;
-    thread_id: string;
-    from_addr: string[];
-    to_addr: string[];
-    subject: string;
-    snippet: string;
-    internal_date: string;
-    seen: boolean;
+  id: string;
+  email_id: string;
+  thread_id: string;
+  from_addr: string[];
+  to_addr: string[];
+  subject: string;
+  snippet: string;
+  internal_date: string;
+  seen: boolean;
+  /** Messages in the conversation behind this row (1 = singleton). */
+  message_count: number;
+  /** True if any message in the thread is unread (bold the whole row). */
+  has_unread: boolean;
+  /** Conversation labels (categories) assigned to the thread. */
+  labels: { id: string; title: string; color: string }[];
 }
 
 interface UniboxListResponse {
-    data: UniboxListRow[];
-    pagination: {
-        has_more: boolean;
-        next_cursor: string | null;
-    };
+  data: UniboxListRow[];
+  pagination: {
+    has_more: boolean;
+    next_cursor: string | null;
+  };
 }
 
 function isoDay(d: Date): string {
-    const y = d.getFullYear();
-    const m = String(d.getMonth() + 1).padStart(2, "0");
-    const day = String(d.getDate()).padStart(2, "0");
-    return `${y}-${m}-${day}`;
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
 }
 
 export default async function searchIncoming(
-    p: UniboxSearchParams = {},
+  p: UniboxSearchParams = {},
 ): Promise<UniboxListResponse> {
-    const usp = new URLSearchParams();
-    // The server's free-text matcher is subject. If the frontend wants
-    // body matching too, that's a server change — surfacing the param
-    // here in case the user passed something.
-    if (p.query) usp.set("subject", p.query);
-    if (p.from) usp.set("from", p.from);
-    if (p.accountIds && p.accountIds.length > 0) {
-        // Backend accepts comma-separated email_ids and falls back to a
-        // single email_id for legacy callers; we always use the multi form.
-        usp.set("email_ids", p.accountIds.join(","));
-    }
-    if (p.unseen) usp.set("unseen", "true");
-    if (p.snoozed === true) usp.set("snoozed", "true");
-    else if (p.snoozed === "any") usp.set("snoozed", "any");
-    if (p.awaitingReply) usp.set("awaiting_reply", "true");
-    if (p.since) usp.set("since", isoDay(p.since));
-    if (p.until) usp.set("until", isoDay(p.until));
-    if (p.cursor) usp.set("cursor", p.cursor);
-    if (p.limit) usp.set("limit", String(p.limit));
+  const usp = new URLSearchParams();
+  // The server's free-text matcher is subject. If the frontend wants
+  // body matching too, that's a server change — surfacing the param
+  // here in case the user passed something.
+  if (p.query) usp.set("subject", p.query);
+  if (p.from) usp.set("from", p.from);
+  if (p.accountIds && p.accountIds.length > 0) {
+    // Backend accepts comma-separated email_ids and falls back to a
+    // single email_id for legacy callers; we always use the multi form.
+    usp.set("email_ids", p.accountIds.join(","));
+  }
+  if (p.unseen) usp.set("unseen", "true");
+  if (p.snoozed === true) usp.set("snoozed", "true");
+  else if (p.snoozed === "any") usp.set("snoozed", "any");
+  if (p.awaitingReply) usp.set("awaiting_reply", "true");
+  if (p.categoryIds && p.categoryIds.length > 0) {
+    usp.set("category_ids", p.categoryIds.join(","));
+  }
+  if (p.since) usp.set("since", isoDay(p.since));
+  if (p.until) usp.set("until", isoDay(p.until));
+  if (p.cursor) usp.set("cursor", p.cursor);
+  if (p.limit) usp.set("limit", String(p.limit));
 
-    const qs = usp.toString();
-    return Request<UniboxListResponse>({
-        method: "GET",
-        url: `/unibox${qs ? `?${qs}` : ""}`,
-        authorization: true,
-    });
+  const qs = usp.toString();
+  return Request<UniboxListResponse>({
+    method: "GET",
+    url: `/unibox${qs ? `?${qs}` : ""}`,
+    authorization: true,
+  });
 }

--- a/web/src/lib/api/client/app/unibox/setThreadLabels.ts
+++ b/web/src/lib/api/client/app/unibox/setThreadLabels.ts
@@ -1,0 +1,22 @@
+// Replaces the full conversation-label set on a thread (idempotent PUT).
+// PUT /unibox/thread/labels { thread_id, category_ids }
+
+import Request from "../../Request";
+import type MiniCategory from "@/lib/api/models/app/contacts/MiniCategory";
+
+interface Response {
+  data: MiniCategory[];
+}
+
+export default async function setThreadLabels(
+  threadId: string,
+  categoryIds: string[],
+): Promise<MiniCategory[]> {
+  const res = await Request<Response>({
+    method: "PUT",
+    url: `/unibox/thread/labels`,
+    data: { thread_id: threadId, category_ids: categoryIds },
+    authorization: true,
+  });
+  return res.data ?? [];
+}

--- a/web/src/lib/api/hooks/app/categories/useDeleteCategory.ts
+++ b/web/src/lib/api/hooks/app/categories/useDeleteCategory.ts
@@ -3,22 +3,25 @@ import type User from "@/lib/api/models/auth/User";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function useDeleteCategory(id: string) {
-    const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
 
-    return useMutation({
-        mutationFn: () => deleteCategory(id),
-        onSuccess: () => {
-            queryClient.setQueryData<User>(
-                ["auth", "me"],
-                (oldData) => {
-                    if (!oldData) return oldData;
+  return useMutation({
+    mutationFn: () => deleteCategory(id),
+    onSuccess: () => {
+      queryClient.setQueryData<User>(["auth", "me"], (oldData) => {
+        if (!oldData) return oldData;
 
-                    return {
-                        ...oldData,
-                        categories: oldData.categories.filter(t => t.id !== id)
-                    }
-                }
-            )
-        }
-    })
+        return {
+          ...oldData,
+          categories: oldData.categories.filter((t) => t.id !== id),
+        };
+      });
+      // The category is also a Unibox conversation label. The DB
+      // cascades the unibox_thread_labels rows away, but the cached
+      // list rows + scope-rail counts still reference it — refresh
+      // them so deleted-label chips/counts don't linger.
+      queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
+    },
+  });
 }

--- a/web/src/lib/api/hooks/app/unibox/useSetThreadLabels.ts
+++ b/web/src/lib/api/hooks/app/unibox/useSetThreadLabels.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import setThreadLabels from "@/lib/api/client/app/unibox/setThreadLabels";
+import type MiniCategory from "@/lib/api/models/app/contacts/MiniCategory";
+
+// Replaces a thread's conversation labels. On success it primes the
+// per-thread labels cache and invalidates everything the label change
+// touches: the (collapsed) inbox list rows that render label chips and
+// the overview that powers the scope-rail category counts.
+export default function useSetThreadLabels(threadId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (categoryIds: string[]) =>
+      setThreadLabels(threadId, categoryIds),
+    onSuccess: (labels: MiniCategory[]) => {
+      queryClient.setQueryData(
+        ["unibox", "thread", "labels", threadId],
+        labels,
+      );
+      queryClient.invalidateQueries({ queryKey: ["unibox", "search"] });
+      queryClient.invalidateQueries({ queryKey: ["unibox", "overview"] });
+    },
+  });
+}

--- a/web/src/lib/api/hooks/app/unibox/useThreadLabels.ts
+++ b/web/src/lib/api/hooks/app/unibox/useThreadLabels.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import getThreadLabels from "@/lib/api/client/app/unibox/getThreadLabels";
+
+export default function useThreadLabels(threadId: string | null) {
+  return useQuery({
+    queryKey: ["unibox", "thread", "labels", threadId],
+    queryFn: () => getThreadLabels(threadId!),
+    enabled: !!threadId,
+    staleTime: 30_000,
+  });
+}

--- a/web/src/lib/api/models/app/unibox/UniboxEmail.ts
+++ b/web/src/lib/api/models/app/unibox/UniboxEmail.ts
@@ -1,11 +1,15 @@
 export default interface UniboxEmail {
-    id: string
-    from: string
-    to: string
-    subject: string
-    body: string
-    date: Date
-    is_seen: boolean
-    thread_id?: string
-    account_id: string
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  date: Date;
+  is_seen: boolean;
+  thread_id?: string;
+  account_id: string;
+  /** Number of messages in the conversation (for the stacked count badge). */
+  message_count?: number;
+  /** Conversation labels (categories) assigned to the thread. */
+  labels?: { id: string; title: string; color: string }[];
 }

--- a/web/src/lib/api/models/app/unibox/UniboxOverview.ts
+++ b/web/src/lib/api/models/app/unibox/UniboxOverview.ts
@@ -2,41 +2,51 @@
 // the scope rail and the top metric strip.
 
 export interface UniboxMailboxOverview {
-    id: string
-    email: string
-    name: string
-    unread: number
-    total: number
+  id: string;
+  email: string;
+  name: string;
+  unread: number;
+  total: number;
 }
 
 export interface UniboxTagOverview {
-    id: string
-    title: string
-    color: string
-    unread: number
-    total: number
+  id: string;
+  title: string;
+  color: string;
+  unread: number;
+  total: number;
+}
+
+// Per-conversation-label counts (unread/total counted as threads).
+export interface UniboxCategoryOverview {
+  id: string;
+  title: string;
+  color: string;
+  unread: number;
+  total: number;
 }
 
 export default interface UniboxOverview {
-    total: number
-    unread: number
-    today: number
-    week: number
-    snoozed: number
-    awaiting_reply: number
-    /** Pending outbound email tasks queued by the user. */
-    scheduled_pending: number
-    /**
-     * Hard cap on how many pending scheduled sends one user can queue
-     * at once. Each pending send occupies a Cloud Tasks queue slot the
-     * platform pays for, so the cap protects against runaway abuse.
-     * Dashboard renders `scheduled_pending / scheduled_pending_max` so
-     * the user sees their position before hitting the wall.
-     */
-    scheduled_pending_max: number
-    mailboxes: UniboxMailboxOverview[]
-    tags: UniboxTagOverview[]
-    generated_at: string
-    window_today_start: string
-    window_week_start: string
+  total: number;
+  unread: number;
+  today: number;
+  week: number;
+  snoozed: number;
+  awaiting_reply: number;
+  /** Pending outbound email tasks queued by the user. */
+  scheduled_pending: number;
+  /**
+   * Hard cap on how many pending scheduled sends one user can queue
+   * at once. Each pending send occupies a Cloud Tasks queue slot the
+   * platform pays for, so the cap protects against runaway abuse.
+   * Dashboard renders `scheduled_pending / scheduled_pending_max` so
+   * the user sees their position before hitting the wall.
+   */
+  scheduled_pending_max: number;
+  mailboxes: UniboxMailboxOverview[];
+  tags: UniboxTagOverview[];
+  categories: UniboxCategoryOverview[];
+  generated_at: string;
+  window_today_start: string;
+  window_week_start: string;
 }

--- a/web/src/lib/api/models/app/unibox/UniboxSearch.ts
+++ b/web/src/lib/api/models/app/unibox/UniboxSearch.ts
@@ -3,33 +3,38 @@
 // stripped before serialization so the URL stays clean.
 
 export interface UniboxSearchParams {
-    query?: string;        // Free text — currently matched as subject ILIKE
-    from?: string;         // Sender substring
-    /**
-     * Selected account IDs. The server filters with email_id IN (…).
-     * Use this directly when picking specific mailboxes, or set
-     * `tagId` instead and let the filter UI resolve it into the set
-     * of accounts that carry the tag.
-     */
-    accountIds?: string[];
-    /**
-     * UI-only convenience: when set, the filter sheet resolves the tag
-     * to the matching account IDs at apply time. The server never sees
-     * this field; it sees the resolved `accountIds` instead.
-     */
-    tagId?: string;
-    unseen?: boolean;      // Only unread
-    /**
-     * Snoozed scope. true = only snoozed threads; undefined = exclude
-     * snoozed (default inbox view); "any" = no snooze filter at all
-     * (debug only).
-     */
-    snoozed?: true | "any";
-    /** Awaiting reply: threads where the last message was from us. */
-    awaitingReply?: boolean;
-    since?: Date;          // From date
-    until?: Date;          // To date
-    sortBy?: "newest" | "oldest";
-    cursor?: string;
-    limit?: number;
+  query?: string; // Free text — currently matched as subject ILIKE
+  from?: string; // Sender substring
+  /**
+   * Selected account IDs. The server filters with email_id IN (…).
+   * Use this directly when picking specific mailboxes, or set
+   * `tagId` instead and let the filter UI resolve it into the set
+   * of accounts that carry the tag.
+   */
+  accountIds?: string[];
+  /**
+   * UI-only convenience: when set, the filter sheet resolves the tag
+   * to the matching account IDs at apply time. The server never sees
+   * this field; it sees the resolved `accountIds` instead.
+   */
+  tagId?: string;
+  unseen?: boolean; // Only unread
+  /**
+   * Snoozed scope. true = only snoozed threads; undefined = exclude
+   * snoozed (default inbox view); "any" = no snooze filter at all
+   * (debug only).
+   */
+  snoozed?: true | "any";
+  /** Awaiting reply: threads where the last message was from us. */
+  awaitingReply?: boolean;
+  /**
+   * Conversation-label filter. Threads carrying any of these category
+   * ids match. Sent to the server as `category_ids`.
+   */
+  categoryIds?: string[];
+  since?: Date; // From date
+  until?: Date; // To date
+  sortBy?: "newest" | "oldest";
+  cursor?: string;
+  limit?: number;
 }

--- a/web/src/stores/slices/uniboxSlice.ts
+++ b/web/src/stores/slices/uniboxSlice.ts
@@ -1,25 +1,30 @@
-import type { StateCreator } from 'zustand'
-import type UniboxEmail from '@/lib/api/models/app/unibox/UniboxEmail'
-import type UniboxThread from '@/lib/api/models/app/unibox/UniboxThread'
+import type { StateCreator } from "zustand";
+import type UniboxEmail from "@/lib/api/models/app/unibox/UniboxEmail";
+import type UniboxThread from "@/lib/api/models/app/unibox/UniboxThread";
 
 export interface UniboxSlice {
-  uniboxEmails: UniboxEmail[]
-  uniboxThreads: UniboxThread[]
-  unseenCount: number
-  selectedThreadId: string | null
-  selectedAccountId: string | null
+  uniboxEmails: UniboxEmail[];
+  uniboxThreads: UniboxThread[];
+  unseenCount: number;
+  selectedThreadId: string | null;
+  selectedAccountId: string | null;
 
-  setUniboxEmails: (emails: UniboxEmail[]) => void
-  addUniboxEmail: (email: UniboxEmail) => void
-  setUniboxThreads: (threads: UniboxThread[]) => void
-  setUnseenCount: (count: number) => void
-  incrementUnseenCount: () => void
-  decrementUnseenCount: (by?: number) => void
-  setSelectedThreadId: (id: string | null) => void
-  setSelectedAccountId: (id: string | null) => void
+  setUniboxEmails: (emails: UniboxEmail[]) => void;
+  addUniboxEmail: (email: UniboxEmail) => void;
+  setUniboxThreads: (threads: UniboxThread[]) => void;
+  setUnseenCount: (count: number) => void;
+  incrementUnseenCount: () => void;
+  decrementUnseenCount: (by?: number) => void;
+  setSelectedThreadId: (id: string | null) => void;
+  setSelectedAccountId: (id: string | null) => void;
 }
 
-export const createUniboxSlice: StateCreator<UniboxSlice, [], [], UniboxSlice> = (set) => ({
+export const createUniboxSlice: StateCreator<
+  UniboxSlice,
+  [],
+  [],
+  UniboxSlice
+> = (set) => ({
   uniboxEmails: [],
   uniboxThreads: [],
   unseenCount: 0,
@@ -27,13 +32,24 @@ export const createUniboxSlice: StateCreator<UniboxSlice, [], [], UniboxSlice> =
   selectedAccountId: null,
 
   setUniboxEmails: (uniboxEmails) => set({ uniboxEmails }),
+  // Upsert by thread: a new message in an existing conversation moves
+  // that conversation to the top instead of stacking a duplicate row —
+  // mirroring the thread-collapsed server list. Falls back to id when a
+  // message has no thread_id.
   addUniboxEmail: (email) =>
-    set((state) => ({ uniboxEmails: [email, ...state.uniboxEmails] })),
+    set((state) => {
+      const key = email.thread_id || email.id;
+      const rest = state.uniboxEmails.filter(
+        (e) => (e.thread_id || e.id) !== key,
+      );
+      return { uniboxEmails: [email, ...rest] };
+    }),
   setUniboxThreads: (uniboxThreads) => set({ uniboxThreads }),
   setUnseenCount: (unseenCount) => set({ unseenCount }),
-  incrementUnseenCount: () => set((state) => ({ unseenCount: state.unseenCount + 1 })),
+  incrementUnseenCount: () =>
+    set((state) => ({ unseenCount: state.unseenCount + 1 })),
   decrementUnseenCount: (by = 1) =>
     set((state) => ({ unseenCount: Math.max(0, state.unseenCount - by) })),
   setSelectedThreadId: (selectedThreadId) => set({ selectedThreadId }),
   setSelectedAccountId: (selectedAccountId) => set({ selectedAccountId }),
-})
+});


### PR DESCRIPTION
## Summary
- add Unibox thread-label storage using existing categories
- collapse Unibox search and overview counters to conversation/thread-level rows
- add backend label APIs plus dashboard category scopes, filters, chips, and thread label menu

## Verification
- find cmd internal -name '*.go' -print0 | xargs -0 gofmt -l
- make lint
- pnpm typecheck (web)
- pnpm lint (web; exits 0 with existing warnings)