### PR TITLE
feat: expand CRM campaign automation

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/socket"
 	"github.com/warmbly/warmbly/internal/app/stripe"
 	"github.com/warmbly/warmbly/internal/app/subscription"
+	"github.com/warmbly/warmbly/internal/app/team"
 	"github.com/warmbly/warmbly/internal/app/template"
 	"github.com/warmbly/warmbly/internal/app/token"
 	"github.com/warmbly/warmbly/internal/app/trial"
@@ -136,6 +137,7 @@ func main() {
 	var tagService group.GroupService
 	var categoryService group.GroupService
 	var crmService crm.CRMService
+	var teamService team.TeamService
 	var apiKeyService apikey.APIKeyService
 	var idempotencyService idempotencyapp.Service
 
@@ -802,6 +804,8 @@ func main() {
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
+		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
+		teamService = team.NewService(teamRepository)
 		socketService = socket.NewService(cache, tokenService)
 
 		// Cloud Tasks client
@@ -993,6 +997,9 @@ func main() {
 
 		// CRM
 		CRMService: crmService,
+
+		// Teams
+		TeamService: teamService,
 
 		// Email send & templates
 		TemplateService:  templateService,

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -290,6 +290,36 @@ func main() {
 	// or WorkerRepo are nil.
 	go jobsService.StartRiskRebalancer(ctx, 1*time.Hour)
 
+	// Tracking consumer (opens/clicks): a second Kafka consumer on the tracking
+	// topic. It records open/click engagement and fires INSTANT open/click action
+	// chains (advancedService), the open/click analog of the reply path. Wired
+	// best-effort: if the tracking config or connection isn't available in this
+	// environment, log and keep running the worker-event consumer rather than
+	// crashing — opens/clicks simply aren't consumed there.
+	if trackingCfg, terr := cfg.LoadTrackingConsumerConfig(ctx); terr != nil {
+		log.Println("tracking consumer config unavailable; opens/clicks not consumed:", terr)
+	} else if trackingConsumer, terr := jobs.NewTrackingConsumer(
+		trackingCfg,
+		avrov2Client,
+		taskRepo,
+		campaignProgressRepo,
+		campaignRepo,
+		contactRepo,
+		streamingPublisher,
+		repository.NewTrackingDedupeRepository(primaryDB.Pool),
+		advancedService,
+	); terr != nil {
+		log.Println("tracking consumer unavailable; opens/clicks not consumed:", terr)
+	} else {
+		defer trackingConsumer.Close()
+		go func() {
+			if err := trackingConsumer.Start(ctx); err != nil {
+				log.Println("tracking consumer stopped:", err)
+			}
+		}()
+		log.Println("Tracking consumer started, listening on", trackingCfg.Topic)
+	}
+
 	log.Println("Consumer started, listening on", kafka.TopicWorkerEvents)
 	jobsService.Start(ctx)
 	log.Println("Consumer stopped")

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -39,6 +39,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
 	"github.com/warmbly/warmbly/internal/pkg/argon2"
 	"github.com/warmbly/warmbly/internal/seed"
 )
@@ -76,6 +77,14 @@ func main() {
 		log.Fatalf("connect: %v", err)
 	}
 	defer pool.Close()
+
+	// Apply embedded migrations before seeding. `make seed` is documented to
+	// assume migrations are already applied, but running them here makes it
+	// robust standalone: without it, new tables (e.g. crm_task_types) are
+	// missing and the seed aborts partway, which looks like "nothing seeded".
+	if err := db.RunMigrations(dsn); err != nil {
+		log.Fatalf("migrations: %v", err)
+	}
 
 	if err := seedBaseline(ctx, pool); err != nil {
 		log.Fatalf("baseline: %v", err)

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -147,6 +147,24 @@ func seedBaseline(ctx context.Context, pool *pgxpool.Pool) error {
 			return fmt.Errorf("dev pool join %s: %w", a.email, err)
 		}
 	}
+	// Dev-org contacts that match the unibox senders below, so opening those
+	// threads resolves to a real contact in the CRM panel instead of
+	// "Not a known contact". The mailer-daemon bounce stays a non-contact.
+	devContacts := []struct {
+		id             uuid.UUID
+		first, last    string
+		email, company string
+	}{
+		{uuid.MustParse("66666666-0000-0000-0000-0000dddc0001"), "Aiden", "Park", "aiden.park@northwind.test", "Northwind"},
+		{uuid.MustParse("66666666-0000-0000-0000-0000dddc0002"), "Beth", "Chen", "beth.chen@initech.test", "Initech"},
+		{uuid.MustParse("66666666-0000-0000-0000-0000dddc0003"), "Carlos", "Diaz", "carlos.diaz@piedpiper.test", "Pied Piper"},
+	}
+	for _, c := range devContacts {
+		if err := upsertContact(ctx, pool, c.id, userDev, orgDev, c.first, c.last, c.email, c.company, true); err != nil {
+			return fmt.Errorf("dev contact %s: %w", c.email, err)
+		}
+	}
+
 	if err := seedLegacyUnibox(ctx, pool, []legacyUniboxEmail{
 		{
 			id: uuid.MustParse("77777777-0000-0000-0000-000000000101"), userID: userDev,

--- a/internal/api/handler/contact_detail.go
+++ b/internal/api/handler/contact_detail.go
@@ -46,6 +46,14 @@ func (h *Handler) GetContact(c *gin.Context) {
 // rather than a 404.
 func (h *Handler) LookupContactByEmail(c *gin.Context) {
 	email := strings.TrimSpace(c.Query("email"))
+	// Senders often arrive as "Display Name <addr@example.com>" (the unibox
+	// stores from_addr that way). Extract the bare address so it matches the
+	// contact's email, otherwise every named sender resolves to "not found".
+	if i := strings.LastIndex(email, "<"); i != -1 {
+		if j := strings.Index(email[i:], ">"); j != -1 {
+			email = strings.TrimSpace(email[i+1 : i+j])
+		}
+	}
 	if email == "" {
 		errx.Handle(c, errx.New(errx.BadRequest, "email is required"))
 		return

--- a/internal/api/handler/contact_detail.go
+++ b/internal/api/handler/contact_detail.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -37,6 +38,28 @@ func (h *Handler) GetContact(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, detail)
+}
+
+// LookupContactByEmail resolves a sender address to a contact in the caller's
+// organization, for the unibox CRM panel. Returns {"contact": null} with 200
+// when no contact matches, so an unknown sender renders a clean empty state
+// rather than a 404.
+func (h *Handler) LookupContactByEmail(c *gin.Context) {
+	email := strings.TrimSpace(c.Query("email"))
+	if email == "" {
+		errx.Handle(c, errx.New(errx.BadRequest, "email is required"))
+		return
+	}
+
+	orgID := middleware.GetOrganizationID(c)
+
+	contact, xerr := h.ContactService.GetByEmail(c.Request.Context(), orgID, email)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"contact": contact})
 }
 
 // ListContactEmails returns one row per email we sent (or tried to

--- a/internal/api/handler/crm.go
+++ b/internal/api/handler/crm.go
@@ -430,6 +430,65 @@ func (h *Handler) ListDeals(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// SearchDeals is the faceted, server-paginated deals surface that powers the
+// cross-pipeline table view. Filters arrive in the JSON body; limit + offset
+// are query params (mirrors the contacts search ergonomics).
+func (h *Handler) SearchDeals(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var filters models.SearchDeals
+	if err := c.ShouldBindJSON(&filters); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	limit := 50
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 200 {
+		limit = l
+	}
+	offset := 0
+	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o > 0 {
+		offset = o
+	}
+
+	result, xerr := h.CRMService.SearchDeals(c.Request.Context(), *orgID, filters, limit, offset)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// DealsSummary returns COUNT + SUM(value) aggregates over the SAME filter body
+// as SearchDeals, so header totals and per-stage board headers are true totals
+// over the whole matching set rather than a client reduce over a loaded page.
+func (h *Handler) DealsSummary(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var filters models.SearchDeals
+	if err := c.ShouldBindJSON(&filters); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	summary, xerr := h.CRMService.DealsSummary(c.Request.Context(), *orgID, filters)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, summary)
+}
+
 func (h *Handler) GetDeal(c *gin.Context) {
 	orgID := middleware.GetOrganizationID(c)
 	if orgID == nil {

--- a/internal/api/handler/crm.go
+++ b/internal/api/handler/crm.go
@@ -745,6 +745,65 @@ func (h *Handler) ListCRMTasks(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// SearchCRMTasks is the faceted, server-paginated tasks surface that powers the
+// tasks list view at scale. Filters arrive in the JSON body; limit + offset are
+// query params (mirrors the deals search ergonomics).
+func (h *Handler) SearchCRMTasks(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var filters models.SearchTasks
+	if err := c.ShouldBindJSON(&filters); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	limit := 50
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 && l <= 200 {
+		limit = l
+	}
+	offset := 0
+	if o, err := strconv.Atoi(c.Query("offset")); err == nil && o > 0 {
+		offset = o
+	}
+
+	result, xerr := h.CRMService.SearchTasks(c.Request.Context(), *orgID, filters, limit, offset)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// TasksSummary returns COUNT aggregates over the SAME filter body as
+// SearchCRMTasks, so header totals (by status, overdue, high priority) are true
+// totals over the whole matching set rather than a client reduce over a page.
+func (h *Handler) TasksSummary(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var filters models.SearchTasks
+	if err := c.ShouldBindJSON(&filters); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	summary, xerr := h.CRMService.TasksSummary(c.Request.Context(), *orgID, filters)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, summary)
+}
+
 func (h *Handler) GetCRMTask(c *gin.Context) {
 	orgID := middleware.GetOrganizationID(c)
 	if orgID == nil {

--- a/internal/api/handler/crm.go
+++ b/internal/api/handler/crm.go
@@ -585,6 +585,85 @@ func (h *Handler) GetDealsByContact(c *gin.Context) {
 }
 
 // =====================
+// CRM Task Types
+// =====================
+
+func (h *Handler) ListTaskTypes(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	types, xerr := h.CRMService.ListTaskTypes(c.Request.Context(), *orgID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": types})
+}
+
+func (h *Handler) CreateTaskType(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	var data models.CreateCRMTaskType
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+	t, xerr := h.CRMService.CreateTaskType(c.Request.Context(), *orgID, &data)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.JSON(http.StatusCreated, t)
+}
+
+func (h *Handler) UpdateTaskType(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	typeID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+	var data models.UpdateCRMTaskType
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+	t, xerr := h.CRMService.UpdateTaskType(c.Request.Context(), *orgID, typeID, &data)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, t)
+}
+
+func (h *Handler) DeleteTaskType(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	typeID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+	if xerr := h.CRMService.DeleteTaskType(c.Request.Context(), *orgID, typeID); xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// =====================
 // CRM Tasks
 // =====================
 

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -30,6 +30,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/socket"
 	"github.com/warmbly/warmbly/internal/app/stripe"
 	"github.com/warmbly/warmbly/internal/app/subscription"
+	"github.com/warmbly/warmbly/internal/app/team"
 	"github.com/warmbly/warmbly/internal/app/template"
 	"github.com/warmbly/warmbly/internal/app/token"
 	"github.com/warmbly/warmbly/internal/app/trial"
@@ -90,6 +91,9 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// Teams
+	TeamService team.TeamService
 
 	// Email send & templates
 	TemplateService  template.TemplateService

--- a/internal/api/handler/team.go
+++ b/internal/api/handler/team.go
@@ -1,0 +1,189 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// =====================
+// Teams
+// =====================
+
+// addTeamMemberRequest is the body for POST /teams/:id/members. The user must
+// already belong to the organization; that is validated in the service/repo.
+type addTeamMemberRequest struct {
+	UserID uuid.UUID `json:"user_id" binding:"required"`
+}
+
+func (h *Handler) ListTeams(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	teams, xerr := h.TeamService.ListTeams(c.Request.Context(), *orgID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": teams})
+}
+
+func (h *Handler) CreateTeam(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var data models.CreateTeam
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	team, xerr := h.TeamService.CreateTeam(c.Request.Context(), *orgID, &data)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusCreated, team)
+}
+
+func (h *Handler) GetTeam(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+
+	team, xerr := h.TeamService.GetTeam(c.Request.Context(), *orgID, teamID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, team)
+}
+
+func (h *Handler) UpdateTeam(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+
+	var data models.UpdateTeam
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	team, xerr := h.TeamService.UpdateTeam(c.Request.Context(), *orgID, teamID, &data)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, team)
+}
+
+func (h *Handler) DeleteTeam(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+
+	xerr := h.TeamService.DeleteTeam(c.Request.Context(), *orgID, teamID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// =====================
+// Team Members
+// =====================
+
+func (h *Handler) AddTeamMember(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+
+	var data addTeamMemberRequest
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	if xerr := h.TeamService.AddMember(c.Request.Context(), *orgID, teamID, data.UserID); xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	team, xerr := h.TeamService.GetTeam(c.Request.Context(), *orgID, teamID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.JSON(http.StatusOK, team)
+}
+
+func (h *Handler) RemoveTeamMember(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	teamID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+	userID, err := uuid.Parse(c.Param("userId"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+
+	if xerr := h.TeamService.RemoveMember(c.Request.Context(), *orgID, teamID, userID); xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -564,6 +564,20 @@ func Run(
 			}
 		}
 
+		// Teams — group existing org members into named teams (for CRM
+		// ownership / routing). Built from members; managed by team managers.
+		teamsGroup := protected.Group("/teams")
+		teamsGroup.Use(m.RequireOrganization(), m.RateLimitMiddleware(models.RateLimitWrite))
+		{
+			teamsGroup.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListTeams)
+			teamsGroup.POST("", m.RequireAccess(models.PermManageTeam, models.APIPermWriteCRM), h.CreateTeam)
+			teamsGroup.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetTeam)
+			teamsGroup.PATCH("/:id", m.RequireAccess(models.PermManageTeam, models.APIPermWriteCRM), h.UpdateTeam)
+			teamsGroup.DELETE("/:id", m.RequireAccess(models.PermManageTeam, models.APIPermWriteCRM), h.DeleteTeam)
+			teamsGroup.POST("/:id/members", m.RequireAccess(models.PermManageTeam, models.APIPermWriteCRM), h.AddTeamMember)
+			teamsGroup.DELETE("/:id/members/:userId", m.RequireAccess(models.PermManageTeam, models.APIPermWriteCRM), h.RemoveTeamMember)
+		}
+
 		// Plans and timezones are essentially public reference data — auth
 		// gates them only to avoid being scraped. Cheap to expose to keys.
 		protected.GET("/plans", h.ListPlans)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -558,6 +558,8 @@ func Run(
 			{
 				crmTasks.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListCRMTasks)
 				crmTasks.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateCRMTask)
+				crmTasks.POST("/search", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.SearchCRMTasks)
+				crmTasks.POST("/summary", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.TasksSummary)
 				crmTasks.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetCRMTask)
 				crmTasks.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateCRMTask)
 				crmTasks.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteCRMTask)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -528,6 +528,8 @@ func Run(
 			{
 				deals.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListDeals)
 				deals.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateDeal)
+				deals.POST("/search", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.SearchDeals)
+				deals.POST("/summary", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.DealsSummary)
 				deals.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.GetDeal)
 				deals.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateDeal)
 				deals.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteDeal)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -546,6 +546,14 @@ func Run(
 				deals.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteDeal)
 			}
 
+			taskTypes := crmGroup.Group("/task-types")
+			{
+				taskTypes.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListTaskTypes)
+				taskTypes.POST("", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.CreateTaskType)
+				taskTypes.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.UpdateTaskType)
+				taskTypes.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.DeleteTaskType)
+			}
+
 			crmTasks := crmGroup.Group("/tasks")
 			{
 				crmTasks.GET("", m.RequireAccess(models.PermViewContacts, models.APIPermReadCRM), h.ListCRMTasks)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -308,6 +308,10 @@ func Run(
 			contacts.PATCH("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.UpdateContact)
 			contacts.DELETE("/:id", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.DeleteContact)
 
+			// Resolve a sender address to a contact (unibox CRM panel).
+			// Registered before /:id so the fixed path wins over the catch-all.
+			contacts.GET("/lookup", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.LookupContactByEmail)
+
 			// Contact 360 view: hydrated detail, every email sent to
 			// the contact, and the merged activity timeline.
 			contacts.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetContact)

--- a/internal/app/advanced/reply_actions.go
+++ b/internal/app/advanced/reply_actions.go
@@ -1,0 +1,344 @@
+package advanced
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// maxInstantReplyChain bounds how many action nodes a single reply event can run
+// in one walk, so a malformed loop in the flow graph (a chain that routes back
+// into itself) can never spin. The flow editor links chains linearly, so a real
+// reply automation is far shorter than this.
+const maxInstantReplyChain = 32
+
+// fireInstantReplyActions runs the matched reply branch's action chain for a
+// single contact the moment their reply is classified, instead of waiting for
+// the contact's next scheduled step boundary. It is the instant, contact-targeted
+// half of the reply-branch system: the scheduler still handles engagement
+// branches (opened/clicked) and the email steps; this only short-circuits the
+// reply_* branches so "on reply, do X then Y" happens immediately.
+//
+// Everything here is best-effort and swallows errors (logging only): reply
+// detection runs in the consumer's inbox hot path, so a CRM hiccup must never
+// block ingest. Exactly-once is enforced by ClaimReplyActionFire before any side
+// effect runs, so a redelivered reply event (or an auto-reply followed by a human
+// reply on the same step) cannot double-fire the chain.
+func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, contactID, currentStepID uuid.UUID, replyClass string) {
+	// Load the campaign's steps with routing fields (kind/action/conditions).
+	steps, err := s.campaignRepo.GetSequencesRoutingByCampaignID(ctx, campaignID)
+	if err != nil {
+		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("instant reply actions: failed to load campaign steps")
+		return
+	}
+	if len(steps) == 0 {
+		return
+	}
+	byID := make(map[uuid.UUID]*models.Sequence, len(steps))
+	for i := range steps {
+		byID[steps[i].ID] = &steps[i]
+	}
+
+	current, ok := byID[currentStepID]
+	if !ok {
+		return
+	}
+
+	// Decode the current step's branching tree and find the matched reply branch.
+	var bc models.BranchConditions
+	if len(current.Conditions) > 0 {
+		if uerr := json.Unmarshal(current.Conditions, &bc); uerr != nil {
+			log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", currentStepID.String()).Msg("instant reply actions: bad conditions json")
+			return
+		}
+	}
+	// REUSE the scheduler's matchers (replyClassMatches / conditionState) via the
+	// exported MatchReplyBranchTarget: first reply_* branch in declared order whose
+	// conditions all hold wins. prog carries the just-classified reply class.
+	prog := &repository.CampaignContactProgress{
+		CampaignID: campaignID,
+		ContactID:  contactID,
+		SequenceID: currentStepID,
+		ReplyClass: replyClass,
+	}
+	matched, target := repository.MatchReplyBranchTarget(&bc, prog)
+	if !matched {
+		return // no reply branch on this step matches this reply
+	}
+	if target == nil {
+		return // matched a STOP branch: nothing to execute instantly
+	}
+
+	// IDEMPOTENCY: claim the one-time fire right BEFORE any side effect. If another
+	// reply event already fired this step's chain, stop here.
+	claimed, cerr := s.campaignProgressRepo.ClaimReplyActionFire(ctx, campaignID, contactID, currentStepID)
+	if cerr != nil {
+		log.Warn().Err(cerr).Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: claim failed")
+		return
+	}
+	if !claimed {
+		return // already fired for this step (or no progress row): no-op
+	}
+
+	// Load the contact once for templating / activity records.
+	contact, xerr := s.contactRepo.GetByID(ctx, contactID)
+	if xerr != nil || contact == nil {
+		log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: contact load failed")
+		return
+	}
+	campaign, cmErr := s.campaignRepo.GetByID(ctx, campaignID)
+	if cmErr != nil || campaign == nil {
+		log.Warn().Str("campaign_id", campaignID.String()).Msg("instant reply actions: campaign load failed")
+		return
+	}
+
+	// Walk the linear ACTION chain from the matched branch's target. Stop at a
+	// non-action node (an email step resumes via the normal scheduler), an "end",
+	// or a "wait" (a wait means "not instant" — hand back to the scheduler).
+	stepID := *target
+	for hops := 0; hops < maxInstantReplyChain; hops++ {
+		node, live := byID[stepID]
+		if !live {
+			return // deleted / dangling target ends the instant chain
+		}
+		if node.Kind != "action" {
+			return // email step (or unknown kind): resumes at the step boundary
+		}
+		var cfg models.ActionConfig
+		if len(node.Action) > 0 {
+			if uerr := json.Unmarshal(node.Action, &cfg); uerr != nil {
+				log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Msg("instant reply actions: bad action json")
+				return
+			}
+		}
+		// A "wait" node means "not instant" — stop here and let the normal
+		// scheduler resume the contact after the wait. "end" terminates the chain.
+		if cfg.Type == "wait" {
+			return
+		}
+		if cfg.Type == "end" || cfg.Type == "" {
+			return
+		}
+
+		s.executeReplyActionNode(ctx, campaign, contact, &cfg)
+
+		// Stamp this action node as "sent" for the contact. The scheduler's
+		// FindNextRoutedPair loop-guard (sentIDs) skips steps with sent_at set, so
+		// this is what stops the scheduler from re-running the very same chain when
+		// it later routes the contact through the reply branch at the next step
+		// boundary. Without it the chain would double-fire (deals/tasks/webhooks)
+		// whenever stop_on_reply is off or the reply was automated. Mirrors the
+		// scheduler's own action-node bookkeeping (tasks.campaign_task).
+		if rerr := s.campaignProgressRepo.RecordEmailSent(ctx, campaignID, contactID, node.ID); rerr != nil {
+			log.Warn().Err(rerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Msg("instant reply actions: failed to stamp action node sent")
+		}
+
+		// Advance to the next node in the chain by following this action node's
+		// own unconditional onward branch (the editor links action chains with a
+		// single catch-all connection). Anything reply-conditional or engagement-
+		// conditional past here is left to the scheduler.
+		next, ok := nextChainTarget(node)
+		if !ok {
+			return
+		}
+		stepID = next
+	}
+	log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: chain exceeded max hops; stopping")
+}
+
+// nextChainTarget returns the single unconditional onward target of an action
+// node (the catch-all branch the editor draws between chained action steps), so
+// the instant walker can follow "action -> action -> ..." without re-evaluating
+// reply/engagement predicates. A node with no unconditional branch ends the
+// instant chain (any conditional routing past it is the scheduler's job).
+func nextChainTarget(node *models.Sequence) (uuid.UUID, bool) {
+	if len(node.Conditions) == 0 {
+		return uuid.Nil, false
+	}
+	var bc models.BranchConditions
+	if err := json.Unmarshal(node.Conditions, &bc); err != nil {
+		return uuid.Nil, false
+	}
+	for i := range bc.Branches {
+		b := &bc.Branches[i]
+		if len(b.Conditions) == 0 && b.TargetSequenceID != nil {
+			return *b.TargetSequenceID, true
+		}
+	}
+	return uuid.Nil, false
+}
+
+// executeReplyActionNode runs one action node's control-plane side effect for a
+// contact, NOW, in response to a reply. It mirrors tasks.executeActionNode but
+// stays inside the advanced service (advanced cannot import tasks — tasks imports
+// advanced), reusing the same repos and the CreateContactDeal / MoveContactDealStage
+// methods. Best-effort: each action logs and continues so one bad node never
+// aborts the rest of the chain or blocks inbox ingest.
+func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.Campaign, contact *models.Contact, cfg *models.ActionConfig) {
+	switch cfg.Type {
+	case "add_tag":
+		if cfg.CategoryID == nil {
+			return
+		}
+		if _, xerr := s.contactRepo.Update(ctx, campaign.UserID, contact.ID.String(), &models.UpdateContact{
+			AddCategories: []string{cfg.CategoryID.String()},
+		}); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	case "remove_tag":
+		if cfg.CategoryID == nil {
+			return
+		}
+		if _, xerr := s.contactRepo.Update(ctx, campaign.UserID, contact.ID.String(), &models.UpdateContact{
+			RemoveCategories: []string{cfg.CategoryID.String()},
+		}); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	case "unsubscribe":
+		if xerr := s.Unsubscribe(ctx, campaign.ID, contact.ID); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	case "notify":
+		if campaign.OrganizationID == nil {
+			return
+		}
+		event := models.WebhookEventCampaignAction
+		if cfg.NotifyEvent != "" {
+			event = models.WebhookEventType(cfg.NotifyEvent)
+		}
+		data := map[string]any{
+			"campaign_id":   campaign.ID.String(),
+			"contact_id":    contact.ID.String(),
+			"contact_email": contact.Email,
+			"trigger":       "reply",
+		}
+		for k, v := range cfg.NotifyData {
+			data[k] = v
+		}
+		s.EmitCampaignEvent(ctx, *campaign.OrganizationID, event, data)
+	case "create_task":
+		if campaign.OrganizationID == nil {
+			return
+		}
+		owner, perr := uuid.Parse(campaign.UserID)
+		if perr != nil {
+			return
+		}
+		title := strings.TrimSpace(cfg.TaskTitle)
+		if title == "" {
+			title = "Follow up: " + contactDisplayName(contact)
+		}
+		assignee := cfg.TaskAssignedTo
+		if assignee == nil {
+			assignee = &owner
+		}
+		cid := contact.ID
+		data := &models.CreateCRMTask{
+			ContactID:  &cid,
+			Title:      title,
+			Type:       cfg.TaskType,
+			Priority:   cfg.TaskPriority,
+			AssignedTo: assignee,
+		}
+		if cfg.TaskDueOffsetDays != nil {
+			due := time.Now().UTC().AddDate(0, 0, *cfg.TaskDueOffsetDays)
+			data.DueDate = &due
+		}
+		if _, xerr := s.CreateContactTask(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	case "create_deal":
+		if campaign.OrganizationID == nil {
+			return
+		}
+		if cfg.DealPipelineID == nil || cfg.DealStageID == nil {
+			return // misconfigured node: skip rather than abort the chain
+		}
+		owner, perr := uuid.Parse(campaign.UserID)
+		if perr != nil {
+			return
+		}
+		name := renderContactTemplate(strings.TrimSpace(cfg.DealName), contact)
+		if name == "" {
+			name = "Deal: " + contactDisplayName(contact)
+		}
+		currency := strings.TrimSpace(cfg.DealCurrency)
+		if currency == "" {
+			currency = "USD"
+		}
+		cid := contact.ID
+		cmpID := campaign.ID
+		data := &models.CreateDeal{
+			PipelineID: *cfg.DealPipelineID,
+			StageID:    *cfg.DealStageID,
+			ContactID:  &cid,
+			Name:       name,
+			Value:      cfg.DealValue,
+			Currency:   currency,
+			CampaignID: &cmpID,
+			AssignedTo: &owner,
+		}
+		if _, xerr := s.CreateContactDeal(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	case "move_deal_stage":
+		if campaign.OrganizationID == nil {
+			return
+		}
+		if cfg.DealPipelineID == nil || cfg.DealStageID == nil {
+			return
+		}
+		if _, xerr := s.MoveContactDealStage(ctx, *campaign.OrganizationID, contact.ID, *cfg.DealPipelineID, *cfg.DealStageID); xerr != nil {
+			s.logActionErr(campaign, contact, cfg.Type, xerr)
+		}
+	default:
+		// "wait" / "end" are handled by the chain walker (they stop the walk);
+		// unknown types are ignored.
+	}
+}
+
+func (s *service) logActionErr(campaign *models.Campaign, contact *models.Contact, action string, err error) {
+	log.Warn().
+		Str("campaign_id", campaign.ID.String()).
+		Str("contact_id", contact.ID.String()).
+		Str("action", action).
+		Str("trigger", "reply").
+		Msg(fmt.Sprintf("instant reply action failed: %v", err))
+}
+
+func contactDisplayName(contact *models.Contact) string {
+	name := strings.TrimSpace(contact.FirstName + " " + contact.LastName)
+	if name == "" {
+		return contact.Email
+	}
+	return name
+}
+
+// renderContactTemplate substitutes {{.FirstName}}-style placeholders in a deal
+// name. It mirrors the naive substitution path of tasks.RenderTemplate (the same
+// {{.Field}} contract used on the canvas) without importing tasks, which would
+// cycle (tasks imports advanced). Standard fields plus custom fields are
+// supported; unknown tokens are left untouched.
+func renderContactTemplate(tmpl string, contact *models.Contact) string {
+	if tmpl == "" || contact == nil {
+		return tmpl
+	}
+	out := tmpl
+	out = strings.ReplaceAll(out, "{{.FirstName}}", contact.FirstName)
+	out = strings.ReplaceAll(out, "{{.LastName}}", contact.LastName)
+	out = strings.ReplaceAll(out, "{{.Email}}", contact.Email)
+	out = strings.ReplaceAll(out, "{{.Company}}", contact.Company)
+	out = strings.ReplaceAll(out, "{{.Phone}}", contact.Phone)
+	for k, v := range contact.CustomFields {
+		out = strings.ReplaceAll(out, "{{."+k+"}}", v)
+	}
+	return out
+}

--- a/internal/app/advanced/reply_actions.go
+++ b/internal/app/advanced/reply_actions.go
@@ -14,29 +14,47 @@ import (
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
-// maxInstantReplyChain bounds how many action nodes a single reply event can run
-// in one walk, so a malformed loop in the flow graph (a chain that routes back
-// into itself) can never spin. The flow editor links chains linearly, so a real
-// reply automation is far shorter than this.
-const maxInstantReplyChain = 32
+// maxInstantChain bounds how many action nodes a single instant event can run in
+// one walk, so a malformed loop in the flow graph (a chain that routes back into
+// itself) can never spin. The flow editor links chains linearly, so a real
+// automation is far shorter than this.
+const maxInstantChain = 32
 
-// fireInstantReplyActions runs the matched reply branch's action chain for a
-// single contact the moment their reply is classified, instead of waiting for
-// the contact's next scheduled step boundary. It is the instant, contact-targeted
-// half of the reply-branch system: the scheduler still handles engagement
-// branches (opened/clicked) and the email steps; this only short-circuits the
-// reply_* branches so "on reply, do X then Y" happens immediately.
+// FireInstantActions is the exported entrypoint for instant engagement triggers
+// (the tracking consumer calls it with "open" / "click" after recording the
+// signal). It guards the eventKind and forwards to the unexported walker. Reply
+// triggers go through ProcessIncomingReply, which calls fireInstantActions
+// directly with "reply". Best-effort and non-blocking, like the rest of the path.
+func (s *service) FireInstantActions(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, eventKind string) {
+	switch eventKind {
+	case "reply", "open", "click":
+	default:
+		return // unknown event kind: nothing instant to fire
+	}
+	s.fireInstantActions(ctx, campaignID, contactID, sequenceID, eventKind)
+}
+
+// fireInstantActions runs the matched INSTANT branch's action chain for a single
+// contact the MOMENT a signal lands for them (a reply is classified, an open is
+// tracked, or a click is tracked), instead of waiting for the contact's next
+// scheduled step boundary. eventKind selects which "it happened" fields can fire:
+// "reply" (the reply_* intent fields), "open" ("opened"), or "click"
+// ("clicked"). It is the instant, contact-targeted half of the branch system: the
+// scheduler still handles negative branches (not_opened/not_clicked), "wait N
+// days" windows, and the email steps; this only short-circuits the positive,
+// instant-capable branches so "on click, do X then Y" happens immediately.
 //
-// Everything here is best-effort and swallows errors (logging only): reply
-// detection runs in the consumer's inbox hot path, so a CRM hiccup must never
-// block ingest. Exactly-once is enforced by ClaimReplyActionFire before any side
-// effect runs, so a redelivered reply event (or an auto-reply followed by a human
-// reply on the same step) cannot double-fire the chain.
-func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, contactID, currentStepID uuid.UUID, replyClass string) {
+// Everything here is best-effort and swallows errors (logging only): the callers
+// run in hot paths (the consumer's inbox path for replies, the tracking consumer
+// for opens/clicks), so a CRM hiccup must never block ingest. Exactly-once PER
+// (step, eventKind) is enforced by ClaimInstantFire before any side effect runs,
+// so a redelivered event of the same kind cannot double-fire that kind's chain,
+// while open/click/reply on the same step each fire their own chain once.
+func (s *service) fireInstantActions(ctx context.Context, campaignID, contactID, currentStepID uuid.UUID, eventKind string) {
 	// Load the campaign's steps with routing fields (kind/action/conditions).
 	steps, err := s.campaignRepo.GetSequencesRoutingByCampaignID(ctx, campaignID)
 	if err != nil {
-		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("instant reply actions: failed to load campaign steps")
+		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Str("event", eventKind).Msg("instant actions: failed to load campaign steps")
 		return
 	}
 	if len(steps) == 0 {
@@ -52,51 +70,55 @@ func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, conta
 		return
 	}
 
-	// Decode the current step's branching tree and find the matched reply branch.
+	// Decode the current step's branching tree and find the matched instant branch.
 	var bc models.BranchConditions
 	if len(current.Conditions) > 0 {
 		if uerr := json.Unmarshal(current.Conditions, &bc); uerr != nil {
-			log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", currentStepID.String()).Msg("instant reply actions: bad conditions json")
+			log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", currentStepID.String()).Str("event", eventKind).Msg("instant actions: bad conditions json")
 			return
 		}
 	}
-	// REUSE the scheduler's matchers (replyClassMatches / conditionState) via the
-	// exported MatchReplyBranchTarget: first reply_* branch in declared order whose
-	// conditions all hold wins. prog carries the just-classified reply class.
-	prog := &repository.CampaignContactProgress{
-		CampaignID: campaignID,
-		ContactID:  contactID,
-		SequenceID: currentStepID,
-		ReplyClass: replyClass,
-	}
-	matched, target := repository.MatchReplyBranchTarget(&bc, prog)
+	// Load the contact's CURRENT progress for this step so any engagement/window
+	// conditions ANDed alongside the trigger field evaluate against real stored
+	// timestamps (e.g. "clicked AND opened"). Falls back to a freshly-stamped row
+	// for the trigger signal itself when no progress row is loadable yet.
+	prog := s.instantProgress(ctx, campaignID, contactID, currentStepID, eventKind)
+
+	// REUSE the scheduler's evaluator via the exported MatchInstantBranchTarget:
+	// first instant branch for this eventKind in declared order whose conditions
+	// all hold wins.
+	matched, target, instant := repository.MatchInstantBranchTarget(&bc, prog, eventKind)
 	if !matched {
-		return // no reply branch on this step matches this reply
+		return // no instant branch on this step matches this signal
+	}
+	if !instant {
+		return // branch opted out of instant: the scheduler routes it at the next step boundary
 	}
 	if target == nil {
 		return // matched a STOP branch: nothing to execute instantly
 	}
 
-	// IDEMPOTENCY: claim the one-time fire right BEFORE any side effect. If another
-	// reply event already fired this step's chain, stop here.
-	claimed, cerr := s.campaignProgressRepo.ClaimReplyActionFire(ctx, campaignID, contactID, currentStepID)
+	// IDEMPOTENCY: claim the one-time fire for THIS event kind right BEFORE any
+	// side effect. If another event of the same kind already fired this step's
+	// chain, stop here.
+	claimed, cerr := s.campaignProgressRepo.ClaimInstantFire(ctx, campaignID, contactID, currentStepID, eventKind)
 	if cerr != nil {
-		log.Warn().Err(cerr).Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: claim failed")
+		log.Warn().Err(cerr).Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Str("event", eventKind).Msg("instant actions: claim failed")
 		return
 	}
 	if !claimed {
-		return // already fired for this step (or no progress row): no-op
+		return // already fired this kind for this step (or no progress row): no-op
 	}
 
 	// Load the contact once for templating / activity records.
 	contact, xerr := s.contactRepo.GetByID(ctx, contactID)
 	if xerr != nil || contact == nil {
-		log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: contact load failed")
+		log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Str("event", eventKind).Msg("instant actions: contact load failed")
 		return
 	}
 	campaign, cmErr := s.campaignRepo.GetByID(ctx, campaignID)
 	if cmErr != nil || campaign == nil {
-		log.Warn().Str("campaign_id", campaignID.String()).Msg("instant reply actions: campaign load failed")
+		log.Warn().Str("campaign_id", campaignID.String()).Str("event", eventKind).Msg("instant actions: campaign load failed")
 		return
 	}
 
@@ -104,7 +126,7 @@ func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, conta
 	// non-action node (an email step resumes via the normal scheduler), an "end",
 	// or a "wait" (a wait means "not instant" — hand back to the scheduler).
 	stepID := *target
-	for hops := 0; hops < maxInstantReplyChain; hops++ {
+	for hops := 0; hops < maxInstantChain; hops++ {
 		node, live := byID[stepID]
 		if !live {
 			return // deleted / dangling target ends the instant chain
@@ -115,7 +137,7 @@ func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, conta
 		var cfg models.ActionConfig
 		if len(node.Action) > 0 {
 			if uerr := json.Unmarshal(node.Action, &cfg); uerr != nil {
-				log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Msg("instant reply actions: bad action json")
+				log.Warn().Err(uerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Str("event", eventKind).Msg("instant actions: bad action json")
 				return
 			}
 		}
@@ -128,17 +150,17 @@ func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, conta
 			return
 		}
 
-		s.executeReplyActionNode(ctx, campaign, contact, &cfg)
+		s.executeInstantActionNode(ctx, campaign, contact, &cfg, eventKind)
 
 		// Stamp this action node as "sent" for the contact. The scheduler's
 		// FindNextRoutedPair loop-guard (sentIDs) skips steps with sent_at set, so
 		// this is what stops the scheduler from re-running the very same chain when
-		// it later routes the contact through the reply branch at the next step
-		// boundary. Without it the chain would double-fire (deals/tasks/webhooks)
-		// whenever stop_on_reply is off or the reply was automated. Mirrors the
+		// it later routes the contact through this branch at the next step boundary.
+		// Without it the chain would double-fire (deals/tasks/webhooks) whenever the
+		// scheduler later routes the same opened/clicked/replied branch. Mirrors the
 		// scheduler's own action-node bookkeeping (tasks.campaign_task).
 		if rerr := s.campaignProgressRepo.RecordEmailSent(ctx, campaignID, contactID, node.ID); rerr != nil {
-			log.Warn().Err(rerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Msg("instant reply actions: failed to stamp action node sent")
+			log.Warn().Err(rerr).Str("campaign_id", campaignID.String()).Str("step_id", node.ID.String()).Str("event", eventKind).Msg("instant actions: failed to stamp action node sent")
 		}
 
 		// Advance to the next node in the chain by following this action node's
@@ -151,7 +173,46 @@ func (s *service) fireInstantReplyActions(ctx context.Context, campaignID, conta
 		}
 		stepID = next
 	}
-	log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Msg("instant reply actions: chain exceeded max hops; stopping")
+	log.Warn().Str("campaign_id", campaignID.String()).Str("contact_id", contactID.String()).Str("event", eventKind).Msg("instant actions: chain exceeded max hops; stopping")
+}
+
+// instantProgress builds the CampaignContactProgress the instant matcher reads.
+// It loads the contact's stored progress row for this step (which already
+// reflects the just-applied signal: RecordEmailOpened / RecordEmailClicked /
+// RecordReplyClassification all run before this) so composite conditions like
+// "clicked AND opened" evaluate against real timestamps. If no row is loadable
+// yet (a rare materialization race), it falls back to a minimal row that stamps
+// only the trigger signal for this eventKind, so the trigger field itself still
+// matches. The reply class is always taken from the loaded row.
+func (s *service) instantProgress(ctx context.Context, campaignID, contactID, stepID uuid.UUID, eventKind string) *repository.CampaignContactProgress {
+	prog := &repository.CampaignContactProgress{
+		CampaignID: campaignID,
+		ContactID:  contactID,
+		SequenceID: stepID,
+	}
+	if rows, err := s.campaignProgressRepo.GetContactProgress(ctx, campaignID, contactID); err == nil {
+		for i := range rows {
+			if rows[i].SequenceID == stepID {
+				r := rows[i]
+				prog = &r
+				break
+			}
+		}
+	}
+	// Guarantee the trigger signal is present even if the just-applied write has
+	// not propagated into the read above. Never clears a signal already loaded.
+	now := time.Now().UTC()
+	switch eventKind {
+	case "open":
+		if prog.OpenedAt == nil {
+			prog.OpenedAt = &now
+		}
+	case "click":
+		if prog.ClickedAt == nil {
+			prog.ClickedAt = &now
+		}
+	}
+	return prog
 }
 
 // nextChainTarget returns the single unconditional onward target of an action
@@ -176,13 +237,15 @@ func nextChainTarget(node *models.Sequence) (uuid.UUID, bool) {
 	return uuid.Nil, false
 }
 
-// executeReplyActionNode runs one action node's control-plane side effect for a
-// contact, NOW, in response to a reply. It mirrors tasks.executeActionNode but
-// stays inside the advanced service (advanced cannot import tasks — tasks imports
-// advanced), reusing the same repos and the CreateContactDeal / MoveContactDealStage
-// methods. Best-effort: each action logs and continues so one bad node never
-// aborts the rest of the chain or blocks inbox ingest.
-func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.Campaign, contact *models.Contact, cfg *models.ActionConfig) {
+// executeInstantActionNode runs one action node's control-plane side effect for a
+// contact, NOW, in response to an instant signal (reply / open / click).
+// eventKind is surfaced as the "trigger" on emitted events / logs. It mirrors
+// tasks.executeActionNode but stays inside the advanced service (advanced cannot
+// import tasks — tasks imports advanced), reusing the same repos and the
+// CreateContactDeal / MoveContactDealStage methods. Best-effort: each action logs
+// and continues so one bad node never aborts the rest of the chain or blocks the
+// caller's hot path.
+func (s *service) executeInstantActionNode(ctx context.Context, campaign *models.Campaign, contact *models.Contact, cfg *models.ActionConfig, eventKind string) {
 	switch cfg.Type {
 	case "add_tag":
 		if cfg.CategoryID == nil {
@@ -191,7 +254,7 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 		if _, xerr := s.contactRepo.Update(ctx, campaign.UserID, contact.ID.String(), &models.UpdateContact{
 			AddCategories: []string{cfg.CategoryID.String()},
 		}); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	case "remove_tag":
 		if cfg.CategoryID == nil {
@@ -200,11 +263,11 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 		if _, xerr := s.contactRepo.Update(ctx, campaign.UserID, contact.ID.String(), &models.UpdateContact{
 			RemoveCategories: []string{cfg.CategoryID.String()},
 		}); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	case "unsubscribe":
 		if xerr := s.Unsubscribe(ctx, campaign.ID, contact.ID); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	case "notify":
 		if campaign.OrganizationID == nil {
@@ -218,7 +281,7 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 			"campaign_id":   campaign.ID.String(),
 			"contact_id":    contact.ID.String(),
 			"contact_email": contact.Email,
-			"trigger":       "reply",
+			"trigger":       eventKind,
 		}
 		for k, v := range cfg.NotifyData {
 			data[k] = v
@@ -253,7 +316,7 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 			data.DueDate = &due
 		}
 		if _, xerr := s.CreateContactTask(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	case "create_deal":
 		if campaign.OrganizationID == nil {
@@ -287,7 +350,7 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 			AssignedTo: &owner,
 		}
 		if _, xerr := s.CreateContactDeal(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	case "move_deal_stage":
 		if campaign.OrganizationID == nil {
@@ -297,7 +360,7 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 			return
 		}
 		if _, xerr := s.MoveContactDealStage(ctx, *campaign.OrganizationID, contact.ID, *cfg.DealPipelineID, *cfg.DealStageID); xerr != nil {
-			s.logActionErr(campaign, contact, cfg.Type, xerr)
+			s.logActionErr(campaign, contact, cfg.Type, eventKind, xerr)
 		}
 	default:
 		// "wait" / "end" are handled by the chain walker (they stop the walk);
@@ -305,13 +368,13 @@ func (s *service) executeReplyActionNode(ctx context.Context, campaign *models.C
 	}
 }
 
-func (s *service) logActionErr(campaign *models.Campaign, contact *models.Contact, action string, err error) {
+func (s *service) logActionErr(campaign *models.Campaign, contact *models.Contact, action, eventKind string, err error) {
 	log.Warn().
 		Str("campaign_id", campaign.ID.String()).
 		Str("contact_id", contact.ID.String()).
 		Str("action", action).
-		Str("trigger", "reply").
-		Msg(fmt.Sprintf("instant reply action failed: %v", err))
+		Str("trigger", eventKind).
+		Msg(fmt.Sprintf("instant action failed: %v", err))
 }
 
 func contactDisplayName(contact *models.Contact) string {

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -82,6 +82,18 @@ type Service interface {
 	// "notify" action node) to customer webhooks and wired integrations.
 	EmitCampaignEvent(ctx context.Context, orgID uuid.UUID, eventType models.WebhookEventType, data map[string]any)
 
+	// FireInstantActions runs the matched INSTANT branch's action chain for a
+	// contact the moment an engagement signal lands for them, instead of waiting
+	// for the next scheduled step boundary. eventKind is "reply", "open", or
+	// "click" and selects which branch fields can fire (reply -> reply_* intent
+	// fields; open -> "opened"; click -> "clicked"). The signal must already be
+	// recorded on the contact's progress row before this is called. Best-effort
+	// and non-blocking: it never returns an error and must never block the caller's
+	// hot path. The tracking consumer calls this after RecordEmailOpened /
+	// RecordEmailClicked; ProcessIncomingReply calls the unexported path with
+	// "reply".
+	FireInstantActions(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, eventKind string)
+
 	// DLQ auto-retry
 	ProcessRetryableDeadLetters(ctx context.Context) (int, *errx.Error)
 }
@@ -775,14 +787,16 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 			_ = s.repo.MarkVariantEvent(ctx, cID, ctID, string(models.DeliverabilityEventReply))
 		}
 
-		// INSTANT reply trigger: if the contact's CURRENT step has a reply_* branch
-		// matching this just-classified reply, run that branch's action chain for
-		// THIS contact right now (instead of waiting for the next scheduled step
-		// boundary). Best-effort and non-blocking like the rest of reply handling —
-		// a failure must never block inbox ingest. Fires for both human and
-		// automated replies (reply_automated drives the auto-reply case) and exactly
-		// once per reply event via the reply_actions_fired_at gate.
-		s.fireInstantReplyActions(ctx, cID, ctID, sID, replyResult.Class)
+		// INSTANT reply trigger: if the contact's CURRENT step has a reply_* intent
+		// branch matching this just-classified reply, run that branch's
+		// action chain for THIS contact right now (instead of waiting for the next
+		// scheduled step boundary). Best-effort and non-blocking like the rest of
+		// reply handling — a failure must never block inbox ingest. Fires for both
+		// human and automated replies (reply_automated drives the auto-reply case)
+		// and exactly once per reply event via the instant_fired["reply"] gate. The
+		// just-classified reply_class and (human-only) replied_at have already been
+		// persisted above, so the matcher reads them off the loaded progress row.
+		s.fireInstantActions(ctx, cID, ctID, sID, "reply")
 	}
 
 	actionTaken := ""

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -774,6 +774,15 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 			_ = s.campaignProgressRepo.RecordEmailReplied(ctx, cID, ctID, sID)
 			_ = s.repo.MarkVariantEvent(ctx, cID, ctID, string(models.DeliverabilityEventReply))
 		}
+
+		// INSTANT reply trigger: if the contact's CURRENT step has a reply_* branch
+		// matching this just-classified reply, run that branch's action chain for
+		// THIS contact right now (instead of waiting for the next scheduled step
+		// boundary). Best-effort and non-blocking like the rest of reply handling —
+		// a failure must never block inbox ingest. Fires for both human and
+		// automated replies (reply_automated drives the auto-reply case) and exactly
+		// once per reply event via the reply_actions_fired_at gate.
+		s.fireInstantReplyActions(ctx, cID, ctID, sID, replyResult.Class)
 	}
 
 	actionTaken := ""

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -60,6 +60,19 @@ type Service interface {
 	// task_created activity on the contact.
 	CreateContactTask(ctx context.Context, orgID, createdBy uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
 
+	// CreateContactDeal opens a CRM deal for a contact, used by the campaign
+	// "create_deal" action node (typically off a positive reply branch). data
+	// carries pipeline/stage/name/value/currency; CampaignID is stamped for deal
+	// attribution. Records a deal-created activity on the contact.
+	CreateContactDeal(ctx context.Context, orgID uuid.UUID, createdBy uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error)
+
+	// MoveContactDealStage moves the contact's most-recent OPEN deal in
+	// pipelineID to stageID, used by the campaign "move_deal_stage" action node.
+	// When the contact has no open deal in that pipeline it is a no-op (returns
+	// nil, nil) rather than an error, so a chained reply automation doesn't fail
+	// just because a deal hasn't been created yet.
+	MoveContactDealStage(ctx context.Context, orgID, contactID, pipelineID, stageID uuid.UUID) (*models.Deal, *errx.Error)
+
 	// WireDispatcher attaches the event dispatcher that fans classified
 	// replies + deliverability events out to customer webhooks and third-party
 	// integration actions (Slack ping, CRM upsert).
@@ -304,6 +317,68 @@ func (s *service) CreateContactTask(ctx context.Context, orgID, createdBy uuid.U
 		})
 	}
 	return task, nil
+}
+
+// CreateContactDeal opens a deal for the contact (campaign "create_deal" node)
+// and records a deal_created activity. Mirrors CreateContactTask.
+func (s *service) CreateContactDeal(ctx context.Context, orgID uuid.UUID, createdBy uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error) {
+	if s.crmRepo == nil {
+		return nil, errx.InternalError()
+	}
+	deal, err := s.crmRepo.CreateDeal(ctx, orgID, data)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	if deal.ContactID != nil {
+		_ = s.crmRepo.RecordActivity(ctx, orgID, *deal.ContactID, &createdBy, models.ActivityDealCreated, map[string]interface{}{
+			"deal_id":   deal.ID.String(),
+			"deal_name": deal.Name,
+			"source":    "campaign",
+		})
+	}
+	return deal, nil
+}
+
+// MoveContactDealStage moves the contact's most-recent OPEN deal in pipelineID
+// to stageID. "Most-recent open deal" is resolved by scanning the contact's
+// deals (GetDealsByContact returns them created_at DESC) and taking the first
+// one whose pipeline matches and whose status is still "open". No open deal in
+// that pipeline is a deliberate no-op (returns nil, nil) so a chained reply
+// automation doesn't error just because nothing has been created yet.
+func (s *service) MoveContactDealStage(ctx context.Context, orgID, contactID, pipelineID, stageID uuid.UUID) (*models.Deal, *errx.Error) {
+	if s.crmRepo == nil {
+		return nil, errx.InternalError()
+	}
+	deals, err := s.crmRepo.GetDealsByContact(ctx, contactID)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	var target *models.Deal
+	for i := range deals {
+		d := deals[i]
+		if d.PipelineID == pipelineID && d.Status == models.DealStatusOpen {
+			target = &d
+			break // GetDealsByContact is created_at DESC => first match is newest
+		}
+	}
+	if target == nil {
+		// No open deal in this pipeline: documented no-op (not an error).
+		return nil, nil
+	}
+	if target.StageID == stageID {
+		return target, nil // already there
+	}
+	updated, uerr := s.crmRepo.UpdateDeal(ctx, orgID, target.ID, &models.UpdateDeal{StageID: &stageID})
+	if uerr != nil {
+		return nil, toErrx(uerr)
+	}
+	_ = s.crmRepo.RecordActivity(ctx, orgID, contactID, nil, models.ActivityDealStageChange, map[string]interface{}{
+		"deal_id": updated.ID.String(),
+		"from":    target.StageID.String(),
+		"to":      stageID.String(),
+		"source":  "campaign",
+	})
+	return updated, nil
 }
 
 func (s *service) Unsubscribe(ctx context.Context, campaignID, contactID uuid.UUID) *errx.Error {

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/replyclassify"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/gtasks"
@@ -475,6 +476,44 @@ func cleanMessageID(mid string) string {
 	return strings.TrimSpace(strings.Trim(mid, "<>"))
 }
 
+// buildReplyHeaders synthesizes the header map the reply classifier's Layer 1
+// (header) scan reads. EmailMessageStoreData does not carry the full raw header
+// block, but it does carry the structured fields the deterministic markers care
+// about (From, Reply-To) plus any custom headers the worker folded into Flags
+// using the "Header-Name:value" convention (the same encoding extractHeaderValue
+// relies on for the warmup token). That lets RFC 3834 / Precedence / X-Autoreply
+// markers reach the classifier when the worker forwarded them, while the From
+// (mailer-daemon / no-reply) and Subject ("Automatic reply") signals work from
+// the always-present structured fields.
+func buildReplyHeaders(msg *models.EmailMessageStoreData) map[string][]string {
+	if msg == nil {
+		return nil
+	}
+	h := map[string][]string{}
+	if len(msg.FromAddr) > 0 {
+		h["From"] = msg.FromAddr
+	}
+	if len(msg.ReplyTo) > 0 {
+		h["Reply-To"] = msg.ReplyTo
+	}
+	if msg.Subject != "" {
+		h["Subject"] = []string{msg.Subject}
+	}
+	// Custom headers the worker stored as "Header-Name:value" flags (auto-reply
+	// markers, Precedence, etc.). Split on the FIRST colon so header values that
+	// contain ':' survive intact.
+	for _, flag := range msg.Flags {
+		if i := strings.Index(flag, ":"); i > 0 {
+			name := strings.TrimSpace(flag[:i])
+			val := strings.TrimSpace(flag[i+1:])
+			if name != "" && !strings.HasPrefix(name, "\\") {
+				h[name] = append(h[name], val)
+			}
+		}
+	}
+	return h
+}
+
 func containsAnyKeyword(text string, keywords []string) bool {
 	if text == "" {
 		return false
@@ -572,6 +611,11 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 	text = strings.TrimSpace(text + "\n" + msg.Subject)
 	intent, confidence := classifyReply(text, settings.ReplyIntent)
 
+	// Layered reply classification (header -> lexicon -> optional model) is run
+	// further down, once the campaign context is known to store it on. Classifying
+	// only inside that block means a reply with no campaign match never spends a
+	// model call.
+
 	var campaignID *uuid.UUID
 	var sequenceID *uuid.UUID
 	var contactID *uuid.UUID
@@ -616,8 +660,45 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 	}
 
 	if campaignID != nil && contactID != nil && sequenceID != nil {
-		_ = s.campaignProgressRepo.RecordEmailReplied(ctx, *campaignID, *contactID, *sequenceID)
-		_ = s.repo.MarkVariantEvent(ctx, *campaignID, *contactID, string(models.DeliverabilityEventReply))
+		cID, ctID, sID := *campaignID, *contactID, *sequenceID
+
+		// Cost guard for the optional AI layer (Layer 3). Layers 1-2 (headers +
+		// lexicon) are free and always run; the paid model is only spent on a
+		// genuinely new, non-trivial, human-looking reply from a contact we have
+		// not already classified. So one contact spamming replies costs at most a
+		// single model call, and trivial/boilerplate bodies never reach the model.
+		gate := func() bool {
+			if !replyclassify.WorthModeling(replyclassify.Input{BodyText: msg.Snippet}) {
+				return false
+			}
+			if prior, perr := s.campaignProgressRepo.GetLatestReplyClass(ctx, ctID, cID); perr == nil &&
+				prior != "" && prior != replyclassify.ClassUnknown {
+				return false
+			}
+			return true
+		}
+
+		replyResult := replyclassify.ClassifyGated(ctx, replyclassify.Input{
+			Headers:  buildReplyHeaders(msg),
+			Subject:  msg.Subject,
+			BodyText: msg.Snippet,
+		}, gate)
+
+		// Always persist the classifier verdict so reply_* branches can route on
+		// it (including reply_automated for OOO / autoresponders). Layers 1-2 run
+		// for every reply, so OOO/unsubscribe stay correct even when the gate
+		// skipped the model.
+		_ = s.campaignProgressRepo.RecordReplyClassification(ctx, cID, ctID, sID, replyResult.Class, replyResult.Source, replyResult.Confidence)
+
+		// OOO trap fix: only a HUMAN reply stamps replied_at. An auto_reply /
+		// out_of_office must NOT count as a reply, or it would (a) trip
+		// stop_on_reply and silently halt the sequence, and (b) match the plain
+		// "replied" branch. Both stop_on_reply and the "replied" condition key off
+		// replied_at IS NOT NULL, so gating the stamp here fixes both at once.
+		if !replyclassify.IsAutomated(replyResult.Class) {
+			_ = s.campaignProgressRepo.RecordEmailReplied(ctx, cID, ctID, sID)
+			_ = s.repo.MarkVariantEvent(ctx, cID, ctID, string(models.DeliverabilityEventReply))
+		}
 	}
 
 	actionTaken := ""

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -53,6 +53,12 @@ type Service interface {
 	ProcessIncomingReply(ctx context.Context, emailAccountID uuid.UUID, msg *models.EmailMessageStoreData) *errx.Error
 	GetABWinnerAnalysis(ctx context.Context, organizationID, campaignID uuid.UUID) (*models.ABWinnerAnalysis, *errx.Error)
 
+	// CreateContactTask creates a CRM task for a contact, used by the campaign
+	// "create task" action node. createdBy is the campaign owner; the task's
+	// AssignedTo (set in data) is the teammate chosen on the step. Records a
+	// task_created activity on the contact.
+	CreateContactTask(ctx context.Context, orgID, createdBy uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
+
 	// WireDispatcher attaches the event dispatcher that fans classified
 	// replies + deliverability events out to customer webhooks and third-party
 	// integration actions (Slack ping, CRM upsert).
@@ -281,6 +287,24 @@ func (s *service) ShouldSuppressRecipient(ctx context.Context, organizationID uu
 // Unsubscribe resolves the campaign + contact behind a List-Unsubscribe link and
 // suppresses the recipient org-wide. Always suppresses (an explicit recipient
 // request), then fans out the campaign.unsubscribed event for Slack/CRM.
+func (s *service) CreateContactTask(ctx context.Context, orgID, createdBy uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error) {
+	if s.crmRepo == nil {
+		return nil, errx.InternalError()
+	}
+	task, err := s.crmRepo.CreateCRMTask(ctx, orgID, createdBy, data)
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	if task.ContactID != nil {
+		_ = s.crmRepo.RecordActivity(ctx, orgID, *task.ContactID, &createdBy, models.ActivityTaskCreated, map[string]interface{}{
+			"task_id":    task.ID.String(),
+			"task_title": task.Title,
+			"source":     "campaign",
+		})
+	}
+	return task, nil
+}
+
 func (s *service) Unsubscribe(ctx context.Context, campaignID, contactID uuid.UUID) *errx.Error {
 	campaign, err := s.campaignRepo.GetByID(ctx, campaignID)
 	if err != nil || campaign == nil || campaign.OrganizationID == nil {

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -43,7 +43,11 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 		s.StreamingPublisher.PublishEmailReceived(ctx, emailInboxEvent(e.UserID, e.Message))
 	}
 
-	// Advanced reply-intent automation is best-effort and should not block inbox ingest.
+	// Advanced reply-intent automation is best-effort and should not block inbox
+	// ingest. ProcessIncomingReply also runs the layered reply classifier
+	// (replyclassify) and persists reply_class/confidence/source on the contact's
+	// campaign progress, gating replied_at so automated replies (auto_reply /
+	// out_of_office) never count as a human reply for stop_on_reply / branching.
 	if s.AdvancedService != nil {
 		_ = s.AdvancedService.ProcessIncomingReply(ctx, e.Message.EmailID, e.Message)
 	}

--- a/internal/app/consumer/event_tracking.go
+++ b/internal/app/consumer/event_tracking.go
@@ -10,6 +10,7 @@ import (
 	ckf "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/app/advanced"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/events"
 	"github.com/warmbly/warmbly/internal/infrastructure/kafka"
@@ -26,7 +27,12 @@ type TrackingConsumer struct {
 	contactRepo          repository.ContactRepository
 	streamingPublisher   *pubsub.StreamingPublisher
 	dedupeRepo           repository.TrackingDedupeRepository
-	topic                string
+	// advancedService fires INSTANT open/click action chains the moment a
+	// tracking event lands (the open/click analog of the reply path in
+	// ProcessIncomingReply). Best-effort and nil-safe: when unset, opens/clicks
+	// are still recorded and routed at the next step boundary by the scheduler.
+	advancedService advanced.Service
+	topic           string
 }
 
 // NewTrackingConsumer creates a new tracking consumer using existing Kafka infrastructure
@@ -40,6 +46,7 @@ func NewTrackingConsumer(
 	contactRepo repository.ContactRepository,
 	streamingPublisher *pubsub.StreamingPublisher,
 	dedupeRepo repository.TrackingDedupeRepository,
+	advancedService advanced.Service,
 ) (*TrackingConsumer, error) {
 	// Create Kafka consumer using existing infrastructure
 	consumerConfig := kafka.NewConsumer(cfg.Brokers)
@@ -77,6 +84,7 @@ func NewTrackingConsumer(
 		contactRepo:          contactRepo,
 		streamingPublisher:   streamingPublisher,
 		dedupeRepo:           dedupeRepo,
+		advancedService:      advancedService,
 		topic:                cfg.Topic,
 	}, nil
 }
@@ -151,18 +159,25 @@ func (tc *TrackingConsumer) HandleTrackingEvent(ctx context.Context, event *even
 		return nil
 	}
 
-	// Record the event
+	// Record the event, then fire any INSTANT open/click action chain for the
+	// contact's current step the moment the signal lands (the open/click analog of
+	// the reply path in ProcessIncomingReply). instantKind maps the tracking event
+	// to the matcher's eventKind. Firing happens AFTER the Record* write so the
+	// matcher reads the just-stamped opened_at / clicked_at off the progress row.
+	var instantKind string
 	switch event.EventType {
 	case events.EventTypeEmailOpened:
 		err = tc.campaignProgressRepo.RecordEmailOpened(ctx,
 			*campaignTask.CampaignID,
 			*campaignTask.ContactID,
 			*campaignTask.SequenceID)
+		instantKind = "open"
 	case events.EventTypeEmailClicked:
 		err = tc.campaignProgressRepo.RecordEmailClicked(ctx,
 			*campaignTask.CampaignID,
 			*campaignTask.ContactID,
 			*campaignTask.SequenceID)
+		instantKind = "click"
 	default:
 		// Unknown event type, skip
 		return nil
@@ -171,6 +186,19 @@ func (tc *TrackingConsumer) HandleTrackingEvent(ctx context.Context, event *even
 	if err != nil {
 		log.Error().Err(err).Str("task_id", event.TaskID).Str("event_type", string(event.EventType)).Msg("failed to record tracking event")
 		return nil
+	}
+
+	// INSTANT open/click trigger: best-effort and non-blocking, mirroring the
+	// reply path. A failure (or a nil service in a process that doesn't wire it)
+	// must never block tracking ingest; the scheduler still routes the matching
+	// opened/clicked branch at the next step boundary. Exactly-once per (step,
+	// eventKind) is enforced inside FireInstantActions via ClaimInstantFire.
+	if tc.advancedService != nil {
+		tc.advancedService.FireInstantActions(ctx,
+			*campaignTask.CampaignID,
+			*campaignTask.ContactID,
+			*campaignTask.SequenceID,
+			instantKind)
 	}
 
 	// Mark as processed for deduplication

--- a/internal/app/contact/handler.go
+++ b/internal/app/contact/handler.go
@@ -2,6 +2,7 @@ package contact
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -98,6 +99,15 @@ func (s *contactService) Delete(ctx context.Context, userID string, contactID st
 
 func (s *contactService) GetDetail(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, contactID uuid.UUID) (*models.ContactDetail, *errx.Error) {
 	return s.contactRepository.GetDetail(ctx, userID, orgID, contactID)
+}
+
+func (s *contactService) GetByEmail(ctx context.Context, orgID *uuid.UUID, email string) (*models.Contact, *errx.Error) {
+	if orgID == nil || strings.TrimSpace(email) == "" {
+		return nil, nil
+	}
+	// The repo already returns (nil, nil) when no contact matches, so an
+	// unknown sender flows through as a clean "no contact" rather than an error.
+	return s.contactRepository.GetByEmailAndOrganization(ctx, *orgID, email)
 }
 
 func (s *contactService) ListSentEmails(ctx context.Context, userID, contactID uuid.UUID, limit int, beforeSentAt *time.Time, beforeTaskID *uuid.UUID) (*models.ContactSentEmailsResult, *errx.Error) {

--- a/internal/app/contact/service.go
+++ b/internal/app/contact/service.go
@@ -38,6 +38,12 @@ type ContactService interface {
 	// slide-over: hydrated contact + engagement summary + suppression.
 	GetDetail(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, contactID uuid.UUID) (*models.ContactDetail, *errx.Error)
 
+	// GetByEmail resolves a sender address to a contact within the
+	// organization (newest match wins). Returns (nil, nil) when the org has
+	// no contact for that address — a "not a known contact" is a normal,
+	// non-error outcome used by the unibox CRM panel.
+	GetByEmail(ctx context.Context, orgID *uuid.UUID, email string) (*models.Contact, *errx.Error)
+
 	// ListSentEmails enumerates every send (or attempted send) we made
 	// to the contact, newest first.
 	ListSentEmails(ctx context.Context, userID, contactID uuid.UUID, limit int, beforeSentAt *time.Time, beforeTaskID *uuid.UUID) (*models.ContactSentEmailsResult, *errx.Error)

--- a/internal/app/crm/service.go
+++ b/internal/app/crm/service.go
@@ -47,6 +47,8 @@ type CRMService interface {
 	CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
 	GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID) (*models.CRMTask, *errx.Error)
 	ListCRMTasks(ctx context.Context, orgID uuid.UUID, contactID, dealID, assignedTo *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.CRMTasksResult, *errx.Error)
+	SearchTasks(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks, limit, offset int) (*models.TasksSearchResult, *errx.Error)
+	TasksSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks) (*models.TasksSummary, *errx.Error)
 	UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID, userID *uuid.UUID, data *models.UpdateCRMTask) (*models.CRMTask, *errx.Error)
 	DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) *errx.Error
 
@@ -396,6 +398,28 @@ func (s *crmService) ListCRMTasks(ctx context.Context, orgID uuid.UUID, contactI
 		limit = 50
 	}
 	result, err := s.repo.ListCRMTasks(ctx, orgID, contactID, dealID, assignedTo, status, limit, cursor)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return result, nil
+}
+
+func (s *crmService) SearchTasks(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks, limit, offset int) (*models.TasksSearchResult, *errx.Error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	result, err := s.repo.SearchCRMTasks(ctx, orgID, filters, limit, offset)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return result, nil
+}
+
+func (s *crmService) TasksSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks) (*models.TasksSummary, *errx.Error) {
+	result, err := s.repo.TasksSummary(ctx, orgID, filters)
 	if err != nil {
 		return nil, toErrx(err)
 	}

--- a/internal/app/crm/service.go
+++ b/internal/app/crm/service.go
@@ -3,6 +3,7 @@ package crm
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/errx"
@@ -48,6 +49,12 @@ type CRMService interface {
 	ListCRMTasks(ctx context.Context, orgID uuid.UUID, contactID, dealID, assignedTo *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.CRMTasksResult, *errx.Error)
 	UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID, userID *uuid.UUID, data *models.UpdateCRMTask) (*models.CRMTask, *errx.Error)
 	DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) *errx.Error
+
+	// CRM Task Types (user-managed)
+	ListTaskTypes(ctx context.Context, orgID uuid.UUID) ([]models.CRMTaskType, *errx.Error)
+	CreateTaskType(ctx context.Context, orgID uuid.UUID, data *models.CreateCRMTaskType) (*models.CRMTaskType, *errx.Error)
+	UpdateTaskType(ctx context.Context, orgID, typeID uuid.UUID, data *models.UpdateCRMTaskType) (*models.CRMTaskType, *errx.Error)
+	DeleteTaskType(ctx context.Context, orgID, typeID uuid.UUID) *errx.Error
 }
 
 type crmService struct {
@@ -410,6 +417,49 @@ func (s *crmService) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID,
 	}
 
 	return task, nil
+}
+
+func (s *crmService) ListTaskTypes(ctx context.Context, orgID uuid.UUID) ([]models.CRMTaskType, *errx.Error) {
+	types, err := s.repo.ListTaskTypes(ctx, orgID)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return types, nil
+}
+
+func (s *crmService) CreateTaskType(ctx context.Context, orgID uuid.UUID, data *models.CreateCRMTaskType) (*models.CRMTaskType, *errx.Error) {
+	name := strings.TrimSpace(data.Name)
+	if name == "" || len(name) > 60 {
+		return nil, errx.New(errx.BadRequest, "task type name must be between 1 and 60 characters")
+	}
+	data.Name = name
+	t, err := s.repo.CreateTaskType(ctx, orgID, data)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return t, nil
+}
+
+func (s *crmService) UpdateTaskType(ctx context.Context, orgID, typeID uuid.UUID, data *models.UpdateCRMTaskType) (*models.CRMTaskType, *errx.Error) {
+	if data.Name != nil {
+		name := strings.TrimSpace(*data.Name)
+		if name == "" || len(name) > 60 {
+			return nil, errx.New(errx.BadRequest, "task type name must be between 1 and 60 characters")
+		}
+		data.Name = &name
+	}
+	t, err := s.repo.UpdateTaskType(ctx, orgID, typeID, data)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return t, nil
+}
+
+func (s *crmService) DeleteTaskType(ctx context.Context, orgID, typeID uuid.UUID) *errx.Error {
+	if err := s.repo.DeleteTaskType(ctx, orgID, typeID); err != nil {
+		return toErrx(err)
+	}
+	return nil
 }
 
 func (s *crmService) DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) *errx.Error {

--- a/internal/app/crm/service.go
+++ b/internal/app/crm/service.go
@@ -36,6 +36,8 @@ type CRMService interface {
 	CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error)
 	GetDeal(ctx context.Context, orgID, dealID uuid.UUID) (*models.Deal, *errx.Error)
 	ListDeals(ctx context.Context, orgID uuid.UUID, pipelineID, stageID *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.DealsResult, *errx.Error)
+	SearchDeals(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals, limit, offset int) (*models.DealsSearchResult, *errx.Error)
+	DealsSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals) (*models.DealsSummary, *errx.Error)
 	UpdateDeal(ctx context.Context, orgID, dealID uuid.UUID, userID *uuid.UUID, data *models.UpdateDeal) (*models.Deal, *errx.Error)
 	DeleteDeal(ctx context.Context, orgID, dealID uuid.UUID) *errx.Error
 	GetDealsByContact(ctx context.Context, contactID uuid.UUID) ([]models.Deal, *errx.Error)
@@ -266,6 +268,28 @@ func (s *crmService) ListDeals(ctx context.Context, orgID uuid.UUID, pipelineID,
 		limit = 50
 	}
 	result, err := s.repo.ListDeals(ctx, orgID, pipelineID, stageID, status, limit, cursor)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return result, nil
+}
+
+func (s *crmService) SearchDeals(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals, limit, offset int) (*models.DealsSearchResult, *errx.Error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	result, err := s.repo.SearchDeals(ctx, orgID, filters, limit, offset)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return result, nil
+}
+
+func (s *crmService) DealsSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals) (*models.DealsSummary, *errx.Error) {
+	result, err := s.repo.DealsSummary(ctx, orgID, filters)
 	if err != nil {
 		return nil, toErrx(err)
 	}

--- a/internal/app/replyclassify/classifier.go
+++ b/internal/app/replyclassify/classifier.go
@@ -1,0 +1,133 @@
+// Package replyclassify classifies an inbound email reply into a small, stable
+// set of classes used by campaign reply automation (reply branching, the
+// OOO-aware stop_on_reply check, and CRM actions).
+//
+// Classification is layered, cheapest-first, and the cheap layers are pure:
+//
+//	Layer 1 (headers): deterministic, offline. RFC 3834 auto-submission markers,
+//	        Precedence: bulk/auto_reply, vendor auto-responder headers, null
+//	        Return-Path, delivery-status reports, mailer-daemon senders, and the
+//	        well-known "Automatic reply" / "Out of Office" subjects.
+//	Layer 2 (lexicon): deterministic, offline keyword scan. Compliance words
+//	        (unsubscribe / stop / remove me) win first; then clear interest
+//	        phrases (positive) and clear rejection (negative).
+//	Layer 3 (model): OPTIONAL, gated by OPENAI_API_KEY. Only the ambiguous middle
+//	        reaches it. When the key is unset we NEVER call out and fall back to
+//	        "unknown".
+//
+// Layers 1 and 2 are pure and deterministic; only Layer 3 has side effects and
+// only when explicitly configured.
+package replyclassify
+
+import (
+	"context"
+	"strings"
+)
+
+// Reply class enum. These exact strings are the shared contract: they are stored
+// on campaign_contact_progress.reply_class and matched by the reply_* branch
+// conditions in the campaign editor. Keep in sync with migration 000027's CHECK
+// constraint and the frontend.
+const (
+	ClassPositive    = "positive"
+	ClassNegative    = "negative"
+	ClassNeutral     = "neutral"
+	ClassAutoReply   = "auto_reply"
+	ClassOutOfOffice = "out_of_office"
+	ClassUnsubscribe = "unsubscribe"
+	ClassUnknown     = "unknown"
+)
+
+// Source enum: which layer produced the verdict. Stored in
+// campaign_contact_progress.reply_source. "" means unclassified.
+const (
+	SourceHeader  = "header"
+	SourceLexicon = "lexicon"
+	SourceModel   = "model"
+)
+
+// Input is the minimal projection of an inbound reply the classifier needs.
+// Headers is the raw header map (canonical or lower-cased keys both tolerated);
+// Subject and BodyText are best-effort plain text (snippet is fine).
+type Input struct {
+	Headers  map[string][]string
+	Subject  string
+	BodyText string
+}
+
+// Result is the classifier verdict. Confidence is in [0,1]. Source names the
+// layer that decided.
+type Result struct {
+	Class      string
+	Confidence float64
+	Source     string
+}
+
+// Classify runs the layered pipeline. Layers 1-2 are pure/deterministic and
+// always run offline. Layer 3 (the model) runs only when an OPENAI_API_KEY-gated
+// classifier is configured; otherwise the ambiguous middle resolves to
+// "unknown" without any network call.
+//
+// Classify uses context.Background for the optional model call so existing pure
+// callers don't need a ctx. Use ClassifyContext to pass a deadline.
+func Classify(in Input) Result {
+	return ClassifyContext(context.Background(), in)
+}
+
+// ClassifyContext is Classify with an explicit context for the optional model
+// layer. Layers 1-2 ignore the context entirely (no I/O). The model layer is
+// always allowed (subject only to the OPENAI_API_KEY gate).
+func ClassifyContext(ctx context.Context, in Input) Result {
+	return ClassifyGated(ctx, in, nil)
+}
+
+// ModelGate decides, lazily, whether the optional Layer-3 model call is worth
+// making. It is consulted ONLY after Layers 1-2 were inconclusive (the cheap,
+// free path already short-circuits auto-replies, OOO, bounces, unsubscribes and
+// clear sentiment), so returning false caps AI spend on a reply flood by falling
+// back to "unknown". The caller supplies the policy (e.g. skip if this contact
+// was already classified, or an org budget is exhausted).
+type ModelGate func() bool
+
+// ClassifyGated is ClassifyContext with a gate on the optional model layer.
+// gate == nil behaves exactly like the ungated pipeline (model allowed whenever
+// the OPENAI_API_KEY classifier is configured).
+func ClassifyGated(ctx context.Context, in Input, gate ModelGate) Result {
+	// Layer 1: headers (deterministic, offline). An automated message is decided
+	// here and never reaches the lexicon/model layers.
+	if r, ok := classifyHeaders(in); ok {
+		return r
+	}
+
+	// Layer 2: lexicon (deterministic, offline). Compliance words win, then
+	// clear interest / rejection.
+	if r, ok := classifyLexicon(in); ok {
+		return r
+	}
+
+	// Layer 3: model (optional, OPENAI_API_KEY-gated AND cost-gated). Skipped
+	// entirely when the gate declines, with no network call.
+	if gate == nil || gate() {
+		if r, ok := classifyModel(ctx, in); ok {
+			return r
+		}
+	}
+
+	return Result{Class: ClassUnknown, Confidence: 0, Source: ""}
+}
+
+// WorthModeling is a cheap content-sanity pre-check for the model layer: a reply
+// with too little human text to carry sentiment the lexicon already missed is not
+// worth a paid classification (trivial "ok"/"thanks" acks, empty/whitespace
+// bodies). Use it inside a ModelGate.
+func WorthModeling(in Input) bool {
+	return len([]rune(strings.TrimSpace(in.BodyText))) >= 12
+}
+
+// IsAutomated reports whether a stored reply_class represents an automated
+// (non-human) reply. This is the single source of truth for the "OOO trap":
+// stop_on_reply and the plain "replied" branch condition must NOT treat these as
+// a human reply.
+func IsAutomated(class string) bool {
+	return class == ClassAutoReply || class == ClassOutOfOffice
+}

--- a/internal/app/replyclassify/headers.go
+++ b/internal/app/replyclassify/headers.go
@@ -1,0 +1,116 @@
+package replyclassify
+
+import "strings"
+
+// classifyHeaders is Layer 1: a deterministic, offline scan of the message
+// headers (plus subject) for the well-known machine-reply markers. It returns
+// (result, true) when it definitively recognizes an automated message; (zero,
+// false) otherwise so the pipeline falls through to the lexicon/model layers.
+//
+// We map out_of_office vs auto_reply where the signal distinguishes them, and
+// fold bounces / delivery-status reports into auto_reply (a non-human, machine
+// reply). Bounces are NOT given a distinct class on purpose: campaign branching
+// only needs "automated vs human", a hard bounce already drives suppression and
+// the dedicated bounced_at signal elsewhere, and a separate "bounce" class would
+// have no branch field to route on. This is documented here as the deliberate
+// choice for the contract's "bounces => ... your call but document it" clause.
+func classifyHeaders(in Input) (Result, bool) {
+	h := newHeaderLookup(in.Headers)
+	subject := strings.ToLower(strings.TrimSpace(in.Subject))
+
+	// --- Out-of-office signals (most specific machine reply) ---
+	// Subject conventions providers emit for vacation autoresponders.
+	if strings.HasPrefix(subject, "out of office") ||
+		strings.HasPrefix(subject, "out of the office") ||
+		strings.Contains(subject, "automatic reply") ||
+		strings.Contains(subject, "auto-reply") ||
+		strings.HasPrefix(subject, "autoreply") ||
+		strings.HasPrefix(subject, "auto:") ||
+		strings.Contains(subject, "on vacation") ||
+		strings.Contains(subject, "on holiday") ||
+		strings.Contains(subject, "away from") {
+		return Result{Class: ClassOutOfOffice, Confidence: 0.98, Source: SourceHeader}, true
+	}
+
+	// RFC 3834 Auto-Submitted. "auto-replied" is canonically a vacation/auto
+	// responder; "auto-generated" is any machine-generated message.
+	if as := strings.ToLower(h.first("Auto-Submitted")); as != "" && as != "no" {
+		if strings.Contains(as, "auto-replied") {
+			return Result{Class: ClassOutOfOffice, Confidence: 0.95, Source: SourceHeader}, true
+		}
+		return Result{Class: ClassAutoReply, Confidence: 0.95, Source: SourceHeader}, true
+	}
+
+	// Vendor auto-responder headers (set by Exchange, Zimbra, helpdesks, etc.).
+	if h.has("X-Autoreply") || h.has("X-Autorespond") ||
+		strings.EqualFold(h.first("X-Autoreply"), "yes") {
+		return Result{Class: ClassOutOfOffice, Confidence: 0.93, Source: SourceHeader}, true
+	}
+	if ars := h.first("X-Auto-Response-Suppress"); ars != "" {
+		// Present on Exchange auto-responses; the message itself is automated.
+		return Result{Class: ClassAutoReply, Confidence: 0.9, Source: SourceHeader}, true
+	}
+
+	// Precedence: bulk/junk/auto_reply marks list/automated traffic.
+	if prec := strings.ToLower(h.first("Precedence")); prec != "" {
+		switch prec {
+		case "auto_reply":
+			return Result{Class: ClassAutoReply, Confidence: 0.9, Source: SourceHeader}, true
+		case "bulk", "junk", "list":
+			return Result{Class: ClassAutoReply, Confidence: 0.75, Source: SourceHeader}, true
+		}
+	}
+
+	// --- Bounce / delivery-status report signals => auto_reply (machine) ---
+	// multipart/report; report-type=delivery-status is a DSN bounce.
+	ct := strings.ToLower(h.first("Content-Type"))
+	if strings.Contains(ct, "multipart/report") &&
+		(strings.Contains(ct, "delivery-status") || strings.Contains(ct, "disposition-notification")) {
+		return Result{Class: ClassAutoReply, Confidence: 0.95, Source: SourceHeader}, true
+	}
+
+	// Null Return-Path <> is the canonical bounce / non-reply-expecting envelope.
+	if rp := strings.TrimSpace(h.first("Return-Path")); rp == "<>" || rp == "" && h.has("Return-Path") {
+		return Result{Class: ClassAutoReply, Confidence: 0.85, Source: SourceHeader}, true
+	}
+
+	// mailer-daemon / postmaster style senders are machine bounce sources.
+	if from := strings.ToLower(h.first("From")); from != "" {
+		if strings.Contains(from, "mailer-daemon") ||
+			strings.Contains(from, "postmaster@") ||
+			strings.Contains(from, "no-reply@") ||
+			strings.Contains(from, "noreply@") ||
+			strings.Contains(from, "donotreply@") {
+			return Result{Class: ClassAutoReply, Confidence: 0.8, Source: SourceHeader}, true
+		}
+	}
+
+	return Result{}, false
+}
+
+// headerLookup is a case-insensitive view over an email header map. MIME header
+// maps are normally canonical-cased ("Auto-Submitted"), but inbound sync may
+// hand us lower-cased keys, so we index both.
+type headerLookup struct {
+	byLower map[string][]string
+}
+
+func newHeaderLookup(h map[string][]string) headerLookup {
+	m := make(map[string][]string, len(h))
+	for k, v := range h {
+		m[strings.ToLower(k)] = v
+	}
+	return headerLookup{byLower: m}
+}
+
+func (h headerLookup) first(name string) string {
+	if vs := h.byLower[strings.ToLower(name)]; len(vs) > 0 {
+		return strings.TrimSpace(vs[0])
+	}
+	return ""
+}
+
+func (h headerLookup) has(name string) bool {
+	_, ok := h.byLower[strings.ToLower(name)]
+	return ok
+}

--- a/internal/app/replyclassify/lexicon.go
+++ b/internal/app/replyclassify/lexicon.go
@@ -1,0 +1,109 @@
+package replyclassify
+
+import "strings"
+
+// classifyLexicon is Layer 2: a deterministic, offline keyword scan over the
+// subject + body. It returns (result, true) only on a CLEAR signal; ambiguous
+// text returns (zero, false) so the optional model layer (or "unknown") decides.
+//
+// Order matters and encodes priority:
+//  1. Compliance words (unsubscribe / stop / remove me / take me off) ALWAYS win.
+//     Treating these as anything other than an unsubscribe request is a
+//     compliance risk, so they short-circuit before sentiment.
+//  2. Clear interest phrases => positive.
+//  3. Clear rejection phrases => negative.
+func classifyLexicon(in Input) (Result, bool) {
+	text := strings.ToLower(strings.TrimSpace(in.Subject + "\n" + in.BodyText))
+	if text == "" {
+		return Result{}, false
+	}
+
+	// 1. Compliance / opt-out (highest priority).
+	for _, kw := range unsubscribeKeywords {
+		if strings.Contains(text, kw) {
+			return Result{Class: ClassUnsubscribe, Confidence: 0.9, Source: SourceLexicon}, true
+		}
+	}
+
+	// 2. Clear interest => positive.
+	for _, kw := range positiveKeywords {
+		if strings.Contains(text, kw) {
+			return Result{Class: ClassPositive, Confidence: 0.8, Source: SourceLexicon}, true
+		}
+	}
+
+	// 3. Clear rejection => negative.
+	for _, kw := range negativeKeywords {
+		if strings.Contains(text, kw) {
+			return Result{Class: ClassNegative, Confidence: 0.8, Source: SourceLexicon}, true
+		}
+	}
+
+	return Result{}, false
+}
+
+// unsubscribeKeywords are explicit opt-out requests. Compliance-first: any of
+// these short-circuits to "unsubscribe" before sentiment is considered.
+var unsubscribeKeywords = []string{
+	"unsubscribe",
+	"opt out",
+	"opt-out",
+	"remove me",
+	"take me off",
+	"stop emailing",
+	"stop contacting",
+	"do not contact",
+	"don't contact",
+	"do not email",
+	"don't email",
+	"please stop",
+}
+
+// positiveKeywords are clear buying / interest signals. Kept conservative so the
+// deterministic layer only fires on unambiguous intent; nuance is left to the
+// model layer.
+var positiveKeywords = []string{
+	"interested",
+	"sounds good",
+	"sounds great",
+	"let's chat",
+	"lets chat",
+	"let's talk",
+	"lets talk",
+	"happy to chat",
+	"happy to talk",
+	"set up a call",
+	"book a call",
+	"schedule a call",
+	"schedule a demo",
+	"book a demo",
+	"send me more",
+	"tell me more",
+	"would love to",
+	"count me in",
+	"sign me up",
+	"how much does it cost",
+	"what's the pricing",
+	"whats the pricing",
+	"send pricing",
+}
+
+// negativeKeywords are clear rejection signals. "not interested" is the canonical
+// cold-outreach brush-off.
+var negativeKeywords = []string{
+	"not interested",
+	"no thanks",
+	"no thank you",
+	"not a fit",
+	"not the right",
+	"not relevant",
+	"no need",
+	"we already have",
+	"we have a solution",
+	"not looking",
+	"wrong person",
+	"wrong contact",
+	"please don't",
+	"leave me alone",
+	"go away",
+}

--- a/internal/app/replyclassify/model.go
+++ b/internal/app/replyclassify/model.go
@@ -1,0 +1,173 @@
+package replyclassify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Layer 3: the OPTIONAL model classifier, gated by OPENAI_API_KEY. It mirrors
+// the repo's existing OPENAI_API_KEY-gated warmup-AI pattern: a client is only
+// constructed when the key is present, and when it is absent the layer is a pure
+// no-op that resolves the ambiguous middle to "unknown" WITHOUT any network
+// call. The cheap, deterministic layers (headers, lexicon) run first and decide
+// most replies, so this layer only ever sees the genuinely ambiguous tail.
+//
+// The model is constrained to the three nuanced sentiment classes the cheap
+// layers can't separate: positive | negative | neutral. Compliance
+// (unsubscribe) and automation (auto_reply / out_of_office) are already settled
+// deterministically upstream and are intentionally NOT in the model's output
+// space.
+
+const (
+	openAIChatURL  = "https://api.openai.com/v1/chat/completions"
+	openAIModel    = "gpt-4o-mini"
+	modelTimeout   = 8 * time.Second
+	modelMaxTokens = 16
+)
+
+// modelClassifier is the package-level, lazily-initialized Layer 3 client. nil
+// means "not configured" (no OPENAI_API_KEY) — the same disabled state the
+// warmupcontent service expresses with a nil generation client.
+var (
+	modelOnce   sync.Once
+	modelClient *openAIClassifier
+)
+
+// classifyModel runs Layer 3 when configured. Returns (zero, false) when the key
+// is unset or the call fails, so the caller falls back to "unknown" and NEVER
+// hard-errors on a classification miss.
+func classifyModel(ctx context.Context, in Input) (Result, bool) {
+	c := modelClassifierInstance()
+	if c == nil {
+		return Result{}, false
+	}
+	return c.classify(ctx, in)
+}
+
+// modelClassifierInstance reads OPENAI_API_KEY once and builds the client only
+// when present. Identical gating to generation.NewClient being called only when
+// the optional key resolves non-empty.
+func modelClassifierInstance() *openAIClassifier {
+	modelOnce.Do(func() {
+		key := strings.TrimSpace(os.Getenv("OPENAI_API_KEY"))
+		if key == "" {
+			return // stays nil => disabled, offline, never calls out
+		}
+		modelClient = &openAIClassifier{
+			apiKey: key,
+			http:   &http.Client{Timeout: modelTimeout},
+		}
+	})
+	return modelClient
+}
+
+type openAIClassifier struct {
+	apiKey string
+	http   *http.Client
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model       string        `json:"model"`
+	Messages    []chatMessage `json:"messages"`
+	MaxTokens   int           `json:"max_tokens"`
+	Temperature float64       `json:"temperature"`
+}
+
+type chatResponse struct {
+	Choices []struct {
+		Message struct {
+			Content string `json:"content"`
+		} `json:"message"`
+	} `json:"choices"`
+}
+
+const modelSystemPrompt = "You classify the sentiment of a reply to a cold sales email. " +
+	"Reply with exactly one lowercase word and nothing else: positive (interested / wants to talk), " +
+	"negative (rejection / not interested), or neutral (a question, deferral, or anything unclear). " +
+	"Do not explain."
+
+func (c *openAIClassifier) classify(ctx context.Context, in Input) (Result, bool) {
+	user := strings.TrimSpace("Subject: " + in.Subject + "\n\n" + in.BodyText)
+	if user == "" {
+		return Result{}, false
+	}
+
+	body, err := json.Marshal(chatRequest{
+		Model:       openAIModel,
+		MaxTokens:   modelMaxTokens,
+		Temperature: 0,
+		Messages: []chatMessage{
+			{Role: "system", Content: modelSystemPrompt},
+			{Role: "user", Content: user},
+		},
+	})
+	if err != nil {
+		return Result{}, false
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, openAIChatURL, bytes.NewReader(body))
+	if err != nil {
+		return Result{}, false
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Result{}, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Result{}, false
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return Result{}, false
+	}
+	var parsed chatResponse
+	if err := json.Unmarshal(raw, &parsed); err != nil || len(parsed.Choices) == 0 {
+		return Result{}, false
+	}
+
+	switch normalizeModelLabel(parsed.Choices[0].Message.Content) {
+	case ClassPositive:
+		return Result{Class: ClassPositive, Confidence: 0.7, Source: SourceModel}, true
+	case ClassNegative:
+		return Result{Class: ClassNegative, Confidence: 0.7, Source: SourceModel}, true
+	case ClassNeutral:
+		return Result{Class: ClassNeutral, Confidence: 0.6, Source: SourceModel}, true
+	default:
+		return Result{}, false
+	}
+}
+
+// normalizeModelLabel reduces the model's free text to one of the three allowed
+// labels, tolerating stray punctuation/whitespace. Anything else is rejected so
+// the caller falls back to "unknown".
+func normalizeModelLabel(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = strings.Trim(s, ".\"' \n\t")
+	switch {
+	case strings.HasPrefix(s, ClassPositive):
+		return ClassPositive
+	case strings.HasPrefix(s, ClassNegative):
+		return ClassNegative
+	case strings.HasPrefix(s, ClassNeutral):
+		return ClassNeutral
+	default:
+		return ""
+	}
+}

--- a/internal/app/team/service.go
+++ b/internal/app/team/service.go
@@ -1,0 +1,115 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// TeamService is the org-scoped CRUD surface for teams and their members. Teams
+// are created from existing organization members; membership in the org is
+// validated on AddMember.
+type TeamService interface {
+	ListTeams(ctx context.Context, orgID uuid.UUID) ([]models.Team, *errx.Error)
+	GetTeam(ctx context.Context, orgID, teamID uuid.UUID) (*models.Team, *errx.Error)
+	CreateTeam(ctx context.Context, orgID uuid.UUID, data *models.CreateTeam) (*models.Team, *errx.Error)
+	UpdateTeam(ctx context.Context, orgID, teamID uuid.UUID, data *models.UpdateTeam) (*models.Team, *errx.Error)
+	DeleteTeam(ctx context.Context, orgID, teamID uuid.UUID) *errx.Error
+
+	AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID) *errx.Error
+	RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) *errx.Error
+}
+
+type teamService struct {
+	repo repository.TeamRepository
+}
+
+// NewService builds the team service over its repository.
+func NewService(repo repository.TeamRepository) TeamService {
+	return &teamService{repo: repo}
+}
+
+func toErrx(err error) *errx.Error {
+	if err == nil {
+		return nil
+	}
+	var bizErr *errx.Error
+	if errors.As(err, &bizErr) {
+		return bizErr
+	}
+	return errx.InternalError()
+}
+
+func (s *teamService) ListTeams(ctx context.Context, orgID uuid.UUID) ([]models.Team, *errx.Error) {
+	teams, err := s.repo.ListTeams(ctx, orgID)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return teams, nil
+}
+
+func (s *teamService) GetTeam(ctx context.Context, orgID, teamID uuid.UUID) (*models.Team, *errx.Error) {
+	team, err := s.repo.GetTeam(ctx, orgID, teamID)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return team, nil
+}
+
+func (s *teamService) CreateTeam(ctx context.Context, orgID uuid.UUID, data *models.CreateTeam) (*models.Team, *errx.Error) {
+	name := strings.TrimSpace(data.Name)
+	if name == "" || len(name) > 255 {
+		return nil, errx.New(errx.BadRequest, "team name must be between 1 and 255 characters")
+	}
+	data.Name = name
+
+	team, err := s.repo.CreateTeam(ctx, orgID, data)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return team, nil
+}
+
+func (s *teamService) UpdateTeam(ctx context.Context, orgID, teamID uuid.UUID, data *models.UpdateTeam) (*models.Team, *errx.Error) {
+	if data.Name != nil {
+		name := strings.TrimSpace(*data.Name)
+		if name == "" || len(name) > 255 {
+			return nil, errx.New(errx.BadRequest, "team name must be between 1 and 255 characters")
+		}
+		data.Name = &name
+	}
+
+	team, err := s.repo.UpdateTeam(ctx, orgID, teamID, data)
+	if err != nil {
+		return nil, toErrx(err)
+	}
+	return team, nil
+}
+
+func (s *teamService) DeleteTeam(ctx context.Context, orgID, teamID uuid.UUID) *errx.Error {
+	if err := s.repo.DeleteTeam(ctx, orgID, teamID); err != nil {
+		return toErrx(err)
+	}
+	return nil
+}
+
+func (s *teamService) AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID) *errx.Error {
+	// The repository validates that the user belongs to the org before the
+	// junction insert; surface its typed error verbatim.
+	if err := s.repo.AddMember(ctx, orgID, teamID, userID); err != nil {
+		return toErrx(err)
+	}
+	return nil
+}
+
+func (s *teamService) RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) *errx.Error {
+	if err := s.repo.RemoveMember(ctx, orgID, teamID, userID); err != nil {
+		return toErrx(err)
+	}
+	return nil
+}

--- a/internal/infrastructure/db/migrations/000022_deal_attribution.down.sql
+++ b/internal/infrastructure/db/migrations/000022_deal_attribution.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS idx_deals_campaign_status_value;
+DROP INDEX IF EXISTS idx_deals_stage_status_value;
+DROP INDEX IF EXISTS idx_deals_org_assigned_status;
+
+ALTER TABLE deals
+    DROP CONSTRAINT IF EXISTS deals_source_mailbox_id_fkey,
+    DROP CONSTRAINT IF EXISTS deals_campaign_id_fkey;
+
+ALTER TABLE deals
+    DROP COLUMN IF EXISTS source_mailbox_id,
+    DROP COLUMN IF EXISTS campaign_id;

--- a/internal/infrastructure/db/migrations/000022_deal_attribution.up.sql
+++ b/internal/infrastructure/db/migrations/000022_deal_attribution.up.sql
@@ -1,0 +1,29 @@
+-- Deal attribution + scale indexes.
+--
+-- Attribution: tie a deal back to the campaign and the sender mailbox that
+-- produced the reply, so won revenue traces to the outreach that created it.
+-- Both columns are nullable and ON DELETE SET NULL so attribution survives
+-- campaign / mailbox cleanup instead of cascading away won-revenue history
+-- (mirrors the existing deals.contact_id ON DELETE SET NULL behaviour).
+--
+-- Indexes back the new faceted POST /crm/deals/search + /crm/deals/summary
+-- surfaces: "my open deals" (org, owner, status), per-stage value rollups for
+-- board column headers (stage, status, value), and per-campaign revenue
+-- (campaign, status, value). Previously every one of these scanned.
+
+ALTER TABLE deals
+    ADD COLUMN IF NOT EXISTS campaign_id uuid,
+    ADD COLUMN IF NOT EXISTS source_mailbox_id uuid;
+
+ALTER TABLE deals
+    ADD CONSTRAINT deals_campaign_id_fkey FOREIGN KEY (campaign_id)
+        REFERENCES campaigns (id) ON DELETE SET NULL,
+    ADD CONSTRAINT deals_source_mailbox_id_fkey FOREIGN KEY (source_mailbox_id)
+        REFERENCES email_accounts (id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_deals_org_assigned_status
+    ON deals (organization_id, assigned_to, status);
+CREATE INDEX IF NOT EXISTS idx_deals_stage_status_value
+    ON deals (stage_id, status, value);
+CREATE INDEX IF NOT EXISTS idx_deals_campaign_status_value
+    ON deals (campaign_id, status, value);

--- a/internal/infrastructure/db/migrations/000023_crm_task_types.down.sql
+++ b/internal/infrastructure/db/migrations/000023_crm_task_types.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_crm_tasks_org_type;
+ALTER TABLE crm_tasks DROP CONSTRAINT IF EXISTS crm_tasks_type_chk;
+ALTER TABLE crm_tasks DROP COLUMN IF EXISTS type;

--- a/internal/infrastructure/db/migrations/000023_crm_task_types.up.sql
+++ b/internal/infrastructure/db/migrations/000023_crm_task_types.up.sql
@@ -1,0 +1,12 @@
+-- Task type: a typed categorisation of CRM tasks (what kind of work the task
+-- represents) distinct from contact "categories". Drives the campaign
+-- "create task" action (e.g. a Call task) and lets the tasks list group/filter
+-- by type. 'general' is the neutral default for existing rows and any task
+-- created without an explicit type.
+ALTER TABLE crm_tasks
+    ADD COLUMN IF NOT EXISTS type text NOT NULL DEFAULT 'general';
+
+ALTER TABLE crm_tasks
+    ADD CONSTRAINT crm_tasks_type_chk CHECK (type IN ('general', 'call', 'email', 'meeting'));
+
+CREATE INDEX IF NOT EXISTS idx_crm_tasks_org_type ON crm_tasks (organization_id, type);

--- a/internal/infrastructure/db/migrations/000024_custom_task_types.down.sql
+++ b/internal/infrastructure/db/migrations/000024_custom_task_types.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE crm_tasks ALTER COLUMN type SET DEFAULT 'general';
+UPDATE crm_tasks SET type = 'general' WHERE type IS NULL OR type NOT IN ('general', 'call', 'email', 'meeting');
+ALTER TABLE crm_tasks ADD CONSTRAINT crm_tasks_type_chk CHECK (type IN ('general', 'call', 'email', 'meeting'));
+
+DROP INDEX IF EXISTS idx_crm_task_types_org;
+DROP TABLE IF EXISTS crm_task_types;

--- a/internal/infrastructure/db/migrations/000024_custom_task_types.up.sql
+++ b/internal/infrastructure/db/migrations/000024_custom_task_types.up.sql
@@ -1,0 +1,22 @@
+-- Make task types user-managed instead of a fixed enum. Each organization
+-- keeps its own set of task types (name + colour) in crm_task_types. A task
+-- stores the chosen type's NAME in crm_tasks.type (free text), so deleting a
+-- type never orphans existing tasks — they keep their label and fall back to a
+-- neutral colour in the UI.
+CREATE TABLE IF NOT EXISTS crm_task_types (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    name text NOT NULL,
+    color text NOT NULL DEFAULT '#94a3b8',
+    position integer NOT NULL DEFAULT 0,
+    created_at timestamp with time zone NOT NULL DEFAULT now(),
+    updated_at timestamp with time zone NOT NULL DEFAULT now(),
+    UNIQUE (organization_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_crm_task_types_org ON crm_task_types (organization_id, position);
+
+-- Retire the fixed-enum gate so custom type names are allowed; an empty string
+-- now means "no type".
+ALTER TABLE crm_tasks DROP CONSTRAINT IF EXISTS crm_tasks_type_chk;
+ALTER TABLE crm_tasks ALTER COLUMN type SET DEFAULT '';

--- a/internal/infrastructure/db/migrations/000025_backfill_task_types.down.sql
+++ b/internal/infrastructure/db/migrations/000025_backfill_task_types.down.sql
@@ -1,0 +1,4 @@
+-- Data backfill; nothing to reverse (the crm_task_types table itself is
+-- dropped by 000024's down migration). Removing only the seeded defaults here
+-- would risk deleting user-renamed types, so this is intentionally a no-op.
+SELECT 1;

--- a/internal/infrastructure/db/migrations/000025_backfill_task_types.up.sql
+++ b/internal/infrastructure/db/migrations/000025_backfill_task_types.up.sql
@@ -1,0 +1,14 @@
+-- Backfill default task types for organizations that already existed before
+-- types were seeded at creation. Idempotent: ON CONFLICT keeps it safe to run
+-- alongside the org-creation seeding and never overwrites a renamed/recoloured
+-- type. New orgs get these via the create path, not this migration.
+INSERT INTO crm_task_types (organization_id, name, color, position)
+SELECT o.id, d.name, d.color, d.position
+FROM organizations o
+CROSS JOIN (
+    VALUES
+        ('Call', '#8b5cf6', 0),
+        ('Email', '#0ea5e9', 1),
+        ('Meeting', '#f59e0b', 2)
+) AS d(name, color, position)
+ON CONFLICT (organization_id, name) DO NOTHING;

--- a/internal/infrastructure/db/migrations/000026_teams.down.sql
+++ b/internal/infrastructure/db/migrations/000026_teams.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS team_members;
+DROP TABLE IF EXISTS teams;

--- a/internal/infrastructure/db/migrations/000026_teams.up.sql
+++ b/internal/infrastructure/db/migrations/000026_teams.up.sql
@@ -1,0 +1,26 @@
+-- Teams: a named, colour-tagged grouping of an organization's members. Teams are
+-- created from existing organization members (the team_members junction only ever
+-- references users who already belong to the org via organization_members). The
+-- (organization_id, name) uniqueness keeps team names distinct within an org.
+CREATE TABLE IF NOT EXISTS teams (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    name text NOT NULL,
+    color text NOT NULL DEFAULT '#94a3b8',
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (organization_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_teams_org ON teams (organization_id);
+
+-- team_members: junction between a team and the org users that belong to it. Both
+-- sides cascade-delete so removing a team or a user cleans up memberships.
+CREATE TABLE IF NOT EXISTS team_members (
+    team_id uuid NOT NULL REFERENCES teams (id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    added_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (team_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_team_members_user ON team_members (user_id);

--- a/internal/infrastructure/db/migrations/000027_reply_classification.down.sql
+++ b/internal/infrastructure/db/migrations/000027_reply_classification.down.sql
@@ -1,0 +1,12 @@
+DROP INDEX IF EXISTS idx_campaign_progress_reply_class;
+
+ALTER TABLE campaign_contact_progress
+    DROP CONSTRAINT IF EXISTS campaign_contact_progress_reply_source_chk;
+
+ALTER TABLE campaign_contact_progress
+    DROP CONSTRAINT IF EXISTS campaign_contact_progress_reply_class_chk;
+
+ALTER TABLE campaign_contact_progress
+    DROP COLUMN IF EXISTS reply_source,
+    DROP COLUMN IF EXISTS reply_confidence,
+    DROP COLUMN IF EXISTS reply_class;

--- a/internal/infrastructure/db/migrations/000027_reply_classification.up.sql
+++ b/internal/infrastructure/db/migrations/000027_reply_classification.up.sql
@@ -1,0 +1,32 @@
+-- Reply classification: persist the layered classifier verdict for each inbound
+-- reply on the per-(campaign, contact, step) progress row. This is what reply
+-- branching ("reply_positive" / "reply_negative" / ...) reads at schedule time,
+-- and what lets stop_on_reply / the plain "replied" condition IGNORE automated
+-- replies (auto_reply / out_of_office) instead of treating them as a human reply.
+--
+-- reply_class    enum string: positive | negative | neutral | auto_reply |
+--                out_of_office | unsubscribe | unknown ('' / NULL when unset).
+-- reply_confidence  classifier confidence in [0,1].
+-- reply_source   which layer decided: header | lexicon | model | '' (unset).
+--
+-- Kept as typed text columns (not jsonb) because they are queried/filtered in
+-- SQL by the branch evaluator and the OOO-aware reply checks.
+ALTER TABLE campaign_contact_progress
+    ADD COLUMN IF NOT EXISTS reply_class text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS reply_confidence real NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS reply_source text NOT NULL DEFAULT '';
+
+-- Discriminator guards so a bad write can't poison branch routing.
+ALTER TABLE campaign_contact_progress
+    ADD CONSTRAINT campaign_contact_progress_reply_class_chk
+    CHECK (reply_class IN ('', 'positive', 'negative', 'neutral', 'auto_reply', 'out_of_office', 'unsubscribe', 'unknown'));
+
+ALTER TABLE campaign_contact_progress
+    ADD CONSTRAINT campaign_contact_progress_reply_source_chk
+    CHECK (reply_source IN ('', 'header', 'lexicon', 'model'));
+
+-- Partial index for the reply-branch evaluator, which only ever reads rows that
+-- carry a non-empty class.
+CREATE INDEX IF NOT EXISTS idx_campaign_progress_reply_class
+    ON campaign_contact_progress (campaign_id, contact_id)
+    WHERE reply_class <> '';

--- a/internal/infrastructure/db/migrations/000028_reply_action_fire.down.sql
+++ b/internal/infrastructure/db/migrations/000028_reply_action_fire.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE campaign_contact_progress
+    DROP COLUMN IF EXISTS reply_actions_fired_at;

--- a/internal/infrastructure/db/migrations/000028_reply_action_fire.down.sql
+++ b/internal/infrastructure/db/migrations/000028_reply_action_fire.down.sql
@@ -1,2 +1,2 @@
 ALTER TABLE campaign_contact_progress
-    DROP COLUMN IF EXISTS reply_actions_fired_at;
+    DROP COLUMN IF EXISTS instant_fired;

--- a/internal/infrastructure/db/migrations/000028_reply_action_fire.up.sql
+++ b/internal/infrastructure/db/migrations/000028_reply_action_fire.up.sql
@@ -1,0 +1,13 @@
+-- Instant reply-triggered action chains: when an inbound reply is classified, a
+-- matching reply_* branch on the contact's current step fires that branch's
+-- action chain IMMEDIATELY (targeted at that one contact) instead of waiting for
+-- the contact's next scheduled step boundary.
+--
+-- reply_actions_fired_at is the exactly-once idempotency gate for that instant
+-- fire. It is stamped the first time a reply event fires the chain for a given
+-- (campaign, contact, step) progress row, and the firing path claims it with a
+-- conditional `WHERE reply_actions_fired_at IS NULL` UPDATE so a redelivered /
+-- duplicated reply event (or an auto-reply followed by a human reply on the same
+-- step) can never run the chain twice. Nullable: NULL means "not yet fired".
+ALTER TABLE campaign_contact_progress
+    ADD COLUMN IF NOT EXISTS reply_actions_fired_at timestamptz;

--- a/internal/infrastructure/db/migrations/000028_reply_action_fire.up.sql
+++ b/internal/infrastructure/db/migrations/000028_reply_action_fire.up.sql
@@ -1,13 +1,19 @@
--- Instant reply-triggered action chains: when an inbound reply is classified, a
--- matching reply_* branch on the contact's current step fires that branch's
--- action chain IMMEDIATELY (targeted at that one contact) instead of waiting for
--- the contact's next scheduled step boundary.
+-- Instant engagement-triggered action chains: when an inbound signal lands for a
+-- contact (a reply is classified, or an open / click is tracked), a matching
+-- INSTANT branch on the contact's current step fires that branch's action chain
+-- IMMEDIATELY (targeted at that one contact) instead of waiting for the contact's
+-- next scheduled step boundary.
 --
--- reply_actions_fired_at is the exactly-once idempotency gate for that instant
--- fire. It is stamped the first time a reply event fires the chain for a given
--- (campaign, contact, step) progress row, and the firing path claims it with a
--- conditional `WHERE reply_actions_fired_at IS NULL` UPDATE so a redelivered /
--- duplicated reply event (or an auto-reply followed by a human reply on the same
--- step) can never run the chain twice. Nullable: NULL means "not yet fired".
+-- instant_fired is the exactly-once idempotency gate for those instant fires,
+-- keyed PER EVENT KIND. A contact can open AND click AND reply on the same step,
+-- and each distinct instant branch should fire exactly once, so a single
+-- "already fired" boolean is not enough. Instead we record which event kinds
+-- ("reply" / "open" / "click") have already fired their chain for this (campaign,
+-- contact, step) progress row. The firing path claims a kind with an atomic
+-- `array_append(...) WHERE NOT ($kind = ANY(instant_fired))` UPDATE, so a
+-- redelivered / duplicated event of the same kind (or an auto-reply followed by a
+-- human reply on the same step) can never run that kind's chain twice, while a
+-- different kind on the same step is still free to fire once. Defaults to '{}'
+-- (nothing fired yet) and is NOT NULL so the array operators never see NULL.
 ALTER TABLE campaign_contact_progress
-    ADD COLUMN IF NOT EXISTS reply_actions_fired_at timestamptz;
+    ADD COLUMN IF NOT EXISTS instant_fired text[] NOT NULL DEFAULT '{}';

--- a/internal/infrastructure/db/migrations/000029_stop_on_reply_default_on.down.sql
+++ b/internal/infrastructure/db/migrations/000029_stop_on_reply_default_on.down.sql
@@ -1,0 +1,2 @@
+-- Revert the column default back to the original false.
+ALTER TABLE campaigns ALTER COLUMN stop_on_reply SET DEFAULT false;

--- a/internal/infrastructure/db/migrations/000029_stop_on_reply_default_on.up.sql
+++ b/internal/infrastructure/db/migrations/000029_stop_on_reply_default_on.up.sql
@@ -1,0 +1,10 @@
+-- Default stop_on_reply ON for newly created campaigns. Continuing to cold-email
+-- a contact who already replied is the classic deliverability / complaint-rate
+-- mistake, so the safe default is to stop the normal sequence on a human reply.
+--
+-- This only changes the DEFAULT for rows that don't specify the column; existing
+-- campaigns keep whatever value they were created with (we do NOT rewrite live
+-- campaign behavior). The reply-flow handling itself is route-aware in the
+-- scheduler: stop_on_reply halts the cold sequence but lets the reply branch's
+-- own path (its actions and any follow-up emails) run to completion.
+ALTER TABLE campaigns ALTER COLUMN stop_on_reply SET DEFAULT true;

--- a/internal/infrastructure/db/migrations/000030_task_team_assignment.down.sql
+++ b/internal/infrastructure/db/migrations/000030_task_team_assignment.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_crm_tasks_assigned_team;
+
+ALTER TABLE crm_tasks
+    DROP COLUMN IF EXISTS assigned_team_id;

--- a/internal/infrastructure/db/migrations/000030_task_team_assignment.up.sql
+++ b/internal/infrastructure/db/migrations/000030_task_team_assignment.up.sql
@@ -1,0 +1,10 @@
+-- A CRM task can be assigned to an individual user (assigned_to) AND/OR a team.
+-- The two are independent: a task may have a person, a team, both, or neither.
+-- ON DELETE SET NULL mirrors the soft-clearing behaviour of the user assignment:
+-- deleting the team unassigns the task rather than deleting it.
+ALTER TABLE crm_tasks
+    ADD COLUMN assigned_team_id uuid REFERENCES teams (id) ON DELETE SET NULL;
+
+-- Filtering and counting by team + status is the hot path for the tasks views
+-- (team filter + status facets share the search/summary predicate).
+CREATE INDEX idx_crm_tasks_assigned_team ON crm_tasks (assigned_team_id, status);

--- a/internal/models/crm.go
+++ b/internal/models/crm.go
@@ -356,3 +356,57 @@ type UpdateCRMTask struct {
 	Type        *string    `json:"type,omitempty"`
 	Status      *string    `json:"status,omitempty"`
 }
+
+// =====================
+// Task search + summary
+// =====================
+
+// SearchTasks is the faceted, server-side filter body shared by
+// POST /crm/tasks/search and POST /crm/tasks/summary. Every facet is optional;
+// an empty body matches every task in the organization. This is the surface
+// that makes the tasks view correct at scale instead of paging a cursor and
+// reducing client-side.
+type SearchTasks struct {
+	Query      string     `json:"query"`       // title ILIKE
+	Statuses   []string   `json:"statuses"`    // pending | in_progress | completed | cancelled (any of)
+	Priorities []string   `json:"priorities"`  // low | medium | high | urgent (any of)
+	Types      []string   `json:"types"`       // task type NAME is any of
+	AssignedTo []string   `json:"assigned_to"` // assignee user id is any of
+	ContactID  *string    `json:"contact_id"`  // linked contact
+	DealID     *string    `json:"deal_id"`     // linked deal
+	DueAfter   *time.Time `json:"due_after"`   // due_date >=
+	DueBefore  *time.Time `json:"due_before"`  // due_date <=
+	Overdue    bool       `json:"overdue"`     // due_date < now() AND not completed/cancelled
+	SortBy     string     `json:"sort_by"`     // created_at|due_date|priority|title|updated_at
+	Reverse    bool       `json:"reverse"`     // true = ASC, false = DESC (default)
+}
+
+// TasksSearchResult is the offset-paginated result of POST /crm/tasks/search.
+// Offset (not keyset) pagination is used because the sortable columns include
+// the nullable due_date, where a keyset cursor would silently drop NULL-valued
+// rows. Total is exact so the UI can show "N of M".
+type TasksSearchResult struct {
+	Data       []CRMTask             `json:"data"`
+	Pagination TasksSearchPagination `json:"pagination"`
+}
+
+type TasksSearchPagination struct {
+	Total      int64 `json:"total"`
+	Limit      int   `json:"limit"`
+	Offset     int   `json:"offset"`
+	HasMore    bool  `json:"has_more"`
+	NextOffset *int  `json:"next_offset,omitempty"`
+}
+
+// TasksSummary is the server-side aggregate over the SAME filter body as a
+// search, so every header total is a true COUNT over the whole matching set
+// rather than a client reduce over a truncated page.
+type TasksSummary struct {
+	Total          int64 `json:"total"`
+	PendingCount   int64 `json:"pending_count"`
+	InProgress     int64 `json:"in_progress_count"`
+	CompletedCount int64 `json:"completed_count"`
+	CancelledCount int64 `json:"cancelled_count"`
+	OverdueCount   int64 `json:"overdue_count"`
+	HighPriority   int64 `json:"high_priority_count"`
+}

--- a/internal/models/crm.go
+++ b/internal/models/crm.go
@@ -280,6 +280,39 @@ const (
 	CRMTaskStatusCancelled  CRMTaskStatus = "cancelled"
 )
 
+// CRMTaskType is a user-managed task type — the kind of work a task represents
+// (e.g. Call / Email / Meeting). Org-scoped. A task references its type by NAME
+// (crm_tasks.type), so deleting a type never orphans existing tasks; they keep
+// the label and fall back to a neutral colour.
+type CRMTaskType struct {
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Name           string    `json:"name"`
+	Color          string    `json:"color"`
+	Position       int       `json:"position"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+type CreateCRMTaskType struct {
+	Name  string `json:"name" binding:"required,min=1,max=60"`
+	Color string `json:"color,omitempty"`
+}
+
+type UpdateCRMTaskType struct {
+	Name     *string `json:"name,omitempty"`
+	Color    *string `json:"color,omitempty"`
+	Position *int    `json:"position,omitempty"`
+}
+
+// DefaultCRMTaskTypes seed an org's set the first time its types are listed, so
+// there's a usable starting point the user can rename, recolour, or delete.
+var DefaultCRMTaskTypes = []CreateCRMTaskType{
+	{Name: "Call", Color: "#8b5cf6"},
+	{Name: "Email", Color: "#0ea5e9"},
+	{Name: "Meeting", Color: "#f59e0b"},
+}
+
 type CRMTask struct {
 	ID             uuid.UUID       `json:"id"`
 	OrganizationID uuid.UUID       `json:"organization_id"`
@@ -291,6 +324,7 @@ type CRMTask struct {
 	Description    *string         `json:"description,omitempty"`
 	DueDate        *time.Time      `json:"due_date,omitempty"`
 	Priority       CRMTaskPriority `json:"priority"`
+	Type           string          `json:"type"`
 	Status         CRMTaskStatus   `json:"status"`
 	CompletedAt    *time.Time      `json:"completed_at,omitempty"`
 	CreatedAt      time.Time       `json:"created_at"`
@@ -310,6 +344,7 @@ type CreateCRMTask struct {
 	Description *string    `json:"description,omitempty"`
 	DueDate     *time.Time `json:"due_date,omitempty"`
 	Priority    string     `json:"priority,omitempty"`
+	Type        string     `json:"type,omitempty"`
 }
 
 type UpdateCRMTask struct {
@@ -318,5 +353,6 @@ type UpdateCRMTask struct {
 	Description *string    `json:"description,omitempty"`
 	DueDate     *time.Time `json:"due_date,omitempty"`
 	Priority    *string    `json:"priority,omitempty"`
+	Type        *string    `json:"type,omitempty"`
 	Status      *string    `json:"status,omitempty"`
 }

--- a/internal/models/crm.go
+++ b/internal/models/crm.go
@@ -149,11 +149,16 @@ type Deal struct {
 	LostAt            *time.Time `json:"lost_at,omitempty"`
 	LostReason        *string    `json:"lost_reason,omitempty"`
 	AssignedTo        *uuid.UUID `json:"assigned_to,omitempty"`
-	CreatedAt         time.Time  `json:"created_at"`
-	UpdatedAt         time.Time  `json:"updated_at"`
-	// Joined
-	Contact *Contact       `json:"contact,omitempty"`
-	Stage   *PipelineStage `json:"stage,omitempty"`
+	// Attribution: the campaign + sender mailbox that produced the reply this
+	// deal was created from. Nullable; editable (best-guess, not ground truth).
+	CampaignID      *uuid.UUID `json:"campaign_id,omitempty"`
+	SourceMailboxID *uuid.UUID `json:"source_mailbox_id,omitempty"`
+	CreatedAt       time.Time  `json:"created_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	// Joined (populated by the search/list query, not by single-row reads).
+	Contact      *Contact       `json:"contact,omitempty"`
+	Stage        *PipelineStage `json:"stage,omitempty"`
+	CampaignName *string        `json:"campaign_name,omitempty"`
 }
 
 type DealsResult struct {
@@ -170,6 +175,75 @@ type CreateDeal struct {
 	Currency          string     `json:"currency,omitempty"`
 	ExpectedCloseDate *time.Time `json:"expected_close_date,omitempty"`
 	AssignedTo        *uuid.UUID `json:"assigned_to,omitempty"`
+	CampaignID        *uuid.UUID `json:"campaign_id,omitempty"`
+	SourceMailboxID   *uuid.UUID `json:"source_mailbox_id,omitempty"`
+}
+
+// =====================
+// Deal search + summary
+// =====================
+
+// SearchDeals is the faceted, server-side filter body shared by
+// POST /crm/deals/search and POST /crm/deals/summary. Every facet is
+// optional; an empty body matches every deal in the organization. This is
+// the surface that makes the deals views correct at scale instead of paging
+// 100 rows and reducing client-side.
+type SearchDeals struct {
+	Query         string     `json:"query"`          // name ILIKE
+	Statuses      []string   `json:"statuses"`       // open | won | lost (any of)
+	PipelineIDs   []string   `json:"pipeline_ids"`   // any of (cross-pipeline by default)
+	StageIDs      []string   `json:"stage_ids"`      // any of
+	AssignedTo    []string   `json:"assigned_to"`    // owner is any of
+	CampaignIDs   []string   `json:"campaign_ids"`   // attributed campaign is any of
+	MinValue      *float64   `json:"min_value"`      // value >=
+	MaxValue      *float64   `json:"max_value"`      // value <=
+	CloseAfter    *time.Time `json:"close_after"`    // expected_close_date >=
+	CloseBefore   *time.Time `json:"close_before"`   // expected_close_date <=
+	CreatedAfter  *time.Time `json:"created_after"`  // created_at >=
+	CreatedBefore *time.Time `json:"created_before"` // created_at <=
+	SortBy        string     `json:"sort_by"`        // created_at|updated_at|value|expected_close_date|name
+	Reverse       bool       `json:"reverse"`        // true = ASC, false = DESC (default)
+}
+
+// DealsSearchResult is the offset-paginated result of POST /crm/deals/search.
+// Offset (not keyset) pagination is used because the sortable columns include
+// nullable value/expected_close_date, where a keyset cursor would silently
+// drop NULL-valued rows. Total is exact so the UI can show "N of M".
+type DealsSearchResult struct {
+	Data       []Deal                `json:"data"`
+	Pagination DealsSearchPagination `json:"pagination"`
+}
+
+type DealsSearchPagination struct {
+	Total      int64 `json:"total"`
+	Limit      int   `json:"limit"`
+	Offset     int   `json:"offset"`
+	HasMore    bool  `json:"has_more"`
+	NextOffset *int  `json:"next_offset,omitempty"`
+}
+
+// DealsSummary is the server-side aggregate over the SAME filter body as a
+// search, so every header total and per-stage column total is a true SUM/COUNT
+// over the whole matching set — never a client reduce over a truncated page.
+type DealsSummary struct {
+	Total         int64              `json:"total"`
+	OpenCount     int64              `json:"open_count"`
+	OpenValue     float64            `json:"open_value"`
+	WonCount      int64              `json:"won_count"`
+	WonValue      float64            `json:"won_value"`
+	LostCount     int64              `json:"lost_count"`
+	LostValue     float64            `json:"lost_value"`
+	Currency      string             `json:"currency"`
+	Stages        []DealStageSummary `json:"stages"`
+	MixedCurrency bool               `json:"mixed_currency"`
+}
+
+// DealStageSummary feeds an accurate per-column header on the kanban board:
+// the count of deals in the stage and the open-deal value in it.
+type DealStageSummary struct {
+	StageID uuid.UUID `json:"stage_id"`
+	Count   int64     `json:"count"`
+	Value   float64   `json:"value"`
 }
 
 type UpdateDeal struct {

--- a/internal/models/crm.go
+++ b/internal/models/crm.go
@@ -319,6 +319,7 @@ type CRMTask struct {
 	ContactID      *uuid.UUID      `json:"contact_id,omitempty"`
 	DealID         *uuid.UUID      `json:"deal_id,omitempty"`
 	AssignedTo     *uuid.UUID      `json:"assigned_to,omitempty"`
+	AssignedTeamID *uuid.UUID      `json:"assigned_team_id,omitempty"`
 	CreatedBy      uuid.UUID       `json:"created_by"`
 	Title          string          `json:"title"`
 	Description    *string         `json:"description,omitempty"`
@@ -337,24 +338,26 @@ type CRMTasksResult struct {
 }
 
 type CreateCRMTask struct {
-	ContactID   *uuid.UUID `json:"contact_id,omitempty"`
-	DealID      *uuid.UUID `json:"deal_id,omitempty"`
-	AssignedTo  *uuid.UUID `json:"assigned_to,omitempty"`
-	Title       string     `json:"title" binding:"required,min=1,max=255"`
-	Description *string    `json:"description,omitempty"`
-	DueDate     *time.Time `json:"due_date,omitempty"`
-	Priority    string     `json:"priority,omitempty"`
-	Type        string     `json:"type,omitempty"`
+	ContactID      *uuid.UUID `json:"contact_id,omitempty"`
+	DealID         *uuid.UUID `json:"deal_id,omitempty"`
+	AssignedTo     *uuid.UUID `json:"assigned_to,omitempty"`
+	AssignedTeamID *uuid.UUID `json:"assigned_team_id,omitempty"`
+	Title          string     `json:"title" binding:"required,min=1,max=255"`
+	Description    *string    `json:"description,omitempty"`
+	DueDate        *time.Time `json:"due_date,omitempty"`
+	Priority       string     `json:"priority,omitempty"`
+	Type           string     `json:"type,omitempty"`
 }
 
 type UpdateCRMTask struct {
-	AssignedTo  *uuid.UUID `json:"assigned_to,omitempty"`
-	Title       *string    `json:"title,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	DueDate     *time.Time `json:"due_date,omitempty"`
-	Priority    *string    `json:"priority,omitempty"`
-	Type        *string    `json:"type,omitempty"`
-	Status      *string    `json:"status,omitempty"`
+	AssignedTo     *uuid.UUID `json:"assigned_to,omitempty"`
+	AssignedTeamID *uuid.UUID `json:"assigned_team_id,omitempty"`
+	Title          *string    `json:"title,omitempty"`
+	Description    *string    `json:"description,omitempty"`
+	DueDate        *time.Time `json:"due_date,omitempty"`
+	Priority       *string    `json:"priority,omitempty"`
+	Type           *string    `json:"type,omitempty"`
+	Status         *string    `json:"status,omitempty"`
 }
 
 // =====================
@@ -367,18 +370,19 @@ type UpdateCRMTask struct {
 // that makes the tasks view correct at scale instead of paging a cursor and
 // reducing client-side.
 type SearchTasks struct {
-	Query      string     `json:"query"`       // title ILIKE
-	Statuses   []string   `json:"statuses"`    // pending | in_progress | completed | cancelled (any of)
-	Priorities []string   `json:"priorities"`  // low | medium | high | urgent (any of)
-	Types      []string   `json:"types"`       // task type NAME is any of
-	AssignedTo []string   `json:"assigned_to"` // assignee user id is any of
-	ContactID  *string    `json:"contact_id"`  // linked contact
-	DealID     *string    `json:"deal_id"`     // linked deal
-	DueAfter   *time.Time `json:"due_after"`   // due_date >=
-	DueBefore  *time.Time `json:"due_before"`  // due_date <=
-	Overdue    bool       `json:"overdue"`     // due_date < now() AND not completed/cancelled
-	SortBy     string     `json:"sort_by"`     // created_at|due_date|priority|title|updated_at
-	Reverse    bool       `json:"reverse"`     // true = ASC, false = DESC (default)
+	Query      string      `json:"query"`       // title ILIKE
+	Statuses   []string    `json:"statuses"`    // pending | in_progress | completed | cancelled (any of)
+	Priorities []string    `json:"priorities"`  // low | medium | high | urgent (any of)
+	Types      []string    `json:"types"`       // task type NAME is any of
+	AssignedTo []string    `json:"assigned_to"` // assignee user id is any of
+	TeamIDs    []uuid.UUID `json:"team_ids"`    // task team is any of, OR assignee is a member of any of
+	ContactID  *string     `json:"contact_id"`  // linked contact
+	DealID     *string     `json:"deal_id"`     // linked deal
+	DueAfter   *time.Time  `json:"due_after"`   // due_date >=
+	DueBefore  *time.Time  `json:"due_before"`  // due_date <=
+	Overdue    bool        `json:"overdue"`     // due_date < now() AND not completed/cancelled
+	SortBy     string      `json:"sort_by"`     // created_at|due_date|priority|title|updated_at
+	Reverse    bool        `json:"reverse"`     // true = ASC, false = DESC (default)
 }
 
 // TasksSearchResult is the offset-paginated result of POST /crm/tasks/search.

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -46,6 +46,12 @@ type OrganizationMember struct {
 	// Joined data
 	User         *User         `json:"user,omitempty"`
 	Organization *Organization `json:"organization,omitempty"`
+
+	// Flattened convenience fields populated from the joined user, so clients
+	// can read member.email / member.name directly (the member list UIs,
+	// assignee pickers, and team pickers all rely on these).
+	Email string `json:"email"`
+	Name  string `json:"name"`
 }
 
 // HasPermission checks if the member has a specific permission

--- a/internal/models/sequence.go
+++ b/internal/models/sequence.go
@@ -42,7 +42,7 @@ type Sequence struct {
 // ActionConfig is the persisted config for a non-email (action/wait) node. Type
 // is the switch the task executes on; the remaining fields are type-scoped.
 type ActionConfig struct {
-	Type string `json:"type"` // wait | add_tag | remove_tag | unsubscribe | notify | create_task | end
+	Type string `json:"type"` // wait | add_tag | remove_tag | unsubscribe | notify | create_task | create_deal | move_deal_stage | end
 
 	// wait
 	WaitMinutes *int `json:"wait_minutes,omitempty"`
@@ -62,6 +62,19 @@ type ActionConfig struct {
 	TaskPriority      string     `json:"task_priority,omitempty"` // low | medium | high | urgent
 	TaskAssignedTo    *uuid.UUID `json:"task_assigned_to,omitempty"`
 	TaskDueOffsetDays *int       `json:"task_due_offset_days,omitempty"` // due N days after the step fires
+
+	// create_deal / move_deal_stage — CRM deal automation off a reply branch.
+	//   create_deal: open a new deal for the contact in DealPipelineID/DealStageID.
+	//   move_deal_stage: move the contact's most-recent OPEN deal in
+	//     DealPipelineID to DealStageID; a contact with no open deal in that
+	//     pipeline is a logged no-op (not an error).
+	// DealName supports the same {{first_name}}/{{company}} templating other
+	// campaign copy uses. DealValue is optional; DealCurrency defaults to "USD".
+	DealPipelineID *uuid.UUID `json:"deal_pipeline_id,omitempty"`
+	DealStageID    *uuid.UUID `json:"deal_stage_id,omitempty"`
+	DealName       string     `json:"deal_name,omitempty"`
+	DealValue      *float64   `json:"deal_value,omitempty"`
+	DealCurrency   string     `json:"deal_currency,omitempty"`
 }
 
 type UpdateSequence struct {

--- a/internal/models/sequence.go
+++ b/internal/models/sequence.go
@@ -116,12 +116,24 @@ type Branch struct {
 // BranchCondition is a single engagement predicate evaluated against the
 // contact's campaign_contact_progress row for the current step.
 type BranchCondition struct {
-	// Field is the engagement signal: "opened" | "clicked" | "replied" and
-	// their negations "not_opened" | "not_clicked" | "not_replied".
+	// Field is the engagement signal:
+	//   "opened" | "clicked" | "replied" and their negations
+	//   "not_opened" | "not_clicked" | "not_replied",
+	// plus the reply-classification fields (operator "ever", no Value), read
+	// from campaign_contact_progress.reply_class:
+	//   "reply_positive"  — reply_class is positive
+	//   "reply_negative"  — reply_class is negative
+	//   "reply_neutral"   — reply_class is neutral
+	//   "reply_automated" — reply_class is auto_reply OR out_of_office
+	// IMPORTANT: the plain "replied"/"not_replied" fields IGNORE automated
+	// replies (auto_reply / out_of_office) — only a human reply sets replied_at,
+	// so a vacation autoresponder never trips "replied" or stop_on_reply. Use the
+	// reply_automated field to branch specifically on an automated reply.
 	Field string `json:"field"`
-	// Operator is the comparison. Currently "within_days" (the signal occurred
-	// in the last Value days) and "ever" (the signal occurred at all). For the
-	// not_* fields the meaning inverts (did NOT happen within / ever).
+	// Operator is the comparison. "within_days" (the signal occurred in the last
+	// Value days) and "ever" (the signal occurred at all). For the not_* fields
+	// the meaning inverts (did NOT happen within / ever). The reply_* fields take
+	// operator "ever" (no Value).
 	Operator string `json:"operator"`
 	// Value is the day window for "within_days". nil for operators that take no
 	// argument (e.g. "ever").

--- a/internal/models/sequence.go
+++ b/internal/models/sequence.go
@@ -42,7 +42,7 @@ type Sequence struct {
 // ActionConfig is the persisted config for a non-email (action/wait) node. Type
 // is the switch the task executes on; the remaining fields are type-scoped.
 type ActionConfig struct {
-	Type string `json:"type"` // wait | add_tag | remove_tag | unsubscribe | notify | end
+	Type string `json:"type"` // wait | add_tag | remove_tag | unsubscribe | notify | create_task | end
 
 	// wait
 	WaitMinutes *int `json:"wait_minutes,omitempty"`
@@ -53,6 +53,15 @@ type ActionConfig struct {
 	// notify — webhook / integration fan-out
 	NotifyEvent string         `json:"notify_event,omitempty"`
 	NotifyData  map[string]any `json:"notify_data,omitempty"`
+
+	// create_task — open a CRM task for the lead when they reach this step
+	// (e.g. a Call task). TaskAssignedTo is the teammate chosen on the step;
+	// when nil the task falls back to the campaign owner.
+	TaskTitle         string     `json:"task_title,omitempty"`
+	TaskType          string     `json:"task_type,omitempty"`     // general | call | email | meeting
+	TaskPriority      string     `json:"task_priority,omitempty"` // low | medium | high | urgent
+	TaskAssignedTo    *uuid.UUID `json:"task_assigned_to,omitempty"`
+	TaskDueOffsetDays *int       `json:"task_due_offset_days,omitempty"` // due N days after the step fires
 }
 
 type UpdateSequence struct {

--- a/internal/models/sequence.go
+++ b/internal/models/sequence.go
@@ -124,6 +124,12 @@ type Branch struct {
 	// Conditions are ANDed together — every condition must hold for the branch
 	// to match. An empty list is an unconditional/catch-all branch ("otherwise").
 	Conditions []BranchCondition `json:"conditions,omitempty"`
+	// Instant, for a reply_* branch, controls whether its action chain fires the
+	// MOMENT the contact replies. nil or true = instant (the default); false =
+	// opt out, leaving the branch to route at the normal step boundary like an
+	// engagement branch. Ignored for non-reply branches. Stored in the
+	// sequences.conditions jsonb, so no migration is needed.
+	Instant *bool `json:"instant,omitempty"`
 }
 
 // BranchCondition is a single engagement predicate evaluated against the

--- a/internal/models/team.go
+++ b/internal/models/team.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Team is a named, colour-tagged grouping of an organization's members. Teams
+// are always created from existing organization members; the Members slice is a
+// joined hydration of the team_members junction and is only populated by reads
+// that ask for it (e.g. ListTeams / GetTeam).
+type Team struct {
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Name           string    `json:"name"`
+	Color          string    `json:"color"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+
+	// Joined data — the members that belong to this team. Always serialized as
+	// an array (never null) so the frontend can iterate without guarding.
+	Members []TeamMember `json:"members"`
+}
+
+// TeamMember is one membership row of a team. UserID is the junction key; Email
+// and Name are joined from the users table for display convenience.
+type TeamMember struct {
+	UserID uuid.UUID `json:"user_id"`
+	Email  string    `json:"email"`
+	Name   string    `json:"name"`
+
+	AddedAt time.Time `json:"added_at"`
+}
+
+// CreateTeam is the request body for creating a team. Color is optional; when
+// omitted the table default (#94a3b8) applies.
+type CreateTeam struct {
+	Name  string `json:"name" binding:"required,min=1,max=255"`
+	Color string `json:"color,omitempty"`
+}
+
+// UpdateTeam is the partial-update request body for a team. Nil fields are left
+// untouched.
+type UpdateTeam struct {
+	Name  *string `json:"name,omitempty"`
+	Color *string `json:"color,omitempty"`
+}

--- a/internal/repository/branch_conditions.go
+++ b/internal/repository/branch_conditions.go
@@ -212,6 +212,10 @@ func conditionState(cond models.BranchCondition, prog *CampaignContactProgress, 
 // string. reply_automated is the union of the two automated classes. Mirrors
 // replyclassify's class constants (kept as literals here so this package stays
 // free of an app-layer import).
+//
+// Note: there is intentionally no reply_unsubscribe branch field. An
+// unsubscribe-classified reply is handled by suppression (advanced.Unsubscribe),
+// not routed through the canvas, so it matches no instant branch here.
 func replyClassMatches(field, class string) bool {
 	switch field {
 	case "reply_positive":
@@ -225,6 +229,68 @@ func replyClassMatches(field, class string) bool {
 	default:
 		return false
 	}
+}
+
+// isReplyField reports whether a branch condition field is one of the
+// reply-classification predicates that fire instantly when a reply is classified
+// (as opposed to engagement predicates, which stay step-boundary).
+func isReplyField(field string) bool {
+	switch field {
+	case "reply_positive", "reply_negative", "reply_neutral", "reply_automated":
+		return true
+	default:
+		return false
+	}
+}
+
+// MatchReplyBranchTarget evaluates a step's branches at reply time and returns
+// the route out of the step for an INSTANT reply trigger. It walks branches in
+// declared order (first match wins, identical to the scheduler) and returns the
+// first branch that (a) carries at least one reply_* condition and (b) has ALL
+// of its conditions decidably matching right now against prog (which must carry
+// the just-classified ReplyClass).
+//
+// Returns:
+//   - matched=false when no reply branch applies (caller does nothing instant);
+//   - matched=true, target=nil for a STOP / deleted-target branch;
+//   - matched=true, target=<step id> for a branch that routes onward.
+//
+// It reuses conditionState (the same predicate evaluator the scheduler uses), so
+// matching lives in exactly one place. Engagement-only branches are skipped here
+// because they are not reply-driven; they keep firing at the step boundary. The
+// caller resolves whether target is a live step.
+func MatchReplyBranchTarget(bc *models.BranchConditions, prog *CampaignContactProgress) (matched bool, target *uuid.UUID) {
+	if bc == nil || prog == nil {
+		return false, nil
+	}
+	// reply_* conditions decide off the stored class with no time window, so
+	// sentAt/now are immaterial for them. A fixed reference time keeps any
+	// engagement conditions ANDed alongside a reply_* condition decidable
+	// (Match/NoMatch) rather than Undecided at evaluation time.
+	now := time.Now()
+	sentAt := now
+	if prog.SentAt != nil {
+		sentAt = *prog.SentAt
+	}
+	for i := range bc.Branches {
+		b := &bc.Branches[i]
+		hasReply := false
+		allMatch := true
+		for j := range b.Conditions {
+			if isReplyField(b.Conditions[j].Field) {
+				hasReply = true
+			}
+			cs, _ := conditionState(b.Conditions[j], prog, b.BranchID, sentAt, now)
+			if cs != BranchMatch {
+				allMatch = false
+				break
+			}
+		}
+		if hasReply && allMatch {
+			return true, b.TargetSequenceID
+		}
+	}
+	return false, nil
 }
 
 // randomHolds deterministically routes Value% of contacts down a random-split

--- a/internal/repository/branch_conditions.go
+++ b/internal/repository/branch_conditions.go
@@ -18,6 +18,15 @@ var branchConditionFields = map[string]bool{
 	"not_opened":  true,
 	"not_clicked": true,
 	"not_replied": true,
+	// Reply-classification branches (operator "ever", no Value). Read from
+	// campaign_contact_progress.reply_class. reply_automated == reply_class is
+	// auto_reply OR out_of_office. The plain "replied" field above intentionally
+	// EXCLUDES automated replies (only a human reply stamps replied_at), so these
+	// are the only way to route on an automated reply.
+	"reply_positive":  true,
+	"reply_negative":  true,
+	"reply_neutral":   true,
+	"reply_automated": true,
 	// "random" routes a deterministic percentage of contacts down this branch
 	// (a random split / split-test). Pairs with operator "chance", Value = %.
 	"random": true,
@@ -133,6 +142,17 @@ func conditionState(cond models.BranchCondition, prog *CampaignContactProgress, 
 		return BranchNoMatch, time.Time{}
 	}
 
+	// Reply-classification fields decide immediately off the stored reply_class
+	// (no time window): the class is set when the reply arrives, so there is
+	// nothing to wait for. reply_automated folds auto_reply + out_of_office.
+	switch cond.Field {
+	case "reply_positive", "reply_negative", "reply_neutral", "reply_automated":
+		if replyClassMatches(cond.Field, prog.ReplyClass) {
+			return BranchMatch, time.Time{}
+		}
+		return BranchNoMatch, time.Time{}
+	}
+
 	var ts *time.Time
 	negate := false
 	switch cond.Field {
@@ -186,6 +206,25 @@ func conditionState(cond models.BranchCondition, prog *CampaignContactProgress, 
 		return BranchMatch, time.Time{}
 	}
 	return BranchNoMatch, time.Time{}
+}
+
+// replyClassMatches maps a reply_* branch field to the stored reply_class
+// string. reply_automated is the union of the two automated classes. Mirrors
+// replyclassify's class constants (kept as literals here so this package stays
+// free of an app-layer import).
+func replyClassMatches(field, class string) bool {
+	switch field {
+	case "reply_positive":
+		return class == "positive"
+	case "reply_negative":
+		return class == "negative"
+	case "reply_neutral":
+		return class == "neutral"
+	case "reply_automated":
+		return class == "auto_reply" || class == "out_of_office"
+	default:
+		return false
+	}
 }
 
 // randomHolds deterministically routes Value% of contacts down a random-split

--- a/internal/repository/branch_conditions.go
+++ b/internal/repository/branch_conditions.go
@@ -231,42 +231,67 @@ func replyClassMatches(field, class string) bool {
 	}
 }
 
-// isReplyField reports whether a branch condition field is one of the
-// reply-classification predicates that fire instantly when a reply is classified
-// (as opposed to engagement predicates, which stay step-boundary).
-func isReplyField(field string) bool {
-	switch field {
-	case "reply_positive", "reply_negative", "reply_neutral", "reply_automated":
-		return true
-	default:
-		return false
+// fieldBelongsToEvent reports whether a branch condition field is one of the
+// positive "it happened" predicates owned by an instant trigger eventKind. These
+// are the only fields that can fire the instant the signal lands:
+//
+//   - "reply": the reply-classification predicates plus the plain "replied"
+//     (a human reply). A reply event carries the just-classified class on prog.
+//   - "open":  "opened".
+//   - "click": "clicked".
+//
+// Negative predicates (not_opened / not_clicked / not_replied) and time windows
+// are deliberately excluded here: you cannot instantly fire "did NOT happen", so
+// those stay step-boundary and are routed by the scheduler.
+func fieldBelongsToEvent(field, eventKind string) bool {
+	switch eventKind {
+	case "reply":
+		switch field {
+		// Only the reply_* intent fields fire instantly. The plain "replied" field
+		// carries a day window and the editor presents it as a step-boundary path
+		// with no instant toggle, so it must NOT instant-fire here (parity with the
+		// frontend's INSTANT_CAPABLE_FIELDS, which also excludes "replied").
+		case "reply_positive", "reply_negative", "reply_neutral", "reply_automated":
+			return true
+		}
+	case "open":
+		return field == "opened"
+	case "click":
+		return field == "clicked"
 	}
+	return false
 }
 
-// MatchReplyBranchTarget evaluates a step's branches at reply time and returns
-// the route out of the step for an INSTANT reply trigger. It walks branches in
-// declared order (first match wins, identical to the scheduler) and returns the
-// first branch that (a) carries at least one reply_* condition and (b) has ALL
-// of its conditions decidably matching right now against prog (which must carry
-// the just-classified ReplyClass).
+// MatchInstantBranchTarget evaluates a step's branches at signal time and returns
+// the route out of the step for an INSTANT trigger of the given eventKind
+// ("reply" / "open" / "click"). It walks branches in declared order (first match
+// wins, identical to the scheduler) and returns the first branch that (a) carries
+// at least one condition whose field belongs to this eventKind (reply -> the
+// reply_* intent fields; open -> "opened"; click -> "clicked"), and (b) has
+// ALL of its conditions decidably matching right now against prog (which must
+// carry the just-recorded signal: ReplyClass / OpenedAt / ClickedAt).
 //
 // Returns:
-//   - matched=false when no reply branch applies (caller does nothing instant);
+//   - matched=false when no instant branch for this eventKind applies (caller
+//     does nothing instant);
 //   - matched=true, target=nil for a STOP / deleted-target branch;
 //   - matched=true, target=<step id> for a branch that routes onward.
 //
 // It reuses conditionState (the same predicate evaluator the scheduler uses), so
-// matching lives in exactly one place. Engagement-only branches are skipped here
-// because they are not reply-driven; they keep firing at the step boundary. The
-// caller resolves whether target is a live step.
-func MatchReplyBranchTarget(bc *models.BranchConditions, prog *CampaignContactProgress) (matched bool, target *uuid.UUID) {
+// matching lives in exactly one place. Branches with no condition owned by this
+// eventKind are skipped here (a click event must not run a reply branch, and a
+// negative-only branch can never fire instantly); they keep being routed at the
+// step boundary by the scheduler. The caller resolves whether target is a live
+// step.
+func MatchInstantBranchTarget(bc *models.BranchConditions, prog *CampaignContactProgress, eventKind string) (matched bool, target *uuid.UUID, instant bool) {
 	if bc == nil || prog == nil {
-		return false, nil
+		return false, nil, false
 	}
-	// reply_* conditions decide off the stored class with no time window, so
-	// sentAt/now are immaterial for them. A fixed reference time keeps any
-	// engagement conditions ANDed alongside a reply_* condition decidable
-	// (Match/NoMatch) rather than Undecided at evaluation time.
+	// The instant-capable fields decide off stored state with no time window
+	// (reply_* off ReplyClass; opened/clicked/replied off their *At via the "ever"
+	// path when no within_days operator is set), so sentAt/now are immaterial for
+	// them. A fixed reference time keeps any window conditions ANDed alongside a
+	// signal condition decidable (Match/NoMatch) rather than Undecided here.
 	now := time.Now()
 	sentAt := now
 	if prog.SentAt != nil {
@@ -274,11 +299,11 @@ func MatchReplyBranchTarget(bc *models.BranchConditions, prog *CampaignContactPr
 	}
 	for i := range bc.Branches {
 		b := &bc.Branches[i]
-		hasReply := false
+		hasSignal := false
 		allMatch := true
 		for j := range b.Conditions {
-			if isReplyField(b.Conditions[j].Field) {
-				hasReply = true
+			if fieldBelongsToEvent(b.Conditions[j].Field, eventKind) {
+				hasSignal = true
 			}
 			cs, _ := conditionState(b.Conditions[j], prog, b.BranchID, sentAt, now)
 			if cs != BranchMatch {
@@ -286,11 +311,13 @@ func MatchReplyBranchTarget(bc *models.BranchConditions, prog *CampaignContactPr
 				break
 			}
 		}
-		if hasReply && allMatch {
-			return true, b.TargetSequenceID
+		if hasSignal && allMatch {
+			// Instant defaults to true for an instant-capable branch; an explicit
+			// false opts out, deferring the branch to the step-boundary scheduler.
+			return true, b.TargetSequenceID, b.Instant == nil || *b.Instant
 		}
 	}
-	return false, nil
+	return false, nil, false
 }
 
 // randomHolds deterministically routes Value% of contacts down a random-split

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -248,7 +248,10 @@ func (r *campaignRepository) Create(ctx context.Context, userID string, orgID *u
 		bcc = []string{}
 	}
 
-	stopOnReply := false
+	// Default stop_on_reply ON: continuing to cold-email someone who already
+	// replied is the classic deliverability / complaint-rate mistake, so new
+	// campaigns ship with it on unless the caller explicitly opts out.
+	stopOnReply := true
 	if data.StopOnReply != nil {
 		stopOnReply = *data.StopOnReply
 	}

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -25,6 +25,13 @@ type CampaignRepository interface {
 	GetByID(ctx context.Context, campaignID uuid.UUID) (*models.Campaign, error)
 	GetSequenceByID(ctx context.Context, sequenceID uuid.UUID) (*models.Sequence, error)
 	GetSequencesByCampaignID(ctx context.Context, campaignID uuid.UUID) ([]models.Sequence, error)
+	// GetSequencesRoutingByCampaignID returns every step of a campaign with the
+	// fields needed to walk the flow graph at reply time: id, position, kind,
+	// action config, and the branching tree (conditions). GetSequencesByCampaignID
+	// deliberately omits conditions/kind/action, so this is the routing-aware
+	// variant used by the instant reply-trigger executor to find the matched
+	// branch and follow its action chain.
+	GetSequencesRoutingByCampaignID(ctx context.Context, campaignID uuid.UUID) ([]models.Sequence, error)
 	Search(ctx context.Context, userID, query string, cursor, folder *string, limit int32) (*models.CampaignsResult, error)
 	Update(ctx context.Context, userID, query string, data *models.UpdateCampaign) (*models.Campaign, *errx.Error)
 	UpdateStatus(ctx context.Context, campaignID uuid.UUID, status string) error
@@ -1143,6 +1150,39 @@ func (r *campaignRepository) GetSequencesByCampaignID(ctx context.Context, campa
 			&seq.BodySync, &seq.BodyCode, &seq.WaitAfter, &seq.Position, &seq.UpdatedAt, &seq.CreatedAt,
 		)
 		if err != nil {
+			db.CaptureError(err, "", nil, "scan")
+			return nil, err
+		}
+		sequences = append(sequences, seq)
+	}
+
+	return sequences, rows.Err()
+}
+
+// GetSequencesRoutingByCampaignID loads every step with its routing fields
+// (kind, action, conditions) so the instant reply-trigger executor can locate
+// the matched reply branch and walk the linear action chain it targets. Ordered
+// by position so the caller can resolve "next step by position" if it ever needs
+// to (the chain here only follows explicit branch targets).
+func (r *campaignRepository) GetSequencesRoutingByCampaignID(ctx context.Context, campaignID uuid.UUID) ([]models.Sequence, error) {
+	query := `
+		SELECT id, position, kind, action, conditions
+		FROM sequences
+		WHERE campaign_id = $1
+		ORDER BY position ASC, created_at ASC
+	`
+
+	rows, err := r.DB.Query(ctx, query, campaignID)
+	if err != nil {
+		db.CaptureError(err, query, []any{campaignID}, "query")
+		return nil, err
+	}
+	defer rows.Close()
+
+	var sequences []models.Sequence
+	for rows.Next() {
+		var seq models.Sequence
+		if err := rows.Scan(&seq.ID, &seq.Position, &seq.Kind, &seq.Action, &seq.Conditions); err != nil {
 			db.CaptureError(err, "", nil, "scan")
 			return nil, err
 		}

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -88,6 +88,17 @@ type CampaignProgressRepository interface {
 	// evaluator / callers that need only the class.
 	GetLatestReplyClass(ctx context.Context, contactID, campaignID uuid.UUID) (string, error)
 
+	// ClaimReplyActionFire atomically claims the one-time right to run the instant
+	// reply-triggered action chain for the contact's current step. It stamps
+	// reply_actions_fired_at = NOW() only when it is still NULL and reports whether
+	// THIS call won the claim (true) or it was already fired (false). This is the
+	// exactly-once gate behind instant reply automations: a redelivered reply event
+	// (or an auto-reply followed by a human reply on the same step) sees the stamp
+	// and is a no-op. The progress row already exists at call time because
+	// RecordReplyClassification upserts it just before, so a missing row (claimed ==
+	// false) safely means "nothing to fire".
+	ClaimReplyActionFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error)
+
 	// Query methods
 	GetCampaignProgress(ctx context.Context, campaignID uuid.UUID) (*CampaignProgress, error)
 	GetCampaignRollingRates(ctx context.Context, campaignID uuid.UUID, since time.Time) (*CampaignRollingRates, error)
@@ -238,6 +249,26 @@ func (r *campaignProgressRepository) GetLatestReplyClass(ctx context.Context, co
 		return "", nil
 	}
 	return class, err
+}
+
+// ClaimReplyActionFire stamps reply_actions_fired_at exactly once per (campaign,
+// contact, step) progress row. The conditional WHERE ... IS NULL makes the claim
+// atomic under concurrent reply events: at most one UPDATE affects a row, so
+// RowsAffected() == 1 identifies the single caller that may run the chain.
+func (r *campaignProgressRepository) ClaimReplyActionFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error) {
+	query := `
+		UPDATE campaign_contact_progress
+		SET reply_actions_fired_at = NOW()
+		WHERE campaign_id = $1
+		  AND contact_id = $2
+		  AND sequence_id = $3
+		  AND reply_actions_fired_at IS NULL
+	`
+	tag, err := r.db.Exec(ctx, query, campaignID, contactID, sequenceID)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
 }
 
 // GetCampaignProgress retrieves overall campaign progress statistics

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -88,16 +88,20 @@ type CampaignProgressRepository interface {
 	// evaluator / callers that need only the class.
 	GetLatestReplyClass(ctx context.Context, contactID, campaignID uuid.UUID) (string, error)
 
-	// ClaimReplyActionFire atomically claims the one-time right to run the instant
-	// reply-triggered action chain for the contact's current step. It stamps
-	// reply_actions_fired_at = NOW() only when it is still NULL and reports whether
-	// THIS call won the claim (true) or it was already fired (false). This is the
-	// exactly-once gate behind instant reply automations: a redelivered reply event
-	// (or an auto-reply followed by a human reply on the same step) sees the stamp
-	// and is a no-op. The progress row already exists at call time because
-	// RecordReplyClassification upserts it just before, so a missing row (claimed ==
-	// false) safely means "nothing to fire".
-	ClaimReplyActionFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error)
+	// ClaimInstantFire atomically claims the one-time right to run the instant
+	// action chain for the contact's current step FOR A SINGLE EVENT KIND
+	// ("reply" / "open" / "click"). It appends eventKind to the instant_fired
+	// array only when that kind is not already present and reports whether THIS
+	// call won the claim (true) or that kind had already fired (false). This is
+	// the per-(step, event) exactly-once gate behind instant automations: a
+	// redelivered event of the same kind (or an auto-reply followed by a human
+	// reply on the same step) sees the kind in the array and is a no-op, while a
+	// DIFFERENT kind on the same step (a contact who opens AND clicks AND replies)
+	// is still free to fire its own chain exactly once. The progress row already
+	// exists at call time (RecordReplyClassification / RecordEmailOpened /
+	// RecordEmailClicked upsert/update it just before), so a missing row
+	// (claimed == false) safely means "nothing to fire".
+	ClaimInstantFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, eventKind string) (bool, error)
 
 	// Query methods
 	GetCampaignProgress(ctx context.Context, campaignID uuid.UUID) (*CampaignProgress, error)
@@ -251,20 +255,22 @@ func (r *campaignProgressRepository) GetLatestReplyClass(ctx context.Context, co
 	return class, err
 }
 
-// ClaimReplyActionFire stamps reply_actions_fired_at exactly once per (campaign,
-// contact, step) progress row. The conditional WHERE ... IS NULL makes the claim
-// atomic under concurrent reply events: at most one UPDATE affects a row, so
-// RowsAffected() == 1 identifies the single caller that may run the chain.
-func (r *campaignProgressRepository) ClaimReplyActionFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error) {
+// ClaimInstantFire appends eventKind to instant_fired exactly once per (campaign,
+// contact, step, eventKind). The conditional NOT ($4 = ANY(instant_fired)) makes
+// the claim atomic under concurrent events of the same kind: at most one UPDATE
+// affects a row for a given kind, so RowsAffected() == 1 identifies the single
+// caller that may run that kind's chain. Different kinds on the same step append
+// independently, so an open, a click, and a reply on one step each fire once.
+func (r *campaignProgressRepository) ClaimInstantFire(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, eventKind string) (bool, error) {
 	query := `
 		UPDATE campaign_contact_progress
-		SET reply_actions_fired_at = NOW()
+		SET instant_fired = array_append(instant_fired, $4)
 		WHERE campaign_id = $1
 		  AND contact_id = $2
 		  AND sequence_id = $3
-		  AND reply_actions_fired_at IS NULL
+		  AND NOT ($4 = ANY(instant_fired))
 	`
-	tag, err := r.db.Exec(ctx, query, campaignID, contactID, sequenceID)
+	tag, err := r.db.Exec(ctx, query, campaignID, contactID, sequenceID, eventKind)
 	if err != nil {
 		return false, err
 	}

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -22,6 +22,12 @@ type CampaignContactProgress struct {
 	RepliedAt    *time.Time
 	BouncedAt    *time.Time
 	ComplainedAt *time.Time
+	// ReplyClass is the layered classifier verdict for the contact's reply
+	// (positive | negative | neutral | auto_reply | out_of_office | unsubscribe |
+	// unknown; "" when no reply was classified). Read by the reply_* branch
+	// conditions. RepliedAt is set ONLY for human replies, so an automated reply
+	// can carry a ReplyClass here without ever tripping "replied"/stop_on_reply.
+	ReplyClass string
 }
 
 // CampaignProgress represents overall campaign progress
@@ -69,6 +75,18 @@ type CampaignProgressRepository interface {
 	RecordEmailReplied(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error
 	RecordEmailBounced(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error
 	RecordEmailComplained(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error
+
+	// RecordReplyClassification stores the layered classifier verdict
+	// (class/confidence/source) for the contact's reply on the given step. This
+	// is the data the reply_* branch conditions read. It does NOT stamp
+	// replied_at — only a HUMAN reply should set replied_at (so automated replies
+	// never trip stop_on_reply / the "replied" condition). Callers stamp
+	// replied_at separately via RecordEmailReplied for human replies only.
+	RecordReplyClassification(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, class, source string, confidence float64) error
+	// GetLatestReplyClass returns the most-recent classified reply class for a
+	// contact in a campaign ("" when none). Convenience getter for the branch
+	// evaluator / callers that need only the class.
+	GetLatestReplyClass(ctx context.Context, contactID, campaignID uuid.UUID) (string, error)
 
 	// Query methods
 	GetCampaignProgress(ctx context.Context, campaignID uuid.UUID) (*CampaignProgress, error)
@@ -186,6 +204,42 @@ func (r *campaignProgressRepository) RecordEmailComplained(ctx context.Context, 
 	return err
 }
 
+// RecordReplyClassification persists the classifier verdict on the progress row.
+// It upserts so the classification lands even if the reply arrives before the
+// step's progress row is materialized (rare, but threading can race). It never
+// touches replied_at — human-vs-automated gating lives in the caller, which
+// stamps replied_at via RecordEmailReplied only for human replies.
+func (r *campaignProgressRepository) RecordReplyClassification(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, class, source string, confidence float64) error {
+	query := `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, reply_class, reply_confidence, reply_source)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (campaign_id, contact_id, sequence_id)
+		DO UPDATE SET reply_class = EXCLUDED.reply_class,
+		              reply_confidence = EXCLUDED.reply_confidence,
+		              reply_source = EXCLUDED.reply_source
+	`
+	_, err := r.db.Exec(ctx, query, campaignID, contactID, sequenceID, class, confidence, source)
+	return err
+}
+
+// GetLatestReplyClass returns the most-recent non-empty reply_class for a
+// contact in a campaign, or "" when none has been classified.
+func (r *campaignProgressRepository) GetLatestReplyClass(ctx context.Context, contactID, campaignID uuid.UUID) (string, error) {
+	query := `
+		SELECT reply_class
+		FROM campaign_contact_progress
+		WHERE contact_id = $1 AND campaign_id = $2 AND reply_class <> ''
+		ORDER BY COALESCE(sent_at, '-infinity'::timestamptz) DESC
+		LIMIT 1
+	`
+	var class string
+	err := r.db.QueryRow(ctx, query, contactID, campaignID).Scan(&class)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return class, err
+}
+
 // GetCampaignProgress retrieves overall campaign progress statistics
 func (r *campaignProgressRepository) GetCampaignProgress(ctx context.Context, campaignID uuid.UUID) (*CampaignProgress, error) {
 	query := `
@@ -262,7 +316,7 @@ func (r *campaignProgressRepository) GetCampaignRollingRates(ctx context.Context
 // GetContactProgress retrieves progress for a specific contact in a campaign
 func (r *campaignProgressRepository) GetContactProgress(ctx context.Context, campaignID, contactID uuid.UUID) ([]CampaignContactProgress, error) {
 	query := `
-		SELECT campaign_id, contact_id, sequence_id, sent_at, opened_at, clicked_at, replied_at, bounced_at, complained_at
+		SELECT campaign_id, contact_id, sequence_id, sent_at, opened_at, clicked_at, replied_at, bounced_at, complained_at, COALESCE(reply_class, '')
 		FROM campaign_contact_progress
 		WHERE campaign_id = $1 AND contact_id = $2
 		ORDER BY sent_at ASC
@@ -287,6 +341,7 @@ func (r *campaignProgressRepository) GetContactProgress(ctx context.Context, cam
 			&progress.RepliedAt,
 			&progress.BouncedAt,
 			&progress.ComplainedAt,
+			&progress.ReplyClass,
 		)
 		if err != nil {
 			return nil, err
@@ -498,12 +553,12 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 
 	query := `
 		SELECT cl.contact_id,
-		       lp.sequence_id, lp.sent_at, lp.opened_at, lp.clicked_at, lp.replied_at,
+		       lp.sequence_id, lp.sent_at, lp.opened_at, lp.clicked_at, lp.replied_at, COALESCE(lp.reply_class, ''),
 		       COALESCE(ss.ids, '{}') AS sent_ids
 		FROM campaign_leads cl
 		JOIN contacts c ON c.id = cl.contact_id
 		LEFT JOIN LATERAL (
-			SELECT sequence_id, sent_at, opened_at, clicked_at, replied_at
+			SELECT sequence_id, sent_at, opened_at, clicked_at, replied_at, reply_class
 			FROM campaign_contact_progress p
 			WHERE p.campaign_id = $1 AND p.contact_id = cl.contact_id AND p.sent_at IS NOT NULL
 			ORDER BY p.sent_at DESC LIMIT 1
@@ -546,8 +601,9 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		var contactID uuid.UUID
 		var lastSeq *uuid.UUID
 		var sentAt, openedAt, clickedAt, repliedAt *time.Time
+		var replyClass string
 		var sentIDs []uuid.UUID
-		if serr := rows.Scan(&contactID, &lastSeq, &sentAt, &openedAt, &clickedAt, &repliedAt, &sentIDs); serr != nil {
+		if serr := rows.Scan(&contactID, &lastSeq, &sentAt, &openedAt, &clickedAt, &repliedAt, &replyClass, &sentIDs); serr != nil {
 			return nil, nil, serr
 		}
 
@@ -563,6 +619,7 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 			prog := &CampaignContactProgress{
 				CampaignID: campaignID, ContactID: contactID, SequenceID: *lastSeq,
 				SentAt: sentAt, OpenedAt: openedAt, ClickedAt: clickedAt, RepliedAt: repliedAt,
+				ReplyClass: replyClass,
 			}
 			sa := time.Time{}
 			if sentAt != nil {

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -505,6 +505,70 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 	entry := steps[0].id
 	now := time.Now()
 
+	// Route-aware stop_on_reply. Rather than blanket-excluding every contact who
+	// has replied (which also kills the reply branch's OWN follow-up steps), a
+	// replied contact keeps moving ONLY while their next routed step is part of the
+	// REPLY FLOW: the subgraph downstream of a reply branch that is NOT also part
+	// of the cold sequence. The normal / fall-through cold sequence stops; the
+	// reply branch's path (its actions AND any follow-up emails) runs to
+	// completion. Compute the reply-flow step set once and load the flag.
+	var stopOnReply bool
+	if serr := r.db.QueryRow(ctx, `SELECT stop_on_reply FROM campaigns WHERE id = $1`, campaignID).Scan(&stopOnReply); serr != nil {
+		return nil, nil, serr
+	}
+	replyFlowSteps := map[uuid.UUID]bool{}
+	if stopOnReply {
+		// bfs walks a directed reachability closure from `seeds`, following the
+		// targets selected by `follow`, and records every visited step into `into`.
+		bfs := func(seeds []uuid.UUID, into map[uuid.UUID]bool, follow func(b *models.Branch) bool) {
+			queue := append([]uuid.UUID(nil), seeds...)
+			for _, s := range seeds {
+				into[s] = true
+			}
+			for len(queue) > 0 {
+				cur := queue[0]
+				queue = queue[1:]
+				idx, ok := idxByID[cur]
+				if !ok {
+					continue
+				}
+				for j := range steps[idx].bc.Branches {
+					b := &steps[idx].bc.Branches[j]
+					if b.TargetSequenceID == nil || into[*b.TargetSequenceID] || !follow(b) {
+						continue
+					}
+					into[*b.TargetSequenceID] = true
+					queue = append(queue, *b.TargetSequenceID)
+				}
+			}
+		}
+
+		// 1. Cold trunk: every step a NON-replier reaches from the entry, i.e.
+		//    following every branch EXCEPT the ones that route on a positive reply.
+		//    A step that also sits here (a reply branch merged back into the cold
+		//    sequence) is NOT reply flow — a replier must stop when they reach it.
+		coldReachable := map[uuid.UUID]bool{}
+		bfs([]uuid.UUID{entry}, coldReachable, func(b *models.Branch) bool {
+			return !branchHasPositiveReplyCondition(b)
+		})
+
+		// 2. Reply flow: everything reachable from a positive-reply branch target
+		//    (following ALL onward branches, so internal reply-flow branching is
+		//    kept), MINUS the cold trunk.
+		var seeds []uuid.UUID
+		for i := range steps {
+			for j := range steps[i].bc.Branches {
+				b := &steps[i].bc.Branches[j]
+				if b.TargetSequenceID != nil && branchHasPositiveReplyCondition(b) && !coldReachable[*b.TargetSequenceID] {
+					seeds = append(seeds, *b.TargetSequenceID)
+				}
+			}
+		}
+		bfs(seeds, replyFlowSteps, func(b *models.Branch) bool {
+			return b.TargetSequenceID != nil && !coldReachable[*b.TargetSequenceID]
+		})
+	}
+
 	// routeResult is the outcome of routing a contact out of their current step:
 	// send `target`, fully `stop`, or `wait` until a condition window elapses.
 	type routeResult struct {
@@ -554,6 +618,37 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		return routeResult{stop: true}
 	}
 
+	// routeReplyOnly is the routing used for a contact who HAS REPLIED but is still
+	// on the cold trunk (stop_on_reply on). It considers ONLY positive-reply
+	// branches that lead into the reply flow, giving them priority regardless of
+	// declared order, and never waits on a cold window. The first such branch that
+	// matches right now routes the contact into the reply flow; anything else means
+	// "no reply handling here for this reply" -> STOP the cold sequence. This is
+	// what lets a non-instant reply branch fire even when an engagement branch is
+	// declared ahead of it, and stops a replier instead of deferring on a cold
+	// "did not open within N days" window forever.
+	routeReplyOnly := func(fromID uuid.UUID, prog *CampaignContactProgress, sentAt time.Time) routeResult {
+		idx, ok := idxByID[fromID]
+		if !ok {
+			return routeResult{stop: true}
+		}
+		for i := range steps[idx].bc.Branches {
+			b := &steps[idx].bc.Branches[i]
+			if b.TargetSequenceID == nil || !branchHasPositiveReplyCondition(b) || !replyFlowSteps[*b.TargetSequenceID] {
+				continue
+			}
+			if st, _ := evaluateBranchState(b, prog, sentAt, now); st != BranchMatch {
+				continue
+			}
+			if _, live := idxByID[*b.TargetSequenceID]; !live {
+				continue
+			}
+			t := *b.TargetSequenceID
+			return routeResult{target: &t}
+		}
+		return routeResult{stop: true}
+	}
+
 	// 2. Ordered candidate contacts + their last-sent step (with engagement) + sent set.
 	var contactOrder string
 	switch orderBy {
@@ -585,7 +680,11 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 	query := `
 		SELECT cl.contact_id,
 		       lp.sequence_id, lp.sent_at, lp.opened_at, lp.clicked_at, lp.replied_at, COALESCE(lp.reply_class, ''),
-		       COALESCE(ss.ids, '{}') AS sent_ids
+		       COALESCE(ss.ids, '{}') AS sent_ids,
+		       EXISTS (
+		         SELECT 1 FROM campaign_contact_progress rp
+		         WHERE rp.campaign_id = $1 AND rp.contact_id = cl.contact_id AND rp.replied_at IS NOT NULL
+		       ) AS has_replied
 		FROM campaign_leads cl
 		JOIN contacts c ON c.id = cl.contact_id
 		LEFT JOIN LATERAL (
@@ -603,14 +702,6 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		  AND NOT EXISTS (
 		    SELECT 1 FROM campaign_contact_progress b
 		    WHERE b.contact_id = cl.contact_id AND b.bounced_at IS NOT NULL
-		  )
-		  AND NOT EXISTS (
-		    -- Global "stop on reply": when the campaign has it on, a contact who
-		    -- has already replied never surfaces as a candidate again.
-		    SELECT 1 FROM campaigns camp_sr
-		    JOIN campaign_contact_progress rp
-		      ON rp.contact_id = cl.contact_id AND rp.campaign_id = $1
-		    WHERE camp_sr.id = $1 AND camp_sr.stop_on_reply = true AND rp.replied_at IS NOT NULL
 		  )
 		  AND NOT EXISTS (
 		    SELECT 1 FROM suppressed_recipients sr
@@ -634,7 +725,8 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		var sentAt, openedAt, clickedAt, repliedAt *time.Time
 		var replyClass string
 		var sentIDs []uuid.UUID
-		if serr := rows.Scan(&contactID, &lastSeq, &sentAt, &openedAt, &clickedAt, &repliedAt, &replyClass, &sentIDs); serr != nil {
+		var hasReplied bool
+		if serr := rows.Scan(&contactID, &lastSeq, &sentAt, &openedAt, &clickedAt, &repliedAt, &replyClass, &sentIDs, &hasReplied); serr != nil {
 			return nil, nil, serr
 		}
 
@@ -657,6 +749,22 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 				sa = *sentAt
 			}
 			res = routeNext(*lastSeq, prog, sa)
+
+			// Route-aware stop_on_reply for a contact who has replied:
+			//   - still on the cold trunk (lastSeq not in the reply flow): they may
+			//     only ENTER the reply flow via a positive-reply branch. Any cold
+			//     route, an undecided cold window, or a stop ends them here — no cold
+			//     sends and no deferring on a cold window.
+			//   - already inside the reply flow: keep the reply flow's own routing
+			//     (its waits are legitimate), but if it would route back out into the
+			//     cold sequence, stop instead.
+			if stopOnReply && hasReplied {
+				if !replyFlowSteps[*lastSeq] {
+					res = routeReplyOnly(*lastSeq, prog, sa)
+				} else if res.target != nil && !replyFlowSteps[*res.target] {
+					res = routeResult{stop: true}
+				}
+			}
 		}
 
 		if res.wait != nil {
@@ -668,7 +776,7 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 			continue
 		}
 		if res.stop || res.target == nil {
-			continue // reached the end / a STOP
+			continue // reached the end / a STOP (incl. a replied contact stopped above)
 		}
 		// Loop guard: never re-send a step the contact already received.
 		already := false
@@ -689,4 +797,19 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 	// Nobody sendable now. If contacts are waiting on a window, hand back the
 	// soonest re-check time so the scheduler defers rather than completing.
 	return nil, earliestWait, nil
+}
+
+// branchHasPositiveReplyCondition reports whether a branch is a "reply branch":
+// one that routes on a POSITIVE reply signal (a human reply, or a classified
+// reply intent). Its target seeds the reply flow used by route-aware
+// stop_on_reply. not_replied is deliberately excluded — it is the "did NOT
+// reply" continuation of the normal cold sequence, not the reply flow.
+func branchHasPositiveReplyCondition(b *models.Branch) bool {
+	for i := range b.Conditions {
+		switch b.Conditions[i].Field {
+		case "replied", "reply_positive", "reply_negative", "reply_neutral", "reply_automated":
+			return true
+		}
+	}
+	return false
 }

--- a/internal/repository/pg_crm.go
+++ b/internal/repository/pg_crm.go
@@ -41,6 +41,8 @@ type CRMRepository interface {
 	CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, error)
 	GetDeal(ctx context.Context, orgID, dealID uuid.UUID) (*models.Deal, error)
 	ListDeals(ctx context.Context, orgID uuid.UUID, pipelineID, stageID *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.DealsResult, error)
+	SearchDeals(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals, limit, offset int) (*models.DealsSearchResult, error)
+	DealsSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals) (*models.DealsSummary, error)
 	UpdateDeal(ctx context.Context, orgID, dealID uuid.UUID, data *models.UpdateDeal) (*models.Deal, error)
 	DeleteDeal(ctx context.Context, orgID, dealID uuid.UUID) error
 	GetDealsByContact(ctx context.Context, contactID uuid.UUID) ([]models.Deal, error)
@@ -493,20 +495,21 @@ func (r *crmRepository) CreateDeal(ctx context.Context, orgID uuid.UUID, data *m
 	}
 
 	query := `
-		INSERT INTO deals (organization_id, pipeline_id, stage_id, contact_id, name, value, currency, expected_close_date, assigned_to)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO deals (organization_id, pipeline_id, stage_id, contact_id, name, value, currency, expected_close_date, assigned_to, campaign_id, source_mailbox_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
 		RETURNING id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status,
-		          expected_close_date, won_at, lost_at, lost_reason, assigned_to, created_at, updated_at
+		          expected_close_date, won_at, lost_at, lost_reason, assigned_to, campaign_id, source_mailbox_id, created_at, updated_at
 	`
 	var deal models.Deal
 	err := r.db.QueryRow(ctx, query,
 		orgID, data.PipelineID, data.StageID, data.ContactID,
 		data.Name, data.Value, currency, data.ExpectedCloseDate, data.AssignedTo,
+		data.CampaignID, data.SourceMailboxID,
 	).Scan(
 		&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
 		&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
 		&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
-		&deal.AssignedTo, &deal.CreatedAt, &deal.UpdatedAt,
+		&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -517,7 +520,7 @@ func (r *crmRepository) CreateDeal(ctx context.Context, orgID uuid.UUID, data *m
 func (r *crmRepository) GetDeal(ctx context.Context, orgID, dealID uuid.UUID) (*models.Deal, error) {
 	query := `
 		SELECT id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status,
-		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, created_at, updated_at
+		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, campaign_id, source_mailbox_id, created_at, updated_at
 		FROM deals
 		WHERE organization_id = $1 AND id = $2
 	`
@@ -526,7 +529,7 @@ func (r *crmRepository) GetDeal(ctx context.Context, orgID, dealID uuid.UUID) (*
 		&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
 		&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
 		&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
-		&deal.AssignedTo, &deal.CreatedAt, &deal.UpdatedAt,
+		&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -566,7 +569,7 @@ func (r *crmRepository) ListDeals(ctx context.Context, orgID uuid.UUID, pipeline
 
 	query := fmt.Sprintf(`
 		SELECT id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status,
-		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, created_at, updated_at
+		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, campaign_id, source_mailbox_id, created_at, updated_at
 		FROM deals
 		WHERE %s
 		ORDER BY created_at DESC, id DESC
@@ -587,7 +590,7 @@ func (r *crmRepository) ListDeals(ctx context.Context, orgID uuid.UUID, pipeline
 			&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
 			&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
 			&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
-			&deal.AssignedTo, &deal.CreatedAt, &deal.UpdatedAt,
+			&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -675,7 +678,7 @@ func (r *crmRepository) UpdateDeal(ctx context.Context, orgID, dealID uuid.UUID,
 		UPDATE deals SET %s
 		WHERE organization_id = $1 AND id = $2
 		RETURNING id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status,
-		          expected_close_date, won_at, lost_at, lost_reason, assigned_to, created_at, updated_at
+		          expected_close_date, won_at, lost_at, lost_reason, assigned_to, campaign_id, source_mailbox_id, created_at, updated_at
 	`, strings.Join(setClauses, ", "))
 
 	var deal models.Deal
@@ -683,7 +686,7 @@ func (r *crmRepository) UpdateDeal(ctx context.Context, orgID, dealID uuid.UUID,
 		&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
 		&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
 		&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
-		&deal.AssignedTo, &deal.CreatedAt, &deal.UpdatedAt,
+		&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -708,7 +711,7 @@ func (r *crmRepository) DeleteDeal(ctx context.Context, orgID, dealID uuid.UUID)
 func (r *crmRepository) GetDealsByContact(ctx context.Context, contactID uuid.UUID) ([]models.Deal, error) {
 	query := `
 		SELECT id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status,
-		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, created_at, updated_at
+		       expected_close_date, won_at, lost_at, lost_reason, assigned_to, campaign_id, source_mailbox_id, created_at, updated_at
 		FROM deals
 		WHERE contact_id = $1
 		ORDER BY created_at DESC
@@ -726,13 +729,276 @@ func (r *crmRepository) GetDealsByContact(ctx context.Context, contactID uuid.UU
 			&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
 			&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
 			&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
-			&deal.AssignedTo, &deal.CreatedAt, &deal.UpdatedAt,
+			&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
 		); err != nil {
 			return nil, err
 		}
 		deals = append(deals, deal)
 	}
 	return deals, nil
+}
+
+// =====================
+// Deal search + summary
+// =====================
+
+// dealSearchWhere builds the shared WHERE clause for SearchDeals / DealsSummary
+// from a filter body. It returns the clause list and the bound args, starting
+// at $1 = orgID. Both the paginated search and the aggregate summary call this
+// so a header total always reflects the exact same filter as the rows below it.
+func dealSearchWhere(orgID uuid.UUID, f models.SearchDeals) ([]string, []any) {
+	clauses := []string{"d.organization_id = $1"}
+	args := []any{orgID}
+	pos := 2
+
+	if f.Query != "" {
+		clauses = append(clauses, fmt.Sprintf("d.name ILIKE $%d", pos))
+		args = append(args, "%"+f.Query+"%")
+		pos++
+	}
+	appendIn := func(col string, vals []string) {
+		if len(vals) == 0 {
+			return
+		}
+		ph := make([]string, len(vals))
+		for i, v := range vals {
+			ph[i] = fmt.Sprintf("$%d", pos)
+			args = append(args, v)
+			pos++
+		}
+		clauses = append(clauses, fmt.Sprintf("d.%s IN (%s)", col, strings.Join(ph, ",")))
+	}
+	appendIn("status", f.Statuses)
+	appendIn("pipeline_id", f.PipelineIDs)
+	appendIn("stage_id", f.StageIDs)
+	appendIn("assigned_to", f.AssignedTo)
+	appendIn("campaign_id", f.CampaignIDs)
+
+	if f.MinValue != nil {
+		clauses = append(clauses, fmt.Sprintf("d.value >= $%d", pos))
+		args = append(args, *f.MinValue)
+		pos++
+	}
+	if f.MaxValue != nil {
+		clauses = append(clauses, fmt.Sprintf("d.value <= $%d", pos))
+		args = append(args, *f.MaxValue)
+		pos++
+	}
+	if f.CloseAfter != nil {
+		clauses = append(clauses, fmt.Sprintf("d.expected_close_date >= $%d", pos))
+		args = append(args, *f.CloseAfter)
+		pos++
+	}
+	if f.CloseBefore != nil {
+		clauses = append(clauses, fmt.Sprintf("d.expected_close_date <= $%d", pos))
+		args = append(args, *f.CloseBefore)
+		pos++
+	}
+	if f.CreatedAfter != nil {
+		clauses = append(clauses, fmt.Sprintf("d.created_at >= $%d", pos))
+		args = append(args, *f.CreatedAfter)
+		pos++
+	}
+	if f.CreatedBefore != nil {
+		clauses = append(clauses, fmt.Sprintf("d.created_at <= $%d", pos))
+		args = append(args, *f.CreatedBefore)
+		pos++
+	}
+
+	return clauses, args
+}
+
+// dealSortColumn whitelists the sortable columns so SortBy can never inject SQL.
+func dealSortColumn(sortBy string) string {
+	switch sortBy {
+	case "value":
+		return "d.value"
+	case "expected_close_date":
+		return "d.expected_close_date"
+	case "name":
+		return "d.name"
+	case "updated_at":
+		return "d.updated_at"
+	default:
+		return "d.created_at"
+	}
+}
+
+func (r *crmRepository) SearchDeals(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals, limit, offset int) (*models.DealsSearchResult, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	clauses, args := dealSearchWhere(orgID, filters)
+	whereSQL := strings.Join(clauses, " AND ")
+
+	// Exact total over the same filter, so the UI can show "N of M" honestly.
+	var total int64
+	if err := r.db.QueryRow(ctx, "SELECT COUNT(*) FROM deals d WHERE "+whereSQL, args...).Scan(&total); err != nil {
+		return nil, err
+	}
+
+	sortCol := dealSortColumn(filters.SortBy)
+	dir := "DESC"
+	if filters.Reverse {
+		dir = "ASC"
+	}
+
+	limitPos := len(args) + 1
+	offsetPos := len(args) + 2
+	query := fmt.Sprintf(`
+		SELECT d.id, d.organization_id, d.pipeline_id, d.stage_id, d.contact_id, d.name, d.value, d.currency, d.status,
+		       d.expected_close_date, d.won_at, d.lost_at, d.lost_reason, d.assigned_to, d.campaign_id, d.source_mailbox_id,
+		       d.created_at, d.updated_at,
+		       co.id, co.first_name, co.last_name, co.email, co.company,
+		       ps.name, ps.color, ps.position,
+		       cam.name
+		FROM deals d
+		LEFT JOIN contacts co ON co.id = d.contact_id
+		LEFT JOIN pipeline_stages ps ON ps.id = d.stage_id
+		LEFT JOIN campaigns cam ON cam.id = d.campaign_id
+		WHERE %s
+		ORDER BY %s %s NULLS LAST, d.id DESC
+		LIMIT $%d OFFSET $%d
+	`, whereSQL, sortCol, dir, limitPos, offsetPos)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	deals := make([]models.Deal, 0, limit)
+	for rows.Next() {
+		var deal models.Deal
+		var (
+			coID                            *uuid.UUID
+			coFirst, coLast, coEmail, coCmp *string
+			stName, stColor                 *string
+			stPos                           *int
+			camName                         *string
+		)
+		if err := rows.Scan(
+			&deal.ID, &deal.OrganizationID, &deal.PipelineID, &deal.StageID,
+			&deal.ContactID, &deal.Name, &deal.Value, &deal.Currency, &deal.Status,
+			&deal.ExpectedCloseDate, &deal.WonAt, &deal.LostAt, &deal.LostReason,
+			&deal.AssignedTo, &deal.CampaignID, &deal.SourceMailboxID, &deal.CreatedAt, &deal.UpdatedAt,
+			&coID, &coFirst, &coLast, &coEmail, &coCmp,
+			&stName, &stColor, &stPos,
+			&camName,
+		); err != nil {
+			return nil, err
+		}
+		if coID != nil {
+			deal.Contact = &models.Contact{ID: *coID}
+			if coFirst != nil {
+				deal.Contact.FirstName = *coFirst
+			}
+			if coLast != nil {
+				deal.Contact.LastName = *coLast
+			}
+			if coEmail != nil {
+				deal.Contact.Email = *coEmail
+			}
+			if coCmp != nil {
+				deal.Contact.Company = *coCmp
+			}
+		}
+		if stName != nil {
+			deal.Stage = &models.PipelineStage{ID: deal.StageID, Name: *stName}
+			if stColor != nil {
+				deal.Stage.Color = *stColor
+			}
+			if stPos != nil {
+				deal.Stage.Position = *stPos
+			}
+		}
+		deal.CampaignName = camName
+		deals = append(deals, deal)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	hasMore := int64(offset+len(deals)) < total
+	var nextOffset *int
+	if hasMore {
+		n := offset + limit
+		nextOffset = &n
+	}
+
+	return &models.DealsSearchResult{
+		Data: deals,
+		Pagination: models.DealsSearchPagination{
+			Total:      total,
+			Limit:      limit,
+			Offset:     offset,
+			HasMore:    hasMore,
+			NextOffset: nextOffset,
+		},
+	}, nil
+}
+
+func (r *crmRepository) DealsSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchDeals) (*models.DealsSummary, error) {
+	clauses, args := dealSearchWhere(orgID, filters)
+	whereSQL := strings.Join(clauses, " AND ")
+
+	var s models.DealsSummary
+	headline := fmt.Sprintf(`
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE d.status = 'open'),
+			COALESCE(SUM(d.value) FILTER (WHERE d.status = 'open'), 0),
+			COUNT(*) FILTER (WHERE d.status = 'won'),
+			COALESCE(SUM(d.value) FILTER (WHERE d.status = 'won'), 0),
+			COUNT(*) FILTER (WHERE d.status = 'lost'),
+			COALESCE(SUM(d.value) FILTER (WHERE d.status = 'lost'), 0),
+			COUNT(DISTINCT d.currency),
+			COALESCE(MAX(d.currency), 'USD')
+		FROM deals d
+		WHERE %s
+	`, whereSQL)
+	var distinctCurrencies int64
+	if err := r.db.QueryRow(ctx, headline, args...).Scan(
+		&s.Total, &s.OpenCount, &s.OpenValue, &s.WonCount, &s.WonValue,
+		&s.LostCount, &s.LostValue, &distinctCurrencies, &s.Currency,
+	); err != nil {
+		return nil, err
+	}
+	// More than one currency in the matched set means a single blended SUM is
+	// not meaningful; flag it so the UI can warn instead of lying with a total.
+	s.MixedCurrency = distinctCurrencies > 1
+
+	// Per-stage rollup for accurate board column headers (count + open value).
+	stageQuery := fmt.Sprintf(`
+		SELECT d.stage_id, COUNT(*), COALESCE(SUM(d.value) FILTER (WHERE d.status = 'open'), 0)
+		FROM deals d
+		WHERE %s
+		GROUP BY d.stage_id
+	`, whereSQL)
+	rows, err := r.db.Query(ctx, stageQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	s.Stages = []models.DealStageSummary{}
+	for rows.Next() {
+		var st models.DealStageSummary
+		if err := rows.Scan(&st.StageID, &st.Count, &st.Value); err != nil {
+			return nil, err
+		}
+		s.Stages = append(s.Stages, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
 }
 
 // =====================

--- a/internal/repository/pg_crm.go
+++ b/internal/repository/pg_crm.go
@@ -51,6 +51,8 @@ type CRMRepository interface {
 	CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, error)
 	GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID) (*models.CRMTask, error)
 	ListCRMTasks(ctx context.Context, orgID uuid.UUID, contactID, dealID, assignedTo *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.CRMTasksResult, error)
+	SearchCRMTasks(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks, limit, offset int) (*models.TasksSearchResult, error)
+	TasksSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks) (*models.TasksSummary, error)
 	UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID, data *models.UpdateCRMTask) (*models.CRMTask, error)
 	DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) error
 
@@ -1187,6 +1189,192 @@ func (r *crmRepository) ListCRMTasks(ctx context.Context, orgID uuid.UUID, conta
 		Data:       tasks,
 		Pagination: models.Pagination{NextCursor: nextCursor, HasMore: hasMore},
 	}, nil
+}
+
+// =====================
+// Task search + summary
+// =====================
+
+// taskSearchWhere builds the shared WHERE clause for SearchCRMTasks / TasksSummary
+// from a filter body. It returns the clause list and the bound args, starting at
+// $1 = orgID. Both the paginated search and the aggregate summary call this so a
+// header total always reflects the exact same filter as the rows below it.
+func taskSearchWhere(orgID uuid.UUID, f models.SearchTasks) ([]string, []any) {
+	clauses := []string{"t.organization_id = $1"}
+	args := []any{orgID}
+	pos := 2
+
+	if f.Query != "" {
+		clauses = append(clauses, fmt.Sprintf("t.title ILIKE $%d", pos))
+		args = append(args, "%"+f.Query+"%")
+		pos++
+	}
+	appendIn := func(col string, vals []string) {
+		if len(vals) == 0 {
+			return
+		}
+		ph := make([]string, len(vals))
+		for i, v := range vals {
+			ph[i] = fmt.Sprintf("$%d", pos)
+			args = append(args, v)
+			pos++
+		}
+		clauses = append(clauses, fmt.Sprintf("t.%s IN (%s)", col, strings.Join(ph, ",")))
+	}
+	appendIn("status", f.Statuses)
+	appendIn("priority", f.Priorities)
+	appendIn("type", f.Types)
+	appendIn("assigned_to", f.AssignedTo)
+
+	if f.ContactID != nil {
+		clauses = append(clauses, fmt.Sprintf("t.contact_id = $%d", pos))
+		args = append(args, *f.ContactID)
+		pos++
+	}
+	if f.DealID != nil {
+		clauses = append(clauses, fmt.Sprintf("t.deal_id = $%d", pos))
+		args = append(args, *f.DealID)
+		pos++
+	}
+	if f.DueAfter != nil {
+		clauses = append(clauses, fmt.Sprintf("t.due_date >= $%d", pos))
+		args = append(args, *f.DueAfter)
+		pos++
+	}
+	if f.DueBefore != nil {
+		clauses = append(clauses, fmt.Sprintf("t.due_date <= $%d", pos))
+		args = append(args, *f.DueBefore)
+		pos++
+	}
+	if f.Overdue {
+		// Overdue = a deadline in the past that is still actionable. Completed and
+		// cancelled tasks are never overdue, and tasks without a due_date can't be.
+		clauses = append(clauses, "t.due_date IS NOT NULL AND t.due_date < now() AND t.status NOT IN ('completed', 'cancelled')")
+	}
+
+	return clauses, args
+}
+
+// taskSortColumn whitelists the sortable columns so SortBy can never inject SQL.
+// priority sorts by its semantic weight (urgent first when DESC), not the enum
+// string, so "priority" ordering matches user intent rather than alphabetical.
+func taskSortColumn(sortBy string) string {
+	switch sortBy {
+	case "due_date":
+		return "t.due_date"
+	case "title":
+		return "t.title"
+	case "updated_at":
+		return "t.updated_at"
+	case "priority":
+		return "CASE t.priority WHEN 'urgent' THEN 4 WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END"
+	default:
+		return "t.created_at"
+	}
+}
+
+func (r *crmRepository) SearchCRMTasks(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks, limit, offset int) (*models.TasksSearchResult, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	clauses, args := taskSearchWhere(orgID, filters)
+	whereSQL := strings.Join(clauses, " AND ")
+
+	// Exact total over the same filter, so the UI can show "N of M" honestly.
+	var total int64
+	if err := r.db.QueryRow(ctx, "SELECT COUNT(*) FROM crm_tasks t WHERE "+whereSQL, args...).Scan(&total); err != nil {
+		return nil, err
+	}
+
+	sortCol := taskSortColumn(filters.SortBy)
+	dir := "DESC"
+	if filters.Reverse {
+		dir = "ASC"
+	}
+
+	limitPos := len(args) + 1
+	offsetPos := len(args) + 2
+	query := fmt.Sprintf(`
+		SELECT t.id, t.organization_id, t.contact_id, t.deal_id, t.assigned_to, t.created_by, t.title, t.description,
+		       t.due_date, t.priority, t.type, t.status, t.completed_at, t.created_at, t.updated_at
+		FROM crm_tasks t
+		WHERE %s
+		ORDER BY %s %s NULLS LAST, t.id DESC
+		LIMIT $%d OFFSET $%d
+	`, whereSQL, sortCol, dir, limitPos, offsetPos)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tasks := make([]models.CRMTask, 0, limit)
+	for rows.Next() {
+		var task models.CRMTask
+		if err := rows.Scan(
+			&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
+			&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+			&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
+			&task.CreatedAt, &task.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	hasMore := int64(offset+len(tasks)) < total
+	var nextOffset *int
+	if hasMore {
+		n := offset + limit
+		nextOffset = &n
+	}
+
+	return &models.TasksSearchResult{
+		Data: tasks,
+		Pagination: models.TasksSearchPagination{
+			Total:      total,
+			Limit:      limit,
+			Offset:     offset,
+			HasMore:    hasMore,
+			NextOffset: nextOffset,
+		},
+	}, nil
+}
+
+func (r *crmRepository) TasksSummary(ctx context.Context, orgID uuid.UUID, filters models.SearchTasks) (*models.TasksSummary, error) {
+	clauses, args := taskSearchWhere(orgID, filters)
+	whereSQL := strings.Join(clauses, " AND ")
+
+	var s models.TasksSummary
+	query := fmt.Sprintf(`
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE t.status = 'pending'),
+			COUNT(*) FILTER (WHERE t.status = 'in_progress'),
+			COUNT(*) FILTER (WHERE t.status = 'completed'),
+			COUNT(*) FILTER (WHERE t.status = 'cancelled'),
+			COUNT(*) FILTER (WHERE t.due_date IS NOT NULL AND t.due_date < now() AND t.status NOT IN ('completed', 'cancelled')),
+			COUNT(*) FILTER (WHERE t.priority IN ('high', 'urgent'))
+		FROM crm_tasks t
+		WHERE %s
+	`, whereSQL)
+	if err := r.db.QueryRow(ctx, query, args...).Scan(
+		&s.Total, &s.PendingCount, &s.InProgress, &s.CompletedCount,
+		&s.CancelledCount, &s.OverdueCount, &s.HighPriority,
+	); err != nil {
+		return nil, err
+	}
+
+	return &s, nil
 }
 
 func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID, data *models.UpdateCRMTask) (*models.CRMTask, error) {

--- a/internal/repository/pg_crm.go
+++ b/internal/repository/pg_crm.go
@@ -357,19 +357,68 @@ func (r *crmRepository) ListPipelines(ctx context.Context, orgID uuid.UUID) ([]m
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
-	var pipelines []models.Pipeline
+	pipelines := []models.Pipeline{}
+	indexByID := make(map[uuid.UUID]int)
 	for rows.Next() {
 		var p models.Pipeline
 		if err := rows.Scan(
 			&p.ID, &p.OrganizationID, &p.Name,
 			&p.Position, &p.CreatedAt, &p.UpdatedAt,
 		); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		p.Stages = []models.PipelineStage{}
+		indexByID[p.ID] = len(pipelines)
 		pipelines = append(pipelines, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(pipelines) == 0 {
+		return pipelines, nil
+	}
+
+	// Hydrate stages (with open-deal counts) for every pipeline in one pass and
+	// attach each to its owner, so the list view renders stages just like
+	// GetPipeline. Without this the Pipelines tab and the deals board always saw
+	// empty stage arrays — a newly added stage "succeeded" but never appeared.
+	pipelineIDs := make([]uuid.UUID, 0, len(pipelines))
+	for _, p := range pipelines {
+		pipelineIDs = append(pipelineIDs, p.ID)
+	}
+
+	stageQuery := `
+		SELECT ps.id, ps.pipeline_id, ps.name, ps.color, ps.position, ps.created_at, ps.updated_at,
+		       COUNT(d.id) AS deal_count
+		FROM pipeline_stages ps
+		LEFT JOIN deals d ON d.stage_id = ps.id AND d.status = 'open'
+		WHERE ps.pipeline_id = ANY($1)
+		GROUP BY ps.id
+		ORDER BY ps.position ASC
+	`
+	stageRows, err := r.db.Query(ctx, stageQuery, pipelineIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer stageRows.Close()
+
+	for stageRows.Next() {
+		var stage models.PipelineStage
+		if err := stageRows.Scan(
+			&stage.ID, &stage.PipelineID, &stage.Name, &stage.Color,
+			&stage.Position, &stage.CreatedAt, &stage.UpdatedAt, &stage.DealCount,
+		); err != nil {
+			return nil, err
+		}
+		if idx, ok := indexByID[stage.PipelineID]; ok {
+			pipelines[idx].Stages = append(pipelines[idx].Stages, stage)
+		}
+	}
+	if err := stageRows.Err(); err != nil {
+		return nil, err
 	}
 
 	return pipelines, nil

--- a/internal/repository/pg_crm.go
+++ b/internal/repository/pg_crm.go
@@ -53,6 +53,12 @@ type CRMRepository interface {
 	ListCRMTasks(ctx context.Context, orgID uuid.UUID, contactID, dealID, assignedTo *uuid.UUID, status *string, limit int, cursor *uuid.UUID) (*models.CRMTasksResult, error)
 	UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UUID, data *models.UpdateCRMTask) (*models.CRMTask, error)
 	DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) error
+
+	// CRM Task Types (user-managed)
+	ListTaskTypes(ctx context.Context, orgID uuid.UUID) ([]models.CRMTaskType, error)
+	CreateTaskType(ctx context.Context, orgID uuid.UUID, data *models.CreateCRMTaskType) (*models.CRMTaskType, error)
+	UpdateTaskType(ctx context.Context, orgID, typeID uuid.UUID, data *models.UpdateCRMTaskType) (*models.CRMTaskType, error)
+	DeleteTaskType(ctx context.Context, orgID, typeID uuid.UUID) error
 }
 
 type crmRepository struct {
@@ -1059,21 +1065,23 @@ func (r *crmRepository) CreateCRMTask(ctx context.Context, orgID, userID uuid.UU
 	if priority == "" {
 		priority = "medium"
 	}
+	// Empty type = untyped; types are user-managed, so no enum coercion here.
+	taskType := data.Type
 
 	query := `
-		INSERT INTO crm_tasks (organization_id, contact_id, deal_id, assigned_to, created_by, title, description, due_date, priority)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		INSERT INTO crm_tasks (organization_id, contact_id, deal_id, assigned_to, created_by, title, description, due_date, priority, type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 		RETURNING id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
-		          due_date, priority, status, completed_at, created_at, updated_at
+		          due_date, priority, type, status, completed_at, created_at, updated_at
 	`
 	var task models.CRMTask
 	err := r.db.QueryRow(ctx, query,
 		orgID, data.ContactID, data.DealID, data.AssignedTo, userID,
-		data.Title, data.Description, data.DueDate, priority,
+		data.Title, data.Description, data.DueDate, priority, taskType,
 	).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
 		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
-		&task.DueDate, &task.Priority, &task.Status, &task.CompletedAt,
+		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)
 	if err != nil {
@@ -1085,7 +1093,7 @@ func (r *crmRepository) CreateCRMTask(ctx context.Context, orgID, userID uuid.UU
 func (r *crmRepository) GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID) (*models.CRMTask, error) {
 	query := `
 		SELECT id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
-		       due_date, priority, status, completed_at, created_at, updated_at
+		       due_date, priority, type, status, completed_at, created_at, updated_at
 		FROM crm_tasks
 		WHERE organization_id = $1 AND id = $2
 	`
@@ -1093,7 +1101,7 @@ func (r *crmRepository) GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID)
 	err := r.db.QueryRow(ctx, query, orgID, taskID).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
 		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
-		&task.DueDate, &task.Priority, &task.Status, &task.CompletedAt,
+		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)
 	if err != nil {
@@ -1139,7 +1147,7 @@ func (r *crmRepository) ListCRMTasks(ctx context.Context, orgID uuid.UUID, conta
 
 	query := fmt.Sprintf(`
 		SELECT id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
-		       due_date, priority, status, completed_at, created_at, updated_at
+		       due_date, priority, type, status, completed_at, created_at, updated_at
 		FROM crm_tasks
 		WHERE %s
 		ORDER BY created_at DESC, id DESC
@@ -1159,7 +1167,7 @@ func (r *crmRepository) ListCRMTasks(ctx context.Context, orgID uuid.UUID, conta
 		if err := rows.Scan(
 			&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
 			&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
-			&task.DueDate, &task.Priority, &task.Status, &task.CompletedAt,
+			&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 			&task.CreatedAt, &task.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -1211,6 +1219,11 @@ func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UU
 		args = append(args, *data.Priority)
 		argPos++
 	}
+	if data.Type != nil {
+		setClauses = append(setClauses, fmt.Sprintf("type = $%d", argPos))
+		args = append(args, *data.Type)
+		argPos++
+	}
 	if data.Status != nil {
 		setClauses = append(setClauses, fmt.Sprintf("status = $%d", argPos))
 		args = append(args, *data.Status)
@@ -1231,14 +1244,14 @@ func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UU
 		UPDATE crm_tasks SET %s
 		WHERE organization_id = $1 AND id = $2
 		RETURNING id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
-		          due_date, priority, status, completed_at, created_at, updated_at
+		          due_date, priority, type, status, completed_at, created_at, updated_at
 	`, strings.Join(setClauses, ", "))
 
 	var task models.CRMTask
 	err := r.db.QueryRow(ctx, query, args...).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
 		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
-		&task.DueDate, &task.Priority, &task.Status, &task.CompletedAt,
+		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)
 	if err != nil {
@@ -1248,6 +1261,126 @@ func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UU
 		return nil, err
 	}
 	return &task, nil
+}
+
+// =====================
+// CRM Task Types
+// =====================
+
+func (r *crmRepository) scanTaskType(row interface {
+	Scan(dest ...any) error
+}) (*models.CRMTaskType, error) {
+	var t models.CRMTaskType
+	if err := row.Scan(&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.Position, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}
+
+func (r *crmRepository) ListTaskTypes(ctx context.Context, orgID uuid.UUID) ([]models.CRMTaskType, error) {
+	// Types are seeded at org creation (see SeedDefaultTaskTypes), so this is a
+	// plain read — it never re-creates defaults, which would resurrect types the
+	// user deliberately deleted.
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, name, color, position, created_at, updated_at
+		FROM crm_task_types
+		WHERE organization_id = $1
+		ORDER BY position ASC, name ASC
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	types := []models.CRMTaskType{}
+	for rows.Next() {
+		var t models.CRMTaskType
+		if err := rows.Scan(&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.Position, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, err
+		}
+		types = append(types, t)
+	}
+	return types, rows.Err()
+}
+
+// SeedDefaultTaskTypes inserts the org's starter task types (idempotent). Called
+// when an organization is created so the CRM tasks UI is usable out of the box;
+// the user can rename, recolour, or delete them afterwards.
+func SeedDefaultTaskTypes(ctx context.Context, db *pgxpool.Pool, orgID uuid.UUID) error {
+	for i, d := range models.DefaultCRMTaskTypes {
+		if _, err := db.Exec(ctx,
+			`INSERT INTO crm_task_types (organization_id, name, color, position)
+			 VALUES ($1, $2, $3, $4)
+			 ON CONFLICT (organization_id, name) DO NOTHING`,
+			orgID, d.Name, d.Color, i,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *crmRepository) CreateTaskType(ctx context.Context, orgID uuid.UUID, data *models.CreateCRMTaskType) (*models.CRMTaskType, error) {
+	color := data.Color
+	if color == "" {
+		color = "#94a3b8"
+	}
+	row := r.db.QueryRow(ctx, `
+		INSERT INTO crm_task_types (organization_id, name, color, position)
+		VALUES ($1, $2, $3, COALESCE((SELECT MAX(position) + 1 FROM crm_task_types WHERE organization_id = $1), 0))
+		RETURNING id, organization_id, name, color, position, created_at, updated_at
+	`, orgID, data.Name, color)
+	return r.scanTaskType(row)
+}
+
+func (r *crmRepository) UpdateTaskType(ctx context.Context, orgID, typeID uuid.UUID, data *models.UpdateCRMTaskType) (*models.CRMTaskType, error) {
+	setClauses := []string{}
+	args := []any{orgID, typeID}
+	argPos := 3
+	if data.Name != nil {
+		setClauses = append(setClauses, fmt.Sprintf("name = $%d", argPos))
+		args = append(args, *data.Name)
+		argPos++
+	}
+	if data.Color != nil {
+		setClauses = append(setClauses, fmt.Sprintf("color = $%d", argPos))
+		args = append(args, *data.Color)
+		argPos++
+	}
+	if data.Position != nil {
+		setClauses = append(setClauses, fmt.Sprintf("position = $%d", argPos))
+		args = append(args, *data.Position)
+		argPos++
+	}
+	if len(setClauses) == 0 {
+		return nil, errx.ErrNotEnough
+	}
+	setClauses = append(setClauses, "updated_at = NOW()")
+
+	query := fmt.Sprintf(`
+		UPDATE crm_task_types SET %s
+		WHERE organization_id = $1 AND id = $2
+		RETURNING id, organization_id, name, color, position, created_at, updated_at
+	`, strings.Join(setClauses, ", "))
+	row := r.db.QueryRow(ctx, query, args...)
+	t, err := r.scanTaskType(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errx.ErrNotFound
+		}
+		return nil, err
+	}
+	return t, nil
+}
+
+func (r *crmRepository) DeleteTaskType(ctx context.Context, orgID, typeID uuid.UUID) error {
+	cmd, err := r.db.Exec(ctx, `DELETE FROM crm_task_types WHERE organization_id = $1 AND id = $2`, orgID, typeID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return errx.ErrNotFound
+	}
+	return nil
 }
 
 func (r *crmRepository) DeleteCRMTask(ctx context.Context, orgID, taskID uuid.UUID) error {

--- a/internal/repository/pg_crm.go
+++ b/internal/repository/pg_crm.go
@@ -1071,18 +1071,18 @@ func (r *crmRepository) CreateCRMTask(ctx context.Context, orgID, userID uuid.UU
 	taskType := data.Type
 
 	query := `
-		INSERT INTO crm_tasks (organization_id, contact_id, deal_id, assigned_to, created_by, title, description, due_date, priority, type)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		RETURNING id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
+		INSERT INTO crm_tasks (organization_id, contact_id, deal_id, assigned_to, assigned_team_id, created_by, title, description, due_date, priority, type)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+		RETURNING id, organization_id, contact_id, deal_id, assigned_to, assigned_team_id, created_by, title, description,
 		          due_date, priority, type, status, completed_at, created_at, updated_at
 	`
 	var task models.CRMTask
 	err := r.db.QueryRow(ctx, query,
-		orgID, data.ContactID, data.DealID, data.AssignedTo, userID,
+		orgID, data.ContactID, data.DealID, data.AssignedTo, data.AssignedTeamID, userID,
 		data.Title, data.Description, data.DueDate, priority, taskType,
 	).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
-		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+		&task.AssignedTo, &task.AssignedTeamID, &task.CreatedBy, &task.Title, &task.Description,
 		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)
@@ -1094,7 +1094,7 @@ func (r *crmRepository) CreateCRMTask(ctx context.Context, orgID, userID uuid.UU
 
 func (r *crmRepository) GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID) (*models.CRMTask, error) {
 	query := `
-		SELECT id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
+		SELECT id, organization_id, contact_id, deal_id, assigned_to, assigned_team_id, created_by, title, description,
 		       due_date, priority, type, status, completed_at, created_at, updated_at
 		FROM crm_tasks
 		WHERE organization_id = $1 AND id = $2
@@ -1102,7 +1102,7 @@ func (r *crmRepository) GetCRMTask(ctx context.Context, orgID, taskID uuid.UUID)
 	var task models.CRMTask
 	err := r.db.QueryRow(ctx, query, orgID, taskID).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
-		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+		&task.AssignedTo, &task.AssignedTeamID, &task.CreatedBy, &task.Title, &task.Description,
 		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)
@@ -1148,7 +1148,7 @@ func (r *crmRepository) ListCRMTasks(ctx context.Context, orgID uuid.UUID, conta
 	}
 
 	query := fmt.Sprintf(`
-		SELECT id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
+		SELECT id, organization_id, contact_id, deal_id, assigned_to, assigned_team_id, created_by, title, description,
 		       due_date, priority, type, status, completed_at, created_at, updated_at
 		FROM crm_tasks
 		WHERE %s
@@ -1168,7 +1168,7 @@ func (r *crmRepository) ListCRMTasks(ctx context.Context, orgID uuid.UUID, conta
 		var task models.CRMTask
 		if err := rows.Scan(
 			&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
-			&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+			&task.AssignedTo, &task.AssignedTeamID, &task.CreatedBy, &task.Title, &task.Description,
 			&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 			&task.CreatedAt, &task.UpdatedAt,
 		); err != nil {
@@ -1225,6 +1225,19 @@ func taskSearchWhere(orgID uuid.UUID, f models.SearchTasks) ([]string, []any) {
 	appendIn("priority", f.Priorities)
 	appendIn("type", f.Types)
 	appendIn("assigned_to", f.AssignedTo)
+
+	// Team filter: a task matches when it is directly assigned to one of the
+	// given teams, OR its individual assignee is a member of one of them. Bound
+	// once as a uuid[] so the same predicate (and the same $N) is reused
+	// identically by the search rows query and the summary aggregate.
+	if len(f.TeamIDs) > 0 {
+		clauses = append(clauses, fmt.Sprintf(
+			"(t.assigned_team_id = ANY($%d) OR t.assigned_to IN (SELECT user_id FROM team_members WHERE team_id = ANY($%d)))",
+			pos, pos,
+		))
+		args = append(args, f.TeamIDs)
+		pos++
+	}
 
 	if f.ContactID != nil {
 		clauses = append(clauses, fmt.Sprintf("t.contact_id = $%d", pos))
@@ -1299,7 +1312,7 @@ func (r *crmRepository) SearchCRMTasks(ctx context.Context, orgID uuid.UUID, fil
 	limitPos := len(args) + 1
 	offsetPos := len(args) + 2
 	query := fmt.Sprintf(`
-		SELECT t.id, t.organization_id, t.contact_id, t.deal_id, t.assigned_to, t.created_by, t.title, t.description,
+		SELECT t.id, t.organization_id, t.contact_id, t.deal_id, t.assigned_to, t.assigned_team_id, t.created_by, t.title, t.description,
 		       t.due_date, t.priority, t.type, t.status, t.completed_at, t.created_at, t.updated_at
 		FROM crm_tasks t
 		WHERE %s
@@ -1319,7 +1332,7 @@ func (r *crmRepository) SearchCRMTasks(ctx context.Context, orgID uuid.UUID, fil
 		var task models.CRMTask
 		if err := rows.Scan(
 			&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
-			&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+			&task.AssignedTo, &task.AssignedTeamID, &task.CreatedBy, &task.Title, &task.Description,
 			&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 			&task.CreatedAt, &task.UpdatedAt,
 		); err != nil {
@@ -1387,6 +1400,11 @@ func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UU
 		args = append(args, *data.AssignedTo)
 		argPos++
 	}
+	if data.AssignedTeamID != nil {
+		setClauses = append(setClauses, fmt.Sprintf("assigned_team_id = $%d", argPos))
+		args = append(args, *data.AssignedTeamID)
+		argPos++
+	}
 	if data.Title != nil {
 		setClauses = append(setClauses, fmt.Sprintf("title = $%d", argPos))
 		args = append(args, *data.Title)
@@ -1431,14 +1449,14 @@ func (r *crmRepository) UpdateCRMTask(ctx context.Context, orgID, taskID uuid.UU
 	query := fmt.Sprintf(`
 		UPDATE crm_tasks SET %s
 		WHERE organization_id = $1 AND id = $2
-		RETURNING id, organization_id, contact_id, deal_id, assigned_to, created_by, title, description,
+		RETURNING id, organization_id, contact_id, deal_id, assigned_to, assigned_team_id, created_by, title, description,
 		          due_date, priority, type, status, completed_at, created_at, updated_at
 	`, strings.Join(setClauses, ", "))
 
 	var task models.CRMTask
 	err := r.db.QueryRow(ctx, query, args...).Scan(
 		&task.ID, &task.OrganizationID, &task.ContactID, &task.DealID,
-		&task.AssignedTo, &task.CreatedBy, &task.Title, &task.Description,
+		&task.AssignedTo, &task.AssignedTeamID, &task.CreatedBy, &task.Title, &task.Description,
 		&task.DueDate, &task.Priority, &task.Type, &task.Status, &task.CompletedAt,
 		&task.CreatedAt, &task.UpdatedAt,
 	)

--- a/internal/repository/pg_organization.go
+++ b/internal/repository/pg_organization.go
@@ -103,10 +103,18 @@ func (r *organizationRepository) Create(ctx context.Context, org *models.Organiz
 		VALUES ($1, $2, $3, $4, $5, $6)
 	`
 	now := time.Now()
-	_, err := r.db.Exec(ctx, query,
+	if _, err := r.db.Exec(ctx, query,
 		org.ID, org.Name, org.Slug, org.OwnerUserID, now, now,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+
+	// Seed the org's default CRM task types so the tasks UI is usable from day
+	// one. Best-effort: a failure here shouldn't block org creation.
+	if err := SeedDefaultTaskTypes(ctx, r.db, org.ID); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetByID retrieves an organization by ID

--- a/internal/repository/pg_organization.go
+++ b/internal/repository/pg_organization.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -253,6 +254,8 @@ func (r *organizationRepository) GetMembers(ctx context.Context, orgID uuid.UUID
 			return nil, err
 		}
 		m.User = &u
+		m.Email = u.Email
+		m.Name = strings.TrimSpace(u.FirstName + " " + u.LastName)
 		members = append(members, m)
 	}
 	return members, nil

--- a/internal/repository/pg_team.go
+++ b/internal/repository/pg_team.go
@@ -1,0 +1,300 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// TeamRepository defines data access for org teams and their members. Teams are
+// always scoped to an organization; member rows reference org users (membership
+// in the org is enforced on write via organization_members).
+type TeamRepository interface {
+	ListTeams(ctx context.Context, orgID uuid.UUID) ([]models.Team, error)
+	GetTeam(ctx context.Context, orgID, teamID uuid.UUID) (*models.Team, error)
+	CreateTeam(ctx context.Context, orgID uuid.UUID, data *models.CreateTeam) (*models.Team, error)
+	UpdateTeam(ctx context.Context, orgID, teamID uuid.UUID, data *models.UpdateTeam) (*models.Team, error)
+	DeleteTeam(ctx context.Context, orgID, teamID uuid.UUID) error
+
+	AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error
+	RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error
+}
+
+type teamRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewTeamRepository creates a new team repository.
+func NewTeamRepository(db *pgxpool.Pool) TeamRepository {
+	return &teamRepository{db: db}
+}
+
+// ListTeams returns every team in the org with its members hydrated. Members are
+// loaded in one extra query and attached to their owning team, mirroring how
+// ListPipelines hydrates stages — so the list view never sees an empty members
+// array for a team that actually has members.
+func (r *teamRepository) ListTeams(ctx context.Context, orgID uuid.UUID) ([]models.Team, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, name, color, created_at, updated_at
+		FROM teams
+		WHERE organization_id = $1
+		ORDER BY name ASC
+		LIMIT 200
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	teams := []models.Team{}
+	indexByID := make(map[uuid.UUID]int)
+	for rows.Next() {
+		var t models.Team
+		if err := rows.Scan(
+			&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt,
+		); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		t.Members = []models.TeamMember{}
+		indexByID[t.ID] = len(teams)
+		teams = append(teams, t)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(teams) == 0 {
+		return teams, nil
+	}
+
+	teamIDs := make([]uuid.UUID, 0, len(teams))
+	for _, t := range teams {
+		teamIDs = append(teamIDs, t.ID)
+	}
+
+	memberRows, err := r.db.Query(ctx, `
+		SELECT tm.team_id, tm.user_id, u.email,
+		       TRIM(CONCAT(u.first_name, ' ', u.last_name)), tm.added_at
+		FROM team_members tm
+		JOIN users u ON u.id = tm.user_id
+		WHERE tm.team_id = ANY($1)
+		ORDER BY tm.added_at ASC
+	`, teamIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer memberRows.Close()
+
+	for memberRows.Next() {
+		var teamID uuid.UUID
+		var m models.TeamMember
+		if err := memberRows.Scan(&teamID, &m.UserID, &m.Email, &m.Name, &m.AddedAt); err != nil {
+			return nil, err
+		}
+		if idx, ok := indexByID[teamID]; ok {
+			teams[idx].Members = append(teams[idx].Members, m)
+		}
+	}
+	if err := memberRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return teams, nil
+}
+
+// GetTeam returns a single team scoped to the org, with its members hydrated.
+func (r *teamRepository) GetTeam(ctx context.Context, orgID, teamID uuid.UUID) (*models.Team, error) {
+	var t models.Team
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, name, color, created_at, updated_at
+		FROM teams
+		WHERE organization_id = $1 AND id = $2
+	`, orgID, teamID).Scan(
+		&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errx.ErrNotFound
+		}
+		return nil, err
+	}
+
+	members, err := r.listMembers(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	t.Members = members
+	return &t, nil
+}
+
+// listMembers loads the hydrated member rows for a single team.
+func (r *teamRepository) listMembers(ctx context.Context, teamID uuid.UUID) ([]models.TeamMember, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT tm.user_id, u.email,
+		       TRIM(CONCAT(u.first_name, ' ', u.last_name)), tm.added_at
+		FROM team_members tm
+		JOIN users u ON u.id = tm.user_id
+		WHERE tm.team_id = $1
+		ORDER BY tm.added_at ASC
+	`, teamID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	members := []models.TeamMember{}
+	for rows.Next() {
+		var m models.TeamMember
+		if err := rows.Scan(&m.UserID, &m.Email, &m.Name, &m.AddedAt); err != nil {
+			return nil, err
+		}
+		members = append(members, m)
+	}
+	return members, rows.Err()
+}
+
+// CreateTeam inserts a new team for the org. Color defaults to the slate accent
+// when the caller leaves it empty.
+func (r *teamRepository) CreateTeam(ctx context.Context, orgID uuid.UUID, data *models.CreateTeam) (*models.Team, error) {
+	color := data.Color
+	if color == "" {
+		color = "#94a3b8"
+	}
+
+	var t models.Team
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO teams (organization_id, name, color)
+		VALUES ($1, $2, $3)
+		RETURNING id, organization_id, name, color, created_at, updated_at
+	`, orgID, data.Name, color).Scan(
+		&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	t.Members = []models.TeamMember{}
+	return &t, nil
+}
+
+// UpdateTeam applies a partial update to a team scoped to the org.
+func (r *teamRepository) UpdateTeam(ctx context.Context, orgID, teamID uuid.UUID, data *models.UpdateTeam) (*models.Team, error) {
+	setClauses := []string{}
+	args := []any{orgID, teamID}
+	argPos := 3
+
+	if data.Name != nil {
+		setClauses = append(setClauses, fmt.Sprintf("name = $%d", argPos))
+		args = append(args, *data.Name)
+		argPos++
+	}
+	if data.Color != nil {
+		setClauses = append(setClauses, fmt.Sprintf("color = $%d", argPos))
+		args = append(args, *data.Color)
+		argPos++
+	}
+
+	if len(setClauses) == 0 {
+		return nil, errx.ErrNotEnough
+	}
+
+	setClauses = append(setClauses, "updated_at = NOW()")
+
+	query := fmt.Sprintf(`
+		UPDATE teams SET %s
+		WHERE organization_id = $1 AND id = $2
+		RETURNING id, organization_id, name, color, created_at, updated_at
+	`, strings.Join(setClauses, ", "))
+
+	var t models.Team
+	err := r.db.QueryRow(ctx, query, args...).Scan(
+		&t.ID, &t.OrganizationID, &t.Name, &t.Color, &t.CreatedAt, &t.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errx.ErrNotFound
+		}
+		return nil, err
+	}
+
+	members, err := r.listMembers(ctx, teamID)
+	if err != nil {
+		return nil, err
+	}
+	t.Members = members
+	return &t, nil
+}
+
+// DeleteTeam removes a team (and, via cascade, its members) scoped to the org.
+func (r *teamRepository) DeleteTeam(ctx context.Context, orgID, teamID uuid.UUID) error {
+	cmd, err := r.db.Exec(ctx, `DELETE FROM teams WHERE organization_id = $1 AND id = $2`, orgID, teamID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return errx.ErrNotFound
+	}
+	return nil
+}
+
+// AddMember adds an org user to a team. The team must belong to the org and the
+// user must already be a member of that org (validated against
+// organization_members); otherwise the insert is rejected before it runs.
+// Re-adding an existing member is a no-op.
+func (r *teamRepository) AddMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error {
+	// Team must belong to the org.
+	var exists bool
+	if err := r.db.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM teams WHERE id = $1 AND organization_id = $2)`,
+		teamID, orgID,
+	).Scan(&exists); err != nil {
+		return err
+	}
+	if !exists {
+		return errx.ErrNotFound
+	}
+
+	// User must belong to the org.
+	var isOrgMember bool
+	if err := r.db.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM organization_members WHERE organization_id = $1 AND user_id = $2)`,
+		orgID, userID,
+	).Scan(&isOrgMember); err != nil {
+		return err
+	}
+	if !isOrgMember {
+		return errx.New(errx.BadRequest, "user is not a member of this organization")
+	}
+
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO team_members (team_id, user_id)
+		VALUES ($1, $2)
+		ON CONFLICT (team_id, user_id) DO NOTHING
+	`, teamID, userID)
+	return err
+}
+
+// RemoveMember removes a user from a team. The team must belong to the org.
+func (r *teamRepository) RemoveMember(ctx context.Context, orgID, teamID, userID uuid.UUID) error {
+	cmd, err := r.db.Exec(ctx, `
+		DELETE FROM team_members tm
+		USING teams t
+		WHERE tm.team_id = t.id
+		  AND t.organization_id = $1
+		  AND tm.team_id = $2
+		  AND tm.user_id = $3
+	`, orgID, teamID, userID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return errx.ErrNotFound
+	}
+	return nil
+}

--- a/internal/repository/pg_token.go
+++ b/internal/repository/pg_token.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
@@ -105,6 +106,14 @@ func (r *tokenRepository) GetSession(ctx context.Context, sessionID uuid.UUID) (
 		&sess.OSName, &sess.BrowserName, &sess.AuthProvider,
 	)
 	if err != nil {
+		// A missing session row is an expected auth outcome, not a server
+		// fault: the session expired, was revoked and purged, or the token
+		// references one that no longer exists. Surface it as a clean 401 so
+		// the client refreshes/logs out, instead of a 500 that also pages
+		// Sentry on every stale refresh.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errx.ErrToken
+		}
 		db.CaptureError(err, query, params, "queryrow")
 		return nil, errx.InternalError()
 	}

--- a/internal/repository/sequence_actions.go
+++ b/internal/repository/sequence_actions.go
@@ -14,7 +14,7 @@ func validateActionConfig(a *models.ActionConfig) *errx.Error {
 		return nil
 	}
 	switch a.Type {
-	case "wait", "add_tag", "remove_tag", "unsubscribe", "notify", "create_task", "end":
+	case "wait", "add_tag", "remove_tag", "unsubscribe", "notify", "create_task", "create_deal", "move_deal_stage", "end":
 		// Type must be known. Sub-config (wait minutes, tag) is filled in the
 		// editor; an unconfigured node is a harmless no-op at send time, so we
 		// don't block creating a draft node here.

--- a/internal/repository/sequence_actions.go
+++ b/internal/repository/sequence_actions.go
@@ -14,7 +14,7 @@ func validateActionConfig(a *models.ActionConfig) *errx.Error {
 		return nil
 	}
 	switch a.Type {
-	case "wait", "add_tag", "remove_tag", "unsubscribe", "notify", "end":
+	case "wait", "add_tag", "remove_tag", "unsubscribe", "notify", "create_task", "end":
 		// Type must be known. Sub-config (wait minutes, tag) is filled in the
 		// editor; an unconfigured node is a harmless no-op at send time, so we
 		// don't block creating a draft node here.

--- a/internal/seed/crm.go
+++ b/internal/seed/crm.go
@@ -43,18 +43,48 @@ func seedCRMPipelines(ctx context.Context, pool *pgxpool.Pool, _ *Result) error 
 	return nil
 }
 
+// seedCRMTaskTypes gives the demo orgs the same starter task types a real org
+// gets at creation, so the tasks UI has Call / Email / Meeting out of the box.
+func seedCRMTaskTypes(ctx context.Context, pool *pgxpool.Pool, _ *Result) error {
+	defaults := []struct {
+		name  string
+		color string
+	}{
+		{"Call", "#8b5cf6"},
+		{"Email", "#0ea5e9"},
+		{"Meeting", "#f59e0b"},
+	}
+	for _, orgID := range []uuid.UUID{OrgAcmeID, OrgGlobexID} {
+		for i, d := range defaults {
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO crm_task_types (organization_id, name, color, position)
+				VALUES ($1, $2, $3, $4)
+				ON CONFLICT (organization_id, name) DO NOTHING
+			`, orgID, d.name, d.color, i); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func seedCRMDeals(ctx context.Context, pool *pgxpool.Pool, _ *Result) error {
 	type deal struct {
-		id     uuid.UUID
-		stage  uuid.UUID
-		name   string
-		value  float64
-		status string
-		won    bool
+		id      uuid.UUID
+		stage   uuid.UUID
+		name    string
+		value   float64
+		status  string
+		won     bool
+		contact uuid.UUID
 	}
 	deals := []deal{
-		{DealAcmeBigID, StageDemoID, "Northwind - team-wide rollout", 24_000, "open", false},
-		{DealAcmeWonID, StageWonID, "Initech - pilot extension", 6_000, "won", true},
+		{DealAcmeBigID, StageDemoID, "Northwind - team-wide rollout", 24_000, "open", false, contactID(0x01, 1)},
+		{DealAcmeWonID, StageWonID, "Initech - pilot extension", 6_000, "won", true, contactID(0x01, 1)},
+		// Deals tied to other contacts that also appear in the unibox, so opening
+		// their threads shows live pipeline in the CRM panel — not just Aiden's.
+		{uuid.MustParse("0000000d-0000-0000-0000-000000000003"), StageDemoID, "Vandelay - list hygiene retainer", 9_000, "open", false, contactID(0x01, 7)},
+		{uuid.MustParse("0000000d-0000-0000-0000-000000000004"), StageDemoID, "Hooli - deliverability pilot", 15_000, "open", false, contactID(0x01, 4)},
 	}
 	for _, d := range deals {
 		wonAt := "NULL"
@@ -65,7 +95,7 @@ func seedCRMDeals(ctx context.Context, pool *pgxpool.Pool, _ *Result) error {
 			INSERT INTO deals (id, organization_id, pipeline_id, stage_id, contact_id, name, value, currency, status, won_at, assigned_to, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, 'USD', $8, `+wonAt+`, $9, NOW(), NOW())
 			ON CONFLICT (id) DO UPDATE SET stage_id = EXCLUDED.stage_id, status = EXCLUDED.status, updated_at = NOW()
-		`, d.id, OrgAcmeID, PipelineSalesID, d.stage, contactID(0x01, 1), d.name, d.value, d.status, UserOwnerID)
+		`, d.id, OrgAcmeID, PipelineSalesID, d.stage, d.contact, d.name, d.value, d.status, UserOwnerID)
 		if err != nil {
 			return err
 		}

--- a/internal/seed/seed.go
+++ b/internal/seed/seed.go
@@ -48,6 +48,7 @@ func Run(ctx context.Context, pool *pgxpool.Pool) (*Result, error) {
 		{"campaign-progress", seedCampaignProgress},
 		{"campaign-logs", seedCampaignLogs},
 		{"crm-pipelines", seedCRMPipelines},
+		{"crm-task-types", seedCRMTaskTypes},
 		{"crm-deals", seedCRMDeals},
 		{"crm-tasks", seedCRMTasks},
 		{"contact-activity", seedContactActivity},

--- a/internal/seed/unibox.go
+++ b/internal/seed/unibox.go
@@ -63,7 +63,7 @@ func seedUnibox(ctx context.Context, pool *pgxpool.Pool, _ *Result) error {
 		{
 			id: UniboxAcmeOOOID, userID: UserOwnerID, emailID: EmailAcmeBobID,
 			threadID: "seed-thread-pied-piper-ooo", messageID: "<seed-pied-piper-ooo@piedpiper.test>",
-			uid: 204, flags: []string{"\\Seen"}, from: []string{"Carlos Diaz <carlos.diaz@piedpiper.test>"},
+			uid: 204, flags: []string{"\\Seen"}, from: []string{"Carlos Diaz <carlos.diaz@pied-piper.test>"},
 			to: []string{"Bob from Acme <bob@acme.test>"}, subject: "Automatic reply: Quick question",
 			snippet:      "I am away until Monday with limited access to email. For anything urgent, please contact the operations alias.",
 			seen:         true,
@@ -90,7 +90,7 @@ func seedUnibox(ctx context.Context, pool *pgxpool.Pool, _ *Result) error {
 		{
 			id: UniboxGlobexReplyID, userID: UserFounderID, emailID: EmailGlobexHansID,
 			threadID: "seed-thread-oldfriend", messageID: "<seed-oldfriend-reply@oldfriend.test>",
-			uid: 301, flags: []string{}, from: []string{"Ivan Petrov <ivan.petrov@oldfriend.test>"},
+			uid: 301, flags: []string{}, from: []string{"Ivan Petrov <ivan.petrov@oldfriend-co.test>"},
 			to: []string{"Hans Globex <hans@globex.test>"}, subject: "Re: Warmup pool policy",
 			snippet:      "The recovery pool approach makes sense. We should not put risky mailboxes back into the shared paid pool automatically.",
 			seen:         false,

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -776,6 +776,70 @@ func (s *tasksService) executeActionNode(ctx context.Context, campaign *models.C
 			return xerr
 		}
 		return nil
+	case "create_deal":
+		if s.advanced == nil || campaign.OrganizationID == nil {
+			return nil
+		}
+		if cfg.DealPipelineID == nil || cfg.DealStageID == nil {
+			// Misconfigured node (no pipeline/stage chosen): skip rather than fail
+			// the whole chain.
+			return nil
+		}
+		owner, perr := uuid.Parse(campaign.UserID)
+		if perr != nil {
+			return nil
+		}
+		// Deal name supports the same {{first_name}}/{{company}} templating other
+		// campaign copy uses; fall back to a contact-derived name when blank.
+		name := RenderTemplate(strings.TrimSpace(cfg.DealName), *contact)
+		if name == "" {
+			cn := strings.TrimSpace(contact.FirstName + " " + contact.LastName)
+			if cn == "" {
+				cn = contact.Email
+			}
+			name = "Deal: " + cn
+		}
+		currency := strings.TrimSpace(cfg.DealCurrency)
+		if currency == "" {
+			currency = "USD"
+		}
+		cid := contact.ID
+		cmpID := campaign.ID
+		data := &models.CreateDeal{
+			PipelineID: *cfg.DealPipelineID,
+			StageID:    *cfg.DealStageID,
+			ContactID:  &cid,
+			Name:       name,
+			Value:      cfg.DealValue,
+			Currency:   currency,
+			CampaignID: &cmpID,
+			AssignedTo: &owner,
+		}
+		if _, xerr := s.advanced.CreateContactDeal(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
+			return xerr
+		}
+		return nil
+	case "move_deal_stage":
+		if s.advanced == nil || campaign.OrganizationID == nil {
+			return nil
+		}
+		if cfg.DealPipelineID == nil || cfg.DealStageID == nil {
+			return nil
+		}
+		moved, xerr := s.advanced.MoveContactDealStage(ctx, *campaign.OrganizationID, contact.ID, *cfg.DealPipelineID, *cfg.DealStageID)
+		if xerr != nil {
+			return xerr
+		}
+		if moved == nil {
+			// No open deal in the target pipeline: documented no-op. Log it so the
+			// gap is observable instead of silently doing nothing.
+			log.Info().
+				Str("campaign_id", campaign.ID.String()).
+				Str("contact_id", contact.ID.String()).
+				Str("pipeline_id", cfg.DealPipelineID.String()).
+				Msg("move_deal_stage no-op: contact has no open deal in pipeline")
+		}
+		return nil
 	default:
 		return nil
 	}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -358,18 +358,11 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		log.Warn().Err(err).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to update campaign task tracking")
 	}
 
-	// STEP 8: Check stop_on_reply
-	if campaign.StopOnReply {
-		hasReplied, err := s.campaignProgressRepo.CheckContactHasReplied(ctx, contact.ID, campaign.ID)
-		if err == nil && hasReplied {
-			// Contact has replied, skip
-			s.taskRepo.UpdateTaskStatus(ctx, taskID, "completed")
-			// Create next task anyway for next contact
-			s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
-			executionStatus = "completed"
-			return nil
-		}
-	}
+	// stop_on_reply is enforced inside FindNextRoutedPair (STEP 6), and it is now
+	// ROUTE-AWARE: a contact who replied is only handed back when their next step
+	// is part of the reply flow (the reply branch's own path). The normal cold
+	// sequence stops there, so there is no longer a blanket "contact has replied,
+	// skip" check here — that would also kill the reply branch's follow-up emails.
 
 	// STEP 9: Load email account
 	account, xerr := s.emailRepo.GetByID(ctx, accountID)

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -735,6 +736,45 @@ func (s *tasksService) executeActionNode(ctx context.Context, campaign *models.C
 			data[k] = v
 		}
 		s.advanced.EmitCampaignEvent(ctx, *campaign.OrganizationID, event, data)
+		return nil
+	case "create_task":
+		if s.advanced == nil || campaign.OrganizationID == nil {
+			return nil
+		}
+		owner, perr := uuid.Parse(campaign.UserID)
+		if perr != nil {
+			return nil
+		}
+		title := strings.TrimSpace(cfg.TaskTitle)
+		if title == "" {
+			name := strings.TrimSpace(contact.FirstName + " " + contact.LastName)
+			if name == "" {
+				name = contact.Email
+			}
+			title = "Follow up: " + name
+		}
+		// Per-step assignee; fall back to the campaign owner when unset.
+		assignee := cfg.TaskAssignedTo
+		if assignee == nil {
+			assignee = &owner
+		}
+		// Task types are user-managed free text; pass the configured name
+		// through (empty = untyped).
+		cid := contact.ID
+		data := &models.CreateCRMTask{
+			ContactID:  &cid,
+			Title:      title,
+			Type:       cfg.TaskType,
+			Priority:   cfg.TaskPriority,
+			AssignedTo: assignee,
+		}
+		if cfg.TaskDueOffsetDays != nil {
+			due := time.Now().UTC().AddDate(0, 0, *cfg.TaskDueOffsetDays)
+			data.DueDate = &due
+		}
+		if _, xerr := s.advanced.CreateContactTask(ctx, *campaign.OrganizationID, owner, data); xerr != nil {
+			return xerr
+		}
 		return nil
 	default:
 		return nil

--- a/web/src/app/app/admin/audit/page.tsx
+++ b/web/src/app/app/admin/audit/page.tsx
@@ -2,6 +2,12 @@ import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { searchAdminAuditLogs } from "@/lib/api/client/app/admin/audit";
 import type { AdminAuditLog, AdminAuditLogSearch } from "@/lib/api/models/app/admin/Audit";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
+
+const LIMIT_OPTIONS: SelectOption[] = [25, 50, 100].map((n) => ({
+    value: String(n),
+    label: String(n),
+}));
 
 // Free-form action / target_type strings used by handlers across the app.
 // These are populated dynamically from the result set too — anything new the
@@ -87,6 +93,22 @@ export default function AdminAuditPage() {
         return Array.from(set).sort();
     }, [data]);
 
+    const actionOptions = useMemo<SelectOption[]>(
+        () => [
+            { value: "", label: "(any)" },
+            ...allActions.map((a) => ({ value: a, label: a })),
+        ],
+        [allActions],
+    );
+
+    const entityTypeOptions = useMemo<SelectOption[]>(
+        () => [
+            { value: "", label: "(any)" },
+            ...allEntityTypes.map((t) => ({ value: t, label: t })),
+        ],
+        [allEntityTypes],
+    );
+
     return (
         <div>
             <div className="flex items-center justify-between mb-4">
@@ -120,28 +142,22 @@ export default function AdminAuditPage() {
             <div className="border rounded-lg p-3 mb-3 bg-slate-50">
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
                     <Field label="Action">
-                        <select
+                        <SelectMenu
                             value={filters.action ?? ""}
-                            onChange={(e) => applyFilter({ action: e.target.value || undefined })}
-                            className={inp}
-                        >
-                            <option value="">(any)</option>
-                            {allActions.map((a) => (
-                                <option key={a} value={a}>{a}</option>
-                            ))}
-                        </select>
+                            onChange={(v) => applyFilter({ action: v || undefined })}
+                            options={actionOptions}
+                            className="w-full"
+                            aria-label="Action"
+                        />
                     </Field>
                     <Field label="Target type">
-                        <select
+                        <SelectMenu
                             value={filters.target_type ?? ""}
-                            onChange={(e) => applyFilter({ target_type: e.target.value || undefined })}
-                            className={inp}
-                        >
-                            <option value="">(any)</option>
-                            {allEntityTypes.map((t) => (
-                                <option key={t} value={t}>{t}</option>
-                            ))}
-                        </select>
+                            onChange={(v) => applyFilter({ target_type: v || undefined })}
+                            options={entityTypeOptions}
+                            className="w-full"
+                            aria-label="Target type"
+                        />
                     </Field>
                     <Field label="Target ID">
                         <input
@@ -177,15 +193,15 @@ export default function AdminAuditPage() {
                     </Field>
                 </div>
                 <div className="flex items-center gap-3 mt-3">
-                    <div className="text-xs text-slate-500">
-                        Limit:{" "}
-                        <select
-                            value={filters.limit ?? 50}
-                            onChange={(e) => applyFilter({ limit: parseInt(e.target.value, 10) })}
-                            className="border rounded px-2 py-1 text-xs"
-                        >
-                            {[25, 50, 100].map((n) => <option key={n} value={n}>{n}</option>)}
-                        </select>
+                    <div className="flex items-center gap-2 text-xs text-slate-500">
+                        Limit:
+                        <SelectMenu
+                            value={String(filters.limit ?? 50)}
+                            onChange={(v) => applyFilter({ limit: parseInt(v, 10) })}
+                            options={LIMIT_OPTIONS}
+                            minWidth={80}
+                            aria-label="Result limit"
+                        />
                     </div>
                     <button
                         onClick={resetFilters}

--- a/web/src/app/app/admin/credentials/page.tsx
+++ b/web/src/app/app/admin/credentials/page.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import {
     applyProfileToAll,
     checkReleases,
@@ -22,6 +23,11 @@ import type {
 } from "@/lib/api/models/app/admin/Credentials";
 
 type Tab = "aws" | "profiles";
+
+const APP_ENV_OPTIONS: SelectOption[] = [
+    { value: "prod", label: "prod" },
+    { value: "dev", label: "dev" },
+];
 
 export default function AdminCredentialsPage() {
     const [tab, setTab] = useState<Tab>("aws");
@@ -414,6 +420,14 @@ function ProfileForm({
     const [channel, setChannel] = useState<"pinned" | "stable" | "dev">(initial?.release_channel ?? "pinned");
     const [autoUpdate, setAutoUpdate] = useState<boolean>(initial?.auto_update ?? false);
 
+    const awsCredentialOptions = useMemo<SelectOption[]>(
+        () => [
+            { value: "", label: "(none)" },
+            ...awsOptions.map((a) => ({ value: a.id, label: `${a.name} (${a.region})` })),
+        ],
+        [awsOptions],
+    );
+
     const mut = useMutation({
         mutationFn: async () => {
             const res = initial
@@ -438,10 +452,12 @@ function ProfileForm({
 
             <div className="grid grid-cols-2 gap-3">
                 <Field label="App env">
-                    <select value={form.app_env} onChange={(e) => setForm({ ...form, app_env: e.target.value })} className={inp}>
-                        <option value="prod">prod</option>
-                        <option value="dev">dev</option>
-                    </select>
+                    <SelectMenu
+                        value={form.app_env ?? ""}
+                        onChange={(v) => setForm({ ...form, app_env: v })}
+                        options={APP_ENV_OPTIONS}
+                        className="w-full"
+                    />
                 </Field>
                 <Field label="Worker image">
                     <input value={form.worker_image} onChange={(e) => setForm({ ...form, worker_image: e.target.value })} className={inp} />
@@ -449,16 +465,12 @@ function ProfileForm({
             </div>
 
             <Field label="AWS credentials">
-                <select
+                <SelectMenu
                     value={form.aws_credential_id ?? ""}
-                    onChange={(e) => setForm({ ...form, aws_credential_id: e.target.value || null })}
-                    className={inp}
-                >
-                    <option value="">(none)</option>
-                    {awsOptions.map((a) => (
-                        <option key={a.id} value={a.id}>{a.name} ({a.region})</option>
-                    ))}
-                </select>
+                    onChange={(v) => setForm({ ...form, aws_credential_id: v || null })}
+                    options={awsCredentialOptions}
+                    className="w-full"
+                />
             </Field>
 
             <h4 className="font-semibold text-slate-600 text-sm mt-4 mb-1">Kafka</h4>

--- a/web/src/app/app/admin/workers/[id]/page.tsx
+++ b/web/src/app/app/admin/workers/[id]/page.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import {
     convertWorkerToDedicated,
     deleteWorker,
@@ -81,6 +82,16 @@ export default function AdminWorkerDetailPage() {
     });
 
     const profiles = useQuery({ queryKey: ["admin", "profiles"], queryFn: listWorkerProfiles });
+    const profileOptions: SelectOption[] = useMemo(
+        () => [
+            { value: "", label: "(use backend env defaults)" },
+            ...(profiles.data?.data?.map((p) => ({
+                value: p.id,
+                label: `${p.name} · ${p.app_env}`,
+            })) ?? []),
+        ],
+        [profiles.data],
+    );
     const assignProfile = useMutation({
         mutationFn: (profileID: string | null) => assignWorkerProfile(id, profileID),
         ...opts("assign profile"),
@@ -261,19 +272,12 @@ export default function AdminWorkerDetailPage() {
 
             <Section title="Worker profile">
                 <div className="flex items-center gap-3">
-                    <select
+                    <SelectMenu
                         value={w.profile_id ?? ""}
-                        onChange={(e) => assignProfile.mutate(e.target.value || null)}
+                        onChange={(v) => assignProfile.mutate(v || null)}
+                        options={profileOptions}
                         disabled={assignProfile.isPending}
-                        className="border rounded px-3 py-1.5 text-sm"
-                    >
-                        <option value="">(use backend env defaults)</option>
-                        {profiles.data?.data?.map((p) => (
-                            <option key={p.id} value={p.id}>
-                                {p.name} · {p.app_env}
-                            </option>
-                        ))}
-                    </select>
+                    />
                     {w.profile_id && (
                         <Btn onClick={() => apply.mutate()} disabled={apply.isPending} primary>
                             Apply config & restart
@@ -389,20 +393,21 @@ export default function AdminWorkerDetailPage() {
                         .filter((other) => other.worker_type === w.worker_type && other.free_tier === w.free_tier)
                         .filter((other) => other.install_state === "installed")
                         .sort((a, b) => a.account_count - b.account_count);
+                    const rewireOptions: SelectOption[] = [
+                        { value: "", label: "— pick a target worker —" },
+                        ...candidates.map((c) => ({
+                            value: c.id,
+                            label: `${c.name || c.id.slice(0, 8)} · ${c.account_count} accounts · ${c.ssh_host || c.ip_addr}`,
+                        })),
+                    ];
                     return (
                         <div className="flex flex-wrap items-center gap-2">
-                            <select
+                            <SelectMenu
                                 value={rewireTarget}
-                                onChange={(e) => setRewireTarget(e.target.value)}
-                                className="border rounded px-3 py-1.5 text-sm w-full sm:min-w-[18rem]"
-                            >
-                                <option value="">— pick a target worker —</option>
-                                {candidates.map((c) => (
-                                    <option key={c.id} value={c.id}>
-                                        {c.name || c.id.slice(0, 8)} · {c.account_count} accounts · {c.ssh_host || c.ip_addr}
-                                    </option>
-                                ))}
-                            </select>
+                                onChange={(v) => setRewireTarget(v)}
+                                options={rewireOptions}
+                                className="w-full sm:min-w-[18rem]"
+                            />
                             <Btn onClick={rewireAll} disabled={!rewireTarget} primary>
                                 Move all {w.account_count} account{w.account_count === 1 ? "" : "s"}
                             </Btn>
@@ -454,26 +459,26 @@ export default function AdminWorkerDetailPage() {
                                         : "Drain target (not needed — this worker is empty)"
                                 }
                             >
-                                <select
+                                <SelectMenu
                                     value={convertDrain}
-                                    onChange={(e) => setConvertDrain(e.target.value)}
-                                    className="w-full border rounded px-3 py-1.5 text-sm"
-                                >
-                                    <option value="">— pick a target —</option>
-                                    {(allWorkers.data?.data ?? [])
-                                        .filter((other) =>
-                                            other.id !== id &&
-                                            other.worker_type === "shared" &&
-                                            other.install_state === "installed",
-                                        )
-                                        .sort((a, b) => a.account_count - b.account_count)
-                                        .map((c) => (
-                                            <option key={c.id} value={c.id}>
-                                                {c.name || c.id.slice(0, 8)} · {c.account_count} accounts ·{" "}
-                                                {c.free_tier ? "free" : "premium"}
-                                            </option>
-                                        ))}
-                                </select>
+                                    onChange={(v) => setConvertDrain(v)}
+                                    options={[
+                                        { value: "", label: "— pick a target —" },
+                                        ...(allWorkers.data?.data ?? [])
+                                            .filter(
+                                                (other) =>
+                                                    other.id !== id &&
+                                                    other.worker_type === "shared" &&
+                                                    other.install_state === "installed",
+                                            )
+                                            .sort((a, b) => a.account_count - b.account_count)
+                                            .map((c) => ({
+                                                value: c.id,
+                                                label: `${c.name || c.id.slice(0, 8)} · ${c.account_count} accounts · ${c.free_tier ? "free" : "premium"}`,
+                                            })),
+                                    ]}
+                                    className="w-full"
+                                />
                             </Field>
                             <div className="flex gap-2 mt-3">
                                 <Btn onClick={doConvertToDedicated} disabled={converting} primary>

--- a/web/src/app/app/admin/workers/new/page.tsx
+++ b/web/src/app/app/admin/workers/new/page.tsx
@@ -13,7 +13,7 @@
 // from the purpose so the admin doesn't have to think about risk_pool and
 // worker_type independently from "what is this worker for."
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
@@ -27,6 +27,7 @@ import {
 } from "@/lib/api/client/app/admin/workers";
 import { assignWorkerProfile, listWorkerProfiles } from "@/lib/api/client/app/admin/credentials";
 import type { CreateWorkerResponse } from "@/lib/api/models/app/admin/Worker";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import { API_URL } from "@/lib/information";
 
 type Purpose = "shared" | "dedicated" | "risky";
@@ -80,6 +81,17 @@ export default function AdminAddWorkerWizard() {
 
     const profiles = useQuery({ queryKey: ["admin", "profiles"], queryFn: listWorkerProfiles });
     const allWorkers = useQuery({ queryKey: ["admin", "workers", "managed"], queryFn: listManagedWorkers });
+
+    const profileOptions = useMemo<SelectOption[]>(
+        () => [
+            { value: "", label: "(use backend env defaults)" },
+            ...(profiles.data?.data?.map((p) => ({
+                value: p.id,
+                label: `${p.name} · ${p.app_env}`,
+            })) ?? []),
+        ],
+        [profiles.data?.data],
+    );
 
     // Steps shown depending on purpose. Dedicated adds an Owner step.
     const totalSteps = state.purpose === "dedicated" ? 5 : 4;
@@ -358,18 +370,13 @@ export default function AdminAddWorkerWizard() {
                     </div>
                     <div className="mt-3">
                         <label className={lbl}>Worker profile</label>
-                        <select
+                        <SelectMenu
                             value={state.profile_id}
-                            onChange={(e) => setState((s) => ({ ...s, profile_id: e.target.value }))}
-                            className={inp}
-                        >
-                            <option value="">(use backend env defaults)</option>
-                            {profiles.data?.data?.map((p) => (
-                                <option key={p.id} value={p.id}>
-                                    {p.name} · {p.app_env}
-                                </option>
-                            ))}
-                        </select>
+                            onChange={(v) => setState((s) => ({ ...s, profile_id: v }))}
+                            options={profileOptions}
+                            placeholder="(use backend env defaults)"
+                            className="w-full"
+                        />
                         <p className="text-slate-400 text-xs mt-1">
                             Supplies Kafka / Schema Registry / Redis / AWS keys at install time.
                         </p>

--- a/web/src/app/app/crm/deals/page.tsx
+++ b/web/src/app/app/crm/deals/page.tsx
@@ -10,9 +10,11 @@
 import React from "react";
 import {
     CircleDollarSignIcon,
+    LayoutGridIcon,
     Loader2Icon,
     PlusIcon,
     SearchIcon,
+    Table2Icon,
     TrashIcon,
     TrophyIcon,
     UserIcon,
@@ -47,6 +49,7 @@ import type Deal from "@/lib/api/models/app/crm/Deal";
 import type { Stage } from "@/lib/api/models/app/crm/Pipeline";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
+import DealsTable from "@/components/app/crm/DealsTable";
 
 const STATUS_LABEL = {
     open: { label: "Open",  tone: "text-slate-700",   dot: "bg-slate-400" },
@@ -56,7 +59,9 @@ const STATUS_LABEL = {
 
 export default function DealsPage() {
     const pipelines = usePipelines();
-    const list = pipelines.data ?? [];
+    // Memoised so it's a stable dependency for the effect + memos below
+    // (a fresh `?? []` each render would re-fire them every time).
+    const list = React.useMemo(() => pipelines.data ?? [], [pipelines.data]);
 
     const [pipelineId, setPipelineId] = React.useState<string | undefined>(undefined);
     React.useEffect(() => {
@@ -71,6 +76,18 @@ export default function DealsPage() {
     const [search, setSearch] = React.useState("");
     const [newOpen, setNewOpen] = React.useState(false);
     const [editing, setEditing] = React.useState<Deal | null>(null);
+    // Table = the cross-pipeline, server-driven "see everything" view (default).
+    // Board = the focused single-pipeline kanban for moving deals through stages.
+    const [view, setView] = React.useState<"table" | "board">("table");
+
+    // When editing a deal opened from the cross-pipeline table, scope the stage
+    // picker to that deal's OWN pipeline, not whichever pipeline the board has
+    // selected — otherwise the picker shows the wrong pipeline's stages.
+    const editingStages = React.useMemo(() => {
+        if (!editing) return stages;
+        const p = list.find((x) => x.id === editing.pipeline_id);
+        return p ? [...(p.stages ?? [])].sort((a, b) => a.position - b.position) : stages;
+    }, [editing, list, stages]);
 
     const allDeals = deals.data?.data ?? [];
     const filtered = search.trim()
@@ -116,12 +133,17 @@ export default function DealsPage() {
             >
                 {list.length > 0 && (
                     <>
-                        <PipelinePicker
-                            pipelines={list}
-                            currentId={pipelineId}
-                            onChange={setPipelineId}
-                        />
-                        <SearchPill value={search} onChange={setSearch} />
+                        <ViewToggle view={view} onChange={setView} />
+                        {view === "board" && (
+                            <>
+                                <PipelinePicker
+                                    pipelines={list}
+                                    currentId={pipelineId}
+                                    onChange={setPipelineId}
+                                />
+                                <SearchPill value={search} onChange={setSearch} />
+                            </>
+                        )}
                         <TopbarAction
                             icon={<PlusIcon className="w-3 h-3" />}
                             onClick={() => currentPipeline && setNewOpen(true)}
@@ -132,30 +154,40 @@ export default function DealsPage() {
                 )}
             </PageTopbar>
 
-            <StatStrip cols={4}>
-                <Stat label="Open" value={openCount} sub="active deals" />
-                <Stat label="Pipeline value" value={formatMoney(totalValue)} sub="all filtered" />
-                <Stat label="Won" value={wonCount} sub="this view" />
-                <Stat label="Stages" value={stages.length} sub="on this pipeline" last />
-            </StatStrip>
-
-            <SectionBar label={deals.isPending ? "Loading…" : `${stages.length} stages`} />
-            <PageBody className="px-5 py-5">
-                {pipelines.isPending ? (
+            {pipelines.isPending ? (
+                <PageBody className="px-5 py-5">
                     <BoardSkeleton />
-                ) : list.length === 0 ? (
+                </PageBody>
+            ) : list.length === 0 ? (
+                <PageBody className="px-5 py-5">
                     <NoPipelinesYet />
-                ) : !currentPipeline || stages.length === 0 ? (
-                    <NoStagesYet />
-                ) : (
-                    <Board
-                        stages={stages}
-                        deals={filtered}
-                        onMove={moveDeal}
-                        onOpen={(d) => setEditing(d)}
-                    />
-                )}
-            </PageBody>
+                </PageBody>
+            ) : view === "table" ? (
+                <DealsTable pipelines={list} onOpenDeal={(d) => setEditing(d)} />
+            ) : (
+                <>
+                    <StatStrip cols={4}>
+                        <Stat label="Open" value={openCount} sub="active deals" />
+                        <Stat label="Pipeline value" value={formatMoney(totalValue)} sub="loaded · this pipeline" />
+                        <Stat label="Won" value={wonCount} sub="this view" />
+                        <Stat label="Stages" value={stages.length} sub="on this pipeline" last />
+                    </StatStrip>
+
+                    <SectionBar label={deals.isPending ? "Loading…" : `${stages.length} stages`} />
+                    <PageBody className="px-5 py-5">
+                        {!currentPipeline || stages.length === 0 ? (
+                            <NoStagesYet />
+                        ) : (
+                            <Board
+                                stages={stages}
+                                deals={filtered}
+                                onMove={moveDeal}
+                                onOpen={(d) => setEditing(d)}
+                            />
+                        )}
+                    </PageBody>
+                </>
+            )}
 
             <DealDialog
                 open={newOpen}
@@ -166,11 +198,44 @@ export default function DealsPage() {
             <DealDialog
                 open={!!editing}
                 onClose={() => setEditing(null)}
-                pipelineId={pipelineId}
-                stages={stages}
+                pipelineId={editing?.pipeline_id ?? pipelineId}
+                stages={editingStages}
                 editing={editing ?? undefined}
             />
         </Page>
+    );
+}
+
+function ViewToggle({
+    view,
+    onChange,
+}: {
+    view: "table" | "board";
+    onChange: (v: "table" | "board") => void;
+}) {
+    return (
+        <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+            {(
+                [
+                    ["table", "Table", Table2Icon],
+                    ["board", "Board", LayoutGridIcon],
+                ] as const
+            ).map(([id, label, Icon]) => (
+                <button
+                    key={id}
+                    type="button"
+                    onClick={() => onChange(id)}
+                    className={`h-6 px-2 rounded text-[11px] font-medium inline-flex items-center gap-1.5 transition-colors ${
+                        view === id
+                            ? "bg-slate-900 text-white"
+                            : "text-slate-500 hover:text-slate-900"
+                    }`}
+                >
+                    <Icon className="w-3 h-3" />
+                    {label}
+                </button>
+            ))}
+        </div>
     );
 }
 

--- a/web/src/app/app/crm/deals/page.tsx
+++ b/web/src/app/app/crm/deals/page.tsx
@@ -216,7 +216,7 @@ function ViewToggle({
     onChange: (v: "table" | "board") => void;
 }) {
     return (
-        <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+        <div className="inline-flex rounded-md bg-slate-100 p-0.5 gap-0.5">
             {(
                 [
                     ["table", "Table", Table2Icon],
@@ -229,7 +229,7 @@ function ViewToggle({
                     onClick={() => onChange(id)}
                     className={`h-6 px-2 rounded text-[11px] font-medium inline-flex items-center gap-1.5 transition-colors ${
                         view === id
-                            ? "bg-slate-900 text-white"
+                            ? "bg-white text-slate-900 shadow-sm"
                             : "text-slate-500 hover:text-slate-900"
                     }`}
                 >
@@ -703,7 +703,7 @@ function DealDialog({
                                 {editing && (
                                     <div>
                                         <Label>Status</Label>
-                                        <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5 w-full">
+                                        <div className="inline-flex rounded-md bg-slate-100 p-0.5 gap-0.5 w-full">
                                             {(["open", "won", "lost"] as const).map((s) => (
                                                 <button
                                                     key={s}
@@ -711,7 +711,7 @@ function DealDialog({
                                                     onClick={() => setStatus(s)}
                                                     className={`flex-1 h-6 px-2 rounded text-[11px] font-medium transition-colors ${
                                                         status === s
-                                                            ? "bg-slate-900 text-white"
+                                                            ? "bg-white text-slate-900 shadow-sm"
                                                             : "text-slate-500 hover:text-slate-900"
                                                     }`}
                                                 >

--- a/web/src/app/app/crm/deals/page.tsx
+++ b/web/src/app/app/crm/deals/page.tsx
@@ -40,7 +40,10 @@ import {
     PopoverMenuItem,
 } from "@/components/ui/popover-menu";
 import usePipelines from "@/lib/api/hooks/app/crm/pipelines/usePipelines";
-import useDeals from "@/lib/api/hooks/app/crm/deals/useDeals";
+import useSearchDeals from "@/lib/api/hooks/app/crm/deals/useSearchDeals";
+import useDealsSummary from "@/lib/api/hooks/app/crm/deals/useDealsSummary";
+import { EMPTY_DEAL_SEARCH } from "@/lib/api/models/app/crm/SearchDeals";
+import type DealsSummary from "@/lib/api/models/app/crm/DealsSummary";
 import useCreateDeal from "@/lib/api/hooks/app/crm/deals/useCreateDeal";
 import useUpdateDeal from "@/lib/api/hooks/app/crm/deals/useUpdateDeal";
 import useDeleteDeal from "@/lib/api/hooks/app/crm/deals/useDeleteDeal";
@@ -70,7 +73,6 @@ export default function DealsPage() {
 
     const currentPipeline = list.find((p) => p.id === pipelineId);
     const stages = [...(currentPipeline?.stages ?? [])].sort((a, b) => a.position - b.position);
-    const deals = useDeals({ pipeline_id: pipelineId, limit: 100 });
     const updateDeal = useUpdateDeal();
 
     const [search, setSearch] = React.useState("");
@@ -89,32 +91,20 @@ export default function DealsPage() {
         return p ? [...(p.stages ?? [])].sort((a, b) => a.position - b.position) : stages;
     }, [editing, list, stages]);
 
-    const allDeals = deals.data?.data ?? [];
-    const filtered = search.trim()
-        ? allDeals.filter((d) =>
-              d.name.toLowerCase().includes(search.trim().toLowerCase()) ||
-              (d.contact?.email ?? "").toLowerCase().includes(search.trim().toLowerCase()),
-          )
-        : allDeals;
-
-    const totalValue = filtered.reduce((acc, d) => acc + (d.value ?? 0), 0);
-    const wonCount = filtered.filter((d) => d.status === "won").length;
-    const openCount = filtered.filter((d) => d.status === "open").length;
+    // The board reads totals + per-column counts/values from the server summary
+    // (computed over the whole pipeline, not the loaded cards), and each column
+    // pages its own deals — so it stays accurate and fast at any size.
+    const boardFilters = React.useMemo(
+        () => ({ ...EMPTY_DEAL_SEARCH, query: search, pipeline_ids: pipelineId ? [pipelineId] : [] }),
+        [search, pipelineId],
+    );
+    const boardSummary = useDealsSummary(boardFilters, view === "board" && !!pipelineId).data;
 
     async function moveDeal(dealId: string, newStageId: string) {
-        const cur = allDeals.find((d) => d.id === dealId);
-        if (!cur || cur.stage_id === newStageId) return;
         try {
             await toast.promise(
-                updateDeal.mutateAsync({
-                    id: dealId,
-                    data: { stage_id: newStageId } as Partial<Deal>,
-                }),
-                {
-                    loading: "Moving…",
-                    success: "Moved",
-                    error: (e: AppError) => buildError(e),
-                },
+                updateDeal.mutateAsync({ id: dealId, data: { stage_id: newStageId } as Partial<Deal> }),
+                { loading: "Moving…", success: "Moved", error: (e: AppError) => buildError(e) },
             );
         } catch {
             /* surfaced */
@@ -128,7 +118,9 @@ export default function DealsPage() {
                 subtitle={
                     list.length === 0
                         ? "Create a pipeline first to start tracking deals."
-                        : `${allDeals.length} ${allDeals.length === 1 ? "deal" : "deals"} on ${currentPipeline?.name ?? "—"}`
+                        : view === "board"
+                          ? (currentPipeline?.name ?? "—")
+                          : "Every deal, across all pipelines"
                 }
             >
                 {list.length > 0 && (
@@ -167,20 +159,30 @@ export default function DealsPage() {
             ) : (
                 <>
                     <StatStrip cols={4}>
-                        <Stat label="Open" value={openCount} sub="active deals" />
-                        <Stat label="Pipeline value" value={formatMoney(totalValue)} sub="loaded · this pipeline" />
-                        <Stat label="Won" value={wonCount} sub="this view" />
+                        <Stat label="Open" value={boardSummary ? boardSummary.open_count : "—"} sub="open deals" />
+                        <Stat
+                            label="Pipeline value"
+                            value={boardSummary ? formatMoney(boardSummary.open_value, boardSummary.currency) : "—"}
+                            sub={boardSummary?.mixed_currency ? "mixed currencies" : "open · server total"}
+                        />
+                        <Stat
+                            label="Won"
+                            value={boardSummary ? formatMoney(boardSummary.won_value, boardSummary.currency) : "—"}
+                            sub="closed won"
+                        />
                         <Stat label="Stages" value={stages.length} sub="on this pipeline" last />
                     </StatStrip>
 
-                    <SectionBar label={deals.isPending ? "Loading…" : `${stages.length} stages`} />
+                    <SectionBar label={`${stages.length} stages`} />
                     <PageBody className="px-5 py-5">
                         {!currentPipeline || stages.length === 0 ? (
                             <NoStagesYet />
                         ) : (
                             <Board
+                                pipelineId={pipelineId}
                                 stages={stages}
-                                deals={filtered}
+                                query={search}
+                                summary={boardSummary}
                                 onMove={moveDeal}
                                 onOpen={(d) => setEditing(d)}
                             />
@@ -240,23 +242,29 @@ function ViewToggle({
 }
 
 function Board({
+    pipelineId,
     stages,
-    deals,
+    query,
+    summary,
     onMove,
     onOpen,
 }: {
+    pipelineId?: string;
     stages: Stage[];
-    deals: Deal[];
+    query: string;
+    summary?: DealsSummary;
     onMove: (dealId: string, stageId: string) => void | Promise<void>;
     onOpen: (deal: Deal) => void;
 }) {
     return (
         <div className="grid gap-3 grid-flow-col auto-cols-[280px] overflow-x-auto pb-2">
             {stages.map((stage) => (
-                <Column
+                <BoardColumn
                     key={stage.id}
+                    pipelineId={pipelineId}
                     stage={stage}
-                    deals={deals.filter((d) => d.stage_id === stage.id)}
+                    query={query}
+                    stat={summary?.stages.find((s) => s.stage_id === stage.id)}
                     onDrop={(dealId) => onMove(dealId, stage.id)}
                     onOpen={onOpen}
                 />
@@ -265,19 +273,40 @@ function Board({
     );
 }
 
-function Column({
+// Each column is its own server-paginated query scoped to its stage, so a
+// 5,000-deal pipeline renders ~15 cards per column (with "load more") instead
+// of every node at once. The header count + open value come from the server
+// summary, so they stay accurate no matter how many are loaded.
+function BoardColumn({
+    pipelineId,
     stage,
-    deals,
+    query,
+    stat,
     onDrop,
     onOpen,
 }: {
+    pipelineId?: string;
     stage: Stage;
-    deals: Deal[];
+    query: string;
+    stat?: { count: number; value: number };
     onDrop: (dealId: string) => void;
     onOpen: (deal: Deal) => void;
 }) {
     const [hover, setHover] = React.useState(false);
-    const total = deals.reduce((acc, d) => acc + (d.value ?? 0), 0);
+    const filters = React.useMemo(
+        () => ({
+            ...EMPTY_DEAL_SEARCH,
+            query,
+            pipeline_ids: pipelineId ? [pipelineId] : [],
+            stage_ids: [stage.id],
+            sort_by: "updated_at" as const,
+        }),
+        [query, pipelineId, stage.id],
+    );
+    const q = useSearchDeals({ filters, limit: 15 });
+    const deals = q.deals ?? [];
+    const count = stat?.count ?? q.total;
+    const value = stat?.value ?? 0;
 
     return (
         <div
@@ -292,11 +321,11 @@ function Column({
                 const dealId = e.dataTransfer.getData("text/deal");
                 if (dealId) onDrop(dealId);
             }}
-            className={`flex flex-col rounded-md min-h-[300px] transition-colors ${
+            className={`flex flex-col rounded-md min-h-[300px] max-h-[calc(100vh-230px)] transition-colors ${
                 hover ? "bg-sky-50 border-sky-300" : "bg-slate-50 border-slate-200"
             } border`}
         >
-            <div className="h-9 px-3 flex items-center gap-2 border-b border-slate-200">
+            <div className="h-9 px-3 flex items-center gap-2 border-b border-slate-200 shrink-0">
                 <span
                     className="size-1.5 rounded-full shrink-0"
                     style={{ backgroundColor: stage.color || "#94a3b8" }}
@@ -304,24 +333,45 @@ function Column({
                 <span className="text-[11px] uppercase tracking-[0.1em] font-semibold text-slate-700 truncate">
                     {stage.name}
                 </span>
-                <span className="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums">
-                    {deals.length}
-                </span>
+                <span className="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums">{count}</span>
             </div>
-            {total > 0 && (
-                <div className="px-3 py-1 border-b border-slate-200/60 bg-white">
+            {value > 0 && (
+                <div className="px-3 py-1 border-b border-slate-200/60 bg-white shrink-0">
                     <span className="text-[10.5px] text-emerald-700 font-mono tabular-nums">
-                        {formatMoney(total)} total
+                        {formatMoney(value)} open
                     </span>
                 </div>
             )}
-            <div className="p-2 space-y-1.5 flex-1">
-                {deals.length === 0 ? (
+            <div className="p-2 space-y-1.5 flex-1 overflow-y-auto">
+                {q.isPending ? (
+                    <>
+                        <div className="h-16 rounded-md bg-white border border-slate-200 animate-pulse" />
+                        <div className="h-16 rounded-md bg-white border border-slate-200 animate-pulse" />
+                    </>
+                ) : deals.length === 0 ? (
                     <div className="h-20 rounded-md border border-dashed border-slate-200 flex items-center justify-center text-[10.5px] text-slate-400">
                         Drop deals here
                     </div>
                 ) : (
-                    deals.map((d) => <DealCard key={d.id} deal={d} onOpen={onOpen} />)
+                    <>
+                        {deals.map((d) => (
+                            <DealCard key={d.id} deal={d} onOpen={onOpen} />
+                        ))}
+                        {q.hasNextPage && (
+                            <button
+                                type="button"
+                                onClick={() => q.fetchNextPage()}
+                                disabled={q.isFetchingNextPage}
+                                className="w-full h-7 rounded-md border border-slate-200 hover:border-slate-300 text-[11px] text-slate-600 hover:text-slate-900 inline-flex items-center justify-center gap-1 transition-colors disabled:opacity-50"
+                            >
+                                {q.isFetchingNextPage ? (
+                                    <Loader2Icon className="w-3 h-3 animate-spin" />
+                                ) : (
+                                    `Load ${Math.max(0, count - deals.length)} more`
+                                )}
+                            </button>
+                        )}
+                    </>
                 )}
             </div>
         </div>

--- a/web/src/app/app/crm/tasks/page.tsx
+++ b/web/src/app/app/crm/tasks/page.tsx
@@ -74,6 +74,7 @@ import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
 import type { TaskSortBy } from "@/lib/api/models/app/crm/SearchTasks";
 import { EMPTY_TASK_SEARCH } from "@/lib/api/models/app/crm/SearchTasks";
 import type OrganizationMember from "@/lib/api/models/app/organizations/OrganizationMember";
+import type Team from "@/lib/api/models/app/teams/Team";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
@@ -169,6 +170,13 @@ export default function TasksPage() {
         return m;
     }, [members]);
 
+    const { data: teams = [] } = useTeams();
+    const teamById = React.useMemo(() => {
+        const m = new Map<string, Team>();
+        for (const t of teams) m.set(t.id, t);
+        return m;
+    }, [teams]);
+
     const { data: types = [] } = useTaskTypes();
 
     const statusTab: "all" | CRMTaskStatus =
@@ -185,6 +193,7 @@ export default function TasksPage() {
         filters.priorities.length +
         filters.types.length +
         filters.assigned_to.length +
+        filters.team_ids.length +
         (filters.overdue ? 1 : 0);
 
     return (
@@ -241,6 +250,11 @@ export default function TasksPage() {
                     selected={filters.assigned_to}
                     onChange={(ids) => setFilters((f) => ({ ...f, assigned_to: ids }))}
                 />
+                <TeamFacet
+                    teams={teams}
+                    selected={filters.team_ids}
+                    onChange={(ids) => setFilters((f) => ({ ...f, team_ids: ids }))}
+                />
                 <TypeFacet
                     types={types}
                     selected={filters.types}
@@ -274,6 +288,7 @@ export default function TasksPage() {
                     <GroupedView
                         tasks={tasks}
                         memberByUser={memberByUser}
+                        teamById={teamById}
                         types={types}
                         onOpen={setEditing}
                     />
@@ -281,6 +296,7 @@ export default function TasksPage() {
                     <FlatView
                         tasks={tasks}
                         memberByUser={memberByUser}
+                        teamById={teamById}
                         types={types}
                         onOpen={setEditing}
                     />
@@ -297,12 +313,18 @@ export default function TasksPage() {
                 )}
             </PageBody>
 
-            <TaskDialog open={newOpen} onClose={() => setNewOpen(false)} members={members} />
+            <TaskDialog
+                open={newOpen}
+                onClose={() => setNewOpen(false)}
+                members={members}
+                teams={teams}
+            />
             <TaskDialog
                 open={!!editing}
                 onClose={() => setEditing(null)}
                 editing={editing ?? undefined}
                 members={members}
+                teams={teams}
             />
         </Page>
     );
@@ -313,11 +335,13 @@ export default function TasksPage() {
 function FlatView({
     tasks,
     memberByUser,
+    teamById,
     types,
     onOpen,
 }: {
     tasks: CRMTask[];
     memberByUser: Map<string, OrganizationMember>;
+    teamById: Map<string, Team>;
     types: { name: string; color: string }[];
     onOpen: (t: CRMTask) => void;
 }) {
@@ -340,6 +364,7 @@ function FlatView({
                         key={t.id}
                         task={t}
                         member={t.assigned_to ? memberByUser.get(t.assigned_to) : undefined}
+                        team={t.assigned_team_id ? teamById.get(t.assigned_team_id) : undefined}
                         types={types}
                         onOpen={() => onOpen(t)}
                     />
@@ -352,11 +377,13 @@ function FlatView({
 function FlatRow({
     task,
     member,
+    team,
     types,
     onOpen,
 }: {
     task: CRMTask;
     member?: OrganizationMember;
+    team?: Team;
     types: { name: string; color: string }[];
     onOpen: () => void;
 }) {
@@ -424,7 +451,12 @@ function FlatRow({
                 <TaskTypeTag type={task.type} types={types} done={isDone} />
             </td>
             <td className="px-3 whitespace-nowrap">
-                <AssigneeCell member={member} assignedTo={task.assigned_to} />
+                <AssigneeCell
+                    member={member}
+                    assignedTo={task.assigned_to}
+                    team={team}
+                    assignedTeamId={task.assigned_team_id}
+                />
             </td>
             <td className="px-3 whitespace-nowrap">
                 <span
@@ -474,11 +506,13 @@ function FlatRow({
 function GroupedView({
     tasks,
     memberByUser,
+    teamById,
     types,
     onOpen,
 }: {
     tasks: CRMTask[];
     memberByUser: Map<string, OrganizationMember>;
+    teamById: Map<string, Team>;
     types: { name: string; color: string }[];
     onOpen: (t: CRMTask) => void;
 }) {
@@ -521,6 +555,7 @@ function GroupedView({
                         bucket={b}
                         tasks={items}
                         memberByUser={memberByUser}
+                        teamById={teamById}
                         types={types}
                         onOpen={onOpen}
                     />
@@ -534,12 +569,14 @@ function BucketGroup({
     bucket,
     tasks,
     memberByUser,
+    teamById,
     types,
     onOpen,
 }: {
     bucket: { id: Bucket; label: string; tone: keyof typeof TONE };
     tasks: CRMTask[];
     memberByUser: Map<string, OrganizationMember>;
+    teamById: Map<string, Team>;
     types: { name: string; color: string }[];
     onOpen: (t: CRMTask) => void;
 }) {
@@ -562,6 +599,7 @@ function BucketGroup({
                         key={t.id}
                         task={t}
                         member={t.assigned_to ? memberByUser.get(t.assigned_to) : undefined}
+                        team={t.assigned_team_id ? teamById.get(t.assigned_team_id) : undefined}
                         types={types}
                         onOpen={onOpen}
                     />
@@ -574,11 +612,13 @@ function BucketGroup({
 function GroupedRow({
     task,
     member,
+    team,
     types,
     onOpen,
 }: {
     task: CRMTask;
     member?: OrganizationMember;
+    team?: Team;
     types: { name: string; color: string }[];
     onOpen: (t: CRMTask) => void;
 }) {
@@ -622,7 +662,13 @@ function GroupedRow({
             >
                 {task.title}
             </span>
-            <AssigneeCell member={member} assignedTo={task.assigned_to} compact />
+            <AssigneeCell
+                member={member}
+                assignedTo={task.assigned_to}
+                team={team}
+                assignedTeamId={task.assigned_team_id}
+                compact
+            />
             <span
                 className={`inline-flex items-center gap-1 text-[10.5px] uppercase tracking-[0.08em] font-semibold ${priority.text}`}
             >
@@ -666,26 +712,59 @@ function memberInitials(member?: OrganizationMember, assignedTo?: string): strin
 function AssigneeCell({
     member,
     assignedTo,
+    team,
+    assignedTeamId,
     compact = false,
 }: {
     member?: OrganizationMember;
     assignedTo?: string;
+    team?: Team;
+    assignedTeamId?: string;
     compact?: boolean;
 }) {
-    if (!assignedTo) {
+    // A task may carry a person, a team, both, or neither. Render whichever are
+    // present; only fall back to "Unassigned" when nothing is set.
+    if (!assignedTo && !assignedTeamId) {
         return <span className="text-slate-300 text-[11.5px]">{compact ? "" : "Unassigned"}</span>;
     }
     const label = memberLabel(member, assignedTo);
     const initials = memberInitials(member, assignedTo);
     return (
+        <span className="inline-flex items-center gap-1.5 min-w-0">
+            {assignedTo && (
+                <span
+                    className="inline-flex items-center gap-1.5 min-w-0"
+                    title={member?.name || member?.email || assignedTo}
+                >
+                    <span className="size-5 shrink-0 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase tracking-tight">
+                        {initials}
+                    </span>
+                    {!compact && <span className="text-[11.5px] text-slate-600 truncate">{label}</span>}
+                </span>
+            )}
+            {assignedTeamId && <TeamChip team={team} teamId={assignedTeamId} compact={compact} />}
+        </span>
+    );
+}
+
+function teamLabel(team?: Team, teamId?: string): string {
+    const name = team?.name?.trim();
+    if (name) return name;
+    return teamId ? `Team ${teamId.slice(0, 6)}` : "";
+}
+
+function TeamChip({ team, teamId, compact = false }: { team?: Team; teamId?: string; compact?: boolean }) {
+    const label = teamLabel(team, teamId);
+    return (
         <span
-            className="inline-flex items-center gap-1.5 min-w-0"
-            title={member?.name || member?.email || assignedTo}
+            className="inline-flex items-center gap-1.5 min-w-0 h-5 px-1.5 rounded-full border border-slate-200 bg-slate-50"
+            title={label}
         >
-            <span className="size-5 shrink-0 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase tracking-tight">
-                {initials}
-            </span>
-            {!compact && <span className="text-[11.5px] text-slate-600 truncate">{label}</span>}
+            <span
+                className="size-2 shrink-0 rounded-full"
+                style={{ backgroundColor: team?.color || "#94a3b8" }}
+            />
+            {!compact && <span className="text-[11px] text-slate-600 truncate max-w-[90px]">{label}</span>}
         </span>
     );
 }
@@ -843,6 +922,76 @@ function AssigneeFacet({
                             }
                         >
                             <span className="truncate">{memberLabel(m)}</span>
+                        </PopoverMenuItem>
+                    ))
+                )}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function TeamFacet({
+    teams,
+    selected,
+    onChange,
+}: {
+    teams: Team[];
+    selected: string[];
+    onChange: (ids: string[]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const label =
+        selected.length === 0
+            ? "Any team"
+            : selected.length === 1
+              ? teamLabel(teams.find((t) => t.id === selected[0]), selected[0])
+              : `${selected.length} teams`;
+
+    function toggle(id: string) {
+        onChange(selected.includes(id) ? selected.filter((x) => x !== id) : [...selected, id]);
+    }
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        selected.length
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <UsersRoundIcon className="w-3 h-3" />
+                    <span className="truncate max-w-[100px]">{label}</span>
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={220} className="max-h-64 overflow-y-auto">
+                {teams.length === 0 ? (
+                    <Link
+                        to="/app/settings/teams"
+                        onClick={() => setOpen(false)}
+                        className="flex items-center gap-2 px-3 h-8 text-[11.5px] text-slate-500 hover:text-sky-700 hover:bg-slate-50 transition-colors"
+                    >
+                        <UsersRoundIcon className="w-3.5 h-3.5 shrink-0" />
+                        No teams yet, create one in Settings
+                    </Link>
+                ) : (
+                    teams.map((t) => (
+                        <PopoverMenuItem
+                            key={t.id}
+                            onSelect={() => toggle(t.id)}
+                            selected={selected.includes(t.id)}
+                            closeOnSelect={false}
+                            icon={
+                                <span
+                                    className="size-2.5 rounded-full"
+                                    style={{ backgroundColor: t.color || "#94a3b8" }}
+                                />
+                            }
+                        >
+                            <span className="truncate">{t.name}</span>
                         </PopoverMenuItem>
                     ))
                 )}
@@ -1221,11 +1370,13 @@ function TaskDialog({
     onClose,
     editing,
     members,
+    teams,
 }: {
     open: boolean;
     onClose: () => void;
     editing?: CRMTask;
     members: OrganizationMember[];
+    teams: Team[];
 }) {
     const create = useCreateCRMTask();
     const update = useUpdateCRMTask();
@@ -1239,6 +1390,7 @@ function TaskDialog({
     const [type, setType] = React.useState<string>("");
     const [status, setStatus] = React.useState<CRMTaskStatus>("pending");
     const [assignedTo, setAssignedTo] = React.useState<string>("");
+    const [assignedTeamId, setAssignedTeamId] = React.useState<string>("");
 
     React.useEffect(() => {
         if (!open) return;
@@ -1250,6 +1402,7 @@ function TaskDialog({
             setType(editing.type ?? "");
             setStatus(editing.status);
             setAssignedTo(editing.assigned_to ?? "");
+            setAssignedTeamId(editing.assigned_team_id ?? "");
         } else {
             setTitle("");
             setDescription("");
@@ -1258,6 +1411,7 @@ function TaskDialog({
             setType("");
             setStatus("pending");
             setAssignedTo("");
+            setAssignedTeamId("");
         }
     }, [open, editing]);
 
@@ -1274,6 +1428,7 @@ function TaskDialog({
         if (description.trim()) data.description = description.trim();
         if (dueDays !== null) data.due_date = dueInDaysToISO(dueDays);
         if (assignedTo) data.assigned_to = assignedTo;
+        if (assignedTeamId) data.assigned_team_id = assignedTeamId;
         if (editing) data.status = status;
 
         try {
@@ -1394,6 +1549,9 @@ function TaskDialog({
                                         value={assignedTo}
                                         members={members}
                                         onChange={setAssignedTo}
+                                        teams={teams}
+                                        teamValue={assignedTeamId}
+                                        onTeamChange={setAssignedTeamId}
                                     />
                                 </div>
                             </div>
@@ -1468,14 +1626,30 @@ function AssigneePicker({
     value,
     members,
     onChange,
+    teams,
+    teamValue,
+    onTeamChange,
 }: {
     value: string;
     members: OrganizationMember[];
     onChange: (id: string) => void;
+    teams: Team[];
+    teamValue: string;
+    onTeamChange: (id: string) => void;
 }) {
     const [open, setOpen] = React.useState(false);
     const cur = members.find((m) => m.user_id === value);
-    const { data: teams = [] } = useTeams();
+    const curTeam = teams.find((t) => t.id === teamValue);
+
+    // Person and team are independent: a task can set one, both, or neither.
+    // The trigger summarizes whichever are selected.
+    const triggerLabel = cur
+        ? curTeam
+            ? `${memberLabel(cur)} + ${curTeam.name}`
+            : memberLabel(cur)
+        : curTeam
+          ? curTeam.name
+          : "Unassigned";
 
     return (
         <PopoverMenu open={open} onOpenChange={setOpen} align="start">
@@ -1488,28 +1662,36 @@ function AssigneePicker({
                         <span className="size-4 shrink-0 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[8px] font-semibold inline-flex items-center justify-center uppercase">
                             {memberInitials(cur)}
                         </span>
+                    ) : curTeam ? (
+                        <span
+                            className="size-2 rounded-full shrink-0"
+                            style={{ backgroundColor: curTeam.color || "#94a3b8" }}
+                        />
                     ) : (
                         <span className="size-2 rounded-full bg-slate-300 shrink-0" />
                     )}
-                    <span className="truncate flex-1 text-left">
-                        {cur ? memberLabel(cur) : "Unassigned"}
-                    </span>
+                    <span className="truncate flex-1 text-left">{triggerLabel}</span>
                     <span className="ml-auto text-slate-400">▾</span>
                 </button>
             </PopoverMenuTrigger>
-            <PopoverMenuContent minWidth={220} className="max-h-56 overflow-y-auto">
+            <PopoverMenuContent minWidth={240} className="max-h-72 overflow-y-auto">
+                <div className="px-3 pt-1.5 pb-1 text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                    Person
+                </div>
                 <PopoverMenuItem
                     onSelect={() => onChange("")}
                     selected={value === ""}
+                    closeOnSelect={false}
                     icon={<span className="size-2 rounded-full bg-slate-300 block" />}
                 >
-                    Unassigned
+                    No person
                 </PopoverMenuItem>
                 {members.map((m) => (
                     <PopoverMenuItem
                         key={m.user_id}
                         onSelect={() => onChange(m.user_id)}
                         selected={m.user_id === value}
+                        closeOnSelect={false}
                         icon={
                             <span className="size-5 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase">
                                 {memberInitials(m)}
@@ -1520,14 +1702,46 @@ function AssigneePicker({
                     </PopoverMenuItem>
                 ))}
                 <div className="my-1 h-px bg-slate-200" />
-                <Link
-                    to="/app/settings/teams"
-                    onClick={() => setOpen(false)}
-                    className="flex items-center gap-2 px-3 h-8 text-[12px] text-slate-500 hover:text-sky-700 hover:bg-slate-50 transition-colors"
-                >
-                    <UsersRoundIcon className="w-3.5 h-3.5 shrink-0" />
-                    {teams.length === 0 ? "No teams yet — create one in Settings" : "Manage teams"}
-                </Link>
+                <div className="px-3 pt-0.5 pb-1 text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                    Team
+                </div>
+                {teams.length === 0 ? (
+                    <Link
+                        to="/app/settings/teams"
+                        onClick={() => setOpen(false)}
+                        className="flex items-center gap-2 px-3 h-8 text-[12px] text-slate-500 hover:text-sky-700 hover:bg-slate-50 transition-colors"
+                    >
+                        <UsersRoundIcon className="w-3.5 h-3.5 shrink-0" />
+                        No teams yet, create one in Settings
+                    </Link>
+                ) : (
+                    <>
+                        <PopoverMenuItem
+                            onSelect={() => onTeamChange("")}
+                            selected={teamValue === ""}
+                            closeOnSelect={false}
+                            icon={<span className="size-2 rounded-full bg-slate-300 block" />}
+                        >
+                            No team
+                        </PopoverMenuItem>
+                        {teams.map((t) => (
+                            <PopoverMenuItem
+                                key={t.id}
+                                onSelect={() => onTeamChange(t.id)}
+                                selected={t.id === teamValue}
+                                closeOnSelect={false}
+                                icon={
+                                    <span
+                                        className="size-2.5 rounded-full"
+                                        style={{ backgroundColor: t.color || "#94a3b8" }}
+                                    />
+                                }
+                            >
+                                <span className="truncate">{t.name}</span>
+                            </PopoverMenuItem>
+                        ))}
+                    </>
+                )}
             </PopoverMenuContent>
         </PopoverMenu>
     );
@@ -1580,6 +1794,7 @@ function hasAnyFilter(f: SearchTasks): boolean {
         f.priorities.length > 0 ||
         f.types.length > 0 ||
         f.assigned_to.length > 0 ||
+        f.team_ids.length > 0 ||
         !!f.contact_id ||
         !!f.deal_id ||
         !!f.due_after ||

--- a/web/src/app/app/crm/tasks/page.tsx
+++ b/web/src/app/app/crm/tasks/page.tsx
@@ -799,15 +799,22 @@ function TaskTypeTag({
     if (!type) {
         return compact ? null : <span className="text-slate-300 text-[11.5px]">—</span>;
     }
-    const color = taskTypeColor(type, types);
+    // Render the type as a colour-tinted chip (faint background in the type's
+    // colour + a solid dot + text in the colour) so the colour is unmistakable,
+    // not a single 8px dot. Done tasks fade to grey. Colours are DB-enforced hex.
+    const color = done ? "#94a3b8" : taskTypeColor(type, types);
     return (
         <span
             title={type}
-            className={`shrink-0 inline-flex items-center gap-1 text-[10.5px] text-slate-500 ${
-                compact ? "max-w-[90px]" : ""
+            className={`shrink-0 inline-flex items-center gap-1 rounded h-[18px] px-1.5 text-[10.5px] font-medium ${
+                compact ? "max-w-[110px]" : ""
             }`}
+            style={{ backgroundColor: `${color}1f`, color }}
         >
-            <span className="size-2 rounded-full" style={{ backgroundColor: done ? "#cbd5e1" : color }} />
+            <span
+                className="w-1.5 h-1.5 rounded-full shrink-0"
+                style={{ backgroundColor: color }}
+            />
             <span className="truncate">{type}</span>
         </span>
     );
@@ -1044,12 +1051,14 @@ function TypeFacet({
                             closeOnSelect={false}
                             icon={
                                 <span
-                                    className="size-2 rounded-full"
-                                    style={{ backgroundColor: t.color }}
+                                    className="w-2.5 h-2.5 rounded-full ring-1 ring-black/5 shrink-0"
+                                    style={{ backgroundColor: t.color || "#94a3b8" }}
                                 />
                             }
                         >
-                            {t.name}
+                            <span style={{ color: t.color || "#94a3b8" }}>
+                                {t.name}
+                            </span>
                         </PopoverMenuItem>
                     ))
                 )}

--- a/web/src/app/app/crm/tasks/page.tsx
+++ b/web/src/app/app/crm/tasks/page.tsx
@@ -48,6 +48,9 @@ import type CRMTask from "@/lib/api/models/app/crm/CRMTask";
 import type { CRMTaskPriority, CRMTaskStatus } from "@/lib/api/models/app/crm/CRMTask";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
+import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
+import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
+import { taskTypeColor } from "@/components/app/crm/taskTypes";
 
 const PRIORITIES: { id: CRMTaskPriority; label: string; dot: string; text: string }[] = [
     { id: "urgent", label: "Urgent", dot: "bg-red-500",     text: "text-red-700" },
@@ -138,8 +141,13 @@ export default function TasksPage() {
         return g;
     }, [visible, showCompleted]);
 
+    // Active = still actionable (not completed/cancelled). Priority breakdown is
+    // computed over the open work, mirroring the campaigns/accounts stat strips.
+    const activeTasks = all.filter((t) => t.status !== "completed" && t.status !== "cancelled");
     const stats = {
         overdue: grouped.overdue.length,
+        highPriority: activeTasks.filter((t) => t.priority === "urgent" || t.priority === "high").length,
+        otherPriority: activeTasks.filter((t) => t.priority === "medium" || t.priority === "low").length,
         today: grouped.today.length,
         week: grouped.this_week.length + grouped.tomorrow.length + grouped.today.length,
         completed: all.filter(
@@ -174,10 +182,11 @@ export default function TasksPage() {
                 </TopbarAction>
             </PageTopbar>
 
-            <StatStrip cols={4}>
+            <StatStrip cols={5}>
                 <Stat label="Overdue" value={stats.overdue} sub="needs attention" />
+                <Stat label="High priority" value={stats.highPriority} sub="urgent + high" accent={stats.highPriority > 0} />
+                <Stat label="Other" value={stats.otherPriority} sub="medium + low" />
                 <Stat label="Today" value={stats.today} sub="due today" />
-                <Stat label="This week" value={stats.week} sub="next 7 days" />
                 <Stat label="Completed (7d)" value={stats.completed} sub="last week" last />
             </StatStrip>
 
@@ -270,6 +279,7 @@ function TaskRow({ task, onOpen }: { task: CRMTask; onOpen: (t: CRMTask) => void
                     <SquareIcon className="w-3.5 h-3.5" />
                 )}
             </button>
+            <TaskTypeIcon type={task.type} done={isDone} />
             <span
                 className={`text-[12px] truncate flex-1 ${
                     isDone ? "text-slate-400 line-through" : "text-slate-900"
@@ -382,6 +392,7 @@ function TaskDialog({
     const [description, setDescription] = React.useState("");
     const [dueDate, setDueDate] = React.useState("");
     const [priority, setPriority] = React.useState<CRMTaskPriority>("medium");
+    const [type, setType] = React.useState<string>("");
     const [status, setStatus] = React.useState<CRMTaskStatus>("pending");
 
     React.useEffect(() => {
@@ -391,12 +402,14 @@ function TaskDialog({
             setDescription(editing.description ?? "");
             setDueDate(editing.due_date ? String(editing.due_date).split("T")[0] : "");
             setPriority(editing.priority);
+            setType(editing.type ?? "");
             setStatus(editing.status);
         } else {
             setTitle("");
             setDescription("");
             setDueDate("");
             setPriority("medium");
+            setType("");
             setStatus("pending");
         }
     }, [open, editing]);
@@ -409,6 +422,7 @@ function TaskDialog({
         const data: Partial<CRMTask> = {
             title: title.trim(),
             priority,
+            type,
         };
         if (description.trim()) data.description = description.trim();
         if (dueDate) data.due_date = new Date(dueDate).toISOString();
@@ -521,6 +535,10 @@ function TaskDialog({
                                     className="w-full px-2.5 py-1.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 placeholder:text-slate-400 outline-none transition-colors focus:border-sky-400 focus:ring-2 focus:ring-sky-100 resize-y"
                                 />
                             </div>
+                            <div>
+                                <Label>Task type</Label>
+                                <TaskTypePicker value={type} onChange={setType} />
+                            </div>
                             <div className="grid grid-cols-2 gap-2">
                                 <div>
                                     <Label>Due date</Label>
@@ -534,7 +552,7 @@ function TaskDialog({
                             {editing && (
                                 <div>
                                     <Label>Status</Label>
-                                    <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5 w-full">
+                                    <div className="inline-flex rounded-md bg-slate-100 p-0.5 w-full gap-0.5">
                                         {(
                                             [
                                                 ["pending", "Pending"],
@@ -549,7 +567,7 @@ function TaskDialog({
                                                 onClick={() => setStatus(id)}
                                                 className={`flex-1 h-6 px-2 rounded text-[11px] font-medium transition-colors ${
                                                     status === id
-                                                        ? "bg-slate-900 text-white"
+                                                        ? "bg-white text-slate-900 shadow-sm"
                                                         : "text-slate-500 hover:text-slate-900"
                                                 }`}
                                             >
@@ -623,6 +641,21 @@ function PriorityPill({
                 ))}
             </PopoverMenuContent>
         </PopoverMenu>
+    );
+}
+
+function TaskTypeIcon({ type, done }: { type: string | undefined; done: boolean }) {
+    const { data: types = [] } = useTaskTypes();
+    if (!type) return null;
+    const color = taskTypeColor(type, types);
+    return (
+        <span
+            title={type}
+            className="shrink-0 inline-flex items-center gap-1 text-[10.5px] text-slate-400 max-w-[90px]"
+        >
+            <span className="size-2 rounded-full" style={{ backgroundColor: done ? "#cbd5e1" : color }} />
+            <span className="truncate">{type}</span>
+        </span>
     );
 }
 

--- a/web/src/app/app/crm/tasks/page.tsx
+++ b/web/src/app/app/crm/tasks/page.tsx
@@ -52,6 +52,8 @@ import {
     TopbarAction,
 } from "@/components/layout/Page";
 import { Label, SearchInput, TextInput } from "@/components/ui/field";
+import DueInDays from "@/components/app/crm/DueInDays";
+import { dueInDaysToISO, isoToDueInDays } from "@/lib/helper/dueDate";
 import {
     PopoverMenu,
     PopoverMenuContent,
@@ -1232,7 +1234,7 @@ function TaskDialog({
 
     const [title, setTitle] = React.useState("");
     const [description, setDescription] = React.useState("");
-    const [dueDate, setDueDate] = React.useState("");
+    const [dueDays, setDueDays] = React.useState<number | null>(null);
     const [priority, setPriority] = React.useState<CRMTaskPriority>("medium");
     const [type, setType] = React.useState<string>("");
     const [status, setStatus] = React.useState<CRMTaskStatus>("pending");
@@ -1243,7 +1245,7 @@ function TaskDialog({
         if (editing) {
             setTitle(editing.title);
             setDescription(editing.description ?? "");
-            setDueDate(editing.due_date ? String(editing.due_date).split("T")[0] : "");
+            setDueDays(isoToDueInDays(editing.due_date));
             setPriority(editing.priority);
             setType(editing.type ?? "");
             setStatus(editing.status);
@@ -1251,7 +1253,7 @@ function TaskDialog({
         } else {
             setTitle("");
             setDescription("");
-            setDueDate("");
+            setDueDays(null);
             setPriority("medium");
             setType("");
             setStatus("pending");
@@ -1270,7 +1272,7 @@ function TaskDialog({
             type,
         };
         if (description.trim()) data.description = description.trim();
-        if (dueDate) data.due_date = new Date(dueDate).toISOString();
+        if (dueDays !== null) data.due_date = dueInDaysToISO(dueDays);
         if (assignedTo) data.assigned_to = assignedTo;
         if (editing) data.status = status;
 
@@ -1398,7 +1400,7 @@ function TaskDialog({
                             <div className="grid grid-cols-2 gap-2">
                                 <div>
                                     <Label>Due date</Label>
-                                    <TextInput value={dueDate} onChange={setDueDate} type="date" className="w-full" />
+                                    <DueInDays value={dueDays} onChange={setDueDays} />
                                 </div>
                                 <div>
                                     <Label>Priority</Label>

--- a/web/src/app/app/crm/tasks/page.tsx
+++ b/web/src/app/app/crm/tasks/page.tsx
@@ -1,26 +1,45 @@
-// Tasks — real CRM task list.
+// Tasks — the server-driven, scale-safe CRM task surface.
 //
-// Tasks are grouped by due-date bucket: Overdue / Today / Tomorrow /
-// This week / Later / No due date. A "Completed" filter pill toggles
-// the grouped vs flat view of completed tasks.
+// This page is built to hold thousands of tasks. Unlike a client-side list
+// that slices the first 100 rows and totals them in memory, it:
+//   - searches, filters and sorts on the server (status, priority, type,
+//     assignee, overdue, text) via POST /crm/tasks/search
+//   - pages the full result set with offset infinite scroll ("N of M loaded")
+//   - reads every header total from POST /crm/tasks/summary, so the Overdue /
+//     High priority / Completed numbers are COUNTs over the whole filtered set,
+//     never a reduce over the loaded page
+//   - resolves assigned_to user ids to org members (useMembers) for a real
+//     ASSIGNEE column (avatar initials + name) and an assignee facet
 //
-// Each row has an inline checkbox that toggles status between
-// `pending` and `completed`. Clicking the row opens an edit dialog
-// for the rest of the fields (title, description, priority, due date,
-// status).
+// Two views share the one paged result list: a flat table and a grouped
+// "by due-date" view. Both page server-side; the grouped view buckets only the
+// rows already loaded, and the same "Load more" affordance pulls the next page.
+//
+// The inline checkbox toggles status between pending and completed. Clicking a
+// row opens the create/edit dialog (title, description, type, due date,
+// priority, status), which preserves the TaskTypePicker + themed selectors.
 
 import React from "react";
 import {
-    AlertCircleIcon,
+    AlertTriangleIcon,
+    ArrowUpDownIcon,
     CalendarClockIcon,
     CheckSquareIcon,
+    LayoutListIcon,
+    ListTreeIcon,
     Loader2Icon,
+    MoreHorizontalIcon,
+    PencilIcon,
     PlusIcon,
-    SearchIcon,
     SquareIcon,
+    TagIcon,
     TrashIcon,
+    UsersIcon,
+    UsersRoundIcon,
     XIcon,
 } from "lucide-react";
+import { Link } from "react-router-dom";
+import useTeams from "@/lib/api/hooks/app/teams/useTeams";
 import toast from "react-hot-toast";
 import { AnimatePresence, motion } from "framer-motion";
 import {
@@ -32,49 +51,72 @@ import {
     StatStrip,
     TopbarAction,
 } from "@/components/layout/Page";
-import { Label, TextInput } from "@/components/ui/field";
+import { Label, SearchInput, TextInput } from "@/components/ui/field";
 import {
     PopoverMenu,
     PopoverMenuContent,
     PopoverMenuItem,
     PopoverMenuTrigger,
 } from "@/components/ui/popover-menu";
-import useCRMTasks from "@/lib/api/hooks/app/crm/tasks/useCRMTasks";
+import useSearchTasks from "@/lib/api/hooks/app/crm/tasks/useSearchTasks";
+import useTasksSummary from "@/lib/api/hooks/app/crm/tasks/useTasksSummary";
 import useCreateCRMTask from "@/lib/api/hooks/app/crm/tasks/useCreateCRMTask";
 import useUpdateCRMTask from "@/lib/api/hooks/app/crm/tasks/useUpdateCRMTask";
 import useDeleteCRMTask from "@/lib/api/hooks/app/crm/tasks/useDeleteCRMTask";
+import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
+import useMembers from "@/lib/api/hooks/app/organizations/useMembers";
 import { useConfirm } from "@/hooks/context/confirm";
 import type CRMTask from "@/lib/api/models/app/crm/CRMTask";
 import type { CRMTaskPriority, CRMTaskStatus } from "@/lib/api/models/app/crm/CRMTask";
+import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
+import type { TaskSortBy } from "@/lib/api/models/app/crm/SearchTasks";
+import { EMPTY_TASK_SEARCH } from "@/lib/api/models/app/crm/SearchTasks";
+import type OrganizationMember from "@/lib/api/models/app/organizations/OrganizationMember";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
-import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
 import { taskTypeColor } from "@/components/app/crm/taskTypes";
 
 const PRIORITIES: { id: CRMTaskPriority; label: string; dot: string; text: string }[] = [
-    { id: "urgent", label: "Urgent", dot: "bg-red-500",     text: "text-red-700" },
-    { id: "high",   label: "High",   dot: "bg-amber-500",   text: "text-amber-700" },
-    { id: "medium", label: "Medium", dot: "bg-sky-500",     text: "text-sky-700" },
-    { id: "low",    label: "Low",    dot: "bg-slate-400",   text: "text-slate-600" },
+    { id: "urgent", label: "Urgent", dot: "bg-red-500", text: "text-red-700" },
+    { id: "high", label: "High", dot: "bg-amber-500", text: "text-amber-700" },
+    { id: "medium", label: "Medium", dot: "bg-sky-500", text: "text-sky-700" },
+    { id: "low", label: "Low", dot: "bg-slate-400", text: "text-slate-600" },
+];
+
+const STATUS_TABS: { id: "all" | CRMTaskStatus; label: string }[] = [
+    { id: "all", label: "All" },
+    { id: "pending", label: "Pending" },
+    { id: "in_progress", label: "Active" },
+    { id: "completed", label: "Done" },
+    { id: "cancelled", label: "Cancelled" },
+];
+
+const SORTS: { id: string; label: string; sort_by: TaskSortBy; reverse: boolean }[] = [
+    { id: "newest", label: "Newest", sort_by: "created_at", reverse: false },
+    { id: "oldest", label: "Oldest", sort_by: "created_at", reverse: true },
+    { id: "due_soon", label: "Due soonest", sort_by: "due_date", reverse: true },
+    { id: "due_late", label: "Due latest", sort_by: "due_date", reverse: false },
+    { id: "priority", label: "Priority · high → low", sort_by: "priority", reverse: false },
+    { id: "title", label: "Title · A → Z", sort_by: "title", reverse: true },
 ];
 
 type Bucket = "overdue" | "today" | "tomorrow" | "this_week" | "later" | "no_due";
 
 const BUCKETS: { id: Bucket; label: string; tone: "red" | "sky" | "slate" | "muted" }[] = [
-    { id: "overdue",   label: "Overdue",     tone: "red" },
-    { id: "today",     label: "Today",       tone: "sky" },
-    { id: "tomorrow",  label: "Tomorrow",    tone: "slate" },
-    { id: "this_week", label: "This week",   tone: "slate" },
-    { id: "later",     label: "Later",       tone: "muted" },
-    { id: "no_due",    label: "No due date", tone: "muted" },
+    { id: "overdue", label: "Overdue", tone: "red" },
+    { id: "today", label: "Today", tone: "sky" },
+    { id: "tomorrow", label: "Tomorrow", tone: "slate" },
+    { id: "this_week", label: "This week", tone: "slate" },
+    { id: "later", label: "Later", tone: "muted" },
+    { id: "no_due", label: "No due date", tone: "muted" },
 ];
 
 const TONE = {
-    red:    { dot: "bg-red-500",    label: "text-red-600" },
-    sky:    { dot: "bg-sky-500",    label: "text-sky-600" },
-    slate:  { dot: "bg-slate-400",  label: "text-slate-700" },
-    muted:  { dot: "bg-slate-300",  label: "text-slate-500" },
+    red: { dot: "bg-red-500", label: "text-red-600" },
+    sky: { dot: "bg-sky-500", label: "text-sky-600" },
+    slate: { dot: "bg-slate-400", label: "text-slate-700" },
+    muted: { dot: "bg-slate-300", label: "text-slate-500" },
 } as const;
 
 function bucketize(due: string | undefined): Bucket {
@@ -97,23 +139,350 @@ function bucketize(due: string | undefined): Bucket {
     return "later";
 }
 
+// Whether a task is past due AND still actionable (mirrors the server's
+// `overdue` predicate so the row badge agrees with the summary count).
+function isOverdue(t: CRMTask): boolean {
+    if (!t.due_date) return false;
+    if (t.status === "completed" || t.status === "cancelled") return false;
+    const d = new Date(t.due_date);
+    return !Number.isNaN(d.getTime()) && d.getTime() < Date.now();
+}
+
 export default function TasksPage() {
-    const tasks = useCRMTasks({ limit: 100 });
-    const [search, setSearch] = React.useState("");
-    const [showCompleted, setShowCompleted] = React.useState(false);
+    const [filters, setFilters] = React.useState<SearchTasks>(EMPTY_TASK_SEARCH);
+    const [view, setView] = React.useState<"flat" | "grouped">("flat");
     const [newOpen, setNewOpen] = React.useState(false);
     const [editing, setEditing] = React.useState<CRMTask | null>(null);
 
-    const all = tasks.data?.data ?? [];
-    const visible = all
-        .filter((t) => (showCompleted ? true : t.status !== "completed"))
-        .filter((t) =>
-            search.trim()
-                ? t.title.toLowerCase().includes(search.trim().toLowerCase()) ||
-                  (t.description ?? "").toLowerCase().includes(search.trim().toLowerCase())
-                : true,
-        );
+    const search = useSearchTasks({ filters, limit: 50 });
+    const summary = useTasksSummary(filters);
+    const tasks = search.tasks ?? [];
+    const total = search.total;
+    const sum = summary.data;
 
+    const { data: members = [] } = useMembers();
+    const memberByUser = React.useMemo(() => {
+        const m = new Map<string, OrganizationMember>();
+        for (const mem of members) m.set(mem.user_id, mem);
+        return m;
+    }, [members]);
+
+    const { data: types = [] } = useTaskTypes();
+
+    const statusTab: "all" | CRMTaskStatus =
+        filters.statuses.length === 1 ? filters.statuses[0] : "all";
+
+    function setStatusTab(tab: "all" | CRMTaskStatus) {
+        setFilters((f) => ({ ...f, statuses: tab === "all" ? [] : [tab] }));
+    }
+
+    const activeSort =
+        SORTS.find((s) => s.sort_by === filters.sort_by && s.reverse === filters.reverse) ?? SORTS[0];
+
+    const advancedCount =
+        filters.priorities.length +
+        filters.types.length +
+        filters.assigned_to.length +
+        (filters.overdue ? 1 : 0);
+
+    return (
+        <Page>
+            <PageTopbar eyebrow="Tasks" subtitle="Follow-ups + reminders across the org">
+                <ViewToggle view={view} onChange={setView} />
+                <TopbarAction icon={<PlusIcon className="w-3 h-3" />} onClick={() => setNewOpen(true)}>
+                    New task
+                </TopbarAction>
+            </PageTopbar>
+
+            <StatStrip cols={5}>
+                <Stat
+                    label="Overdue"
+                    value={sum ? sum.overdue_count : "—"}
+                    sub="needs attention"
+                    accent={!!sum && sum.overdue_count > 0}
+                />
+                <Stat
+                    label="High priority"
+                    value={sum ? sum.high_priority_count : "—"}
+                    sub="urgent + high"
+                />
+                <Stat label="Pending" value={sum ? sum.pending_count : "—"} sub="not started" />
+                <Stat label="Active" value={sum ? sum.in_progress_count : "—"} sub="in progress" />
+                <Stat label="Completed" value={sum ? sum.completed_count : "—"} sub="done" last />
+            </StatStrip>
+
+            <SectionBar label={search.isPending ? "Loading…" : `${total} ${total === 1 ? "task" : "tasks"}`}>
+                <SearchInput
+                    value={filters.query}
+                    onChange={(v) => setFilters((f) => ({ ...f, query: v }))}
+                    placeholder="Search tasks…"
+                    className="w-full sm:w-[180px]"
+                />
+                <div className="inline-flex rounded-md bg-slate-100 p-0.5 gap-0.5">
+                    {STATUS_TABS.map((t) => (
+                        <button
+                            key={t.id}
+                            type="button"
+                            onClick={() => setStatusTab(t.id)}
+                            className={`h-6 px-2 rounded text-[11px] font-medium transition-colors ${
+                                statusTab === t.id
+                                    ? "bg-white text-slate-900 shadow-sm"
+                                    : "text-slate-500 hover:text-slate-900"
+                            }`}
+                        >
+                            {t.label}
+                        </button>
+                    ))}
+                </div>
+                <AssigneeFacet
+                    members={members}
+                    selected={filters.assigned_to}
+                    onChange={(ids) => setFilters((f) => ({ ...f, assigned_to: ids }))}
+                />
+                <TypeFacet
+                    types={types}
+                    selected={filters.types}
+                    onChange={(names) => setFilters((f) => ({ ...f, types: names }))}
+                />
+                <FilterPopover filters={filters} onChange={setFilters} activeCount={advancedCount} />
+                <SortPopover
+                    active={activeSort.id}
+                    onChange={(s) => setFilters((f) => ({ ...f, sort_by: s.sort_by, reverse: s.reverse }))}
+                />
+            </SectionBar>
+
+            <PageBody className={view === "grouped" ? "px-5 py-5" : ""}>
+                {search.isError ? (
+                    <div className="px-5 py-16 text-center text-[12.5px] text-red-600">
+                        Couldn't load tasks. Try again.
+                    </div>
+                ) : search.isPending ? (
+                    view === "grouped" ? (
+                        <GroupedSkeleton />
+                    ) : (
+                        <FlatSkeleton />
+                    )
+                ) : tasks.length === 0 ? (
+                    <EmptyState
+                        hasFilters={total === 0 && hasAnyFilter(filters)}
+                        onCreate={() => setNewOpen(true)}
+                        onClear={() => setFilters(EMPTY_TASK_SEARCH)}
+                    />
+                ) : view === "grouped" ? (
+                    <GroupedView
+                        tasks={tasks}
+                        memberByUser={memberByUser}
+                        types={types}
+                        onOpen={setEditing}
+                    />
+                ) : (
+                    <FlatView
+                        tasks={tasks}
+                        memberByUser={memberByUser}
+                        types={types}
+                        onOpen={setEditing}
+                    />
+                )}
+
+                {!search.isPending && tasks.length > 0 && (
+                    <LoadMore
+                        hasNextPage={!!search.hasNextPage}
+                        isFetchingNextPage={search.isFetchingNextPage}
+                        onLoadMore={() => search.fetchNextPage()}
+                        loaded={tasks.length}
+                        total={total}
+                    />
+                )}
+            </PageBody>
+
+            <TaskDialog open={newOpen} onClose={() => setNewOpen(false)} members={members} />
+            <TaskDialog
+                open={!!editing}
+                onClose={() => setEditing(null)}
+                editing={editing ?? undefined}
+                members={members}
+            />
+        </Page>
+    );
+}
+
+// ── Views ────────────────────────────────────────────────────────────────
+
+function FlatView({
+    tasks,
+    memberByUser,
+    types,
+    onOpen,
+}: {
+    tasks: CRMTask[];
+    memberByUser: Map<string, OrganizationMember>;
+    types: { name: string; color: string }[];
+    onOpen: (t: CRMTask) => void;
+}) {
+    return (
+        <table className="w-full border-collapse">
+            <thead className="sticky top-0 bg-white z-[1]">
+                <tr className="border-b border-slate-200">
+                    <Th className="text-left">Task</Th>
+                    <Th className="text-left">Type</Th>
+                    <Th className="text-left">Assignee</Th>
+                    <Th className="text-left">Priority</Th>
+                    <Th className="text-left">Status</Th>
+                    <Th className="text-left">Due</Th>
+                    <Th className="text-right"> </Th>
+                </tr>
+            </thead>
+            <tbody>
+                {tasks.map((t) => (
+                    <FlatRow
+                        key={t.id}
+                        task={t}
+                        member={t.assigned_to ? memberByUser.get(t.assigned_to) : undefined}
+                        types={types}
+                        onOpen={() => onOpen(t)}
+                    />
+                ))}
+            </tbody>
+        </table>
+    );
+}
+
+function FlatRow({
+    task,
+    member,
+    types,
+    onOpen,
+}: {
+    task: CRMTask;
+    member?: OrganizationMember;
+    types: { name: string; color: string }[];
+    onOpen: () => void;
+}) {
+    const update = useUpdateCRMTask();
+    const del = useDeleteCRMTask();
+    const confirm = useConfirm();
+    const [menuOpen, setMenuOpen] = React.useState(false);
+    const isDone = task.status === "completed";
+    const priority = PRIORITIES.find((p) => p.id === task.priority) ?? PRIORITIES[3];
+    const overdue = isOverdue(task);
+
+    async function setDone(done: boolean) {
+        try {
+            await update.mutateAsync({
+                id: task.id,
+                data: { status: done ? "completed" : "pending" } as Partial<CRMTask>,
+            });
+        } catch (err) {
+            toast.error(buildError(err as AppError));
+        }
+    }
+
+    function doDelete() {
+        confirm?.show(`Delete task "${task.title}"?`, async () => {
+            try {
+                await del.mutateAsync(task.id);
+            } catch (err) {
+                toast.error(buildError(err as AppError));
+            }
+        });
+    }
+
+    return (
+        <tr
+            onClick={onOpen}
+            className="group h-11 border-b border-slate-200/60 hover:bg-slate-50/80 cursor-pointer transition-colors"
+        >
+            <td className="px-3 max-w-0">
+                <div className="flex items-center gap-2.5 min-w-0">
+                    <button
+                        type="button"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            setDone(!isDone);
+                        }}
+                        aria-label={isDone ? "Mark pending" : "Mark complete"}
+                        className="size-4 rounded text-slate-400 hover:text-slate-900 inline-flex items-center justify-center shrink-0"
+                    >
+                        {isDone ? (
+                            <CheckSquareIcon className="w-3.5 h-3.5 text-emerald-600" />
+                        ) : (
+                            <SquareIcon className="w-3.5 h-3.5" />
+                        )}
+                    </button>
+                    <span
+                        className={`text-[12.5px] truncate ${
+                            isDone ? "text-slate-400 line-through" : "text-slate-900 font-medium"
+                        }`}
+                    >
+                        {task.title}
+                    </span>
+                </div>
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <TaskTypeTag type={task.type} types={types} done={isDone} />
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <AssigneeCell member={member} assignedTo={task.assigned_to} />
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <span
+                    className={`inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.08em] font-semibold ${priority.text}`}
+                >
+                    <span className={`size-1.5 rounded-full ${priority.dot}`} />
+                    {priority.label}
+                </span>
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <StatusTag status={task.status} />
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <DueCell due={task.due_date} overdue={overdue} />
+            </td>
+            <td className="px-2 w-9 text-right" onClick={(e) => e.stopPropagation()}>
+                <PopoverMenu open={menuOpen} onOpenChange={setMenuOpen} align="end">
+                    <PopoverMenuTrigger asChild>
+                        <button
+                            type="button"
+                            aria-label="Task actions"
+                            className="size-7 rounded-md text-slate-400 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-opacity opacity-100 md:opacity-0 md:group-hover:opacity-100"
+                        >
+                            <MoreHorizontalIcon className="w-4 h-4" />
+                        </button>
+                    </PopoverMenuTrigger>
+                    <PopoverMenuContent minWidth={170}>
+                        <PopoverMenuItem onSelect={onOpen} icon={<PencilIcon className="w-3 h-3" />}>
+                            Edit
+                        </PopoverMenuItem>
+                        <PopoverMenuItem
+                            onSelect={() => setDone(!isDone)}
+                            icon={isDone ? <SquareIcon className="w-3 h-3" /> : <CheckSquareIcon className="w-3 h-3" />}
+                        >
+                            {isDone ? "Mark pending" : "Mark complete"}
+                        </PopoverMenuItem>
+                        <PopoverMenuItem onSelect={doDelete} danger icon={<TrashIcon className="w-3 h-3" />}>
+                            Delete
+                        </PopoverMenuItem>
+                    </PopoverMenuContent>
+                </PopoverMenu>
+            </td>
+        </tr>
+    );
+}
+
+function GroupedView({
+    tasks,
+    memberByUser,
+    types,
+    onOpen,
+}: {
+    tasks: CRMTask[];
+    memberByUser: Map<string, OrganizationMember>;
+    types: { name: string; color: string }[];
+    onOpen: (t: CRMTask) => void;
+}) {
+    // Bucket only the rows already paged in. "Load more" pulls the next server
+    // page, so this is never an in-memory slice of a larger set: it is exactly
+    // the rows we have, regrouped.
     const grouped = React.useMemo(() => {
         const g: Record<Bucket, CRMTask[]> = {
             overdue: [],
@@ -123,13 +492,11 @@ export default function TasksPage() {
             later: [],
             no_due: [],
         };
-        for (const t of visible) {
-            if (t.status === "completed" && showCompleted) {
-                // Group completed tasks separately for visibility.
-                g.later.push(t);
-                continue;
-            }
-            g[bucketize(t.due_date)].push(t);
+        for (const t of tasks) {
+            // A completed/cancelled past-due task is not "overdue" work, so it
+            // falls through to its real calendar bucket instead.
+            const b = isOverdue(t) ? "overdue" : bucketize(t.due_date);
+            g[b].push(t);
         }
         for (const k of Object.keys(g) as Bucket[]) {
             g[k] = g[k].sort((a, b) => {
@@ -139,96 +506,48 @@ export default function TasksPage() {
             });
         }
         return g;
-    }, [visible, showCompleted]);
-
-    // Active = still actionable (not completed/cancelled). Priority breakdown is
-    // computed over the open work, mirroring the campaigns/accounts stat strips.
-    const activeTasks = all.filter((t) => t.status !== "completed" && t.status !== "cancelled");
-    const stats = {
-        overdue: grouped.overdue.length,
-        highPriority: activeTasks.filter((t) => t.priority === "urgent" || t.priority === "high").length,
-        otherPriority: activeTasks.filter((t) => t.priority === "medium" || t.priority === "low").length,
-        today: grouped.today.length,
-        week: grouped.this_week.length + grouped.tomorrow.length + grouped.today.length,
-        completed: all.filter(
-            (t) =>
-                t.status === "completed" &&
-                t.completed_at &&
-                Date.now() - new Date(t.completed_at).getTime() < 7 * 24 * 3600 * 1000,
-        ).length,
-    };
+    }, [tasks]);
 
     return (
-        <Page>
-            <PageTopbar
-                eyebrow="Tasks"
-                subtitle="Follow-ups + reminders, grouped by due-date"
-            >
-                <button
-                    type="button"
-                    onClick={() => setShowCompleted((c) => !c)}
-                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
-                        showCompleted
-                            ? "border-slate-300 bg-slate-100 text-slate-900"
-                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
-                    }`}
-                >
-                    <CheckSquareIcon className="w-3 h-3" />
-                    Show completed
-                </button>
-                <SearchPill value={search} onChange={setSearch} />
-                <TopbarAction icon={<PlusIcon className="w-3 h-3" />} onClick={() => setNewOpen(true)}>
-                    New task
-                </TopbarAction>
-            </PageTopbar>
-
-            <StatStrip cols={5}>
-                <Stat label="Overdue" value={stats.overdue} sub="needs attention" />
-                <Stat label="High priority" value={stats.highPriority} sub="urgent + high" accent={stats.highPriority > 0} />
-                <Stat label="Other" value={stats.otherPriority} sub="medium + low" />
-                <Stat label="Today" value={stats.today} sub="due today" />
-                <Stat label="Completed (7d)" value={stats.completed} sub="last week" last />
-            </StatStrip>
-
-            <SectionBar label={tasks.isPending ? "Loading…" : `${visible.length} ${visible.length === 1 ? "task" : "tasks"}`} />
-            <PageBody className="px-5 py-5">
-                {tasks.isPending ? (
-                    <Skeleton />
-                ) : visible.length === 0 ? (
-                    <EmptyState onCreate={() => setNewOpen(true)} showCompleted={showCompleted} />
-                ) : (
-                    <div className="space-y-3">
-                        {BUCKETS.map((b) => {
-                            const items = grouped[b.id];
-                            if (items.length === 0) return null;
-                            return (
-                                <BucketGroup key={b.id} bucket={b} tasks={items} onOpen={setEditing} />
-                            );
-                        })}
-                    </div>
-                )}
-            </PageBody>
-
-            <TaskDialog open={newOpen} onClose={() => setNewOpen(false)} />
-            <TaskDialog open={!!editing} onClose={() => setEditing(null)} editing={editing ?? undefined} />
-        </Page>
+        <div className="space-y-3">
+            {BUCKETS.map((b) => {
+                const items = grouped[b.id];
+                if (items.length === 0) return null;
+                return (
+                    <BucketGroup
+                        key={b.id}
+                        bucket={b}
+                        tasks={items}
+                        memberByUser={memberByUser}
+                        types={types}
+                        onOpen={onOpen}
+                    />
+                );
+            })}
+        </div>
     );
 }
 
 function BucketGroup({
     bucket,
     tasks,
+    memberByUser,
+    types,
     onOpen,
 }: {
     bucket: { id: Bucket; label: string; tone: keyof typeof TONE };
     tasks: CRMTask[];
+    memberByUser: Map<string, OrganizationMember>;
+    types: { name: string; color: string }[];
     onOpen: (t: CRMTask) => void;
 }) {
     return (
         <div className="rounded-md border border-slate-200 bg-white overflow-hidden">
             <div className="h-8 px-3 border-b border-slate-200 flex items-center gap-1.5">
                 <span className={`size-1.5 rounded-full ${TONE[bucket.tone].dot}`} />
-                <span className={`text-[11px] uppercase tracking-[0.1em] font-semibold ${TONE[bucket.tone].label}`}>
+                <span
+                    className={`text-[11px] uppercase tracking-[0.1em] font-semibold ${TONE[bucket.tone].label}`}
+                >
                     {bucket.label}
                 </span>
                 <span className="ml-auto font-mono text-[10.5px] text-slate-400 tabular-nums">
@@ -237,26 +556,40 @@ function BucketGroup({
             </div>
             <div className="divide-y divide-slate-200/60">
                 {tasks.map((t) => (
-                    <TaskRow key={t.id} task={t} onOpen={onOpen} />
+                    <GroupedRow
+                        key={t.id}
+                        task={t}
+                        member={t.assigned_to ? memberByUser.get(t.assigned_to) : undefined}
+                        types={types}
+                        onOpen={onOpen}
+                    />
                 ))}
             </div>
         </div>
     );
 }
 
-function TaskRow({ task, onOpen }: { task: CRMTask; onOpen: (t: CRMTask) => void }) {
+function GroupedRow({
+    task,
+    member,
+    types,
+    onOpen,
+}: {
+    task: CRMTask;
+    member?: OrganizationMember;
+    types: { name: string; color: string }[];
+    onOpen: (t: CRMTask) => void;
+}) {
     const update = useUpdateCRMTask();
     const isDone = task.status === "completed";
     const priority = PRIORITIES.find((p) => p.id === task.priority) ?? PRIORITIES[3];
+    const overdue = isOverdue(task);
 
     async function toggle(e: React.MouseEvent) {
         e.stopPropagation();
         const next: CRMTaskStatus = isDone ? "pending" : "completed";
         try {
-            await update.mutateAsync({
-                id: task.id,
-                data: { status: next } as Partial<CRMTask>,
-            });
+            await update.mutateAsync({ id: task.id, data: { status: next } as Partial<CRMTask> });
         } catch (err) {
             toast.error(buildError(err as AppError));
         }
@@ -279,7 +612,7 @@ function TaskRow({ task, onOpen }: { task: CRMTask; onOpen: (t: CRMTask) => void
                     <SquareIcon className="w-3.5 h-3.5" />
                 )}
             </button>
-            <TaskTypeIcon type={task.type} done={isDone} />
+            <TaskTypeTag type={task.type} types={types} done={isDone} compact />
             <span
                 className={`text-[12px] truncate flex-1 ${
                     isDone ? "text-slate-400 line-through" : "text-slate-900"
@@ -287,42 +620,546 @@ function TaskRow({ task, onOpen }: { task: CRMTask; onOpen: (t: CRMTask) => void
             >
                 {task.title}
             </span>
-            <span className={`inline-flex items-center gap-1 text-[10.5px] uppercase tracking-[0.08em] font-semibold ${priority.text}`}>
+            <AssigneeCell member={member} assignedTo={task.assigned_to} compact />
+            <span
+                className={`inline-flex items-center gap-1 text-[10.5px] uppercase tracking-[0.08em] font-semibold ${priority.text}`}
+            >
                 <span className={`size-1.5 rounded-full ${priority.dot}`} />
                 {priority.label}
             </span>
-            <span className="inline-flex items-center gap-1 font-mono text-[10.5px] text-slate-400 tabular-nums shrink-0 w-16 justify-end">
-                {task.due_date && (
-                    <>
-                        <CalendarClockIcon className="w-2.5 h-2.5" />
-                        {fmtDue(task.due_date)}
-                    </>
-                )}
+            <span className="inline-flex items-center gap-1 font-mono text-[10.5px] tabular-nums shrink-0 w-20 justify-end">
+                <DueCell due={task.due_date} overdue={overdue} />
             </span>
         </div>
     );
 }
 
-function SearchPill({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+// ── Cells ────────────────────────────────────────────────────────────────
+
+function memberLabel(member?: OrganizationMember, assignedTo?: string): string {
+    const name = member?.name?.trim();
+    if (name) return name;
+    const email = member?.email?.trim();
+    if (email) return email.split("@")[0] || email;
+    // No resolved name/email yet (e.g. the member API hasn't been re-read).
+    // Show a distinct, truthful identifier per person rather than "Unknown"
+    // for everyone, so the list never reads as duplicate/phantom rows.
+    const id = member?.user_id ?? assignedTo;
+    if (id) return `Member ${id.slice(0, 6)}`;
+    return "";
+}
+
+function memberInitials(member?: OrganizationMember, assignedTo?: string): string {
+    const src = (member?.name?.trim() || member?.email?.trim() || "").trim();
+    if (src) {
+        const local = src.split("@")[0] || src;
+        const parts = local.split(/[\s.\-_+]/).filter(Boolean);
+        if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+        return (local.slice(0, 2) || "?").toUpperCase();
+    }
+    const id = member?.user_id ?? assignedTo;
+    return id ? id.slice(0, 2).toUpperCase() : "?";
+}
+
+function AssigneeCell({
+    member,
+    assignedTo,
+    compact = false,
+}: {
+    member?: OrganizationMember;
+    assignedTo?: string;
+    compact?: boolean;
+}) {
+    if (!assignedTo) {
+        return <span className="text-slate-300 text-[11.5px]">{compact ? "" : "Unassigned"}</span>;
+    }
+    const label = memberLabel(member, assignedTo);
+    const initials = memberInitials(member, assignedTo);
     return (
-        <div className="h-7 px-2 rounded-md border border-slate-200 bg-white flex items-center gap-1.5 focus-within:border-sky-400 transition-colors">
-            <SearchIcon className="w-3 h-3 text-slate-400" />
-            <input
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-                placeholder="Search tasks…"
-                className="w-full sm:w-[160px] h-5 bg-transparent text-[12px] text-slate-900 placeholder:text-slate-400 outline-none"
-            />
-            {value && (
-                <button type="button" onClick={() => onChange("")} aria-label="Clear" className="text-slate-400 hover:text-slate-700">
+        <span
+            className="inline-flex items-center gap-1.5 min-w-0"
+            title={member?.name || member?.email || assignedTo}
+        >
+            <span className="size-5 shrink-0 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase tracking-tight">
+                {initials}
+            </span>
+            {!compact && <span className="text-[11.5px] text-slate-600 truncate">{label}</span>}
+        </span>
+    );
+}
+
+function StatusTag({ status }: { status: CRMTaskStatus }) {
+    const map: Record<CRMTaskStatus, { label: string; cls: string; dot: string }> = {
+        pending: { label: "Pending", cls: "text-slate-600", dot: "bg-slate-400" },
+        in_progress: { label: "Active", cls: "text-sky-700", dot: "bg-sky-500" },
+        completed: { label: "Done", cls: "text-emerald-700", dot: "bg-emerald-500" },
+        cancelled: { label: "Cancelled", cls: "text-slate-400", dot: "bg-slate-300" },
+    };
+    const s = map[status];
+    return (
+        <span className={`inline-flex items-center gap-1.5 text-[11px] font-medium ${s.cls}`}>
+            <span className={`size-1.5 rounded-full ${s.dot}`} />
+            {s.label}
+        </span>
+    );
+}
+
+function TaskTypeTag({
+    type,
+    types,
+    done,
+    compact = false,
+}: {
+    type: string | undefined;
+    types: { name: string; color: string }[];
+    done: boolean;
+    compact?: boolean;
+}) {
+    if (!type) {
+        return compact ? null : <span className="text-slate-300 text-[11.5px]">—</span>;
+    }
+    const color = taskTypeColor(type, types);
+    return (
+        <span
+            title={type}
+            className={`shrink-0 inline-flex items-center gap-1 text-[10.5px] text-slate-500 ${
+                compact ? "max-w-[90px]" : ""
+            }`}
+        >
+            <span className="size-2 rounded-full" style={{ backgroundColor: done ? "#cbd5e1" : color }} />
+            <span className="truncate">{type}</span>
+        </span>
+    );
+}
+
+function DueCell({ due, overdue }: { due: string | undefined; overdue: boolean }) {
+    if (!due) return <span className="text-slate-300 text-[11px]">—</span>;
+    if (overdue) {
+        return (
+            <span className="inline-flex items-center gap-1 font-mono text-[10.5px] text-red-600 tabular-nums">
+                <AlertTriangleIcon className="w-2.5 h-2.5" />
+                {fmtDue(due)}
+            </span>
+        );
+    }
+    return (
+        <span className="inline-flex items-center gap-1 font-mono text-[10.5px] text-slate-400 tabular-nums">
+            <CalendarClockIcon className="w-2.5 h-2.5" />
+            {fmtDue(due)}
+        </span>
+    );
+}
+
+// ── Toolbar pieces ─────────────────────────────────────────────────────────
+
+function ViewToggle({
+    view,
+    onChange,
+}: {
+    view: "flat" | "grouped";
+    onChange: (v: "flat" | "grouped") => void;
+}) {
+    return (
+        <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+            <button
+                type="button"
+                onClick={() => onChange("grouped")}
+                aria-label="Grouped by due date"
+                className={`h-6 px-2 rounded text-[11px] font-medium inline-flex items-center gap-1.5 transition-colors ${
+                    view === "grouped" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-900"
+                }`}
+            >
+                <ListTreeIcon className="w-3 h-3" />
+                Grouped
+            </button>
+            <button
+                type="button"
+                onClick={() => onChange("flat")}
+                aria-label="Flat list"
+                className={`h-6 px-2 rounded text-[11px] font-medium inline-flex items-center gap-1.5 transition-colors ${
+                    view === "flat" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-900"
+                }`}
+            >
+                <LayoutListIcon className="w-3 h-3" />
+                Table
+            </button>
+        </div>
+    );
+}
+
+function AssigneeFacet({
+    members,
+    selected,
+    onChange,
+}: {
+    members: OrganizationMember[];
+    selected: string[];
+    onChange: (ids: string[]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const label =
+        selected.length === 0
+            ? "Anyone"
+            : selected.length === 1
+              ? memberLabel(members.find((m) => m.user_id === selected[0]), selected[0])
+              : `${selected.length} assignees`;
+
+    function toggle(id: string) {
+        onChange(selected.includes(id) ? selected.filter((x) => x !== id) : [...selected, id]);
+    }
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        selected.length
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <UsersIcon className="w-3 h-3" />
+                    <span className="truncate max-w-[100px]">{label}</span>
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={220} className="max-h-64 overflow-y-auto">
+                {members.length === 0 ? (
+                    <div className="px-2 py-1.5 text-[11.5px] text-slate-400">No members</div>
+                ) : (
+                    members.map((m) => (
+                        <PopoverMenuItem
+                            key={m.user_id}
+                            onSelect={() => toggle(m.user_id)}
+                            selected={selected.includes(m.user_id)}
+                            closeOnSelect={false}
+                            icon={
+                                <span className="size-5 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase">
+                                    {memberInitials(m)}
+                                </span>
+                            }
+                        >
+                            <span className="truncate">{memberLabel(m)}</span>
+                        </PopoverMenuItem>
+                    ))
+                )}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function TypeFacet({
+    types,
+    selected,
+    onChange,
+}: {
+    types: { name: string; color: string }[];
+    selected: string[];
+    onChange: (names: string[]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const label = selected.length === 0 ? "All types" : `${selected.length} type${selected.length === 1 ? "" : "s"}`;
+
+    function toggle(name: string) {
+        onChange(selected.includes(name) ? selected.filter((x) => x !== name) : [...selected, name]);
+    }
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        selected.length
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <TagIcon className="w-3 h-3" />
+                    {label}
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={200} className="max-h-64 overflow-y-auto">
+                {types.length === 0 ? (
+                    <div className="px-2 py-1.5 text-[11.5px] text-slate-400">No types yet</div>
+                ) : (
+                    types.map((t) => (
+                        <PopoverMenuItem
+                            key={t.name}
+                            onSelect={() => toggle(t.name)}
+                            selected={selected.includes(t.name)}
+                            closeOnSelect={false}
+                            icon={
+                                <span
+                                    className="size-2 rounded-full"
+                                    style={{ backgroundColor: t.color }}
+                                />
+                            }
+                        >
+                            {t.name}
+                        </PopoverMenuItem>
+                    ))
+                )}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function SortPopover({
+    active,
+    onChange,
+}: {
+    active: string;
+    onChange: (s: (typeof SORTS)[number]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = SORTS.find((s) => s.id === active) ?? SORTS[0];
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className="h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-600 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+                >
+                    <ArrowUpDownIcon className="w-3 h-3" />
+                    {cur.label}
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={200}>
+                {SORTS.map((s) => (
+                    <PopoverMenuItem key={s.id} onSelect={() => onChange(s)} selected={s.id === active}>
+                        {s.label}
+                    </PopoverMenuItem>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function FilterPopover({
+    filters,
+    onChange,
+    activeCount,
+}: {
+    filters: SearchTasks;
+    onChange: React.Dispatch<React.SetStateAction<SearchTasks>>;
+    activeCount: number;
+}) {
+    const [open, setOpen] = React.useState(false);
+
+    function togglePriority(p: CRMTaskPriority) {
+        onChange((f) => ({
+            ...f,
+            priorities: f.priorities.includes(p)
+                ? f.priorities.filter((x) => x !== p)
+                : [...f.priorities, p],
+        }));
+    }
+
+    const setDate = (key: "due_after" | "due_before", v: string) =>
+        onChange((f) => ({ ...f, [key]: v ? new Date(v).toISOString() : undefined }));
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        activeCount
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <AlertTriangleIcon className="w-3 h-3" />
+                    Filters
+                    {activeCount > 0 && (
+                        <span className="size-4 rounded-full bg-sky-600 text-white text-[9.5px] inline-flex items-center justify-center tabular-nums">
+                            {activeCount}
+                        </span>
+                    )}
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={260} className="p-3">
+                <div className="space-y-3">
+                    <div>
+                        <Label>Priority</Label>
+                        <div className="flex flex-wrap gap-1.5">
+                            {PRIORITIES.map((p) => {
+                                const on = filters.priorities.includes(p.id);
+                                return (
+                                    <button
+                                        key={p.id}
+                                        type="button"
+                                        onClick={() => togglePriority(p.id)}
+                                        className={`h-7 px-2 rounded-md border text-[11.5px] inline-flex items-center gap-1.5 transition-colors ${
+                                            on
+                                                ? "border-sky-300 bg-sky-50 text-sky-700"
+                                                : "border-slate-200 text-slate-600 hover:border-slate-300"
+                                        }`}
+                                    >
+                                        <span className={`size-1.5 rounded-full ${p.dot}`} />
+                                        {p.label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
+                    <div>
+                        <Label>Due date</Label>
+                        <div className="flex items-center gap-1.5">
+                            <TextInput
+                                value={filters.due_after ? String(filters.due_after).split("T")[0] : ""}
+                                onChange={(v) => setDate("due_after", v)}
+                                type="date"
+                                className="w-full"
+                            />
+                            <span className="text-slate-300">–</span>
+                            <TextInput
+                                value={filters.due_before ? String(filters.due_before).split("T")[0] : ""}
+                                onChange={(v) => setDate("due_before", v)}
+                                type="date"
+                                className="w-full"
+                            />
+                        </div>
+                    </div>
+                    <label className="flex items-center gap-2 cursor-pointer select-none">
+                        <button
+                            type="button"
+                            onClick={() => onChange((f) => ({ ...f, overdue: f.overdue ? undefined : true }))}
+                            className={`size-4 rounded border inline-flex items-center justify-center transition-colors ${
+                                filters.overdue
+                                    ? "bg-sky-600 border-sky-600 text-white"
+                                    : "border-slate-300 bg-white"
+                            }`}
+                        >
+                            {filters.overdue && <CheckSquareIcon className="w-3 h-3" />}
+                        </button>
+                        <span className="text-[12px] text-slate-700">Only overdue + actionable</span>
+                    </label>
+                    <div className="flex items-center justify-between pt-1 border-t border-slate-100">
+                        <button
+                            type="button"
+                            onClick={() =>
+                                onChange((f) => ({
+                                    ...f,
+                                    priorities: [],
+                                    due_after: undefined,
+                                    due_before: undefined,
+                                    overdue: undefined,
+                                }))
+                            }
+                            className="text-[11.5px] text-slate-500 hover:text-slate-900 inline-flex items-center gap-1"
+                        >
+                            <XIcon className="w-3 h-3" />
+                            Clear
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="h-6 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium transition-colors"
+                        >
+                            Done
+                        </button>
+                    </div>
+                </div>
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function LoadMore({
+    hasNextPage,
+    isFetchingNextPage,
+    onLoadMore,
+    loaded,
+    total,
+}: {
+    hasNextPage: boolean;
+    isFetchingNextPage: boolean;
+    onLoadMore: () => void;
+    loaded: number;
+    total: number;
+}) {
+    return (
+        <div className="px-5 py-3 flex items-center justify-center gap-3 border-t border-slate-200/60">
+            {hasNextPage ? (
+                <button
+                    type="button"
+                    onClick={onLoadMore}
+                    disabled={isFetchingNextPage}
+                    className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                >
+                    {isFetchingNextPage ? (
+                        <>
+                            <Loader2Icon className="w-3 h-3 animate-spin" />
+                            Loading…
+                        </>
+                    ) : (
+                        <>
+                            <PlusIcon className="w-3 h-3" />
+                            Load more
+                        </>
+                    )}
+                </button>
+            ) : null}
+            <span className="font-mono text-[10.5px] text-slate-400 tabular-nums">
+                {hasNextPage ? `${loaded} of ${total} loaded` : `${total} ${total === 1 ? "task" : "tasks"}`}
+            </span>
+        </div>
+    );
+}
+
+// ── Empty / skeleton ───────────────────────────────────────────────────────
+
+function EmptyState({
+    hasFilters,
+    onCreate,
+    onClear,
+}: {
+    hasFilters: boolean;
+    onCreate: () => void;
+    onClear: () => void;
+}) {
+    return (
+        <div className="px-5 py-16 text-center">
+            <div className="mx-auto size-9 rounded-md bg-slate-50 border border-slate-200 flex items-center justify-center mb-3">
+                <CheckSquareIcon className="w-4 h-4 text-slate-400" />
+            </div>
+            <p className="text-[12.5px] text-slate-700 font-medium mb-1">
+                {hasFilters ? "No tasks match these filters" : "No tasks yet"}
+            </p>
+            <p className="text-[11.5px] text-slate-400 mb-4 max-w-[42ch] mx-auto leading-relaxed">
+                {hasFilters
+                    ? "Try widening or clearing the filters to see more."
+                    : "Tasks attach to a contact or a deal. Create one and it shows up here: searchable, filterable, and grouped by due-date."}
+            </p>
+            {hasFilters ? (
+                <button
+                    type="button"
+                    onClick={onClear}
+                    className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+                >
                     <XIcon className="w-3 h-3" />
+                    Clear filters
+                </button>
+            ) : (
+                <button
+                    type="button"
+                    onClick={onCreate}
+                    className="h-7 px-3 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors"
+                >
+                    <PlusIcon className="w-3 h-3" />
+                    Create task
                 </button>
             )}
         </div>
     );
 }
 
-function Skeleton() {
+function GroupedSkeleton() {
     return (
         <div className="space-y-3">
             {[0, 1].map((i) => (
@@ -344,44 +1181,49 @@ function Skeleton() {
     );
 }
 
-function EmptyState({
-    onCreate,
-    showCompleted,
-}: {
-    onCreate: () => void;
-    showCompleted: boolean;
-}) {
+function FlatSkeleton() {
     return (
-        <div className="rounded-md border border-dashed border-slate-300 bg-slate-50/40 p-8 text-center">
-            <div className="mx-auto size-9 rounded-md bg-white border border-slate-200 flex items-center justify-center mb-3">
-                <CheckSquareIcon className="w-4 h-4 text-slate-400" />
-            </div>
-            <h3 className="text-[13px] font-semibold text-slate-900 mb-1">
-                {showCompleted ? "No tasks yet" : "Nothing on deck"}
-            </h3>
-            <p className="text-[12px] text-slate-500 max-w-md mx-auto mb-4 leading-relaxed">
-                Tasks attach to a contact or a deal and show up grouped by due-date.
-            </p>
-            <button
-                type="button"
-                onClick={onCreate}
-                className="h-7 px-3 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors"
-            >
-                <PlusIcon className="w-3 h-3" />
-                Create task
-            </button>
-        </div>
+        <table className="w-full border-collapse">
+            <tbody>
+                {Array.from({ length: 8 }).map((_, i) => (
+                    <tr key={i} className="h-11 border-b border-slate-200/60">
+                        {Array.from({ length: 6 }).map((__, j) => (
+                            <td key={j} className="px-3">
+                                <div
+                                    className="h-3 bg-slate-100 rounded animate-pulse"
+                                    style={{ width: `${50 + ((j * 13) % 40)}%` }}
+                                />
+                            </td>
+                        ))}
+                    </tr>
+                ))}
+            </tbody>
+        </table>
     );
 }
+
+function Th({ children, className }: { children: React.ReactNode; className?: string }) {
+    return (
+        <th
+            className={`px-3 py-2 text-[10px] font-medium text-slate-400 uppercase tracking-[0.14em] ${className ?? ""}`}
+        >
+            {children}
+        </th>
+    );
+}
+
+// ── Dialog ─────────────────────────────────────────────────────────────────
 
 function TaskDialog({
     open,
     onClose,
     editing,
+    members,
 }: {
     open: boolean;
     onClose: () => void;
     editing?: CRMTask;
+    members: OrganizationMember[];
 }) {
     const create = useCreateCRMTask();
     const update = useUpdateCRMTask();
@@ -394,6 +1236,7 @@ function TaskDialog({
     const [priority, setPriority] = React.useState<CRMTaskPriority>("medium");
     const [type, setType] = React.useState<string>("");
     const [status, setStatus] = React.useState<CRMTaskStatus>("pending");
+    const [assignedTo, setAssignedTo] = React.useState<string>("");
 
     React.useEffect(() => {
         if (!open) return;
@@ -404,6 +1247,7 @@ function TaskDialog({
             setPriority(editing.priority);
             setType(editing.type ?? "");
             setStatus(editing.status);
+            setAssignedTo(editing.assigned_to ?? "");
         } else {
             setTitle("");
             setDescription("");
@@ -411,6 +1255,7 @@ function TaskDialog({
             setPriority("medium");
             setType("");
             setStatus("pending");
+            setAssignedTo("");
         }
     }, [open, editing]);
 
@@ -426,6 +1271,7 @@ function TaskDialog({
         };
         if (description.trim()) data.description = description.trim();
         if (dueDate) data.due_date = new Date(dueDate).toISOString();
+        if (assignedTo) data.assigned_to = assignedTo;
         if (editing) data.status = status;
 
         try {
@@ -535,9 +1381,19 @@ function TaskDialog({
                                     className="w-full px-2.5 py-1.5 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 placeholder:text-slate-400 outline-none transition-colors focus:border-sky-400 focus:ring-2 focus:ring-sky-100 resize-y"
                                 />
                             </div>
-                            <div>
-                                <Label>Task type</Label>
-                                <TaskTypePicker value={type} onChange={setType} />
+                            <div className="grid grid-cols-2 gap-2">
+                                <div>
+                                    <Label>Task type</Label>
+                                    <TaskTypePicker value={type} onChange={setType} />
+                                </div>
+                                <div>
+                                    <Label>Assignee</Label>
+                                    <AssigneePicker
+                                        value={assignedTo}
+                                        members={members}
+                                        onChange={setAssignedTo}
+                                    />
+                                </div>
                             </div>
                             <div className="grid grid-cols-2 gap-2">
                                 <div>
@@ -606,6 +1462,75 @@ function TaskDialog({
     );
 }
 
+function AssigneePicker({
+    value,
+    members,
+    onChange,
+}: {
+    value: string;
+    members: OrganizationMember[];
+    onChange: (id: string) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = members.find((m) => m.user_id === value);
+    const { data: teams = [] } = useTeams();
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className="h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+                >
+                    {cur ? (
+                        <span className="size-4 shrink-0 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[8px] font-semibold inline-flex items-center justify-center uppercase">
+                            {memberInitials(cur)}
+                        </span>
+                    ) : (
+                        <span className="size-2 rounded-full bg-slate-300 shrink-0" />
+                    )}
+                    <span className="truncate flex-1 text-left">
+                        {cur ? memberLabel(cur) : "Unassigned"}
+                    </span>
+                    <span className="ml-auto text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={220} className="max-h-56 overflow-y-auto">
+                <PopoverMenuItem
+                    onSelect={() => onChange("")}
+                    selected={value === ""}
+                    icon={<span className="size-2 rounded-full bg-slate-300 block" />}
+                >
+                    Unassigned
+                </PopoverMenuItem>
+                {members.map((m) => (
+                    <PopoverMenuItem
+                        key={m.user_id}
+                        onSelect={() => onChange(m.user_id)}
+                        selected={m.user_id === value}
+                        icon={
+                            <span className="size-5 rounded-full bg-sky-50 border border-sky-200 text-sky-700 text-[9px] font-semibold inline-flex items-center justify-center uppercase">
+                                {memberInitials(m)}
+                            </span>
+                        }
+                    >
+                        <span className="truncate">{memberLabel(m)}</span>
+                    </PopoverMenuItem>
+                ))}
+                <div className="my-1 h-px bg-slate-200" />
+                <Link
+                    to="/app/settings/teams"
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-2 px-3 h-8 text-[12px] text-slate-500 hover:text-sky-700 hover:bg-slate-50 transition-colors"
+                >
+                    <UsersRoundIcon className="w-3.5 h-3.5 shrink-0" />
+                    {teams.length === 0 ? "No teams yet — create one in Settings" : "Manage teams"}
+                </Link>
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
 function PriorityPill({
     value,
     onChange,
@@ -644,18 +1569,20 @@ function PriorityPill({
     );
 }
 
-function TaskTypeIcon({ type, done }: { type: string | undefined; done: boolean }) {
-    const { data: types = [] } = useTaskTypes();
-    if (!type) return null;
-    const color = taskTypeColor(type, types);
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function hasAnyFilter(f: SearchTasks): boolean {
     return (
-        <span
-            title={type}
-            className="shrink-0 inline-flex items-center gap-1 text-[10.5px] text-slate-400 max-w-[90px]"
-        >
-            <span className="size-2 rounded-full" style={{ backgroundColor: done ? "#cbd5e1" : color }} />
-            <span className="truncate">{type}</span>
-        </span>
+        f.query.trim() !== "" ||
+        f.statuses.length > 0 ||
+        f.priorities.length > 0 ||
+        f.types.length > 0 ||
+        f.assigned_to.length > 0 ||
+        !!f.contact_id ||
+        !!f.deal_id ||
+        !!f.due_after ||
+        !!f.due_before ||
+        !!f.overdue
     );
 }
 
@@ -675,5 +1602,3 @@ function fmtDue(d: string) {
         return "—";
     }
 }
-
-void AlertCircleIcon; // kept for future overdue badge

--- a/web/src/app/app/integrations/_components/ConnectionDetail.tsx
+++ b/web/src/app/app/integrations/_components/ConnectionDetail.tsx
@@ -27,6 +27,7 @@ import {
 import toast from "react-hot-toast";
 
 import { Label, TextInput } from "@/components/ui/field";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import { useConfirm } from "@/hooks/context/confirm";
 import useConnectionDetail from "@/lib/api/hooks/app/integrations/useConnectionDetail";
 import useDisconnectIntegration from "@/lib/api/hooks/app/integrations/useDisconnectIntegration";
@@ -342,6 +343,10 @@ function AddAutomation({
     const [eventType, setEventType] = React.useState(
         availableEvents.includes(REPLY_EVENT) ? REPLY_EVENT : availableEvents[0] ?? REPLY_EVENT,
     );
+    const eventOptions = React.useMemo<SelectOption[]>(
+        () => availableEvents.map((ev) => ({ value: ev, label: EVENT_LABELS[ev] ?? ev })),
+        [availableEvents],
+    );
     const [dest, setDest] = React.useState("");
     const [intents, setIntents] = React.useState<string[]>([]);
     const [minConf, setMinConf] = React.useState(0);
@@ -375,17 +380,13 @@ function AddAutomation({
         <div className="rounded-md border border-sky-200 bg-sky-50/40 p-3 space-y-3">
             <div>
                 <Label>When this happens</Label>
-                <select
+                <SelectMenu
                     value={eventType}
-                    onChange={(e) => setEventType(e.target.value)}
-                    className="w-full h-7 px-2 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
-                >
-                    {availableEvents.map((ev) => (
-                        <option key={ev} value={ev}>
-                            {EVENT_LABELS[ev] ?? ev}
-                        </option>
-                    ))}
-                </select>
+                    onChange={setEventType}
+                    options={eventOptions}
+                    className="w-full"
+                    aria-label="When this happens"
+                />
             </div>
 
             {/* Reply-only filters */}

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -42,6 +42,7 @@ const SECTIONS: SectionDef[] = [
     { path: "notifications", label: "Notifications", icon: BellIcon,         description: "What you get notified about." },
     { path: "security",      label: "Security",      icon: ShieldIcon,       description: "Password, 2FA, active sessions." },
     { path: "members",       label: "Members",       icon: UsersIcon,        description: "Team and invitations." },
+    { path: "teams",         label: "Teams",         icon: UsersIcon,        description: "Group members into teams." },
     { path: "roles",         label: "Roles & access", icon: ShieldCheckIcon,  description: "Who can do what.", ownerOnly: true },
     { path: "workspace",     label: "Workspace",     icon: BriefcaseIcon,    description: "Org-wide settings.", ownerOnly: true },
     { path: "billing",       label: "Billing",       icon: CreditCardIcon,   description: "Plan, payment, invoices.", ownerOnly: true },

--- a/web/src/app/app/settings/limits/page.tsx
+++ b/web/src/app/app/settings/limits/page.tsx
@@ -3,9 +3,10 @@
 // effective limit going up on the org; rejection surfaces with the
 // admin's notes attached to the row.
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import { Section, SectionShell } from "../_components/SectionShell";
 import getCurrentOrganization from "@/lib/api/client/app/organizations/getCurrentOrganization";
 import listLimitRequests from "@/lib/api/client/app/organizations/listLimitRequests";
@@ -50,6 +51,11 @@ export default function LimitsSettingsPage() {
     const [field, setField] = useState<LimitField>("max_email_accounts");
     const [requested, setRequested] = useState<string>("");
     const [reason, setReason] = useState<string>("");
+
+    const fieldSelectOptions = useMemo<SelectOption[]>(
+        () => FIELD_OPTIONS.map((opt) => ({ value: opt.value, label: opt.label })),
+        [],
+    );
 
     const submit = useMutation({
         mutationFn: () =>
@@ -108,17 +114,13 @@ export default function LimitsSettingsPage() {
                 <form onSubmit={onSubmit} className="space-y-3">
                     <div>
                         <label className="text-[12px] font-medium text-slate-700">Resource</label>
-                        <select
+                        <SelectMenu
                             value={field}
-                            onChange={(e) => setField(e.target.value as LimitField)}
-                            className="mt-1 block w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
-                        >
-                            {FIELD_OPTIONS.map((opt) => (
-                                <option key={opt.value} value={opt.value}>
-                                    {opt.label}
-                                </option>
-                            ))}
-                        </select>
+                            onChange={(v) => setField(v as LimitField)}
+                            options={fieldSelectOptions}
+                            className="mt-1 w-full"
+                            aria-label="Resource"
+                        />
                         <p className="text-[11px] text-slate-500 mt-1">
                             {FIELD_OPTIONS.find((o) => o.value === field)?.hint}
                         </p>

--- a/web/src/app/app/settings/teams/page.tsx
+++ b/web/src/app/app/settings/teams/page.tsx
@@ -1,0 +1,406 @@
+// Teams — group organization members under named, colored labels.
+//
+// Follows the flat Section + Row shape shared by the rest of the
+// Settings outlet (see members/page.tsx + SectionShell). The page
+// has two parts: a create form (name + color swatch) at the top, and
+// the roster of existing teams below, each with a member picker
+// sourced from the org's members and removable member chips.
+
+import React from "react";
+import {
+    CheckIcon,
+    Loader2Icon,
+    PlusIcon,
+    TrashIcon,
+    UserPlusIcon,
+    UsersIcon,
+    XIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
+import { Label, SearchInput, TextInput } from "@/components/ui/field";
+import {
+    PopoverMenu,
+    PopoverMenuContent,
+    PopoverMenuTrigger,
+} from "@/components/ui/popover-menu";
+import { useConfirm } from "@/hooks/context/confirm";
+import useMembers from "@/lib/api/hooks/app/organizations/useMembers";
+import useTeams from "@/lib/api/hooks/app/teams/useTeams";
+import useCreateTeam from "@/lib/api/hooks/app/teams/useCreateTeam";
+import useDeleteTeam from "@/lib/api/hooks/app/teams/useDeleteTeam";
+import useAddTeamMember from "@/lib/api/hooks/app/teams/useAddTeamMember";
+import useRemoveTeamMember from "@/lib/api/hooks/app/teams/useRemoveTeamMember";
+import type Team from "@/lib/api/models/app/teams/Team";
+import type OrganizationMember from "@/lib/api/models/app/organizations/OrganizationMember";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import buildError from "@/lib/helper/buildError";
+import { useAppStore } from "@/stores";
+import { Section, SectionShell, initials, safeEmail } from "../_components/SectionShell";
+
+const TEAM_COLORS = [
+    { id: "slate", bg: "bg-slate-400", hex: "#94a3b8" },
+    { id: "sky", bg: "bg-sky-500", hex: "#0ea5e9" },
+    { id: "violet", bg: "bg-violet-500", hex: "#8b5cf6" },
+    { id: "amber", bg: "bg-amber-500", hex: "#f59e0b" },
+    { id: "emerald", bg: "bg-emerald-500", hex: "#10b981" },
+    { id: "rose", bg: "bg-rose-500", hex: "#f43f5e" },
+    { id: "indigo", bg: "bg-indigo-500", hex: "#6366f1" },
+    { id: "teal", bg: "bg-teal-500", hex: "#14b8a6" },
+];
+const DEFAULT_COLOR = TEAM_COLORS[0].hex;
+
+export default function TeamsSettingsPage() {
+    const confirm = useConfirm();
+    const currentOrg = useAppStore((s) => s.currentOrganization);
+    const teamsQuery = useTeams();
+    const membersQuery = useMembers();
+    const createTeam = useCreateTeam();
+    const deleteTeam = useDeleteTeam();
+
+    const teams = teamsQuery.data ?? [];
+    const members = membersQuery.data ?? [];
+
+    function doDelete(team: Team) {
+        confirm?.show(`Delete the team "${team.name}"?`, async () => {
+            try {
+                await toast.promise(deleteTeam.mutateAsync(team.id), {
+                    loading: "Deleting…",
+                    success: "Team deleted",
+                    error: (e: AppError) => buildError(e),
+                });
+            } catch {
+                /* surfaced */
+            }
+        });
+    }
+
+    return (
+        <SectionShell
+            title="Teams"
+            description={`Group members of ${currentOrg?.name ?? "this workspace"} into named teams.`}
+        >
+            <Section
+                eyebrow="Create a team"
+                description="Give the team a name and a color, then add members below."
+            >
+                <CreateTeamForm
+                    pending={createTeam.isPending}
+                    onSubmit={async (name, color) => {
+                        try {
+                            await toast.promise(createTeam.mutateAsync({ name, color }), {
+                                loading: "Creating…",
+                                success: `Team "${name}" created`,
+                                error: (e: AppError) => buildError(e),
+                            });
+                            return true;
+                        } catch {
+                            return false;
+                        }
+                    }}
+                />
+            </Section>
+
+            <Section
+                eyebrow="Teams"
+                description={`${teams.length} ${teams.length === 1 ? "team" : "teams"} in this workspace.`}
+            >
+                {teamsQuery.isPending ? (
+                    <p className="text-[11.5px] text-slate-400 py-2">Loading…</p>
+                ) : teams.length === 0 ? (
+                    <p className="text-[11.5px] text-slate-400 py-2">
+                        No teams yet. Create one above.
+                    </p>
+                ) : (
+                    <div className="space-y-3">
+                        {teams.map((team) => (
+                            <TeamCard
+                                key={team.id}
+                                team={team}
+                                members={members}
+                                onDelete={() => doDelete(team)}
+                            />
+                        ))}
+                    </div>
+                )}
+            </Section>
+        </SectionShell>
+    );
+}
+
+function CreateTeamForm({
+    pending,
+    onSubmit,
+}: {
+    pending: boolean;
+    onSubmit: (name: string, color: string) => Promise<boolean>;
+}) {
+    const [name, setName] = React.useState("");
+    const [color, setColor] = React.useState(DEFAULT_COLOR);
+
+    async function submit() {
+        const trimmed = name.trim();
+        if (!trimmed) {
+            toast.error("Enter a team name");
+            return;
+        }
+        const ok = await onSubmit(trimmed, color);
+        if (ok) {
+            setName("");
+            setColor(DEFAULT_COLOR);
+        }
+    }
+
+    return (
+        <div className="space-y-3">
+            <div>
+                <Label>Name</Label>
+                <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-1.5 shrink-0">
+                        {TEAM_COLORS.map((c) => (
+                            <button
+                                key={c.id}
+                                type="button"
+                                onClick={() => setColor(c.hex)}
+                                aria-label={`Use ${c.id}`}
+                                className={`size-5 rounded-full ${c.bg} flex items-center justify-center transition-transform hover:scale-110 ${
+                                    c.hex.toLowerCase() === color.toLowerCase()
+                                        ? "ring-2 ring-offset-1 ring-slate-400"
+                                        : ""
+                                }`}
+                            >
+                                {c.hex.toLowerCase() === color.toLowerCase() && (
+                                    <CheckIcon className="w-3 h-3 text-white" />
+                                )}
+                            </button>
+                        ))}
+                    </div>
+                    <TextInput
+                        value={name}
+                        onChange={setName}
+                        placeholder="Sales, Support, Founders…"
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                e.preventDefault();
+                                submit();
+                            }
+                        }}
+                        className="flex-1"
+                    />
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={pending || name.trim() === ""}
+                        className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60 shrink-0"
+                    >
+                        {pending ? (
+                            <Loader2Icon className="w-3 h-3 animate-spin" />
+                        ) : (
+                            <PlusIcon className="w-3 h-3" />
+                        )}
+                        Create team
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function TeamCard({
+    team,
+    members,
+    onDelete,
+}: {
+    team: Team;
+    members: OrganizationMember[];
+    onDelete: () => void;
+}) {
+    const addMember = useAddTeamMember();
+    const removeMember = useRemoveTeamMember();
+
+    const memberIds = React.useMemo(
+        () => new Set(team.members.map((m) => m.user_id)),
+        [team.members],
+    );
+    const available = React.useMemo(
+        () => members.filter((m) => !memberIds.has(m.user_id)),
+        [members, memberIds],
+    );
+
+    async function add(userId: string) {
+        try {
+            await toast.promise(addMember.mutateAsync({ id: team.id, userId }), {
+                loading: "Adding…",
+                success: "Member added",
+                error: (e: AppError) => buildError(e),
+            });
+        } catch {
+            /* surfaced */
+        }
+    }
+    async function remove(userId: string) {
+        try {
+            await toast.promise(removeMember.mutateAsync({ id: team.id, userId }), {
+                loading: "Removing…",
+                success: "Member removed",
+                error: (e: AppError) => buildError(e),
+            });
+        } catch {
+            /* surfaced */
+        }
+    }
+
+    return (
+        <div className="rounded-md border border-slate-200 bg-white overflow-hidden">
+            <div className="px-3 h-11 flex items-center gap-2.5 border-b border-slate-200">
+                <span
+                    className="size-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: team.color || DEFAULT_COLOR }}
+                />
+                <span className="text-[13px] font-semibold text-slate-900 truncate">
+                    {team.name}
+                </span>
+                <span className="text-[11px] text-slate-400 inline-flex items-center gap-1 shrink-0">
+                    <UsersIcon className="w-3 h-3" />
+                    {team.members.length}
+                </span>
+                <div className="ml-auto flex items-center gap-1 shrink-0">
+                    <AddMemberPicker
+                        available={available}
+                        pending={addMember.isPending}
+                        onAdd={add}
+                    />
+                    <button
+                        type="button"
+                        onClick={onDelete}
+                        aria-label="Delete team"
+                        title="Delete team"
+                        className="size-6 rounded text-slate-400 hover:text-red-600 hover:bg-red-50 inline-flex items-center justify-center transition-colors"
+                    >
+                        <TrashIcon className="w-3.5 h-3.5" />
+                    </button>
+                </div>
+            </div>
+
+            <div className="px-3 py-2.5">
+                {team.members.length === 0 ? (
+                    <p className="text-[11.5px] text-slate-400 py-1">
+                        No members yet. Use Add member to assign someone.
+                    </p>
+                ) : (
+                    <div className="flex flex-wrap gap-1.5">
+                        {team.members.map((m) => {
+                            const label = m.name?.trim() || safeEmail(m.email) || `user ${m.user_id.slice(0, 8)}`;
+                            return (
+                                <span
+                                    key={m.user_id}
+                                    className="group inline-flex items-center gap-1.5 h-6 pl-1 pr-1.5 rounded-full border border-slate-200 bg-slate-50 text-[11.5px] text-slate-700"
+                                >
+                                    <span className="size-4 rounded-full bg-white border border-slate-200 flex items-center justify-center shrink-0">
+                                        <span className="text-[8px] font-semibold text-slate-600">
+                                            {initials(m.email, m.user_id)}
+                                        </span>
+                                    </span>
+                                    <span className="truncate max-w-[160px]">{label}</span>
+                                    <button
+                                        type="button"
+                                        onClick={() => remove(m.user_id)}
+                                        disabled={removeMember.isPending}
+                                        aria-label={`Remove ${label}`}
+                                        className="size-4 rounded-full text-slate-400 hover:text-red-600 hover:bg-red-100 inline-flex items-center justify-center transition-colors disabled:opacity-50"
+                                    >
+                                        <XIcon className="w-2.5 h-2.5" />
+                                    </button>
+                                </span>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function AddMemberPicker({
+    available,
+    pending,
+    onAdd,
+}: {
+    available: OrganizationMember[];
+    pending: boolean;
+    onAdd: (userId: string) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const [query, setQuery] = React.useState("");
+
+    const filtered = React.useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return available;
+        return available.filter((m) => safeEmail(m.email).toLowerCase().includes(q));
+    }, [available, query]);
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    disabled={pending}
+                    className="h-6 px-2 rounded-md border border-slate-200 hover:border-slate-300 text-[11.5px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1 transition-colors disabled:opacity-60"
+                >
+                    {pending ? (
+                        <Loader2Icon className="w-3 h-3 animate-spin" />
+                    ) : (
+                        <UserPlusIcon className="w-3 h-3" />
+                    )}
+                    Add member
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={260} className="max-w-[calc(100vw-2rem)] p-1.5">
+                <div className="px-1 pb-1.5">
+                    <SearchInput
+                        value={query}
+                        onChange={setQuery}
+                        placeholder="Search members…"
+                        autoFocus
+                    />
+                </div>
+                {filtered.length === 0 ? (
+                    <p className="px-2 py-3 text-[11.5px] text-slate-400 text-center">
+                        {available.length === 0 ? "Everyone is already on this team." : "No matches."}
+                    </p>
+                ) : (
+                    <div className="max-h-56 overflow-y-auto">
+                        {filtered.map((m) => {
+                            const email = safeEmail(m.email) || `(user ${m.user_id.slice(0, 8)})`;
+                            return (
+                                <button
+                                    key={m.user_id}
+                                    type="button"
+                                    onClick={() => {
+                                        setOpen(false);
+                                        setQuery("");
+                                        onAdd(m.user_id);
+                                    }}
+                                    className="w-full px-1.5 py-1.5 rounded text-left hover:bg-slate-100 transition-colors flex items-center gap-2"
+                                >
+                                    <span className="size-6 rounded-full bg-slate-100 flex items-center justify-center shrink-0">
+                                        <span className="text-[9px] font-semibold text-slate-600">
+                                            {initials(m.email, m.user_id)}
+                                        </span>
+                                    </span>
+                                    <span className="min-w-0">
+                                        <span className="block text-[12px] text-slate-900 truncate leading-tight">
+                                            {email}
+                                        </span>
+                                        <span className="block text-[10px] text-slate-400 truncate font-mono leading-tight">
+                                            {m.user_id.slice(0, 8)}
+                                        </span>
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                )}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}

--- a/web/src/app/app/unibox/page.tsx
+++ b/web/src/app/app/unibox/page.tsx
@@ -13,7 +13,7 @@
 // Awaiting reply are real backend scopes, not "soon" placeholders.
 
 import React from "react";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { ChevronLeftIcon, InboxIcon } from "lucide-react";
 
 import { ConversationList } from "@/components/app/unibox/ConversationList";
@@ -44,53 +44,53 @@ function startOfWeek(): Date {
 export default function UniboxPage() {
   const access = useFeatureAccess();
   const overview = useUniboxOverview();
-  const [searchParams, setSearchParams] = useSearchParams();
+  const routeParams = useParams<{ scope?: string; threadId?: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const [scopeSheetOpen, setScopeSheetOpen] = React.useState(false);
 
-  // ── URL state (deep-linkable threads + scope) ──────────────────
-  const urlThread = searchParams.get("thread");
-  const urlAccount = searchParams.get("account");
-  const urlScope = searchParams.get("scope") ?? "all";
+  // ── URL state ──────────────────────────────────────────────────
+  // Readable, path-based URLs: /app/unibox/<scope>[/<threadId>]. The scope is a
+  // path segment (all, unread, today, week, awaiting, snoozed, scheduled, or a
+  // mailbox/tag/category view); an open thread is the next segment; ref (the
+  // opaque mailbox/tag/label id for those scopes) is the only query param left.
+  // Accounts are no longer in the URL: the thread fetch scans every mailbox the
+  // user owns, which is the right default for a unified inbox.
+  const urlScope = routeParams.scope ?? "all";
+  const urlThread = routeParams.threadId ?? null;
   const urlScopeRef = searchParams.get("ref");
 
-  const setUrl = React.useCallback(
-    (next: {
-      thread?: string | null;
-      account?: string | null;
-      scope?: string | null;
-      ref?: string | null;
-    }) => {
-      setSearchParams(
-        (prev) => {
-          const sp = new URLSearchParams(prev);
-          for (const [k, v] of Object.entries(next)) {
-            if (v === null || v === undefined || v === "") sp.delete(k);
-            else sp.set(k, v);
-          }
-          return sp;
-        },
-        { replace: true },
-      );
+  // goTo writes the URL by merging the requested changes over the current path
+  // (an omitted field keeps its current value; pass null to clear).
+  const goTo = React.useCallback(
+    (next: { scope?: string; threadId?: string | null; ref?: string | null }) => {
+      const scope = next.scope ?? urlScope;
+      const threadId =
+        next.threadId === undefined ? urlThread : next.threadId;
+      const ref = next.ref === undefined ? urlScopeRef : next.ref;
+      let path = `/app/unibox/${scope || "all"}`;
+      if (threadId) path += `/${encodeURIComponent(threadId)}`;
+      if (ref) path += `?ref=${encodeURIComponent(ref)}`;
+      navigate(path, { replace: true });
     },
-    [setSearchParams],
+    [navigate, urlScope, urlThread, urlScopeRef],
   );
 
-  // Mirror URL ↔ store so ConversationItem clicks update the URL.
+  // Mirror URL → store (so a deep link / refresh restores the open thread) and
+  // store → URL (so a ConversationItem click, which sets the store, updates the
+  // path). The two stay in lock-step because each only writes on a real change.
   const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
-  const setSelectedAccountId = useAppStore((s) => s.setSelectedAccountId);
   React.useEffect(() => {
     setSelectedThreadId(urlThread);
-    setSelectedAccountId(urlAccount);
-  }, [urlThread, urlAccount, setSelectedThreadId, setSelectedAccountId]);
+  }, [urlThread, setSelectedThreadId]);
 
   const storeThread = useAppStore((s) => s.selectedThreadId);
-  const storeAccount = useAppStore((s) => s.selectedAccountId);
   React.useEffect(() => {
-    if (storeThread !== urlThread || storeAccount !== urlAccount) {
-      setUrl({ thread: storeThread, account: storeAccount });
+    if (storeThread !== urlThread) {
+      goTo({ threadId: storeThread });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storeThread, storeAccount]);
+  }, [storeThread]);
 
   // ── Scope (derived from URL + ref) ─────────────────────────────
   const scope: UniboxScope = React.useMemo(() => {
@@ -128,22 +128,22 @@ export default function UniboxPage() {
     (s: UniboxScope) => {
       switch (s.kind) {
         case "mailbox":
-          setUrl({ scope: "mailbox", ref: s.mailboxId });
+          goTo({ scope: "mailbox", ref: s.mailboxId });
           return;
         case "tag":
-          setUrl({ scope: "tag", ref: s.tagId });
+          goTo({ scope: "tag", ref: s.tagId });
           return;
         case "category":
-          setUrl({ scope: "category", ref: s.categoryId });
+          goTo({ scope: "category", ref: s.categoryId });
           return;
         case "all":
-          setUrl({ scope: null, ref: null });
+          goTo({ scope: "all", ref: null });
           return;
         default:
-          setUrl({ scope: s.kind, ref: null });
+          goTo({ scope: s.kind, ref: null });
       }
     },
-    [setUrl],
+    [goTo],
   );
 
   // ── Scope → server search params ───────────────────────────────
@@ -246,7 +246,7 @@ export default function UniboxPage() {
       bullets={[
         "Live overview: unread, awaiting reply, snoozed, today, week",
         "Scope rail with per-mailbox + per-tag unread counts",
-        "Deep-linkable threads via ?thread= in the URL",
+        "Deep-linkable threads as a clean URL path",
         "Snooze any thread to clear it from the inbox until later",
       ]}
     >
@@ -300,17 +300,14 @@ export default function UniboxPage() {
                   <>
                     <button
                       type="button"
-                      onClick={() => setUrl({ thread: null, account: null })}
+                      onClick={() => goTo({ threadId: null })}
                       className="md:hidden flex items-center gap-1 px-3 h-10 shrink-0 border-b border-slate-200 text-[13px] font-medium text-slate-600 hover:text-slate-900 active:bg-slate-50"
                     >
                       <ChevronLeftIcon className="w-4 h-4" />
                       Inbox
                     </button>
                     <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-                      <ThreadView
-                        threadId={urlThread}
-                        emailId={urlAccount ?? undefined}
-                      />
+                      <ThreadView threadId={urlThread} />
                     </div>
                   </>
                 ) : (
@@ -323,8 +320,8 @@ export default function UniboxPage() {
                         Select a conversation
                       </p>
                       <p className="text-[11.5px] text-slate-400 mt-1 max-w-[34ch] leading-relaxed">
-                        Pick a thread from the list — its id will appear in the
-                        URL so you can share or refresh.
+                        Pick a thread from the list. It opens in the URL path so
+                        you can share or refresh.
                       </p>
                     </div>
                   </div>

--- a/web/src/components/app/campaigns/NewCampaignDialog.tsx
+++ b/web/src/components/app/campaigns/NewCampaignDialog.tsx
@@ -27,6 +27,7 @@ import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import useCreateCampaign from "@/lib/api/hooks/app/campaigns/useCreateCampaign";
 import { Label, TextInput } from "@/components/ui/field";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import WeekdayBitmask from "@/components/app/campaigns/schedule/WeekdayBitmask";
 import TagSelector from "@/components/app/popup/select/TagSelector";
 import { useUserProfile } from "@/hooks/context/user";
@@ -449,21 +450,26 @@ function ScheduleStep({
     setEndTime: (v: string) => void;
 }) {
     const profile = useUserProfile();
+    const timezoneOptions = React.useMemo<SelectOption[]>(
+        () =>
+            (profile?.timezones || []).map((tz) => ({
+                value: tz.name,
+                label: tz.display_name,
+            })),
+        [profile?.timezones],
+    );
     return (
         <div className="space-y-5 max-w-[560px]">
             <div>
                 <Label>Sending timezone</Label>
-                <select
+                <SelectMenu
                     value={timezone}
-                    onChange={(e) => setTimezone(e.target.value)}
-                    className="w-full h-7 px-2 rounded-md border border-slate-200 bg-white text-[12.5px] text-slate-900 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
-                >
-                    {(profile?.timezones || []).map((tz) => (
-                        <option key={tz.name} value={tz.name}>
-                            {tz.display_name}
-                        </option>
-                    ))}
-                </select>
+                    onChange={(v) => setTimezone(v)}
+                    options={timezoneOptions}
+                    className="w-full"
+                    placeholder="Select a timezone"
+                    aria-label="Sending timezone"
+                />
                 <p className="text-[11px] text-slate-400 mt-1">
                     Sends are scheduled in this zone. Worker IPs spread distribution naturally.
                 </p>

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -1546,10 +1546,11 @@ function ConnectionEditor({
                 <button
                     type="button"
                     onClick={onDelete}
-                    title="Delete connection"
-                    className="inline-flex size-7 items-center justify-center rounded-md text-slate-400 hover:bg-rose-50 hover:text-rose-600"
+                    title="Remove this line and the branch it represents"
+                    className="inline-flex h-7 items-center gap-1.5 rounded-md px-2 text-[12px] font-medium text-rose-500 transition-colors hover:bg-rose-50 hover:text-rose-600"
                 >
                     <Trash2Icon className="w-3.5 h-3.5" />
+                    Disconnect
                 </button>
                 <button
                     type="button"

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -1531,6 +1531,9 @@ function ConnectionEditor({
                                 ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
                                 : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
                         </p>
+                        <p className="text-[10.5px] text-amber-600">
+                            A reply is matched to the email it answers. If a contact replies to an earlier email after later steps already sent, it still triggers that email's reply path (and pauses the sequence when stop-on-reply is on).
+                        </p>
                     </div>
                 )}
                 {isNegative && (

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -896,8 +896,12 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                         data: { sourceId: s.id, branchId: b.branch_id },
                     });
                 }
-                // THEN path -> the condition's target.
-                const wt = waitTag(b.target_sequence_id);
+                // THEN path -> the condition's target. A reply branch fires the
+                // moment the contact replies, so the target step's wait_after is
+                // irrelevant. Showing "wait 10d" there is misleading. Label it
+                // "instant" instead.
+                const isReplyBr = (b.conditions ?? []).some((c) => isReplyBranchField(c.field));
+                const wt = isReplyBr ? "instant" : waitTag(b.target_sequence_id);
                 flowEdges.push({
                     id: `then-${b.branch_id}`,
                     source: nid,

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -60,7 +60,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import type Sequence from "@/lib/api/models/app/campaigns/sequences/Sequence";
 import type { SequenceBranch, BranchCondition, BranchField } from "@/lib/api/models/app/campaigns/sequences/Branching";
-import { BRANCH_FIELD_LABELS, isReplyBranchField } from "@/lib/api/models/app/campaigns/sequences/Branching";
+import { BRANCH_FIELD_LABELS, isReplyBranchField, isInstantCapableField } from "@/lib/api/models/app/campaigns/sequences/Branching";
 import useSequences from "@/lib/api/hooks/app/campaigns/sequences/useSequences";
 import useCreateSequence from "@/lib/api/hooks/app/campaigns/sequences/useCreateSequence";
 import useDeleteSequence from "@/lib/api/hooks/app/campaigns/sequences/useDeleteSequence";
@@ -105,6 +105,28 @@ function newBranchId(): string {
 
 const isCond = (b: SequenceBranch) => (b.conditions?.length ?? 0) > 0;
 const stepName = (s: Sequence | undefined) => (s?.name?.trim() ? s.name : "Untitled step");
+
+// "Positive" reply fields are the ones that route a contact INTO a reply flow
+// (a human reply, or a classified reply intent). Mirrors the backend's
+// branchHasPositiveReplyCondition. not_replied is excluded — that is the cold
+// sequence's "didn't reply" continuation, not reply handling. Used to decide
+// whether a campaign has any reply handling at all (the stop-on-reply warning).
+const POSITIVE_REPLY_FIELDS: BranchField[] = [
+    "replied",
+    "reply_positive",
+    "reply_negative",
+    "reply_neutral",
+    "reply_automated",
+];
+const isPositiveReplyField = (f: BranchField) => POSITIVE_REPLY_FIELDS.includes(f);
+
+// A branch is "instant" when its condition is an instant-capable signal
+// (reply intent, opened, or clicked) and the per-branch toggle isn't opted out.
+// Such a branch's action chain fires the moment the event lands (reply recorded,
+// or open / click tracked), so the target step's wait_after is irrelevant.
+function isInstantBranch(b: SequenceBranch): boolean {
+    return (b.conditions ?? []).some((c) => isInstantCapableField(c.field)) && b.instant !== false;
+}
 
 // Conditions first-match; unconditional ("just go there") paths are the fallback.
 function ordered(branches: SequenceBranch[]): SequenceBranch[] {
@@ -299,15 +321,16 @@ type IfNodeData = { label: string; instant: boolean; onDelete: () => void };
 
 function IfNode({ data, selected }: NodeProps) {
     const d = data as IfNodeData;
-    // Reply-class branches fire the moment the contact replies, not at the next
-    // scheduled step. A violet "instant" badge distinguishes them from the
-    // engagement (opened / clicked / within-N-days) branches that are checked at
-    // the next step boundary. The whole node carries a tooltip explaining it.
+    // Instant-capable branches (reply intent, opened, clicked) fire the moment
+    // the event lands, not at the next scheduled step. A violet "instant" badge
+    // distinguishes them from the branches checked at the next step boundary
+    // (negative "didn't" signals, within-N-days windows, random / always). The
+    // whole node carries a tooltip explaining it.
     return (
         <div
             title={
                 d.instant
-                    ? "Runs the moment the contact replies, not at the next scheduled step."
+                    ? "Runs the moment it happens (reply / open / click), not at the next scheduled step."
                     : undefined
             }
             className={`rounded-lg border bg-gradient-to-b from-sky-50 to-white px-2 py-1 shadow-sm transition-shadow duration-200 hover:shadow-md ${
@@ -934,8 +957,9 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                     position: { x: 0, y: 0 },
                     data: {
                         label: conditionText(b),
-                        // Reply-class branches run instantly on reply; flag the node.
-                        instant: (b.conditions ?? []).some((c) => isReplyBranchField(c.field)),
+                        // Instant-capable branches (reply intent / opened / clicked)
+                        // run the moment the event lands; flag the node.
+                        instant: isInstantBranch(b),
                         onDelete: () => deleteBranchRef.current(s.id, b.branch_id),
                     } satisfies IfNodeData,
                 });
@@ -965,12 +989,20 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                         data: { sourceId: s.id, branchId: b.branch_id },
                     });
                 }
-                // THEN path -> the condition's target. A reply branch fires the
-                // moment the contact replies, so the target step's wait_after is
-                // irrelevant. Showing "wait 10d" there is misleading. Label it
-                // "instant" instead.
-                const isReplyBr = (b.conditions ?? []).some((c) => isReplyBranchField(c.field));
-                const wt = isReplyBr ? "instant" : waitTag(b.target_sequence_id);
+                // THEN path -> the condition's target. Engagement branches
+                // (opened/clicked) carry a window the event must land inside; an
+                // instant branch fires the MOMENT it happens BUT only within that
+                // window, so surface it ("instant <=10d") rather than just
+                // "instant" or the target step's (irrelevant) wait_after. Reply
+                // branches have no window.
+                const withinDays = (b.conditions ?? []).find((c) => c.operator === "within_days")?.value;
+                const wt = isInstantBranch(b)
+                    ? withinDays
+                        ? `instant <=${withinDays}d`
+                        : "instant"
+                    : withinDays
+                      ? `within ${withinDays}d`
+                      : waitTag(b.target_sequence_id);
                 flowEdges.push({
                     id: `then-${b.branch_id}`,
                     source: nid,
@@ -1417,10 +1449,16 @@ function ConnectionEditor({
     const c0 = branch.conditions?.[0];
     const [field, setField] = React.useState<string>(c0 ? c0.field : "always");
     const [value, setValue] = React.useState<number>(c0?.value ?? (c0?.field === "random" ? 50 : 3));
+    // Instant-capable branches (reply intent, opened, clicked) fire the moment
+    // the event lands by default; this lets the user opt out so the path routes
+    // at the next step boundary instead.
+    const [instant, setInstant] = React.useState<boolean>(branch.instant !== false);
 
     const isAlways = field === "always";
     const isRandom = field === "random";
     const isReply = isReplyBranchField(field as BranchField);
+    const isInstantCapable = isInstantCapableField(field as BranchField);
+    const instantVerb = field === "opened" ? "open" : field === "clicked" ? "click" : "reply";
     const isNegative = field === "not_opened" || field === "not_clicked" || field === "not_replied";
     const target = steps.find((s) => s.id === branch.target_sequence_id);
     const targetLabel = branch.target_sequence_id === null ? "Stop the sequence" : target ? `“${stepName(target)}”` : "—";
@@ -1433,7 +1471,14 @@ function ConnectionEditor({
         return [{ field: field as BranchField, operator: "within_days", value }];
     };
     const save = (target_sequence_id: string | null) =>
-        onSave({ branch_id: branch.branch_id, target_sequence_id, conditions: buildConditions() });
+        onSave({
+            branch_id: branch.branch_id,
+            target_sequence_id,
+            conditions: buildConditions(),
+            // Persist the instant opt-out for any instant-capable signal (reply
+            // intent, opened, clicked). Other fields can't fire instantly.
+            instant: isInstantCapable ? instant : undefined,
+        });
 
     return (
         <div className="absolute right-3 top-3 z-20 w-[300px] max-w-[calc(100vw-1.5rem)] rounded-md border border-slate-200 bg-white p-3 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
@@ -1517,20 +1562,61 @@ function ConnectionEditor({
                         <span>days</span>
                     </div>
                 )}
-                {isReply && (
+                {isInstantCapable && (
                     <div className="space-y-1">
-                        <div className="flex items-center gap-1.5 rounded-md bg-violet-50 px-2 py-1 text-[10.5px] font-medium text-violet-600 ring-1 ring-violet-200">
-                            <ZapIcon className="w-3 h-3 shrink-0" />
-                            Instant: runs the moment they reply (no wait)
+                        <div
+                            className={`flex items-center gap-2 rounded-md px-2 py-1.5 ring-1 transition-colors ${
+                                instant ? "bg-violet-50 ring-violet-200" : "bg-slate-50 ring-slate-200"
+                            }`}
+                        >
+                            <ZapIcon
+                                className={`w-3.5 h-3.5 shrink-0 transition-colors ${
+                                    instant ? "text-violet-600" : "text-slate-400"
+                                }`}
+                            />
+                            <span
+                                className={`min-w-0 flex-1 text-[11px] font-medium leading-tight transition-colors ${
+                                    instant ? "text-violet-700" : "text-slate-500"
+                                }`}
+                            >
+                                {instant ? `Instant: runs the moment they ${instantVerb}` : "Routes at the next step"}
+                            </span>
+                            <button
+                                type="button"
+                                role="switch"
+                                aria-checked={instant}
+                                aria-label="Run instantly"
+                                onClick={() => setInstant((v) => !v)}
+                                title="Toggle whether this path fires the moment it happens or waits for the next step"
+                                className={`relative inline-flex h-[18px] w-8 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-violet-300 ${
+                                    instant ? "bg-violet-600" : "bg-slate-300"
+                                }`}
+                            >
+                                <span
+                                    className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform duration-200 ${
+                                        instant ? "translate-x-[15px]" : "translate-x-[2px]"
+                                    }`}
+                                />
+                            </button>
                         </div>
-                        <p className="text-[10.5px] text-slate-400">
-                            {field === "reply_automated"
-                                ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
-                                : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
-                        </p>
-                        <p className="text-[10.5px] text-amber-600">
-                            A reply is matched to the email it answers. If a contact replies to an earlier email after later steps already sent, it still triggers that email's reply path (and pauses the sequence when stop-on-reply is on).
-                        </p>
+                        {isReply ? (
+                            <>
+                                <p className="text-[10.5px] text-slate-400">
+                                    {field === "reply_automated"
+                                        ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
+                                        : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
+                                </p>
+                                <p className="text-[10.5px] text-amber-600">
+                                    A reply triggers the reply path of the specific email it answers (matched by the reply's threading headers): the earlier email, not the latest step, and never both. It falls back to the latest step only when the reply can't be threaded. With stop-on-reply on, the sequence also pauses.
+                                </p>
+                            </>
+                        ) : (
+                            <p className="text-[10.5px] text-slate-400">
+                                {instant
+                                    ? `Runs the moment they ${instantVerb}, as long as they ${instantVerb} within the ${value}-day window above. If they don't ${instantVerb} in that time, this path never runs. Chain action steps after it (create deal, move stage, notify).`
+                                    : `Waits up to ${value} day${value === 1 ? "" : "s"} for them to ${instantVerb}, then checks at the next step. If they don't ${instantVerb} in that window, this path never runs.`}
+                            </p>
+                        )}
                     </div>
                 )}
                 {isNegative && (
@@ -1539,7 +1625,9 @@ function ConnectionEditor({
                     </p>
                 )}
 
-                {branch.target_sequence_id !== null && !isReply && <WaitRow value={waitDays} onCommit={onSetWait} />}
+                {branch.target_sequence_id !== null && !(isInstantCapable && instant) && (
+                    <WaitRow value={waitDays} onCommit={onSetWait} />
+                )}
             </div>
 
             <div className="mt-3 flex items-center gap-2">

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -53,7 +53,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import type Sequence from "@/lib/api/models/app/campaigns/sequences/Sequence";
 import type { SequenceBranch, BranchCondition, BranchField } from "@/lib/api/models/app/campaigns/sequences/Branching";
-import { BRANCH_FIELD_LABELS } from "@/lib/api/models/app/campaigns/sequences/Branching";
+import { BRANCH_FIELD_LABELS, isReplyBranchField } from "@/lib/api/models/app/campaigns/sequences/Branching";
 import useSequences from "@/lib/api/hooks/app/campaigns/sequences/useSequences";
 import useCreateSequence from "@/lib/api/hooks/app/campaigns/sequences/useCreateSequence";
 import useDeleteSequence from "@/lib/api/hooks/app/campaigns/sequences/useDeleteSequence";
@@ -102,6 +102,8 @@ function conditionText(b: SequenceBranch): string {
         .map((c) => {
             if (c.field === "random") return `${c.value ?? 50}% random`;
             const f = BRANCH_FIELD_LABELS[c.field] ?? c.field;
+            // Reply-class conditions are "ever" (no day window).
+            if (isReplyBranchField(c.field)) return f;
             return `${f} within ${c.value ?? 3}d`;
         })
         .join(" + ");
@@ -1144,7 +1146,10 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
 // ── Stop-on-reply toggle ────────────────────────────────────────────────────
 function StopOnReplyToggle({ on, onToggle }: { on: boolean; onToggle: (next: boolean) => void }) {
     return (
-        <div className="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm">
+        <div
+            className="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm"
+            title="Auto-replies and out-of-office messages don't count as a reply, so the sequence keeps going."
+        >
             <span className="text-[11.5px] text-slate-600">Stop on reply</span>
             <button
                 type="button"
@@ -1221,6 +1226,7 @@ function ConnectionEditor({
         "h-7 w-full rounded-md border border-slate-200 bg-white px-2 text-[12px] text-slate-800 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100";
     const isAlways = field === "always";
     const isRandom = field === "random";
+    const isReply = isReplyBranchField(field as BranchField);
     const isNegative = field === "not_opened" || field === "not_clicked" || field === "not_replied";
     const target = steps.find((s) => s.id === branch.target_sequence_id);
     const targetLabel = branch.target_sequence_id === null ? "Stop the sequence" : target ? `“${stepName(target)}”` : "—";
@@ -1228,6 +1234,8 @@ function ConnectionEditor({
     const buildConditions = (): BranchCondition[] => {
         if (isAlways) return [];
         if (isRandom) return [{ field: "random", operator: "chance", value }];
+        // Reply-class conditions are checked once, ever (no day window / value).
+        if (isReply) return [{ field: field as BranchField, operator: "ever" }];
         return [{ field: field as BranchField, operator: "within_days", value }];
     };
     const save = (target_sequence_id: string | null) =>
@@ -1296,16 +1304,25 @@ function ConnectionEditor({
                             const f = e.target.value;
                             setField(f);
                             if (f === "random") setValue((v) => (v >= 1 && v <= 99 ? v : 50));
-                            else if (f !== "always") setValue((v) => (v >= 1 && v <= 60 ? v : 3));
+                            else if (f !== "always" && !isReplyBranchField(f as BranchField))
+                                setValue((v) => (v >= 1 && v <= 60 ? v : 3));
                         }}
                     >
                         <option value="always">always (right after the wait)</option>
-                        <option value="opened">if opened the email</option>
-                        <option value="clicked">if clicked a link</option>
-                        <option value="replied">if replied</option>
-                        <option value="not_opened">if didn’t open</option>
-                        <option value="not_clicked">if didn’t click</option>
-                        <option value="not_replied">if didn’t reply</option>
+                        <optgroup label="Engagement">
+                            <option value="opened">if opened the email</option>
+                            <option value="clicked">if clicked a link</option>
+                            <option value="replied">if replied</option>
+                            <option value="not_opened">if didn’t open</option>
+                            <option value="not_clicked">if didn’t click</option>
+                            <option value="not_replied">if didn’t reply</option>
+                        </optgroup>
+                        <optgroup label="Reply intent">
+                            <option value="reply_positive">if replied: positive</option>
+                            <option value="reply_negative">if replied: negative</option>
+                            <option value="reply_neutral">if replied: neutral</option>
+                            <option value="reply_automated">if auto-reply / out of office</option>
+                        </optgroup>
                         <option value="random">random split</option>
                     </select>
                 </div>
@@ -1316,12 +1333,19 @@ function ConnectionEditor({
                         <span>% of contacts (chosen at random)</span>
                     </div>
                 )}
-                {!isAlways && !isRandom && (
+                {!isAlways && !isRandom && !isReply && (
                     <div className="flex flex-wrap items-center gap-1.5">
                         <span>within</span>
                         <NumberInput value={value} onChange={(v) => setValue(Math.max(1, Math.min(60, Math.round(v) || 1)))} min={1} max={60} className="w-16" align="center" />
                         <span>days</span>
                     </div>
+                )}
+                {isReply && (
+                    <p className="text-[10.5px] text-slate-400">
+                        {field === "reply_automated"
+                            ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
+                            : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
+                    </p>
                 )}
                 {isNegative && (
                     <p className="text-[10.5px] text-slate-400">

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -1521,11 +1521,17 @@ function ConnectionEditor({
                     </div>
                 )}
                 {isReply && (
-                    <p className="text-[10.5px] text-slate-400">
-                        {field === "reply_automated"
-                            ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
-                            : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
-                    </p>
+                    <div className="space-y-1">
+                        <div className="flex items-center gap-1.5 rounded-md bg-violet-50 px-2 py-1 text-[10.5px] font-medium text-violet-600 ring-1 ring-violet-200">
+                            <ZapIcon className="w-3 h-3 shrink-0" />
+                            Instant: runs the moment they reply (no wait)
+                        </div>
+                        <p className="text-[10.5px] text-slate-400">
+                            {field === "reply_automated"
+                                ? "Routes when the contact's reply is an auto-reply or out-of-office bounce, not a real human reply. Pair this with action steps (create deal, move stage, notify) to react."
+                                : "Routes when the contact's reply is classified this way. Chain action steps after it, for example create deal then move stage then notify."}
+                        </p>
+                    </div>
                 )}
                 {isNegative && (
                     <p className="text-[10.5px] text-slate-400">
@@ -1533,7 +1539,7 @@ function ConnectionEditor({
                     </p>
                 )}
 
-                {branch.target_sequence_id !== null && <WaitRow value={waitDays} onCommit={onSetWait} />}
+                {branch.target_sequence_id !== null && !isReply && <WaitRow value={waitDays} onCommit={onSetWait} />}
             </div>
 
             <div className="mt-3 flex items-center gap-2">

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -17,6 +17,7 @@ import React from "react";
 import {
     ArrowRightLeftIcon,
     BellOffIcon,
+    AlertTriangleIcon,
     BracesIcon,
     CheckSquareIcon,
     ChevronDownIcon,
@@ -563,6 +564,32 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
     }, [sequences]);
 
     const invalidate = React.useCallback(() => qc.invalidateQueries({ queryKey: SEQ_KEY(campaignId) }), [qc, campaignId]);
+
+    // Does the campaign handle replies at all? True when any step has a branch
+    // routing on a positive reply signal. Drives the stop-on-reply warning copy.
+    const hasReplyBranch = React.useMemo(
+        () =>
+            (sequences ?? []).some((s) =>
+                (s.conditions?.branches ?? []).some((b) =>
+                    (b.conditions ?? []).some((c) => isPositiveReplyField(c.field)),
+                ),
+            ),
+        [sequences],
+    );
+
+    // Single place that flips stop_on_reply (optimistic + persisted). Shared by
+    // the toolbar toggle and the warning's "turn it on" shortcut.
+    const setStopOnReply = React.useCallback(
+        (next: boolean) => {
+            qc.setQueryData(["campaigns", campaignId], (old: unknown) =>
+                old ? { ...(old as object), stop_on_reply: next } : old,
+            );
+            updateCampaign
+                .mutateAsync({ stop_on_reply: next })
+                .catch((err) => toast.error(buildError(err as AppError)));
+        },
+        [qc, campaignId, updateCampaign],
+    );
 
     const openCondition = React.useCallback((sourceId: string, branchId: string) => {
         setSelectedEdge({ sourceId, branchId });
@@ -1253,31 +1280,29 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                 <Controls showInteractive={false} />
 
                 <Panel position="top-left">
-                    <div className="flex max-w-[calc(100vw-1.5rem)] flex-wrap items-center gap-1.5">
-                        <AddNodeMenu
-                            onAddEmail={addStep}
-                            onAddAction={addAction}
-                            disabled={adding || atMax}
-                            busy={adding}
-                        />
-                        <button
-                            type="button"
-                            onClick={() => setNodes((ns) => stackComponents(layoutGraph(ns, edges), edges))}
-                            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 text-[12px] font-medium text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:text-slate-900"
-                        >
-                            Tidy up
-                        </button>
-                        <StopOnReplyToggle
-                            on={!!campaign?.stop_on_reply}
-                            onToggle={(next) => {
-                                qc.setQueryData(["campaigns", campaignId], (old: unknown) =>
-                                    old ? { ...(old as object), stop_on_reply: next } : old,
-                                );
-                                updateCampaign
-                                    .mutateAsync({ stop_on_reply: next })
-                                    .catch((err) => toast.error(buildError(err as AppError)));
-                            }}
-                        />
+                    <div className="flex max-w-[calc(100vw-1.5rem)] flex-col gap-1.5">
+                        <div className="flex flex-wrap items-center gap-1.5">
+                            <AddNodeMenu
+                                onAddEmail={addStep}
+                                onAddAction={addAction}
+                                disabled={adding || atMax}
+                                busy={adding}
+                            />
+                            <button
+                                type="button"
+                                onClick={() => setNodes((ns) => stackComponents(layoutGraph(ns, edges), edges))}
+                                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 text-[12px] font-medium text-slate-700 shadow-sm transition-colors hover:border-slate-300 hover:text-slate-900"
+                            >
+                                Tidy up
+                            </button>
+                            <StopOnReplyToggle on={!!campaign?.stop_on_reply} onToggle={setStopOnReply} />
+                        </div>
+                        {campaign && !campaign.stop_on_reply && (sequences?.length ?? 0) > 1 && (
+                            <ReplyStopWarning
+                                hasReplyBranch={hasReplyBranch}
+                                onEnable={() => setStopOnReply(true)}
+                            />
+                        )}
                     </div>
                 </Panel>
 
@@ -1361,7 +1386,13 @@ function StopOnReplyToggle({ on, onToggle }: { on: boolean; onToggle: (next: boo
     return (
         <div
             className="flex items-center gap-2 rounded-md border border-slate-200 bg-white px-2.5 py-1.5 shadow-sm"
-            title="Auto-replies and out-of-office messages don't count as a reply, so the sequence keeps going."
+            title={
+                "When a contact replies, the rest of the sequence stops for them, " +
+                "while the reply branch you connected to the email they answered still " +
+                "runs (it fires instantly). So on reply: that reply flow runs, every other " +
+                "remaining step is cancelled. Auto-replies and out-of-office messages don't " +
+                "count as a reply, so the sequence keeps going."
+            }
         >
             <span className="text-[11.5px] text-slate-600">Stop on reply</span>
             <button
@@ -1380,6 +1411,33 @@ function StopOnReplyToggle({ on, onToggle }: { on: boolean; onToggle: (next: boo
                     }`}
                 />
             </button>
+        </div>
+    );
+}
+
+// Shown on the canvas when stop-on-reply is OFF and the sequence keeps sending.
+// Continuing to cold-email a contact who replied is the classic deliverability
+// mistake; turning stop-on-reply on still runs the reply branches (routing is
+// reply-flow aware), so it is strictly safer. Copy adapts to whether the
+// campaign has any reply handling at all.
+function ReplyStopWarning({ hasReplyBranch, onEnable }: { hasReplyBranch: boolean; onEnable: () => void }) {
+    return (
+        <div className="flex max-w-[19rem] items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-2.5 py-1.5 text-[11px] text-amber-700 shadow-sm">
+            <AlertTriangleIcon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <div className="space-y-1">
+                <p className="leading-snug">
+                    {hasReplyBranch
+                        ? "Stop on reply is off. Replies that don't match a reply branch (say, a reply to an older email) keep getting cold emails. Turning it on still runs your reply branches."
+                        : "No reply handling. With stop on reply off, contacts who reply keep moving through the cold sequence. Turn it on, or add a reply branch."}
+                </p>
+                <button
+                    type="button"
+                    onClick={onEnable}
+                    className="font-medium text-amber-800 underline underline-offset-2 hover:text-amber-900"
+                >
+                    Turn on stop on reply
+                </button>
+            </div>
         </div>
     );
 }

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -15,13 +15,16 @@
 
 import React from "react";
 import {
+    ArrowRightLeftIcon,
     BellOffIcon,
+    BracesIcon,
     CheckSquareIcon,
     ChevronDownIcon,
     ChevronUpIcon,
     ClockIcon,
     FlagIcon,
     GitBranchIcon,
+    HandshakeIcon,
     Loader2Icon,
     MailIcon,
     PlusIcon,
@@ -69,7 +72,13 @@ import SequenceView from "./SequenceView";
 import CategoryPicker from "@/components/app/contacts/CategoryPicker";
 import type { SequenceAction, SequenceActionType } from "@/lib/api/models/app/campaigns/sequences/Action";
 import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
+import DealStagePicker from "@/components/app/crm/DealStagePicker";
 import useMembers from "@/lib/api/hooks/app/organizations/useMembers";
+
+// Personalization tokens available in templated copy. Mirrors SequenceView's
+// VARIABLES so a deal name can use the same {{.FirstName}}/{{.Company}} tokens
+// every other campaign copy field does.
+const DEAL_NAME_VARIABLES = ["{{.FirstName}}", "{{.LastName}}", "{{.Company}}", "{{.Email}}"];
 
 const STOP_ID = "__stop__";
 const IF_PREFIX = "if-";
@@ -314,6 +323,8 @@ const ACTION_META: Record<string, { label: string; Icon: typeof ClockIcon; tint:
     add_tag: { label: "Add tag", Icon: TagIcon, tint: "text-emerald-600" },
     remove_tag: { label: "Remove tag", Icon: TagIcon, tint: "text-amber-600" },
     create_task: { label: "Create task", Icon: CheckSquareIcon, tint: "text-violet-600" },
+    create_deal: { label: "Create deal", Icon: HandshakeIcon, tint: "text-emerald-600" },
+    move_deal_stage: { label: "Move deal stage", Icon: ArrowRightLeftIcon, tint: "text-sky-600" },
     unsubscribe: { label: "Unsubscribe", Icon: BellOffIcon, tint: "text-rose-600" },
     notify: { label: "Notify", Icon: SendIcon, tint: "text-sky-600" },
 };
@@ -326,6 +337,10 @@ function actionSummary(a?: SequenceAction | null): string {
             return a.category_id ? "Add a tag" : "Pick a tag…";
         case "remove_tag":
             return a.category_id ? "Remove a tag" : "Pick a tag…";
+        case "create_deal":
+            return a.deal_pipeline_id && a.deal_stage_id ? "Create a CRM deal" : "Pick a pipeline and stage…";
+        case "move_deal_stage":
+            return a.deal_pipeline_id && a.deal_stage_id ? "Move the deal forward" : "Pick a pipeline and stage…";
         case "unsubscribe":
             return "Unsubscribe the contact";
         case "notify":
@@ -1385,6 +1400,8 @@ const ADD_ACTION_OPTIONS: { type: SequenceActionType; label: string }[] = [
     { type: "add_tag", label: "Add tag" },
     { type: "remove_tag", label: "Remove tag" },
     { type: "create_task", label: "Create task" },
+    { type: "create_deal", label: "Create deal" },
+    { type: "move_deal_stage", label: "Move deal stage" },
     { type: "unsubscribe", label: "Unsubscribe" },
     { type: "notify", label: "Notify (webhook)" },
 ];
@@ -1470,6 +1487,12 @@ function AddNodeMenu({
 function defaultActionFor(type: SequenceActionType): SequenceAction {
     if (type === "create_task") {
         return { type, task_priority: "medium", task_due_offset_days: 1 };
+    }
+    if (type === "create_deal") {
+        return { type, deal_currency: "USD", deal_name: "{{.Company}} ({{.FirstName}})" };
+    }
+    if (type === "move_deal_stage") {
+        return { type };
     }
     return { type };
 }
@@ -1691,6 +1714,72 @@ function ActionEditor({
                 </div>
             )}
 
+            {(action.type === "create_deal" || action.type === "move_deal_stage") && (
+                <div className="space-y-4">
+                    <div>
+                        <Label>{action.type === "create_deal" ? "Create the deal in" : "Move the deal to"}</Label>
+                        <DealStagePicker
+                            pipelineId={action.deal_pipeline_id}
+                            stageId={action.deal_stage_id}
+                            onChange={({ pipelineId, stageId }) =>
+                                setAction((a) => ({ ...a, deal_pipeline_id: pipelineId, deal_stage_id: stageId }))
+                            }
+                        />
+                        {action.type === "move_deal_stage" && (
+                            <p className="mt-1.5 text-[11px] text-slate-400">
+                                Moves the contact's most recent open deal in this pipeline to this stage. If they have no
+                                open deal here, nothing happens.
+                            </p>
+                        )}
+                    </div>
+
+                    {action.type === "create_deal" && (
+                        <>
+                            <div>
+                                <div className="mb-1.5 flex items-center justify-between gap-2">
+                                    <Label className="mb-0">Deal name</Label>
+                                    <DealNameVariableMenu
+                                        onPick={(token) =>
+                                            setAction((a) => ({ ...a, deal_name: (a.deal_name ?? "") + token }))
+                                        }
+                                    />
+                                </div>
+                                <TextInput
+                                    value={action.deal_name ?? ""}
+                                    onChange={(v) => setAction((a) => ({ ...a, deal_name: v }))}
+                                    placeholder="{{.Company}} ({{.FirstName}})"
+                                    className="w-full max-w-[320px]"
+                                />
+                                <p className="mt-1.5 text-[11px] text-slate-400">
+                                    Supports the same {"{{.FirstName}}"} / {"{{.Company}}"} variables as your email copy.
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap items-end gap-4">
+                                <div>
+                                    <Label>Value (optional)</Label>
+                                    <NumberInput
+                                        value={action.deal_value ?? 0}
+                                        onChange={(n) =>
+                                            setAction((a) => ({ ...a, deal_value: n > 0 ? n : undefined }))
+                                        }
+                                        min={0}
+                                        max={1_000_000_000}
+                                        className="w-36"
+                                    />
+                                </div>
+                                <div>
+                                    <Label>Currency</Label>
+                                    <CurrencyPicker
+                                        value={action.deal_currency ?? "USD"}
+                                        onChange={(c) => setAction((a) => ({ ...a, deal_currency: c }))}
+                                    />
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+            )}
+
             <div className="flex items-center justify-end pt-1">
                 <button
                     type="button"
@@ -1757,6 +1846,86 @@ function AssigneePicker({
                         >
                             <span className="truncate flex-1">{m.email}</span>
                             <span className="text-[10px] text-slate-400 capitalize">{m.role}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// DealNameVariableMenu — a compact "insert variable" trigger for the deal-name
+// field, mirroring the VariableMenu affordance the email subject/body use.
+// Appends a {{.Token}} into the deal name so it can personalize per contact.
+function DealNameVariableMenu({ onPick }: { onPick: (token: string) => void }) {
+    const [open, setOpen] = React.useState(false);
+    const ref = React.useRef<HTMLDivElement>(null);
+    useClickOutside(ref, () => setOpen(false));
+    return (
+        <div ref={ref} className="relative">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                title="Insert a personalization variable"
+                className="inline-flex h-7 items-center gap-1 rounded px-1.5 text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-900"
+            >
+                <BracesIcon className="w-3.5 h-3.5" />
+                <ChevronDownIcon className="w-3 h-3" />
+            </button>
+            {open && (
+                <div className="absolute right-0 top-full z-30 mt-1 w-44 overflow-hidden rounded-md border border-slate-200 bg-white py-1 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
+                    {DEAL_NAME_VARIABLES.map((v) => (
+                        <button
+                            key={v}
+                            type="button"
+                            onClick={() => {
+                                onPick(v);
+                                setOpen(false);
+                            }}
+                            className="flex w-full items-center px-2.5 py-1.5 text-left font-mono text-[11.5px] text-slate-700 transition-colors hover:bg-slate-100"
+                        >
+                            {v}
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+// CurrencyPicker — a small themed dropdown for the deal currency (ISO code).
+// Defaults to USD; the value persisted is the bare ISO code (e.g. "USD").
+const DEAL_CURRENCIES = ["USD", "EUR", "GBP", "CAD", "AUD", "JPY", "CHF", "SEK", "INR", "BRL"];
+
+function CurrencyPicker({ value, onChange }: { value: string; onChange: (c: string) => void }) {
+    const [open, setOpen] = React.useState(false);
+    const ref = React.useRef<HTMLDivElement>(null);
+    useClickOutside(ref, () => setOpen(false));
+    return (
+        <div ref={ref} className="relative inline-flex">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="inline-flex h-7 w-24 items-center gap-1.5 rounded-md border border-slate-200 bg-white px-2.5 text-[12px] text-slate-700 transition-colors hover:border-slate-300 hover:text-slate-900"
+            >
+                <span className="flex-1 truncate text-left">{value || "USD"}</span>
+                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+            </button>
+            {open && (
+                <div className="absolute left-0 top-full z-30 mt-1 max-h-56 w-24 overflow-y-auto rounded-md border border-slate-200 bg-white py-1 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
+                    {DEAL_CURRENCIES.map((c) => (
+                        <button
+                            key={c}
+                            type="button"
+                            onClick={() => {
+                                onChange(c);
+                                setOpen(false);
+                            }}
+                            className={`flex w-full items-center px-2.5 py-1.5 text-left text-[12px] transition-colors hover:bg-slate-100 ${
+                                c === value ? "font-medium text-slate-900" : "text-slate-700"
+                            }`}
+                        >
+                            {c}
                         </button>
                     ))}
                 </div>

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -38,17 +38,21 @@ import {
 import {
     ReactFlow,
     Background,
+    BaseEdge,
     Controls,
+    EdgeLabelRenderer,
     Panel,
     Handle,
     MarkerType,
     Position,
+    getBezierPath,
     useNodesState,
     useEdgesState,
     type Node,
     type Edge,
     type Connection,
     type NodeProps,
+    type EdgeProps,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import dagre from "@dagrejs/dagre";
@@ -442,6 +446,70 @@ function ActionNode({ data, selected }: NodeProps) {
 }
 
 const nodeTypes = { step: StepNode, ifcond: IfNode, stop: StopNode, action: ActionNode };
+
+// Convergent edge.
+// Several branches can route to the same next step (many in -> one node). They
+// all terminate at the node's single top handle, so by default the curves pile
+// onto one point and the arrowheads stack. This edge fans the incoming lines
+// across the top of the target node by index, so each inbound connection lands
+// at its own point and stays readable. A lone inbound edge renders unchanged.
+//
+// data.conIndex / data.conTotal are filled in by the layout effect once it
+// knows how many edges share a target.
+type ConvergeEdgeData = { conIndex?: number; conTotal?: number };
+
+function ConvergeEdge({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    markerEnd,
+    style,
+    label,
+    labelStyle,
+    labelBgStyle,
+    data,
+}: EdgeProps) {
+    const d = (data ?? {}) as ConvergeEdgeData;
+    const total = d.conTotal ?? 1;
+    const index = d.conIndex ?? 0;
+    // Spread the landing points across ~70% of the node's width, centred on the
+    // handle. One inbound edge keeps dead-centre (offset 0).
+    const span = Math.min(170, NODE_W * 0.7);
+    const offset = total > 1 ? (index - (total - 1) / 2) * (span / Math.max(1, total - 1)) : 0;
+    const [path, labelX, labelY] = getBezierPath({
+        sourceX,
+        sourceY,
+        sourcePosition,
+        targetX: targetX + offset,
+        targetY,
+        targetPosition,
+    });
+    return (
+        <>
+            <BaseEdge path={path} markerEnd={markerEnd} style={style} />
+            {label ? (
+                <EdgeLabelRenderer>
+                    <div
+                        className="nodrag nopan pointer-events-none absolute rounded border px-1 py-px text-[10px]"
+                        style={{
+                            transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+                            borderColor: (labelBgStyle as { stroke?: string } | undefined)?.stroke ?? "#e2e8f0",
+                            background: (labelBgStyle as { fill?: string } | undefined)?.fill ?? "#fff",
+                            color: (labelStyle as { fill?: string } | undefined)?.fill ?? "#475569",
+                        }}
+                    >
+                        {label}
+                    </div>
+                </EdgeLabelRenderer>
+            ) : null}
+        </>
+    );
+}
+
+const edgeTypes = { converge: ConvergeEdge };
 
 type IfMeta = { sourceId: string; branchId: string };
 
@@ -961,18 +1029,40 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
         const anyStop = sequences.some((s) => (s.conditions?.branches ?? []).some((b) => b.target_sequence_id === null));
         if (anyStop) allNodes.push({ id: STOP_ID, type: "stop", position: { x: 0, y: 0 }, data: {} });
 
+        // Convergence: more than one branch can route to the SAME next step, so
+        // a node can have several inbound edges. Count them per target and number
+        // each one, so the custom "converge" edge can fan the lines across the
+        // target's top instead of piling them all onto its single handle. Targets
+        // with one inbound edge stay on the plain bezier (no fan, no overhead).
+        const inboundCount = new Map<string, number>();
+        for (const e of flowEdges) inboundCount.set(e.target, (inboundCount.get(e.target) ?? 0) + 1);
+        const inboundSeen = new Map<string, number>();
+
         // Flowing curved (bezier) connectors with arrowheads — no boxy right
         // angles. The arrow takes the edge's own stroke colour.
-        const smoothEdges: Edge[] = flowEdges.map((e) => ({
-            ...e,
-            type: "default",
-            markerEnd: {
-                type: MarkerType.ArrowClosed,
-                width: 16,
-                height: 16,
-                color: (e.style as { stroke?: string } | undefined)?.stroke ?? "#94a3b8",
-            },
-        }));
+        const smoothEdges: Edge[] = flowEdges.map((e) => {
+            const total = inboundCount.get(e.target) ?? 1;
+            const index = inboundSeen.get(e.target) ?? 0;
+            inboundSeen.set(e.target, index + 1);
+            // Always use the converge edge type. With a single inbound edge it
+            // renders identically (offset 0); with several it fans them out. The
+            // point is the type NEVER changes in-session: when a second edge is
+            // added to a target, only conTotal updates (1 -> 2). Flipping an
+            // existing edge's `type` live makes React Flow drop the whole edge
+            // layer until reload. The "lines disappeared after I connected two to
+            // the same step" bug.
+            return {
+                ...e,
+                type: "converge",
+                data: { ...e.data, conIndex: index, conTotal: total },
+                markerEnd: {
+                    type: MarkerType.ArrowClosed,
+                    width: 16,
+                    height: 16,
+                    color: (e.style as { stroke?: string } | undefined)?.stroke ?? "#94a3b8",
+                },
+            };
+        });
 
         const laid = stackComponents(layoutGraph(allNodes, smoothEdges), smoothEdges);
         const sig =
@@ -1110,6 +1200,7 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                     })
                 }
                 nodeTypes={nodeTypes}
+                edgeTypes={edgeTypes}
                 onEdgeClick={(_, edge) => {
                     const d = edge.data as { sourceId?: string; branchId?: string } | undefined;
                     if (d?.sourceId && d?.branchId) openCondition(d.sourceId, d.branchId);

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -16,6 +16,7 @@
 import React from "react";
 import {
     BellOffIcon,
+    CheckSquareIcon,
     ChevronDownIcon,
     ChevronUpIcon,
     ClockIcon,
@@ -67,6 +68,8 @@ import buildError from "@/lib/helper/buildError";
 import SequenceView from "./SequenceView";
 import CategoryPicker from "@/components/app/contacts/CategoryPicker";
 import type { SequenceAction, SequenceActionType } from "@/lib/api/models/app/campaigns/sequences/Action";
+import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
+import useMembers from "@/lib/api/hooks/app/organizations/useMembers";
 
 const STOP_ID = "__stop__";
 const IF_PREFIX = "if-";
@@ -308,6 +311,7 @@ function StopNode() {
 const ACTION_META: Record<string, { label: string; Icon: typeof ClockIcon; tint: string }> = {
     add_tag: { label: "Add tag", Icon: TagIcon, tint: "text-emerald-600" },
     remove_tag: { label: "Remove tag", Icon: TagIcon, tint: "text-amber-600" },
+    create_task: { label: "Create task", Icon: CheckSquareIcon, tint: "text-violet-600" },
     unsubscribe: { label: "Unsubscribe", Icon: BellOffIcon, tint: "text-rose-600" },
     notify: { label: "Notify", Icon: SendIcon, tint: "text-sky-600" },
 };
@@ -1356,6 +1360,7 @@ function ConnectionEditor({
 const ADD_ACTION_OPTIONS: { type: SequenceActionType; label: string }[] = [
     { type: "add_tag", label: "Add tag" },
     { type: "remove_tag", label: "Remove tag" },
+    { type: "create_task", label: "Create task" },
     { type: "unsubscribe", label: "Unsubscribe" },
     { type: "notify", label: "Notify (webhook)" },
 ];
@@ -1439,6 +1444,9 @@ function AddNodeMenu({
 
 // defaultActionFor returns a fresh action config for a newly-picked type.
 function defaultActionFor(type: SequenceActionType): SequenceAction {
+    if (type === "create_task") {
+        return { type, task_priority: "medium", task_due_offset_days: 1 };
+    }
     return { type };
 }
 
@@ -1595,6 +1603,70 @@ function ActionEditor({
                 </p>
             )}
 
+            {action.type === "create_task" && (
+                <div className="space-y-4">
+                    <div>
+                        <Label>Task title</Label>
+                        <TextInput
+                            value={action.task_title ?? ""}
+                            onChange={(v) => setAction((a) => ({ ...a, task_title: v }))}
+                            placeholder="e.g. Call this lead"
+                            className="w-full max-w-[320px]"
+                        />
+                        <p className="mt-1.5 text-[11px] text-slate-400">
+                            Left blank, it defaults to “Follow up: {"{contact}"}”.
+                        </p>
+                    </div>
+                    <div>
+                        <Label>Task type</Label>
+                        <TaskTypePicker
+                            value={action.task_type ?? ""}
+                            onChange={(name) => setAction((a) => ({ ...a, task_type: name }))}
+                            className="max-w-[280px]"
+                        />
+                    </div>
+                    <div className="flex flex-wrap items-end gap-4">
+                        <div>
+                            <Label>Priority</Label>
+                            <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+                                {(["low", "medium", "high", "urgent"] as const).map((p) => (
+                                    <button
+                                        key={p}
+                                        type="button"
+                                        onClick={() => setAction((a) => ({ ...a, task_priority: p }))}
+                                        className={`h-7 px-2 rounded text-[11px] font-medium capitalize transition-colors ${
+                                            (action.task_priority ?? "medium") === p
+                                                ? "bg-slate-900 text-white"
+                                                : "text-slate-500 hover:text-slate-900"
+                                        }`}
+                                    >
+                                        {p}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                        <div>
+                            <Label>Due in (days)</Label>
+                            <NumberInput
+                                value={action.task_due_offset_days ?? 1}
+                                onChange={(n) => setAction((a) => ({ ...a, task_due_offset_days: n }))}
+                                min={0}
+                                max={365}
+                                className="w-28"
+                            />
+                        </div>
+                    </div>
+                    <div>
+                        <Label>Assign to</Label>
+                        <AssigneePicker
+                            value={action.task_assigned_to ?? null}
+                            onChange={(id) => setAction((a) => ({ ...a, task_assigned_to: id }))}
+                        />
+                        <p className="mt-1.5 text-[11px] text-slate-400">Unassigned falls back to the campaign owner.</p>
+                    </div>
+                </div>
+            )}
+
             <div className="flex items-center justify-end pt-1">
                 <button
                     type="button"
@@ -1605,6 +1677,66 @@ function ActionEditor({
                     {saving ? "Saving…" : "Save action"}
                 </button>
             </div>
+        </div>
+    );
+}
+
+// AssigneePicker — choose the teammate a campaign-created task is assigned to.
+// `null` means "campaign owner" (the executor's fallback). Values are user ids.
+function AssigneePicker({
+    value,
+    onChange,
+}: {
+    value: string | null;
+    onChange: (id: string | null) => void;
+}) {
+    const { data: members } = useMembers();
+    const [open, setOpen] = React.useState(false);
+    const ref = React.useRef<HTMLDivElement>(null);
+    useClickOutside(ref, () => setOpen(false));
+    const list = members ?? [];
+    const selected = list.find((m) => m.user_id === value);
+    const label = value === null ? "Campaign owner" : (selected?.email ?? "Unknown member");
+    return (
+        <div ref={ref} className="relative inline-flex">
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="h-7 min-w-[200px] px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+            >
+                <span className="truncate flex-1 text-left">{label}</span>
+                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+            </button>
+            {open && (
+                <div className="absolute left-0 top-full z-30 mt-1 w-60 max-h-56 overflow-y-auto rounded-md border border-slate-200 bg-white py-1 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onChange(null);
+                            setOpen(false);
+                        }}
+                        className={`flex w-full items-center px-2.5 py-1.5 text-left text-[12px] transition-colors hover:bg-slate-100 ${
+                            value === null ? "font-medium text-slate-900" : "text-slate-700"
+                        }`}
+                    >
+                        Campaign owner
+                    </button>
+                    {list.map((m) => (
+                        <button
+                            key={m.id}
+                            type="button"
+                            onClick={() => {
+                                onChange(m.user_id);
+                                setOpen(false);
+                            }}
+                            className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left text-[12px] text-slate-700 transition-colors hover:bg-slate-100"
+                        >
+                            <span className="truncate flex-1">{m.email}</span>
+                            <span className="text-[10px] text-slate-400 capitalize">{m.role}</span>
+                        </button>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -70,6 +70,7 @@ import useUpdateCampaign from "@/lib/api/hooks/app/campaigns/useUpdateCampaign";
 import { useConfirm } from "@/hooks/context/confirm";
 import useClickOutside from "@/hooks/useClickOutside";
 import { NumberInput, Label, TextInput } from "@/components/ui/field";
+import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import SequenceView from "./SequenceView";
@@ -1373,6 +1374,21 @@ function WaitRow({ value, onCommit }: { value: number; onCommit: (v: number) => 
 }
 
 // ── Connection editor (optional condition + wait behind a connection) ───────
+const BRANCH_PATH_OPTIONS: SelectOption[] = [
+    { value: "always", label: "always (right after the wait)" },
+    { value: "opened", label: "if opened the email", group: "Engagement" },
+    { value: "clicked", label: "if clicked a link", group: "Engagement" },
+    { value: "replied", label: "if replied", group: "Engagement" },
+    { value: "not_opened", label: "if didn't open", group: "Engagement" },
+    { value: "not_clicked", label: "if didn't click", group: "Engagement" },
+    { value: "not_replied", label: "if didn't reply", group: "Engagement" },
+    { value: "reply_positive", label: "if replied: positive", group: "Reply intent" },
+    { value: "reply_negative", label: "if replied: negative", group: "Reply intent" },
+    { value: "reply_neutral", label: "if replied: neutral", group: "Reply intent" },
+    { value: "reply_automated", label: "if auto-reply / out of office", group: "Reply intent" },
+    { value: "random", label: "random split" },
+];
+
 function ConnectionEditor({
     source,
     branch,
@@ -1402,8 +1418,6 @@ function ConnectionEditor({
     const [field, setField] = React.useState<string>(c0 ? c0.field : "always");
     const [value, setValue] = React.useState<number>(c0?.value ?? (c0?.field === "random" ? 50 : 3));
 
-    const sel =
-        "h-7 w-full rounded-md border border-slate-200 bg-white px-2 text-[12px] text-slate-800 focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-100";
     const isAlways = field === "always";
     const isRandom = field === "random";
     const isReply = isReplyBranchField(field as BranchField);
@@ -1477,34 +1491,17 @@ function ConnectionEditor({
 
                 <div>
                     <p className="mb-1 text-[10px] font-medium uppercase tracking-[0.14em] text-slate-400">Take this path</p>
-                    <select
-                        className={sel}
+                    <SelectMenu
+                        className="w-full"
                         value={field}
-                        onChange={(e) => {
-                            const f = e.target.value;
+                        options={BRANCH_PATH_OPTIONS}
+                        onChange={(f) => {
                             setField(f);
                             if (f === "random") setValue((v) => (v >= 1 && v <= 99 ? v : 50));
                             else if (f !== "always" && !isReplyBranchField(f as BranchField))
                                 setValue((v) => (v >= 1 && v <= 60 ? v : 3));
                         }}
-                    >
-                        <option value="always">always (right after the wait)</option>
-                        <optgroup label="Engagement">
-                            <option value="opened">if opened the email</option>
-                            <option value="clicked">if clicked a link</option>
-                            <option value="replied">if replied</option>
-                            <option value="not_opened">if didn’t open</option>
-                            <option value="not_clicked">if didn’t click</option>
-                            <option value="not_replied">if didn’t reply</option>
-                        </optgroup>
-                        <optgroup label="Reply intent">
-                            <option value="reply_positive">if replied: positive</option>
-                            <option value="reply_negative">if replied: negative</option>
-                            <option value="reply_neutral">if replied: neutral</option>
-                            <option value="reply_automated">if auto-reply / out of office</option>
-                        </optgroup>
-                        <option value="random">random split</option>
-                    </select>
+                    />
                 </div>
 
                 {isRandom && (

--- a/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
+++ b/web/src/components/app/campaigns/sequences/CampaignFlow.tsx
@@ -216,6 +216,7 @@ type StepNodeData = {
     endsHere: boolean;
     orphan: boolean;
     onDelete: () => void;
+    onAddReply: () => void;
 };
 
 function StepNode({ data, selected }: NodeProps) {
@@ -266,6 +267,22 @@ function StepNode({ data, selected }: NodeProps) {
                     Ends here
                 </div>
             ) : null}
+            {/* Explicit, discoverable way to build a reply-triggered step (the
+                reply branch is otherwise only reachable via a connection's
+                condition dropdown). Creates an action step that fires instantly
+                on reply. */}
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    d.onAddReply();
+                }}
+                title="Create a step that runs the moment the contact replies"
+                className="nodrag flex w-full items-center gap-1.5 border-t border-slate-200/70 px-2.5 py-1.5 text-[10.5px] font-medium text-violet-600 transition-colors hover:bg-violet-50"
+            >
+                <ZapIcon className="w-3 h-3" />
+                On reply
+            </button>
             {/* Right dot = start an "if" branch; bottom dot = plain "go there". */}
             <Handle type="source" id="if" position={Position.Right} className="!h-3 !w-3 !border-2 !border-white !bg-amber-400" />
             <Handle type="source" id="s" position={Position.Bottom} className="!h-3 !w-3 !border-2 !border-white !bg-sky-500" />
@@ -273,14 +290,23 @@ function StepNode({ data, selected }: NodeProps) {
     );
 }
 
-type IfNodeData = { label: string; onDelete: () => void };
+type IfNodeData = { label: string; instant: boolean; onDelete: () => void };
 
 function IfNode({ data, selected }: NodeProps) {
     const d = data as IfNodeData;
+    // Reply-class branches fire the moment the contact replies, not at the next
+    // scheduled step. A violet "instant" badge distinguishes them from the
+    // engagement (opened / clicked / within-N-days) branches that are checked at
+    // the next step boundary. The whole node carries a tooltip explaining it.
     return (
         <div
+            title={
+                d.instant
+                    ? "Runs the moment the contact replies, not at the next scheduled step."
+                    : undefined
+            }
             className={`rounded-lg border bg-gradient-to-b from-sky-50 to-white px-2 py-1 shadow-sm transition-shadow duration-200 hover:shadow-md ${
-                selected ? "border-sky-400 ring-2 ring-sky-100" : "border-sky-200"
+                selected ? "border-sky-400 ring-2 ring-sky-100" : d.instant ? "border-violet-200" : "border-sky-200"
             }`}
         >
             <Handle type="target" position={Position.Top} className="!h-2 !w-2 !border-2 !border-white !bg-slate-300" />
@@ -290,6 +316,12 @@ function IfNode({ data, selected }: NodeProps) {
                 <GitBranchIcon className="w-3 h-3 shrink-0 text-sky-600" />
                 <span className="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-sky-500">if</span>
                 <span className="max-w-[150px] truncate text-[11px] font-medium text-sky-800">{d.label}</span>
+                {d.instant && (
+                    <span className="inline-flex shrink-0 items-center gap-0.5 rounded bg-violet-50 px-1 py-px text-[8.5px] font-semibold uppercase tracking-[0.1em] text-violet-600 ring-1 ring-violet-200/70">
+                        <ZapIcon className="w-2.5 h-2.5" />
+                        instant
+                    </span>
+                )}
                 <button
                     type="button"
                     onClick={(e) => {
@@ -656,6 +688,39 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
         },
         [adding, sequences.length, seqById, createSequence, saveBranches, openCondition],
     );
+    // "On reply" on a step: create a new action step + a reply branch that fires
+    // it the moment the contact replies, then open the branch so you can pick the
+    // reply type (positive/negative/automated) and build the action chain. Reuses
+    // the same instant reply-branch mechanism the backend executes on reply.
+    const addReplyStep = React.useCallback(
+        async (sourceId: string) => {
+            if (adding || sequences.length >= MAX_STEPS) return;
+            const src = seqById.get(sourceId);
+            setAdding(true);
+            try {
+                const created = (await createSequence.mutateAsync()) as Sequence;
+                await updateSequence(campaignId, created.id, {
+                    kind: "action",
+                    action: defaultActionFor("create_task"),
+                });
+                const branch: SequenceBranch = {
+                    branch_id: newBranchId(),
+                    target_sequence_id: created.id,
+                    conditions: [{ field: "reply_positive", operator: "ever" }],
+                };
+                await saveBranches(sourceId, [...(src?.conditions?.branches ?? []), branch]);
+                invalidate();
+                openCondition(sourceId, branch.branch_id);
+                toast.success("Reply step added. It runs the moment they reply.");
+            } catch {
+                toast.error("Couldn't add the reply step");
+            } finally {
+                setAdding(false);
+            }
+        },
+        [adding, sequences.length, seqById, createSequence, campaignId, saveBranches, openCondition, invalidate],
+    );
+
     // Drag an IF block's bottom dot to empty -> new step the if leads to.
     const retargetToNew = React.useCallback(
         async (sourceId: string, branchId: string) => {
@@ -710,10 +775,12 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
     // Node-data callbacks via refs so the layout effect deps don't churn.
     const deleteStepRef = React.useRef(deleteStep);
     const deleteBranchRef = React.useRef(deleteBranch);
+    const addReplyStepRef = React.useRef(addReplyStep);
     React.useEffect(() => {
         deleteStepRef.current = deleteStep;
         deleteBranchRef.current = deleteBranch;
-    }, [deleteStep, deleteBranch]);
+        addReplyStepRef.current = addReplyStep;
+    }, [deleteStep, deleteBranch, addReplyStep]);
 
     React.useEffect(() => {
         const waitTag = (targetId: string | null) => {
@@ -774,6 +841,7 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                     endsHere: branches.length === 0,
                     orphan: !reachable.has(s.id),
                     onDelete: () => deleteStepRef.current(s.id),
+                    onAddReply: () => addReplyStepRef.current(s.id),
                 } satisfies StepNodeData,
             };
         });
@@ -797,6 +865,8 @@ export default function CampaignFlow({ campaignId }: { campaignId: string }) {
                     position: { x: 0, y: 0 },
                     data: {
                         label: conditionText(b),
+                        // Reply-class branches run instantly on reply; flag the node.
+                        instant: (b.conditions ?? []).some((c) => isReplyBranchField(c.field)),
                         onDelete: () => deleteBranchRef.current(s.id, b.branch_id),
                     } satisfies IfNodeData,
                 });

--- a/web/src/components/app/crm/DealStagePicker.tsx
+++ b/web/src/components/app/crm/DealStagePicker.tsx
@@ -1,0 +1,156 @@
+// DealStagePicker — a paired pipeline + stage selector for CRM deal automation.
+// Mirrors the inline StagePicker pattern used in the unibox ContactContextPanel
+// (PopoverMenu trigger + coloured stage dots), but adds a pipeline selector and
+// loads the org's pipelines itself. Used by the campaign "Create deal" /
+// "Move deal stage" action editors.
+//
+// The pipeline + stage are persisted as the action's deal_pipeline_id /
+// deal_stage_id. When the pipeline changes, the stage resets to that pipeline's
+// first stage so the pair always stays consistent.
+
+import React from "react";
+import { ChevronDownIcon } from "lucide-react";
+
+import {
+    PopoverMenu,
+    PopoverMenuTrigger,
+    PopoverMenuContent,
+    PopoverMenuItem,
+} from "@/components/ui/popover-menu";
+import usePipelines from "@/lib/api/hooks/app/crm/pipelines/usePipelines";
+import type { Stage } from "@/lib/api/models/app/crm/Pipeline";
+
+function sortedStages(stages: Stage[] | undefined): Stage[] {
+    return stages ? [...stages].sort((a, b) => a.position - b.position) : [];
+}
+
+export default function DealStagePicker({
+    pipelineId,
+    stageId,
+    onChange,
+}: {
+    pipelineId?: string;
+    stageId?: string;
+    onChange: (next: { pipelineId: string; stageId: string }) => void;
+}) {
+    const { data: pipelines = [], isPending } = usePipelines();
+
+    const pipeline = pipelines.find((p) => p.id === pipelineId);
+    const stages = sortedStages(pipeline?.stages);
+
+    const pickPipeline = (id: string) => {
+        const p = pipelines.find((x) => x.id === id);
+        const first = sortedStages(p?.stages)[0];
+        onChange({ pipelineId: id, stageId: first?.id ?? "" });
+    };
+
+    if (!isPending && pipelines.length === 0) {
+        return (
+            <p className="rounded-md border border-slate-200 bg-slate-50/60 px-3 py-2.5 text-[11.5px] leading-relaxed text-slate-600">
+                You don't have a CRM pipeline yet. Create one under CRM, then come back to choose where deals land.
+            </p>
+        );
+    }
+
+    return (
+        <div className="grid grid-cols-2 gap-2">
+            <div>
+                <p className="mb-1 text-[10px] font-medium uppercase tracking-[0.14em] text-slate-400">Pipeline</p>
+                <PipelineSelect
+                    pipelines={pipelines.map((p) => ({ id: p.id, name: p.name }))}
+                    value={pipelineId}
+                    onChange={pickPipeline}
+                />
+            </div>
+            <div>
+                <p className="mb-1 text-[10px] font-medium uppercase tracking-[0.14em] text-slate-400">Stage</p>
+                <StageSelect
+                    stages={stages}
+                    value={stageId}
+                    disabled={!pipeline}
+                    onChange={(id) => onChange({ pipelineId: pipelineId ?? "", stageId: id })}
+                />
+            </div>
+        </div>
+    );
+}
+
+function PipelineSelect({
+    pipelines,
+    value,
+    onChange,
+}: {
+    pipelines: { id: string; name: string }[];
+    value?: string;
+    onChange: (id: string) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = pipelines.find((p) => p.id === value);
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className="h-7 w-full px-2 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 inline-flex items-center gap-1.5 transition-colors"
+                >
+                    <span className="truncate flex-1 text-left">{cur?.name ?? "Pick a pipeline…"}</span>
+                    <ChevronDownIcon className="w-3 h-3 text-slate-400 shrink-0" />
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={180} className="max-h-56 overflow-y-auto">
+                {pipelines.map((p) => (
+                    <PopoverMenuItem key={p.id} onSelect={() => onChange(p.id)} selected={p.id === value}>
+                        {p.name}
+                    </PopoverMenuItem>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function StageSelect({
+    stages,
+    value,
+    disabled,
+    onChange,
+}: {
+    stages: Stage[];
+    value?: string;
+    disabled?: boolean;
+    onChange: (id: string) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = stages.find((s) => s.id === value);
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    disabled={disabled || stages.length === 0}
+                    className="h-7 w-full px-2 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 inline-flex items-center gap-1.5 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                    <span className="size-1.5 rounded-full shrink-0" style={{ backgroundColor: cur?.color || "#cbd5e1" }} />
+                    <span className="truncate flex-1 text-left">{cur?.name ?? "Pick a stage…"}</span>
+                    <ChevronDownIcon className="w-3 h-3 text-slate-400 shrink-0" />
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={180} className="max-h-56 overflow-y-auto">
+                {stages.map((s) => (
+                    <PopoverMenuItem
+                        key={s.id}
+                        onSelect={() => onChange(s.id)}
+                        selected={s.id === value}
+                        icon={
+                            <span
+                                className="size-2 rounded-full block"
+                                style={{ backgroundColor: s.color || "#94a3b8" }}
+                            />
+                        }
+                    >
+                        {s.name}
+                    </PopoverMenuItem>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}

--- a/web/src/components/app/crm/DealsTable.tsx
+++ b/web/src/components/app/crm/DealsTable.tsx
@@ -503,7 +503,7 @@ function EmptyDeals({ hasFilters, onClear }: { hasFilters: boolean; onClear: () 
             <p className="text-[11.5px] text-slate-400 mb-4 max-w-[40ch] mx-auto leading-relaxed">
                 {hasFilters
                     ? "Try widening or clearing the filters to see more."
-                    : "Deals you create across any pipeline show up here — searchable, sortable, and totalled across every pipeline."}
+                    : "Deals you create across any pipeline show up here: searchable, sortable, and totalled across every pipeline."}
             </p>
             {hasFilters && (
                 <button

--- a/web/src/components/app/crm/DealsTable.tsx
+++ b/web/src/components/app/crm/DealsTable.tsx
@@ -1,0 +1,579 @@
+// DealsTable — the cross-pipeline, server-driven "see everything" surface.
+//
+// Unlike the kanban board (one pipeline, first 100 rows, client-side totals),
+// this view:
+//   - spans every pipeline by default (pipeline is a column + a facet)
+//   - pages the full result set server-side (offset infinite scroll)
+//   - reads every header total from /crm/deals/summary, so the Open / Pipeline
+//     value / Won numbers are SUMs over the whole filtered set, never a reduce
+//     over the loaded page
+//   - filters + sorts on the server (status, pipeline, value range, close-date
+//     range, text) instead of an in-memory substring match
+//
+// Visual language mirrors ContactsTable (sticky hairline header, h-11 rows,
+// "N of M loaded" footer) so the CRM finally reuses the contacts toolkit.
+
+import React from "react";
+import {
+    CalendarIcon,
+    CircleDollarSignIcon,
+    FilterIcon,
+    Loader2Icon,
+    PlusIcon,
+    ArrowUpDownIcon,
+    GitBranchIcon,
+    UserIcon,
+    XIcon,
+} from "lucide-react";
+import { SectionBar, Stat, StatStrip } from "@/components/layout/Page";
+import { Label, SearchInput, TextInput } from "@/components/ui/field";
+import {
+    PopoverMenu,
+    PopoverMenuContent,
+    PopoverMenuItem,
+    PopoverMenuTrigger,
+} from "@/components/ui/popover-menu";
+import useSearchDeals from "@/lib/api/hooks/app/crm/deals/useSearchDeals";
+import useDealsSummary from "@/lib/api/hooks/app/crm/deals/useDealsSummary";
+import type Deal from "@/lib/api/models/app/crm/Deal";
+import type Pipeline from "@/lib/api/models/app/crm/Pipeline";
+import type SearchDeals from "@/lib/api/models/app/crm/SearchDeals";
+import type { DealSortBy } from "@/lib/api/models/app/crm/SearchDeals";
+import { EMPTY_DEAL_SEARCH } from "@/lib/api/models/app/crm/SearchDeals";
+
+const STATUS_TABS: { id: "all" | "open" | "won" | "lost"; label: string }[] = [
+    { id: "all", label: "All" },
+    { id: "open", label: "Open" },
+    { id: "won", label: "Won" },
+    { id: "lost", label: "Lost" },
+];
+
+const STATUS_STYLE: Record<Deal["status"], { label: string; cls: string; dot: string }> = {
+    open: { label: "Open", cls: "text-slate-600", dot: "bg-slate-400" },
+    won: { label: "Won", cls: "text-emerald-700", dot: "bg-emerald-500" },
+    lost: { label: "Lost", cls: "text-red-700", dot: "bg-red-500" },
+};
+
+const SORTS: { id: string; label: string; sort_by: DealSortBy; reverse: boolean }[] = [
+    { id: "newest", label: "Newest", sort_by: "created_at", reverse: false },
+    { id: "oldest", label: "Oldest", sort_by: "created_at", reverse: true },
+    { id: "value_desc", label: "Value · high → low", sort_by: "value", reverse: false },
+    { id: "value_asc", label: "Value · low → high", sort_by: "value", reverse: true },
+    { id: "closing", label: "Closing soonest", sort_by: "expected_close_date", reverse: true },
+    { id: "name", label: "Name · A → Z", sort_by: "name", reverse: true },
+];
+
+export default function DealsTable({
+    pipelines,
+    onOpenDeal,
+}: {
+    pipelines: Pipeline[];
+    onOpenDeal: (deal: Deal) => void;
+}) {
+    const [filters, setFilters] = React.useState<SearchDeals>(EMPTY_DEAL_SEARCH);
+
+    const search = useSearchDeals({ filters, limit: 50 });
+    const summary = useDealsSummary(filters);
+    const deals = search.deals ?? [];
+    const total = search.total;
+    const sum = summary.data;
+
+    const pipelineName = React.useMemo(() => {
+        const m = new Map<string, string>();
+        for (const p of pipelines) m.set(p.id, p.name);
+        return m;
+    }, [pipelines]);
+
+    const statusTab: "all" | "open" | "won" | "lost" =
+        filters.statuses.length === 1 ? filters.statuses[0] : "all";
+
+    function setStatusTab(tab: "all" | "open" | "won" | "lost") {
+        setFilters((f) => ({ ...f, statuses: tab === "all" ? [] : [tab] }));
+    }
+
+    const activeSort =
+        SORTS.find((s) => s.sort_by === filters.sort_by && s.reverse === filters.reverse) ?? SORTS[0];
+
+    const advancedCount =
+        filters.pipeline_ids.length +
+        (filters.min_value != null ? 1 : 0) +
+        (filters.max_value != null ? 1 : 0) +
+        (filters.close_after ? 1 : 0) +
+        (filters.close_before ? 1 : 0);
+
+    return (
+        <>
+            <StatStrip cols={4}>
+                <Stat
+                    label="Open"
+                    value={sum ? sum.open_count : "—"}
+                    sub="open deals"
+                />
+                <Stat
+                    label="Pipeline value"
+                    value={sum ? money(sum.open_value, sum.currency) : "—"}
+                    sub={sum?.mixed_currency ? "mixed currencies" : "open · server total"}
+                />
+                <Stat
+                    label="Won"
+                    value={sum ? money(sum.won_value, sum.currency) : "—"}
+                    sub={`${sum?.won_count ?? 0} closed won`}
+                />
+                <Stat label="Total" value={sum ? sum.total : total} sub="matching filter" last />
+            </StatStrip>
+
+            <SectionBar label={search.isPending ? "Loading…" : `${total} ${total === 1 ? "deal" : "deals"}`}>
+                <SearchInput
+                    value={filters.query}
+                    onChange={(v) => setFilters((f) => ({ ...f, query: v }))}
+                    placeholder="Search deals…"
+                    className="w-full sm:w-[180px]"
+                />
+                <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+                    {STATUS_TABS.map((t) => (
+                        <button
+                            key={t.id}
+                            type="button"
+                            onClick={() => setStatusTab(t.id)}
+                            className={`h-6 px-2 rounded text-[11px] font-medium transition-colors ${
+                                statusTab === t.id
+                                    ? "bg-slate-900 text-white"
+                                    : "text-slate-500 hover:text-slate-900"
+                            }`}
+                        >
+                            {t.label}
+                        </button>
+                    ))}
+                </div>
+                <PipelineFacet
+                    pipelines={pipelines}
+                    selected={filters.pipeline_ids}
+                    onChange={(ids) => setFilters((f) => ({ ...f, pipeline_ids: ids }))}
+                />
+                <FilterPopover filters={filters} onChange={setFilters} activeCount={advancedCount} />
+                <SortPopover active={activeSort.id} onChange={(s) => setFilters((f) => ({ ...f, sort_by: s.sort_by, reverse: s.reverse }))} />
+            </SectionBar>
+
+            {search.isError ? (
+                <div className="px-5 py-16 text-center text-[12.5px] text-red-600">
+                    Couldn’t load deals. Try again.
+                </div>
+            ) : !search.isPending && deals.length === 0 ? (
+                <EmptyDeals hasFilters={total === 0 && hasAnyFilter(filters)} onClear={() => setFilters(EMPTY_DEAL_SEARCH)} />
+            ) : (
+                <div className="flex-1 min-h-0 overflow-auto">
+                    <table className="w-full border-collapse">
+                        <thead className="sticky top-0 bg-white z-[1]">
+                            <tr className="border-b border-slate-200">
+                                <Th className="text-left">Deal</Th>
+                                <Th className="text-left">Contact</Th>
+                                <Th className="text-left">Pipeline</Th>
+                                <Th className="text-left">Stage</Th>
+                                <Th className="text-right">Value</Th>
+                                <Th className="text-left">Status</Th>
+                                <Th className="text-left">Close</Th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {search.isPending
+                                ? Array.from({ length: 8 }).map((_, i) => <SkeletonRow key={i} />)
+                                : deals.map((d) => (
+                                      <DealRow
+                                          key={d.id}
+                                          deal={d}
+                                          pipelineName={pipelineName.get(d.pipeline_id)}
+                                          onOpen={() => onOpenDeal(d)}
+                                      />
+                                  ))}
+                        </tbody>
+                    </table>
+
+                    <div className="px-5 py-3 flex items-center justify-center gap-3 border-t border-slate-200/60">
+                        {search.hasNextPage ? (
+                            <button
+                                type="button"
+                                onClick={() => search.fetchNextPage()}
+                                disabled={search.isFetchingNextPage}
+                                className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                            >
+                                {search.isFetchingNextPage ? (
+                                    <>
+                                        <Loader2Icon className="w-3 h-3 animate-spin" />
+                                        Loading…
+                                    </>
+                                ) : (
+                                    <>
+                                        <PlusIcon className="w-3 h-3" />
+                                        Load more
+                                    </>
+                                )}
+                            </button>
+                        ) : null}
+                        <span className="font-mono text-[10.5px] text-slate-400 tabular-nums">
+                            {search.hasNextPage
+                                ? `${deals.length} of ${total} loaded`
+                                : `${total} ${total === 1 ? "deal" : "deals"}`}
+                        </span>
+                    </div>
+                </div>
+            )}
+        </>
+    );
+}
+
+function DealRow({
+    deal,
+    pipelineName,
+    onOpen,
+}: {
+    deal: Deal;
+    pipelineName?: string;
+    onOpen: () => void;
+}) {
+    const status = STATUS_STYLE[deal.status];
+    const contactLabel = deal.contact
+        ? [deal.contact.first_name, deal.contact.last_name].filter(Boolean).join(" ").trim() ||
+          deal.contact.email
+        : "";
+
+    return (
+        <tr
+            onClick={onOpen}
+            className="group h-11 border-b border-slate-200/60 hover:bg-slate-50/80 cursor-pointer transition-colors"
+        >
+            <td className="px-3 max-w-0">
+                <div className="text-[12.5px] font-medium text-slate-900 truncate">{deal.name}</div>
+            </td>
+            <td className="px-3 max-w-0">
+                {contactLabel ? (
+                    <div className="flex items-center gap-1.5 text-[11.5px] text-slate-500 truncate">
+                        <UserIcon className="w-3 h-3 shrink-0 text-slate-400" />
+                        <span className="truncate">{contactLabel}</span>
+                    </div>
+                ) : (
+                    <span className="text-slate-300 text-[11.5px]">—</span>
+                )}
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <span className="inline-flex items-center gap-1.5 text-[11.5px] text-slate-500">
+                    <GitBranchIcon className="w-3 h-3 text-slate-400" />
+                    {pipelineName ?? "—"}
+                </span>
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                {deal.stage ? (
+                    <span className="inline-flex items-center gap-1.5 text-[11.5px] text-slate-600">
+                        <span
+                            className="size-1.5 rounded-full shrink-0"
+                            style={{ backgroundColor: deal.stage.color || "#94a3b8" }}
+                        />
+                        {deal.stage.name}
+                    </span>
+                ) : (
+                    <span className="text-slate-300 text-[11.5px]">—</span>
+                )}
+            </td>
+            <td className="px-3 text-right whitespace-nowrap">
+                {deal.value != null ? (
+                    <span className="font-mono text-[11.5px] text-emerald-700 tabular-nums">
+                        {money(deal.value, deal.currency)}
+                    </span>
+                ) : (
+                    <span className="text-slate-300">—</span>
+                )}
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                <span className={`inline-flex items-center gap-1.5 text-[11px] font-medium ${status.cls}`}>
+                    <span className={`size-1.5 rounded-full ${status.dot}`} />
+                    {status.label}
+                </span>
+            </td>
+            <td className="px-3 whitespace-nowrap">
+                {deal.expected_close_date ? (
+                    <span className="inline-flex items-center gap-1 font-mono text-[11px] text-slate-400 tabular-nums">
+                        <CalendarIcon className="w-2.5 h-2.5" />
+                        {fmtDate(deal.expected_close_date)}
+                    </span>
+                ) : (
+                    <span className="text-slate-300 text-[11.5px]">—</span>
+                )}
+            </td>
+        </tr>
+    );
+}
+
+function PipelineFacet({
+    pipelines,
+    selected,
+    onChange,
+}: {
+    pipelines: Pipeline[];
+    selected: string[];
+    onChange: (ids: string[]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const label = selected.length === 0 ? "All pipelines" : `${selected.length} pipeline${selected.length === 1 ? "" : "s"}`;
+
+    function toggle(id: string) {
+        onChange(selected.includes(id) ? selected.filter((x) => x !== id) : [...selected, id]);
+    }
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        selected.length
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <GitBranchIcon className="w-3 h-3" />
+                    {label}
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={200} className="max-h-64 overflow-y-auto">
+                {pipelines.length === 0 ? (
+                    <div className="px-2 py-1.5 text-[11.5px] text-slate-400">No pipelines yet</div>
+                ) : (
+                    pipelines.map((p) => (
+                        <PopoverMenuItem
+                            key={p.id}
+                            onSelect={() => toggle(p.id)}
+                            selected={selected.includes(p.id)}
+                            closeOnSelect={false}
+                        >
+                            {p.name}
+                        </PopoverMenuItem>
+                    ))
+                )}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function SortPopover({
+    active,
+    onChange,
+}: {
+    active: string;
+    onChange: (s: (typeof SORTS)[number]) => void;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = SORTS.find((s) => s.id === active) ?? SORTS[0];
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className="h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-600 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+                >
+                    <ArrowUpDownIcon className="w-3 h-3" />
+                    {cur.label}
+                    <span className="text-slate-400">▾</span>
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={180}>
+                {SORTS.map((s) => (
+                    <PopoverMenuItem key={s.id} onSelect={() => onChange(s)} selected={s.id === active}>
+                        {s.label}
+                    </PopoverMenuItem>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function FilterPopover({
+    filters,
+    onChange,
+    activeCount,
+}: {
+    filters: SearchDeals;
+    onChange: React.Dispatch<React.SetStateAction<SearchDeals>>;
+    activeCount: number;
+}) {
+    const [open, setOpen] = React.useState(false);
+
+    const setNum = (key: "min_value" | "max_value", v: string) =>
+        onChange((f) => ({ ...f, [key]: v.trim() === "" ? undefined : Number(v) }));
+    const setDate = (key: "close_after" | "close_before", v: string) =>
+        onChange((f) => ({ ...f, [key]: v ? new Date(v).toISOString() : undefined }));
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="end">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 px-2.5 rounded-md border text-[12px] inline-flex items-center gap-1.5 transition-colors ${
+                        activeCount
+                            ? "border-sky-300 bg-sky-50 text-sky-700"
+                            : "border-slate-200 text-slate-600 hover:text-slate-900 hover:border-slate-300"
+                    }`}
+                >
+                    <FilterIcon className="w-3 h-3" />
+                    Filters
+                    {activeCount > 0 && (
+                        <span className="size-4 rounded-full bg-sky-600 text-white text-[9.5px] inline-flex items-center justify-center tabular-nums">
+                            {activeCount}
+                        </span>
+                    )}
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={260} className="p-3">
+                <div className="space-y-3">
+                    <div>
+                        <Label>Value range</Label>
+                        <div className="flex items-center gap-1.5">
+                            <TextInput
+                                value={filters.min_value != null ? String(filters.min_value) : ""}
+                                onChange={(v) => setNum("min_value", v)}
+                                placeholder="Min"
+                                className="w-full"
+                            />
+                            <span className="text-slate-300">–</span>
+                            <TextInput
+                                value={filters.max_value != null ? String(filters.max_value) : ""}
+                                onChange={(v) => setNum("max_value", v)}
+                                placeholder="Max"
+                                className="w-full"
+                            />
+                        </div>
+                    </div>
+                    <div>
+                        <Label>Expected close</Label>
+                        <div className="flex items-center gap-1.5">
+                            <TextInput
+                                value={filters.close_after ? String(filters.close_after).split("T")[0] : ""}
+                                onChange={(v) => setDate("close_after", v)}
+                                type="date"
+                                className="w-full"
+                            />
+                            <span className="text-slate-300">–</span>
+                            <TextInput
+                                value={filters.close_before ? String(filters.close_before).split("T")[0] : ""}
+                                onChange={(v) => setDate("close_before", v)}
+                                type="date"
+                                className="w-full"
+                            />
+                        </div>
+                    </div>
+                    <div className="flex items-center justify-between pt-1 border-t border-slate-100">
+                        <button
+                            type="button"
+                            onClick={() =>
+                                onChange((f) => ({
+                                    ...f,
+                                    min_value: undefined,
+                                    max_value: undefined,
+                                    close_after: undefined,
+                                    close_before: undefined,
+                                }))
+                            }
+                            className="text-[11.5px] text-slate-500 hover:text-slate-900 inline-flex items-center gap-1"
+                        >
+                            <XIcon className="w-3 h-3" />
+                            Clear
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => setOpen(false)}
+                            className="h-6 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium transition-colors"
+                        >
+                            Done
+                        </button>
+                    </div>
+                </div>
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function EmptyDeals({ hasFilters, onClear }: { hasFilters: boolean; onClear: () => void }) {
+    return (
+        <div className="px-5 py-16 text-center">
+            <div className="mx-auto size-9 rounded-md bg-slate-50 border border-slate-200 flex items-center justify-center mb-3">
+                <CircleDollarSignIcon className="w-4 h-4 text-slate-400" />
+            </div>
+            <p className="text-[12.5px] text-slate-700 font-medium mb-1">
+                {hasFilters ? "No deals match these filters" : "No deals yet"}
+            </p>
+            <p className="text-[11.5px] text-slate-400 mb-4 max-w-[40ch] mx-auto leading-relaxed">
+                {hasFilters
+                    ? "Try widening or clearing the filters to see more."
+                    : "Deals you create across any pipeline show up here — searchable, sortable, and totalled across every pipeline."}
+            </p>
+            {hasFilters && (
+                <button
+                    type="button"
+                    onClick={onClear}
+                    className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+                >
+                    <XIcon className="w-3 h-3" />
+                    Clear filters
+                </button>
+            )}
+        </div>
+    );
+}
+
+function Th({ children, className }: { children: React.ReactNode; className?: string }) {
+    return (
+        <th
+            className={`px-3 py-2 text-[10px] font-medium text-slate-400 uppercase tracking-[0.14em] ${className ?? ""}`}
+        >
+            {children}
+        </th>
+    );
+}
+
+function SkeletonRow() {
+    return (
+        <tr className="h-11 border-b border-slate-200/60">
+            {Array.from({ length: 7 }).map((_, i) => (
+                <td key={i} className="px-3">
+                    <div className="h-3 bg-slate-100 rounded animate-pulse" style={{ width: `${50 + ((i * 13) % 40)}%` }} />
+                </td>
+            ))}
+        </tr>
+    );
+}
+
+function hasAnyFilter(f: SearchDeals): boolean {
+    return (
+        f.query.trim() !== "" ||
+        f.statuses.length > 0 ||
+        f.pipeline_ids.length > 0 ||
+        f.stage_ids.length > 0 ||
+        f.assigned_to.length > 0 ||
+        f.campaign_ids.length > 0 ||
+        f.min_value != null ||
+        f.max_value != null ||
+        !!f.close_after ||
+        !!f.close_before
+    );
+}
+
+function money(n: number | undefined, currency = "USD") {
+    if (n == null) return "—";
+    try {
+        return new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: currency || "USD",
+            maximumFractionDigits: 0,
+        }).format(n);
+    } catch {
+        return `$${Math.round(n).toLocaleString()}`;
+    }
+}
+
+function fmtDate(d: string | undefined) {
+    if (!d) return "—";
+    try {
+        return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    } catch {
+        return "—";
+    }
+}

--- a/web/src/components/app/crm/DealsTable.tsx
+++ b/web/src/components/app/crm/DealsTable.tsx
@@ -129,7 +129,7 @@ export default function DealsTable({
                     placeholder="Search deals…"
                     className="w-full sm:w-[180px]"
                 />
-                <div className="inline-flex rounded-md border border-slate-200 bg-white p-0.5">
+                <div className="inline-flex rounded-md bg-slate-100 p-0.5 gap-0.5">
                     {STATUS_TABS.map((t) => (
                         <button
                             key={t.id}
@@ -137,7 +137,7 @@ export default function DealsTable({
                             onClick={() => setStatusTab(t.id)}
                             className={`h-6 px-2 rounded text-[11px] font-medium transition-colors ${
                                 statusTab === t.id
-                                    ? "bg-slate-900 text-white"
+                                    ? "bg-white text-slate-900 shadow-sm"
                                     : "text-slate-500 hover:text-slate-900"
                             }`}
                         >

--- a/web/src/components/app/crm/DueInDays.tsx
+++ b/web/src/components/app/crm/DueInDays.tsx
@@ -1,0 +1,77 @@
+// DueInDays — a relative "due in N days" control used wherever a task due date
+// is set (the unibox thread panel + the tasks-tab dialog). People think in
+// "follow up in 3 days", not absolute calendar dates, so we capture a day
+// offset and convert to an ISO timestamp at the boundary. `null` = no due date.
+
+import React from "react";
+import { CalendarClockIcon, XIcon } from "lucide-react";
+import { NumberInput } from "@/components/ui/field";
+
+const PRESETS = [
+    { label: "Today", days: 0 },
+    { label: "Tomorrow", days: 1 },
+    { label: "3d", days: 3 },
+    { label: "1w", days: 7 },
+];
+
+export default function DueInDays({
+    value,
+    onChange,
+    defaultDays = 3,
+}: {
+    value: number | null;
+    onChange: (days: number | null) => void;
+    defaultDays?: number;
+}) {
+    if (value === null) {
+        return (
+            <button
+                type="button"
+                onClick={() => onChange(defaultDays)}
+                className="h-7 px-2.5 rounded-md border border-dashed border-slate-300 text-[12px] text-slate-500 hover:text-slate-900 hover:border-slate-400 inline-flex items-center gap-1.5 transition-colors"
+            >
+                <CalendarClockIcon className="w-3 h-3" />
+                Set due date
+            </button>
+        );
+    }
+
+    return (
+        <div className="flex items-center gap-2 flex-wrap">
+            <div className="inline-flex items-center gap-1.5">
+                <span className="text-[11px] text-slate-400">Due in</span>
+                <NumberInput
+                    value={value}
+                    onChange={(n) => onChange(Math.max(0, Math.round(n)))}
+                    min={0}
+                    className="w-[64px]"
+                />
+                <span className="text-[11px] text-slate-400">{value === 1 ? "day" : "days"}</span>
+                <button
+                    type="button"
+                    onClick={() => onChange(null)}
+                    aria-label="Clear due date"
+                    className="size-5 rounded text-slate-400 hover:text-slate-700 inline-flex items-center justify-center"
+                >
+                    <XIcon className="w-3 h-3" />
+                </button>
+            </div>
+            <div className="flex items-center gap-0.5">
+                {PRESETS.map((p) => (
+                    <button
+                        key={p.days}
+                        type="button"
+                        onClick={() => onChange(p.days)}
+                        className={`h-6 px-1.5 rounded text-[10.5px] transition-colors ${
+                            value === p.days
+                                ? "bg-sky-50 text-sky-700 font-medium"
+                                : "text-slate-500 hover:text-slate-900"
+                        }`}
+                    >
+                        {p.label}
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/app/crm/TaskTypePicker.tsx
+++ b/web/src/components/app/crm/TaskTypePicker.tsx
@@ -2,6 +2,14 @@
 // create, rename, recolour, delete. The selected value is the type NAME
 // (empty string = no type). Shared by the tasks dialog and the campaign
 // "Create task" action editor so types stay consistent everywhere.
+//
+// The dropdown shell is the shared PopoverMenu primitive (portal +
+// framer-motion animation + click-outside/Esc handled for us), so it
+// stays smooth and consistent with the rest of the app chrome. The
+// rich rows — select, inline rename/recolour, inline "New type" form —
+// live as arbitrary children inside PopoverMenuContent. The edit/create
+// forms stopPropagation on their interactions so typing or picking a
+// swatch never bubbles up to close the menu.
 
 import React from "react";
 import toast from "react-hot-toast";
@@ -14,7 +22,13 @@ import {
     Trash2Icon,
     XIcon,
 } from "lucide-react";
-import useClickOutside from "@/hooks/useClickOutside";
+import {
+    PopoverMenu,
+    PopoverMenuTrigger,
+    PopoverMenuContent,
+    PopoverMenuItem,
+    PopoverMenuSeparator,
+} from "@/components/ui/popover-menu";
 import { useConfirm } from "@/hooks/context/confirm";
 import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
 import useCreateTaskType from "@/lib/api/hooks/app/crm/taskTypes/useCreateTaskType";
@@ -36,68 +50,61 @@ export default function TaskTypePicker({
 }) {
     const { data: types = [], isPending } = useTaskTypes();
     const [open, setOpen] = React.useState(false);
-    const ref = React.useRef<HTMLDivElement>(null);
-    useClickOutside(ref, () => setOpen(false));
 
     const selected = types.find((t) => t.name === value);
 
     return (
-        <div ref={ref} className={`relative ${className ?? ""}`}>
-            <button
-                type="button"
-                onClick={() => setOpen((o) => !o)}
-                className="h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
-            >
-                <span
-                    className="size-2 rounded-full shrink-0"
-                    style={{ backgroundColor: selected?.color ?? "#cbd5e1" }}
-                />
-                <span className="truncate flex-1 text-left">{value || "No type"}</span>
-                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
-            </button>
+        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={`h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors ${className ?? ""}`}
+                >
+                    <span
+                        className="size-2 rounded-full shrink-0"
+                        style={{ backgroundColor: selected?.color ?? "#cbd5e1" }}
+                    />
+                    <span className="truncate flex-1 text-left">{value || "No type"}</span>
+                    <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+                </button>
+            </PopoverMenuTrigger>
 
-            {open && (
-                <div className="absolute left-0 top-full z-40 mt-1 w-64 rounded-md border border-slate-200 bg-white py-1 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
-                    <button
-                        type="button"
-                        onClick={() => {
-                            onChange("");
-                            setOpen(false);
-                        }}
-                        className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-[12px] transition-colors hover:bg-slate-50 ${
-                            value === "" ? "text-slate-900 font-medium" : "text-slate-600"
-                        }`}
-                    >
-                        <span className="size-2 rounded-full bg-slate-300" />
-                        No type
-                    </button>
+            <PopoverMenuContent minWidth={256} className="w-64">
+                <PopoverMenuItem
+                    onSelect={() => onChange("")}
+                    selected={value === ""}
+                    icon={<span className="size-2 rounded-full bg-slate-300 block" />}
+                    trailing={
+                        value === "" ? <CheckIcon className="w-3 h-3 text-sky-600" /> : null
+                    }
+                >
+                    No type
+                </PopoverMenuItem>
 
-                    <div className="max-h-48 overflow-y-auto">
-                        {isPending ? (
-                            <div className="px-2.5 py-2 text-[11.5px] text-slate-400">Loading…</div>
-                        ) : (
-                            types.map((t) => (
-                                <TypeRow
-                                    key={t.id}
-                                    type={t}
-                                    selected={t.name === value}
-                                    onSelect={() => {
-                                        onChange(t.name);
-                                        setOpen(false);
-                                    }}
-                                    onDeletedSelected={() => onChange("")}
-                                    isSelectedValue={t.name === value}
-                                />
-                            ))
-                        )}
-                    </div>
-
-                    <div className="border-t border-slate-100 mt-1 pt-1">
-                        <NewTypeRow onCreated={(name) => onChange(name)} />
-                    </div>
+                <div className="max-h-48 overflow-y-auto">
+                    {isPending ? (
+                        <div className="px-3 py-2 text-[11.5px] text-slate-400">Loading…</div>
+                    ) : (
+                        types.map((t) => (
+                            <TypeRow
+                                key={t.id}
+                                type={t}
+                                selected={t.name === value}
+                                onSelect={() => {
+                                    onChange(t.name);
+                                    setOpen(false);
+                                }}
+                                onDeletedSelected={() => onChange("")}
+                                isSelectedValue={t.name === value}
+                            />
+                        ))
+                    )}
                 </div>
-            )}
-        </div>
+
+                <PopoverMenuSeparator />
+                <NewTypeRow onCreated={(name) => onChange(name)} />
+            </PopoverMenuContent>
+        </PopoverMenu>
     );
 }
 
@@ -148,16 +155,25 @@ function TypeRow({
         });
     }
 
+    // The inline edit form is interactive — typing, swatch picks and the
+    // Save/Cancel buttons must never bubble up to the row's select handler
+    // or close the menu, so the wrapper stops propagation outright.
     if (editing) {
         return (
-            <div className="px-2 py-1.5 space-y-1.5 bg-slate-50/60">
+            <div
+                className="px-2 py-1.5 space-y-1.5 bg-slate-50/60"
+                onClick={(e) => e.stopPropagation()}
+            >
                 <input
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     autoFocus
                     onKeyDown={(e) => {
                         if (e.key === "Enter") save();
-                        if (e.key === "Escape") setEditing(false);
+                        if (e.key === "Escape") {
+                            e.stopPropagation();
+                            setEditing(false);
+                        }
                     }}
                     className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
                 />
@@ -186,7 +202,7 @@ function TypeRow({
 
     return (
         <div
-            className={`group flex items-center gap-2 px-2.5 py-1.5 text-[12px] cursor-pointer transition-colors hover:bg-slate-50 ${
+            className={`group flex items-center gap-2 px-3 py-1.5 text-[12px] cursor-pointer transition-colors hover:bg-slate-50 ${
                 selected ? "text-slate-900 font-medium" : "text-slate-700"
             }`}
             onClick={onSelect}
@@ -239,8 +255,11 @@ function NewTypeRow({ onCreated }: { onCreated: (name: string) => void }) {
         return (
             <button
                 type="button"
-                onClick={() => setAdding(true)}
-                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-[12px] text-sky-700 hover:bg-sky-50 transition-colors"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setAdding(true);
+                }}
+                className="flex w-full items-center gap-2 px-3 py-1.5 text-[12px] text-sky-700 hover:bg-sky-50 transition-colors"
             >
                 <PlusIcon className="w-3 h-3" />
                 New type
@@ -248,8 +267,10 @@ function NewTypeRow({ onCreated }: { onCreated: (name: string) => void }) {
         );
     }
 
+    // Inline create form — stop propagation so typing, swatch picks and the
+    // Add button stay inside the menu instead of selecting/closing it.
     return (
-        <div className="px-2 py-1.5 space-y-1.5">
+        <div className="px-2 py-1.5 space-y-1.5" onClick={(e) => e.stopPropagation()}>
             <div className="flex items-center gap-1.5">
                 <input
                     value={name}
@@ -258,7 +279,10 @@ function NewTypeRow({ onCreated }: { onCreated: (name: string) => void }) {
                     autoFocus
                     onKeyDown={(e) => {
                         if (e.key === "Enter") submit();
-                        if (e.key === "Escape") setAdding(false);
+                        if (e.key === "Escape") {
+                            e.stopPropagation();
+                            setAdding(false);
+                        }
                     }}
                     className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
                 />

--- a/web/src/components/app/crm/TaskTypePicker.tsx
+++ b/web/src/components/app/crm/TaskTypePicker.tsx
@@ -3,15 +3,21 @@
 // (empty string = no type). Shared by the tasks dialog and the campaign
 // "Create task" action editor so types stay consistent everywhere.
 //
-// The dropdown shell is the shared PopoverMenu primitive (portal +
-// framer-motion animation + click-outside/Esc handled for us), so it
-// stays smooth and consistent with the rest of the app chrome. The
-// rich rows — select, inline rename/recolour, inline "New type" form —
-// live as arbitrary children inside PopoverMenuContent. The edit/create
-// forms stopPropagation on their interactions so typing or picking a
-// swatch never bubbles up to close the menu.
+// This mirrors the canonical contacts CategoryPicker: a bordered trigger
+// plus a framer-motion dropdown with a typeahead SEARCH HEADER at the top,
+// single-select rows (coloured dot + name + check), and an inline
+// "Create '<query>'" row that appears when the search doesn't match an
+// existing type — that inline create is the primary way to add a type, far
+// smoother than a separate form. Per-row recolour/rename/delete affordances
+// reveal on hover and stay lightweight and inline.
+//
+// closeOnSelect: selecting a type (or "No type", or creating a new one)
+// closes the dropdown; recolour / rename / delete keep it open. Editing
+// interactions stopPropagation so typing or picking a swatch never bubbles
+// up to a row's select handler.
 
 import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import toast from "react-hot-toast";
 import {
     CheckIcon,
@@ -20,16 +26,11 @@ import {
     PencilIcon,
     PlusIcon,
     Trash2Icon,
-    XIcon,
 } from "lucide-react";
-import {
-    PopoverMenu,
-    PopoverMenuTrigger,
-    PopoverMenuContent,
-    PopoverMenuItem,
-    PopoverMenuSeparator,
-} from "@/components/ui/popover-menu";
+
 import { useConfirm } from "@/hooks/context/confirm";
+import useClickOutside from "@/hooks/useClickOutside";
+import useFlipPlacement from "@/hooks/useFlipPlacement";
 import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
 import useCreateTaskType from "@/lib/api/hooks/app/crm/taskTypes/useCreateTaskType";
 import useUpdateTaskType from "@/lib/api/hooks/app/crm/taskTypes/useUpdateTaskType";
@@ -49,95 +50,225 @@ export default function TaskTypePicker({
     className?: string;
 }) {
     const { data: types = [], isPending } = useTaskTypes();
+    const createType = useCreateTaskType();
+
     const [open, setOpen] = React.useState(false);
+    const [query, setQuery] = React.useState("");
+    const ref = React.useRef<HTMLDivElement>(null);
+    const triggerRef = React.useRef<HTMLButtonElement>(null);
+    useClickOutside(ref, () => setOpen(false));
+    // ~290px: 33px search input + 56 max-h list (224px) + the "No type"
+    // row + borders, so the flip kicks in before a tall list clips.
+    const placement = useFlipPlacement(triggerRef, open, 290);
 
     const selected = types.find((t) => t.name === value);
 
+    React.useEffect(() => {
+        if (!open) setQuery("");
+    }, [open]);
+
+    const filtered = React.useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return types;
+        return types.filter((t) => t.name.toLowerCase().includes(q));
+    }, [types, query]);
+
+    const queryMatchesExisting = React.useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return true;
+        return types.some((t) => t.name.toLowerCase() === q);
+    }, [types, query]);
+
+    function pick(name: string) {
+        onChange(name);
+        setOpen(false);
+    }
+
+    // Auto-assign the next palette colour, preferring one not already in
+    // use so freshly created types are visually distinct.
+    function nextColor(): string {
+        const used = new Set(types.map((t) => t.color));
+        return TASK_TYPE_COLORS.find((c) => !used.has(c)) ?? TASK_TYPE_COLORS[0];
+    }
+
+    async function createAndPick() {
+        const name = query.trim();
+        if (!name) return;
+        try {
+            const t = await createType.mutateAsync({ name, color: nextColor() });
+            onChange(t.name);
+            setQuery("");
+            setOpen(false);
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }
+
     return (
-        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
-            <PopoverMenuTrigger asChild>
-                <button
-                    type="button"
-                    className={`h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors ${className ?? ""}`}
-                >
-                    <span
-                        className="size-2 rounded-full shrink-0"
-                        style={{ backgroundColor: selected?.color ?? "#cbd5e1" }}
-                    />
-                    <span className="truncate flex-1 text-left">{value || "No type"}</span>
-                    <ChevronDownIcon className="w-3 h-3 text-slate-400" />
-                </button>
-            </PopoverMenuTrigger>
+        <div ref={ref} className={`relative ${className ?? ""}`}>
+            <button
+                ref={triggerRef}
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+            >
+                <span
+                    className="size-2 rounded-full shrink-0"
+                    style={{ backgroundColor: selected?.color ?? "#cbd5e1" }}
+                />
+                <span className="truncate flex-1 text-left">{value || "No type"}</span>
+                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+            </button>
 
-            <PopoverMenuContent minWidth={256} className="w-64">
-                <PopoverMenuItem
-                    onSelect={() => onChange("")}
-                    selected={value === ""}
-                    icon={<span className="size-2 rounded-full bg-slate-300 block" />}
-                    trailing={
-                        value === "" ? <CheckIcon className="w-3 h-3 text-sky-600" /> : null
-                    }
-                >
-                    No type
-                </PopoverMenuItem>
-
-                <div className="max-h-48 overflow-y-auto">
-                    {isPending ? (
-                        <div className="px-3 py-2 text-[11.5px] text-slate-400">Loading…</div>
-                    ) : (
-                        types.map((t) => (
-                            <TypeRow
-                                key={t.id}
-                                type={t}
-                                selected={t.name === value}
-                                onSelect={() => {
-                                    onChange(t.name);
-                                    setOpen(false);
+            <AnimatePresence>
+                {open && (
+                    <motion.div
+                        initial={{ opacity: 0, y: placement === "top" ? 4 : -4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: placement === "top" ? 4 : -4 }}
+                        transition={{ duration: 0.12 }}
+                        className={`absolute left-0 right-0 z-30 rounded-md border border-slate-200 bg-white shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)] overflow-hidden ${
+                            placement === "top" ? "bottom-full mb-1" : "top-full mt-1"
+                        }`}
+                    >
+                        <div className="px-2 py-1.5 border-b border-slate-200">
+                            <input
+                                value={query}
+                                onChange={(e) => setQuery(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (
+                                        e.key === "Enter" &&
+                                        query.trim() &&
+                                        !queryMatchesExisting
+                                    ) {
+                                        e.preventDefault();
+                                        createAndPick();
+                                    }
+                                    if (e.key === "Escape") {
+                                        e.stopPropagation();
+                                        setOpen(false);
+                                    }
                                 }}
-                                onDeletedSelected={() => onChange("")}
-                                isSelectedValue={t.name === value}
+                                placeholder="Search or create…"
+                                autoFocus
+                                className="w-full h-5 bg-transparent text-[12px] text-slate-900 placeholder:text-slate-400 outline-none"
                             />
-                        ))
-                    )}
-                </div>
+                        </div>
 
-                <PopoverMenuSeparator />
-                <NewTypeRow onCreated={(name) => onChange(name)} />
-            </PopoverMenuContent>
-        </PopoverMenu>
+                        <div className="max-h-56 overflow-y-auto py-1">
+                            <button
+                                type="button"
+                                onClick={() => pick("")}
+                                className="w-full px-2.5 h-7 flex items-center gap-2 text-[12px] text-slate-700 hover:bg-slate-100 transition-colors"
+                            >
+                                <span className="size-2.5 rounded-full shrink-0 bg-slate-300" />
+                                <span className="truncate flex-1 text-left">No type</span>
+                                {value === "" && (
+                                    <CheckIcon className="w-3 h-3 text-sky-600 shrink-0" />
+                                )}
+                            </button>
+
+                            {isPending ? (
+                                <div className="px-3 py-3 text-[11.5px] text-slate-400 text-center">
+                                    Loading…
+                                </div>
+                            ) : (
+                                filtered.map((t) => (
+                                    <TypeRow
+                                        key={t.id}
+                                        type={t}
+                                        selected={t.name === value}
+                                        usedColors={types.map((x) => x.color)}
+                                        onSelect={() => pick(t.name)}
+                                        onRenamedSelected={(name) => onChange(name)}
+                                        onDeletedSelected={() => onChange("")}
+                                    />
+                                ))
+                            )}
+
+                            {query.trim() && !queryMatchesExisting && (
+                                <button
+                                    type="button"
+                                    onClick={createAndPick}
+                                    disabled={createType.isPending}
+                                    className="w-full px-2.5 h-7 flex items-center gap-2 text-[12px] text-slate-900 font-medium hover:bg-sky-50 border-t border-slate-100 transition-colors disabled:opacity-60"
+                                >
+                                    {createType.isPending ? (
+                                        <Loader2Icon className="w-3 h-3 animate-spin text-slate-400" />
+                                    ) : (
+                                        <PlusIcon className="w-3 h-3 text-sky-600" />
+                                    )}
+                                    Create "{query.trim()}"
+                                </button>
+                            )}
+
+                            {!isPending &&
+                                filtered.length === 0 &&
+                                !query.trim() && (
+                                    <div className="px-3 py-3 text-[11.5px] text-slate-400 text-center">
+                                        No types yet. Type a name to create one.
+                                    </div>
+                                )}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
     );
 }
 
+// TypeRow — a single existing type. Click anywhere to select; hovering
+// reveals lightweight recolour / rename / delete affordances. The recolour
+// swatch popover and the inline rename input stopPropagation so they never
+// trigger select or close the dropdown.
 function TypeRow({
     type,
     selected,
+    usedColors,
     onSelect,
+    onRenamedSelected,
     onDeletedSelected,
-    isSelectedValue,
 }: {
     type: TaskType;
     selected: boolean;
+    usedColors: string[];
     onSelect: () => void;
+    onRenamedSelected: (name: string) => void;
     onDeletedSelected: () => void;
-    isSelectedValue: boolean;
 }) {
     const update = useUpdateTaskType();
     const del = useDeleteTaskType();
     const confirm = useConfirm();
-    const [editing, setEditing] = React.useState(false);
+
+    const [renaming, setRenaming] = React.useState(false);
     const [name, setName] = React.useState(type.name);
-    const [color, setColor] = React.useState(type.color);
+    const [swatches, setSwatches] = React.useState(false);
 
     React.useEffect(() => {
         setName(type.name);
-        setColor(type.color);
-    }, [type.name, type.color]);
+    }, [type.name]);
 
-    async function save() {
-        if (!name.trim()) return;
+    async function saveName() {
+        const next = name.trim();
+        if (!next || next === type.name) {
+            setRenaming(false);
+            setName(type.name);
+            return;
+        }
         try {
-            await update.mutateAsync({ id: type.id, data: { name: name.trim(), color } });
-            setEditing(false);
+            await update.mutateAsync({ id: type.id, data: { name: next } });
+            if (selected) onRenamedSelected(next);
+            setRenaming(false);
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }
+
+    async function recolour(color: string) {
+        setSwatches(false);
+        if (color === type.color) return;
+        try {
+            await update.mutateAsync({ id: type.id, data: { color } });
         } catch (e) {
             toast.error(buildError(e as AppError));
         }
@@ -145,79 +276,85 @@ function TypeRow({
 
     function remove(e: React.MouseEvent) {
         e.stopPropagation();
-        confirm?.show(`Delete the “${type.name}” type? Existing tasks keep the label.`, async () => {
-            try {
-                await del.mutateAsync(type.id);
-                if (isSelectedValue) onDeletedSelected();
-            } catch (e) {
-                toast.error(buildError(e as AppError));
-            }
-        });
+        confirm?.show(
+            `Delete the "${type.name}" type? Existing tasks keep the label.`,
+            async () => {
+                try {
+                    await del.mutateAsync(type.id);
+                    if (selected) onDeletedSelected();
+                } catch (e) {
+                    toast.error(buildError(e as AppError));
+                }
+            },
+        );
     }
 
-    // The inline edit form is interactive — typing, swatch picks and the
-    // Save/Cancel buttons must never bubble up to the row's select handler
-    // or close the menu, so the wrapper stops propagation outright.
-    if (editing) {
+    // Inline rename — a tight input that replaces the row label. Stops
+    // propagation so typing never bubbles to the row's select handler.
+    if (renaming) {
         return (
             <div
-                className="px-2 py-1.5 space-y-1.5 bg-slate-50/60"
+                className="px-2.5 h-7 flex items-center gap-2 bg-slate-50"
                 onClick={(e) => e.stopPropagation()}
             >
+                <span
+                    className="size-2.5 rounded-full shrink-0"
+                    style={{ backgroundColor: type.color }}
+                />
                 <input
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     autoFocus
+                    onBlur={saveName}
                     onKeyDown={(e) => {
-                        if (e.key === "Enter") save();
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            saveName();
+                        }
                         if (e.key === "Escape") {
                             e.stopPropagation();
-                            setEditing(false);
+                            setName(type.name);
+                            setRenaming(false);
                         }
                     }}
-                    className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
+                    className="flex-1 h-5 bg-transparent text-[12px] text-slate-900 outline-none"
                 />
-                <Swatches value={color} onChange={setColor} />
-                <div className="flex items-center gap-1.5 justify-end">
-                    <button
-                        type="button"
-                        onClick={() => setEditing(false)}
-                        className="h-6 px-2 rounded text-[11px] text-slate-500 hover:text-slate-900 hover:bg-slate-100"
-                    >
-                        Cancel
-                    </button>
-                    <button
-                        type="button"
-                        onClick={save}
-                        disabled={update.isPending}
-                        className="h-6 px-2 rounded bg-slate-900 hover:bg-slate-800 text-white text-[11px] font-medium inline-flex items-center gap-1 disabled:opacity-60"
-                    >
-                        {update.isPending ? <Loader2Icon className="w-2.5 h-2.5 animate-spin" /> : <CheckIcon className="w-2.5 h-2.5" />}
-                        Save
-                    </button>
-                </div>
+                {update.isPending && (
+                    <Loader2Icon className="w-3 h-3 animate-spin text-slate-400 shrink-0" />
+                )}
             </div>
         );
     }
 
     return (
         <div
-            className={`group flex items-center gap-2 px-3 py-1.5 text-[12px] cursor-pointer transition-colors hover:bg-slate-50 ${
+            className={`group relative px-2.5 h-7 flex items-center gap-2 text-[12px] cursor-pointer transition-colors hover:bg-slate-100 ${
                 selected ? "text-slate-900 font-medium" : "text-slate-700"
             }`}
             onClick={onSelect}
         >
-            <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: type.color }} />
-            <span className="truncate flex-1">{type.name}</span>
-            {selected && <CheckIcon className="w-3 h-3 text-sky-600 shrink-0" />}
             <button
                 type="button"
                 onClick={(e) => {
                     e.stopPropagation();
-                    setEditing(true);
+                    setSwatches((s) => !s);
                 }}
-                aria-label="Edit type"
-                className="size-5 rounded text-slate-400 hover:text-slate-700 hover:bg-slate-100 inline-flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                aria-label="Recolour type"
+                className="size-2.5 rounded-full shrink-0 ring-offset-1 hover:ring-2 hover:ring-slate-300 transition-shadow"
+                style={{ backgroundColor: type.color }}
+            />
+            <span className="truncate flex-1">{type.name}</span>
+
+            {selected && <CheckIcon className="w-3 h-3 text-sky-600 shrink-0" />}
+
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setRenaming(true);
+                }}
+                aria-label="Rename type"
+                className="size-5 rounded text-slate-400 hover:text-slate-700 hover:bg-slate-200/70 inline-flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
             >
                 <PencilIcon className="w-2.5 h-2.5" />
             </button>
@@ -229,99 +366,73 @@ function TypeRow({
             >
                 <Trash2Icon className="w-2.5 h-2.5" />
             </button>
+
+            <AnimatePresence>
+                {swatches && (
+                    <SwatchPopover
+                        value={type.color}
+                        usedColors={usedColors}
+                        onPick={recolour}
+                        onClose={() => setSwatches(false)}
+                    />
+                )}
+            </AnimatePresence>
         </div>
     );
 }
 
-function NewTypeRow({ onCreated }: { onCreated: (name: string) => void }) {
-    const create = useCreateTaskType();
-    const [adding, setAdding] = React.useState(false);
-    const [name, setName] = React.useState("");
-    const [color, setColor] = React.useState(TASK_TYPE_COLORS[0]);
+// SwatchPopover — a small floating palette anchored to the type's colour
+// dot. Lives inside the row; stops propagation so picking a colour never
+// selects the row or closes the parent dropdown. Click-outside (scoped to
+// this popover) dismisses it.
+function SwatchPopover({
+    value,
+    usedColors,
+    onPick,
+    onClose,
+}: {
+    value: string;
+    usedColors: string[];
+    onPick: (color: string) => void;
+    onClose: () => void;
+}) {
+    const ref = React.useRef<HTMLDivElement>(null);
+    useClickOutside(ref, onClose);
 
-    async function submit() {
-        if (!name.trim()) return;
-        try {
-            const t = await create.mutateAsync({ name: name.trim(), color });
-            onCreated(t.name);
-            setName("");
-            setAdding(false);
-        } catch (e) {
-            toast.error(buildError(e as AppError));
-        }
-    }
-
-    if (!adding) {
-        return (
-            <button
-                type="button"
-                onClick={(e) => {
-                    e.stopPropagation();
-                    setAdding(true);
-                }}
-                className="flex w-full items-center gap-2 px-3 py-1.5 text-[12px] text-sky-700 hover:bg-sky-50 transition-colors"
-            >
-                <PlusIcon className="w-3 h-3" />
-                New type
-            </button>
-        );
-    }
-
-    // Inline create form — stop propagation so typing, swatch picks and the
-    // Add button stay inside the menu instead of selecting/closing it.
     return (
-        <div className="px-2 py-1.5 space-y-1.5" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center gap-1.5">
-                <input
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    placeholder="Type name (e.g. LinkedIn)"
-                    autoFocus
-                    onKeyDown={(e) => {
-                        if (e.key === "Enter") submit();
-                        if (e.key === "Escape") {
-                            e.stopPropagation();
-                            setAdding(false);
-                        }
-                    }}
-                    className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
-                />
-                <button
-                    type="button"
-                    onClick={() => setAdding(false)}
-                    aria-label="Cancel"
-                    className="size-7 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 inline-flex items-center justify-center shrink-0"
-                >
-                    <XIcon className="w-3 h-3" />
-                </button>
+        <motion.div
+            ref={ref}
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.96 }}
+            transition={{ duration: 0.1 }}
+            onClick={(e) => e.stopPropagation()}
+            className="absolute left-1.5 top-full mt-1 z-40 rounded-md border border-slate-200 bg-white p-1.5 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]"
+        >
+            <div className="grid grid-cols-4 gap-1.5">
+                {TASK_TYPE_COLORS.map((c) => {
+                    const isCurrent = c === value;
+                    const inUse = !isCurrent && usedColors.includes(c);
+                    return (
+                        <button
+                            key={c}
+                            type="button"
+                            onClick={() => onPick(c)}
+                            aria-label={c}
+                            className={`relative size-5 rounded-full transition-transform ${
+                                isCurrent
+                                    ? "ring-2 ring-offset-1 ring-slate-900"
+                                    : "hover:scale-110"
+                            } ${inUse ? "opacity-60" : ""}`}
+                            style={{ backgroundColor: c }}
+                        >
+                            {isCurrent && (
+                                <CheckIcon className="absolute inset-0 m-auto w-2.5 h-2.5 text-white" />
+                            )}
+                        </button>
+                    );
+                })}
             </div>
-            <Swatches value={color} onChange={setColor} />
-            <button
-                type="button"
-                onClick={submit}
-                disabled={create.isPending || !name.trim()}
-                className="h-7 w-full rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center justify-center gap-1 transition-colors disabled:opacity-60"
-            >
-                {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <PlusIcon className="w-3 h-3" />}
-                Add type
-            </button>
-        </div>
-    );
-}
-
-function Swatches({ value, onChange }: { value: string; onChange: (c: string) => void }) {
-    return (
-        <div className="flex flex-wrap gap-1">
-            {TASK_TYPE_COLORS.map((c) => (
-                <button
-                    key={c}
-                    type="button"
-                    onClick={() => onChange(c)}
-                    aria-label={c}
-                    className={`size-4 rounded-full transition-transform ${value === c ? "ring-2 ring-offset-1 ring-slate-900" : "hover:scale-110"}`}
-                    style={{ backgroundColor: c }}
-                />
-            ))}
-        </div>
+        </motion.div>
     );
 }

--- a/web/src/components/app/crm/TaskTypePicker.tsx
+++ b/web/src/components/app/crm/TaskTypePicker.tsx
@@ -1,0 +1,303 @@
+// TaskTypePicker — choose a task type, and manage the org's types inline:
+// create, rename, recolour, delete. The selected value is the type NAME
+// (empty string = no type). Shared by the tasks dialog and the campaign
+// "Create task" action editor so types stay consistent everywhere.
+
+import React from "react";
+import toast from "react-hot-toast";
+import {
+    CheckIcon,
+    ChevronDownIcon,
+    Loader2Icon,
+    PencilIcon,
+    PlusIcon,
+    Trash2Icon,
+    XIcon,
+} from "lucide-react";
+import useClickOutside from "@/hooks/useClickOutside";
+import { useConfirm } from "@/hooks/context/confirm";
+import useTaskTypes from "@/lib/api/hooks/app/crm/taskTypes/useTaskTypes";
+import useCreateTaskType from "@/lib/api/hooks/app/crm/taskTypes/useCreateTaskType";
+import useUpdateTaskType from "@/lib/api/hooks/app/crm/taskTypes/useUpdateTaskType";
+import useDeleteTaskType from "@/lib/api/hooks/app/crm/taskTypes/useDeleteTaskType";
+import { TASK_TYPE_COLORS } from "./taskTypes";
+import type TaskType from "@/lib/api/models/app/crm/TaskType";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import buildError from "@/lib/helper/buildError";
+
+export default function TaskTypePicker({
+    value,
+    onChange,
+    className,
+}: {
+    value: string;
+    onChange: (name: string) => void;
+    className?: string;
+}) {
+    const { data: types = [], isPending } = useTaskTypes();
+    const [open, setOpen] = React.useState(false);
+    const ref = React.useRef<HTMLDivElement>(null);
+    useClickOutside(ref, () => setOpen(false));
+
+    const selected = types.find((t) => t.name === value);
+
+    return (
+        <div ref={ref} className={`relative ${className ?? ""}`}>
+            <button
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                className="h-7 w-full px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors"
+            >
+                <span
+                    className="size-2 rounded-full shrink-0"
+                    style={{ backgroundColor: selected?.color ?? "#cbd5e1" }}
+                />
+                <span className="truncate flex-1 text-left">{value || "No type"}</span>
+                <ChevronDownIcon className="w-3 h-3 text-slate-400" />
+            </button>
+
+            {open && (
+                <div className="absolute left-0 top-full z-40 mt-1 w-64 rounded-md border border-slate-200 bg-white py-1 shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)]">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onChange("");
+                            setOpen(false);
+                        }}
+                        className={`flex w-full items-center gap-2 px-2.5 py-1.5 text-[12px] transition-colors hover:bg-slate-50 ${
+                            value === "" ? "text-slate-900 font-medium" : "text-slate-600"
+                        }`}
+                    >
+                        <span className="size-2 rounded-full bg-slate-300" />
+                        No type
+                    </button>
+
+                    <div className="max-h-48 overflow-y-auto">
+                        {isPending ? (
+                            <div className="px-2.5 py-2 text-[11.5px] text-slate-400">Loading…</div>
+                        ) : (
+                            types.map((t) => (
+                                <TypeRow
+                                    key={t.id}
+                                    type={t}
+                                    selected={t.name === value}
+                                    onSelect={() => {
+                                        onChange(t.name);
+                                        setOpen(false);
+                                    }}
+                                    onDeletedSelected={() => onChange("")}
+                                    isSelectedValue={t.name === value}
+                                />
+                            ))
+                        )}
+                    </div>
+
+                    <div className="border-t border-slate-100 mt-1 pt-1">
+                        <NewTypeRow onCreated={(name) => onChange(name)} />
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function TypeRow({
+    type,
+    selected,
+    onSelect,
+    onDeletedSelected,
+    isSelectedValue,
+}: {
+    type: TaskType;
+    selected: boolean;
+    onSelect: () => void;
+    onDeletedSelected: () => void;
+    isSelectedValue: boolean;
+}) {
+    const update = useUpdateTaskType();
+    const del = useDeleteTaskType();
+    const confirm = useConfirm();
+    const [editing, setEditing] = React.useState(false);
+    const [name, setName] = React.useState(type.name);
+    const [color, setColor] = React.useState(type.color);
+
+    React.useEffect(() => {
+        setName(type.name);
+        setColor(type.color);
+    }, [type.name, type.color]);
+
+    async function save() {
+        if (!name.trim()) return;
+        try {
+            await update.mutateAsync({ id: type.id, data: { name: name.trim(), color } });
+            setEditing(false);
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }
+
+    function remove(e: React.MouseEvent) {
+        e.stopPropagation();
+        confirm?.show(`Delete the “${type.name}” type? Existing tasks keep the label.`, async () => {
+            try {
+                await del.mutateAsync(type.id);
+                if (isSelectedValue) onDeletedSelected();
+            } catch (e) {
+                toast.error(buildError(e as AppError));
+            }
+        });
+    }
+
+    if (editing) {
+        return (
+            <div className="px-2 py-1.5 space-y-1.5 bg-slate-50/60">
+                <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    autoFocus
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") save();
+                        if (e.key === "Escape") setEditing(false);
+                    }}
+                    className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
+                />
+                <Swatches value={color} onChange={setColor} />
+                <div className="flex items-center gap-1.5 justify-end">
+                    <button
+                        type="button"
+                        onClick={() => setEditing(false)}
+                        className="h-6 px-2 rounded text-[11px] text-slate-500 hover:text-slate-900 hover:bg-slate-100"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={save}
+                        disabled={update.isPending}
+                        className="h-6 px-2 rounded bg-slate-900 hover:bg-slate-800 text-white text-[11px] font-medium inline-flex items-center gap-1 disabled:opacity-60"
+                    >
+                        {update.isPending ? <Loader2Icon className="w-2.5 h-2.5 animate-spin" /> : <CheckIcon className="w-2.5 h-2.5" />}
+                        Save
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className={`group flex items-center gap-2 px-2.5 py-1.5 text-[12px] cursor-pointer transition-colors hover:bg-slate-50 ${
+                selected ? "text-slate-900 font-medium" : "text-slate-700"
+            }`}
+            onClick={onSelect}
+        >
+            <span className="size-2 rounded-full shrink-0" style={{ backgroundColor: type.color }} />
+            <span className="truncate flex-1">{type.name}</span>
+            {selected && <CheckIcon className="w-3 h-3 text-sky-600 shrink-0" />}
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    setEditing(true);
+                }}
+                aria-label="Edit type"
+                className="size-5 rounded text-slate-400 hover:text-slate-700 hover:bg-slate-100 inline-flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+            >
+                <PencilIcon className="w-2.5 h-2.5" />
+            </button>
+            <button
+                type="button"
+                onClick={remove}
+                aria-label="Delete type"
+                className="size-5 rounded text-slate-400 hover:text-red-600 hover:bg-red-50 inline-flex items-center justify-center opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+            >
+                <Trash2Icon className="w-2.5 h-2.5" />
+            </button>
+        </div>
+    );
+}
+
+function NewTypeRow({ onCreated }: { onCreated: (name: string) => void }) {
+    const create = useCreateTaskType();
+    const [adding, setAdding] = React.useState(false);
+    const [name, setName] = React.useState("");
+    const [color, setColor] = React.useState(TASK_TYPE_COLORS[0]);
+
+    async function submit() {
+        if (!name.trim()) return;
+        try {
+            const t = await create.mutateAsync({ name: name.trim(), color });
+            onCreated(t.name);
+            setName("");
+            setAdding(false);
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }
+
+    if (!adding) {
+        return (
+            <button
+                type="button"
+                onClick={() => setAdding(true)}
+                className="flex w-full items-center gap-2 px-2.5 py-1.5 text-[12px] text-sky-700 hover:bg-sky-50 transition-colors"
+            >
+                <PlusIcon className="w-3 h-3" />
+                New type
+            </button>
+        );
+    }
+
+    return (
+        <div className="px-2 py-1.5 space-y-1.5">
+            <div className="flex items-center gap-1.5">
+                <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Type name (e.g. LinkedIn)"
+                    autoFocus
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") submit();
+                        if (e.key === "Escape") setAdding(false);
+                    }}
+                    className="w-full h-7 px-2 rounded-md border border-slate-200 text-[12px] outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100"
+                />
+                <button
+                    type="button"
+                    onClick={() => setAdding(false)}
+                    aria-label="Cancel"
+                    className="size-7 rounded-md text-slate-400 hover:text-slate-700 hover:bg-slate-100 inline-flex items-center justify-center shrink-0"
+                >
+                    <XIcon className="w-3 h-3" />
+                </button>
+            </div>
+            <Swatches value={color} onChange={setColor} />
+            <button
+                type="button"
+                onClick={submit}
+                disabled={create.isPending || !name.trim()}
+                className="h-7 w-full rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center justify-center gap-1 transition-colors disabled:opacity-60"
+            >
+                {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <PlusIcon className="w-3 h-3" />}
+                Add type
+            </button>
+        </div>
+    );
+}
+
+function Swatches({ value, onChange }: { value: string; onChange: (c: string) => void }) {
+    return (
+        <div className="flex flex-wrap gap-1">
+            {TASK_TYPE_COLORS.map((c) => (
+                <button
+                    key={c}
+                    type="button"
+                    onClick={() => onChange(c)}
+                    aria-label={c}
+                    className={`size-4 rounded-full transition-transform ${value === c ? "ring-2 ring-offset-1 ring-slate-900" : "hover:scale-110"}`}
+                    style={{ backgroundColor: c }}
+                />
+            ))}
+        </div>
+    );
+}

--- a/web/src/components/app/crm/taskTypes.tsx
+++ b/web/src/components/app/crm/taskTypes.tsx
@@ -18,5 +18,13 @@ export function taskTypeColor(
     types: { name: string; color: string }[],
 ): string {
     if (!name) return "#94a3b8";
-    return types.find((t) => t.name === name)?.color ?? "#94a3b8";
+    const key = name.trim().toLowerCase();
+    const found = types.find((t) => t.name.trim().toLowerCase() === key)?.color;
+    if (found) return found;
+    // No matching type (renamed/removed, or a case/whitespace mismatch between the
+    // task's stored type string and the type list): hash the name into the palette
+    // so it still gets a stable, DISTINCT colour instead of one grey for everything.
+    let h = 0;
+    for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+    return TASK_TYPE_COLORS[h % TASK_TYPE_COLORS.length];
 }

--- a/web/src/components/app/crm/taskTypes.tsx
+++ b/web/src/components/app/crm/taskTypes.tsx
@@ -1,0 +1,22 @@
+// Task-type helpers. Types are user-managed (see TaskTypePicker), so this no
+// longer holds a fixed list — just the colour palette used by the create/edit
+// form and a resolver from a task's type name to its colour.
+
+export const TASK_TYPE_COLORS = [
+    "#8b5cf6",
+    "#0ea5e9",
+    "#f59e0b",
+    "#10b981",
+    "#f43f5e",
+    "#6366f1",
+    "#14b8a6",
+    "#94a3b8",
+];
+
+export function taskTypeColor(
+    name: string | undefined,
+    types: { name: string; color: string }[],
+): string {
+    if (!name) return "#94a3b8";
+    return types.find((t) => t.name === name)?.color ?? "#94a3b8";
+}

--- a/web/src/components/app/unibox/ContactContextPanel.tsx
+++ b/web/src/components/app/unibox/ContactContextPanel.tsx
@@ -206,7 +206,7 @@ export default function ContactContextPanel({
                         />
 
                         {/* Notes */}
-                        <NotesSection contactId={contact.id} notes={notesQ.data ?? []} loading={notesQ.isPending} />
+                        <NotesSection contactId={contact.id} notes={asNoteList(notesQ.data)} loading={notesQ.isPending} />
                     </div>
                 )}
             </div>
@@ -597,6 +597,14 @@ function NotAContact({ email }: { email?: string }) {
             </Link>
         </div>
     );
+}
+
+// The notes endpoint returns either a bare array or a { data, pagination }
+// envelope depending on the path; normalise to a plain list (mirrors the
+// contacts NotesTab helper) so .slice/.map never blow up.
+function asNoteList(raw: unknown): { id: string; content: string; created_at: Date | string }[] {
+    const arr = Array.isArray(raw) ? raw : ((raw as { data?: unknown } | null | undefined)?.data ?? []);
+    return Array.isArray(arr) ? (arr as { id: string; content: string; created_at: Date | string }[]) : [];
 }
 
 function initials(name: string): string {

--- a/web/src/components/app/unibox/ContactContextPanel.tsx
+++ b/web/src/components/app/unibox/ContactContextPanel.tsx
@@ -11,7 +11,6 @@ import React from "react";
 import toast from "react-hot-toast";
 import {
     BanIcon,
-    CalendarClockIcon,
     CheckIcon,
     ChevronDownIcon,
     CircleDollarSignIcon,
@@ -35,6 +34,8 @@ import {
     PopoverMenuTrigger,
 } from "@/components/ui/popover-menu";
 import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
+import DueInDays from "@/components/app/crm/DueInDays";
+import { dueInDaysToISO } from "@/lib/helper/dueDate";
 import useContactByEmail from "@/lib/api/hooks/app/contacts/useContactByEmail";
 import useContact from "@/lib/api/hooks/app/contacts/useContact";
 import useContactDeals from "@/lib/api/hooks/app/contacts/useContactDeals";
@@ -486,7 +487,7 @@ function TasksSection({
     const [title, setTitle] = React.useState(defaultTitle);
     const [type, setType] = React.useState("");
     const [priority, setPriority] = React.useState<CRMTask["priority"]>("medium");
-    const [due, setDue] = React.useState("");
+    const [dueDays, setDueDays] = React.useState<number | null>(3);
     const [desc, setDesc] = React.useState("");
 
     React.useEffect(() => setTitle(defaultTitle), [defaultTitle]);
@@ -502,7 +503,7 @@ function TasksSection({
             priority,
         };
         if (type) data.type = type;
-        if (due) data.due_date = new Date(`${due}T09:00:00`).toISOString();
+        if (dueDays !== null) data.due_date = dueInDaysToISO(dueDays);
         if (desc.trim()) data.description = desc.trim();
         if (dealId) data.deal_id = dealId;
         try {
@@ -514,7 +515,7 @@ function TasksSection({
             setOpen(false);
             setType("");
             setPriority("medium");
-            setDue("");
+            setDueDays(3);
             setDesc("");
         } catch {
             /* surfaced */
@@ -532,19 +533,8 @@ function TasksSection({
                         className="w-full"
                         autoFocus
                     />
-                    <div className="flex items-center gap-1.5">
-                        <TaskTypePicker value={type} onChange={setType} className="flex-1" />
-                        <label className="h-7 px-2 rounded-md border border-slate-200 bg-white inline-flex items-center gap-1.5 shrink-0 cursor-pointer focus-within:border-sky-400 focus-within:ring-2 focus-within:ring-sky-100">
-                            <CalendarClockIcon className="w-3 h-3 text-slate-400 shrink-0" />
-                            <input
-                                type="date"
-                                value={due}
-                                onChange={(e) => setDue(e.target.value)}
-                                aria-label="Due date"
-                                className="bg-transparent outline-none text-[12px] text-slate-700 w-[104px]"
-                            />
-                        </label>
-                    </div>
+                    <TaskTypePicker value={type} onChange={setType} className="w-full" />
+                    <DueInDays value={dueDays} onChange={setDueDays} />
                     <div className="flex items-center gap-0.5">
                         {PRIORITY_OPTS.map((p) => (
                             <button

--- a/web/src/components/app/unibox/ContactContextPanel.tsx
+++ b/web/src/components/app/unibox/ContactContextPanel.tsx
@@ -11,7 +11,9 @@ import React from "react";
 import toast from "react-hot-toast";
 import {
     BanIcon,
+    CalendarClockIcon,
     CheckIcon,
+    ChevronDownIcon,
     CircleDollarSignIcon,
     ExternalLinkIcon,
     Loader2Icon,
@@ -26,6 +28,13 @@ import {
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { TextInput } from "@/components/ui/field";
+import {
+    PopoverMenu,
+    PopoverMenuContent,
+    PopoverMenuItem,
+    PopoverMenuTrigger,
+} from "@/components/ui/popover-menu";
+import TaskTypePicker from "@/components/app/crm/TaskTypePicker";
 import useContactByEmail from "@/lib/api/hooks/app/contacts/useContactByEmail";
 import useContact from "@/lib/api/hooks/app/contacts/useContact";
 import useContactDeals from "@/lib/api/hooks/app/contacts/useContactDeals";
@@ -34,7 +43,9 @@ import useCreateContactNote from "@/lib/api/hooks/app/contacts/useCreateContactN
 import useCRMTasks from "@/lib/api/hooks/app/crm/tasks/useCRMTasks";
 import useCreateCRMTask from "@/lib/api/hooks/app/crm/tasks/useCreateCRMTask";
 import useCreateDeal from "@/lib/api/hooks/app/crm/deals/useCreateDeal";
+import useUpdateDeal from "@/lib/api/hooks/app/crm/deals/useUpdateDeal";
 import usePipelines from "@/lib/api/hooks/app/crm/pipelines/usePipelines";
+import type { Stage } from "@/lib/api/models/app/crm/Pipeline";
 import type Deal from "@/lib/api/models/app/crm/Deal";
 import type CRMTask from "@/lib/api/models/app/crm/CRMTask";
 import type { AppError } from "@/lib/api/client/normalizeError";
@@ -52,6 +63,13 @@ const PRIORITY_DOT: Record<CRMTask["priority"], string> = {
     medium: "bg-sky-500",
     low: "bg-slate-400",
 };
+
+const PRIORITY_OPTS: { id: CRMTask["priority"]; label: string }[] = [
+    { id: "low", label: "Low" },
+    { id: "medium", label: "Med" },
+    { id: "high", label: "High" },
+    { id: "urgent", label: "Urgent" },
+];
 
 export default function ContactContextPanel({
     email,
@@ -194,7 +212,7 @@ export default function ContactContextPanel({
                             campaignId={campaigns[0]?.id}
                             mailboxId={mailboxId}
                             pipelineId={dealDefault.pipelineId}
-                            stageId={dealDefault.stageId}
+                            stages={dealDefault.stages}
                         />
 
                         {/* Tasks */}
@@ -203,6 +221,9 @@ export default function ContactContextPanel({
                             tasks={(tasksQ.data?.data ?? []).filter((t) => t.status !== "completed" && t.status !== "cancelled")}
                             loading={tasksQ.isPending}
                             defaultTitle={`Follow up with ${name}`}
+                            contactName={name}
+                            company={contact.company}
+                            dealId={(dealsQ.data ?? []).find((d) => d.status === "open")?.id}
                         />
 
                         {/* Notes */}
@@ -220,8 +241,8 @@ export default function ContactContextPanel({
 function usePipelinesDefault() {
     const pipelines = usePipelines();
     const first = pipelines.data?.[0];
-    const stage = first ? [...(first.stages ?? [])].sort((a, b) => a.position - b.position)[0] : undefined;
-    return { pipelineId: first?.id, stageId: stage?.id };
+    const stages: Stage[] = first ? [...(first.stages ?? [])].sort((a, b) => a.position - b.position) : [];
+    return { pipelineId: first?.id, stageId: stages[0]?.id, stages };
 }
 
 function DealsSection({
@@ -232,7 +253,7 @@ function DealsSection({
     campaignId,
     mailboxId,
     pipelineId,
-    stageId,
+    stages,
 }: {
     contactId: string;
     deals: Deal[];
@@ -241,16 +262,19 @@ function DealsSection({
     campaignId?: string;
     mailboxId?: string;
     pipelineId?: string;
-    stageId?: string;
+    stages: Stage[];
 }) {
     const create = useCreateDeal();
+    const updateDeal = useUpdateDeal();
     const [open, setOpen] = React.useState(false);
     const [name, setName] = React.useState(defaultName);
     const [value, setValue] = React.useState("");
+    const [stageId, setStageId] = React.useState<string | undefined>(stages[0]?.id);
 
     React.useEffect(() => setName(defaultName), [defaultName]);
+    React.useEffect(() => setStageId((s) => s ?? stages[0]?.id), [stages]);
 
-    const canAdd = !!pipelineId && !!stageId;
+    const canAdd = !!pipelineId && stages.length > 0;
 
     async function submit() {
         if (!name.trim()) {
@@ -283,6 +307,17 @@ function DealsSection({
         }
     }
 
+    async function moveDeal(dealId: string, newStageId: string) {
+        try {
+            await toast.promise(
+                updateDeal.mutateAsync({ id: dealId, data: { stage_id: newStageId } as Partial<Deal> }),
+                { loading: "Moving…", success: "Moved", error: (e: AppError) => buildError(e) },
+            );
+        } catch {
+            /* surfaced */
+        }
+    }
+
     return (
         <Section
             label="Deals"
@@ -300,16 +335,8 @@ function DealsSection({
                 <div className="mb-2 rounded-md border border-slate-200 bg-white p-2 space-y-1.5">
                     <TextInput value={name} onChange={setName} placeholder="Deal name" className="w-full" autoFocus />
                     <div className="flex items-center gap-1.5">
-                        <TextInput value={value} onChange={setValue} placeholder="Value (optional)" className="w-full" />
-                        <button
-                            type="button"
-                            onClick={submit}
-                            disabled={create.isPending}
-                            className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-60 shrink-0"
-                        >
-                            {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
-                            Add
-                        </button>
+                        <StagePicker stages={stages} value={stageId} onChange={setStageId} className="flex-1" />
+                        <TextInput value={value} onChange={setValue} placeholder="Value" className="w-[88px]" />
                     </div>
                     {(campaignId || mailboxId) && (
                         <p className="text-[10px] text-slate-400 leading-snug">
@@ -318,6 +345,15 @@ function DealsSection({
                             {mailboxId ? "mailbox" : ""}.
                         </p>
                     )}
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={create.isPending}
+                        className="w-full h-7 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center justify-center gap-1 transition-colors disabled:opacity-60"
+                    >
+                        {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
+                        Create deal
+                    </button>
                 </div>
             )}
             {loading ? (
@@ -328,6 +364,7 @@ function DealsSection({
                 <div className="space-y-1">
                     {deals.map((d) => {
                         const st = DEAL_STATUS[d.status];
+                        const canMove = d.status === "open" && stages.length > 0 && d.pipeline_id === pipelineId;
                         return (
                             <div
                                 key={d.id}
@@ -340,7 +377,16 @@ function DealsSection({
                                             <span className={`size-1.5 rounded-full ${st.dot}`} />
                                             {st.label}
                                         </span>
-                                        {d.stage?.name && <span className="text-[10px] text-slate-400 truncate">· {d.stage.name}</span>}
+                                        {canMove ? (
+                                            <StagePicker
+                                                stages={stages}
+                                                value={d.stage_id}
+                                                onChange={(s) => moveDeal(d.id, s)}
+                                                compact
+                                            />
+                                        ) : d.stage?.name ? (
+                                            <span className="text-[10px] text-slate-400 truncate">· {d.stage.name}</span>
+                                        ) : null}
                                     </div>
                                 </div>
                                 {d.value != null && (
@@ -357,20 +403,91 @@ function DealsSection({
     );
 }
 
+// Compact stage selector used both to place a new deal and to move an existing
+// open deal through the pipeline without leaving the inbox. `compact` renders
+// the inline text trigger used inside a deal row.
+function StagePicker({
+    stages,
+    value,
+    onChange,
+    className,
+    compact,
+}: {
+    stages: Stage[];
+    value?: string;
+    onChange: (stageId: string) => void;
+    className?: string;
+    compact?: boolean;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const cur = stages.find((s) => s.id === value);
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align="start">
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    className={
+                        compact
+                            ? "inline-flex items-center gap-1 text-[10px] text-slate-500 hover:text-slate-900 transition-colors"
+                            : `h-7 px-2 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 inline-flex items-center gap-1.5 transition-colors ${className ?? ""}`
+                    }
+                >
+                    <span
+                        className="size-1.5 rounded-full shrink-0"
+                        style={{ backgroundColor: cur?.color || "#94a3b8" }}
+                    />
+                    <span className={compact ? "truncate" : "truncate flex-1 text-left"}>
+                        {cur?.name ?? "Stage"}
+                    </span>
+                    <ChevronDownIcon className="w-3 h-3 text-slate-400 shrink-0" />
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={170} className="max-h-56 overflow-y-auto">
+                {stages.map((s) => (
+                    <PopoverMenuItem
+                        key={s.id}
+                        onSelect={() => onChange(s.id)}
+                        selected={s.id === value}
+                        icon={
+                            <span
+                                className="size-2 rounded-full block"
+                                style={{ backgroundColor: s.color || "#94a3b8" }}
+                            />
+                        }
+                    >
+                        {s.name}
+                    </PopoverMenuItem>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
 function TasksSection({
     contactId,
     tasks,
     loading,
     defaultTitle,
+    contactName,
+    company,
+    dealId,
 }: {
     contactId: string;
     tasks: CRMTask[];
     loading: boolean;
     defaultTitle: string;
+    contactName: string;
+    company?: string;
+    dealId?: string;
 }) {
     const create = useCreateCRMTask();
     const [open, setOpen] = React.useState(false);
     const [title, setTitle] = React.useState(defaultTitle);
+    const [type, setType] = React.useState("");
+    const [priority, setPriority] = React.useState<CRMTask["priority"]>("medium");
+    const [due, setDue] = React.useState("");
+    const [desc, setDesc] = React.useState("");
 
     React.useEffect(() => setTitle(defaultTitle), [defaultTitle]);
 
@@ -379,12 +496,26 @@ function TasksSection({
             toast.error("Task title required");
             return;
         }
+        const data: Partial<CRMTask> = {
+            title: title.trim(),
+            contact_id: contactId,
+            priority,
+        };
+        if (type) data.type = type;
+        if (due) data.due_date = new Date(`${due}T09:00:00`).toISOString();
+        if (desc.trim()) data.description = desc.trim();
+        if (dealId) data.deal_id = dealId;
         try {
-            await toast.promise(
-                create.mutateAsync({ title: title.trim(), contact_id: contactId, priority: "medium" } as Partial<CRMTask>),
-                { loading: "Adding task…", success: "Task added", error: (e: AppError) => buildError(e) },
-            );
+            await toast.promise(create.mutateAsync(data), {
+                loading: "Adding task…",
+                success: "Task added",
+                error: (e: AppError) => buildError(e),
+            });
             setOpen(false);
+            setType("");
+            setPriority("medium");
+            setDue("");
+            setDesc("");
         } catch {
             /* surfaced */
         }
@@ -393,16 +524,64 @@ function TasksSection({
     return (
         <Section label="Tasks" action={<AddButton open={open} onClick={() => setOpen((o) => !o)} />}>
             {open && (
-                <div className="mb-2 rounded-md border border-slate-200 bg-white p-2 flex items-center gap-1.5">
-                    <TextInput value={title} onChange={setTitle} placeholder="Follow-up…" className="w-full" autoFocus />
+                <div className="mb-2 rounded-md border border-slate-200 bg-white p-2 space-y-1.5">
+                    <TextInput
+                        value={title}
+                        onChange={setTitle}
+                        placeholder={`Follow up with ${contactName}…`}
+                        className="w-full"
+                        autoFocus
+                    />
+                    <div className="flex items-center gap-1.5">
+                        <TaskTypePicker value={type} onChange={setType} className="flex-1" />
+                        <label className="h-7 px-2 rounded-md border border-slate-200 bg-white inline-flex items-center gap-1.5 shrink-0 cursor-pointer focus-within:border-sky-400 focus-within:ring-2 focus-within:ring-sky-100">
+                            <CalendarClockIcon className="w-3 h-3 text-slate-400 shrink-0" />
+                            <input
+                                type="date"
+                                value={due}
+                                onChange={(e) => setDue(e.target.value)}
+                                aria-label="Due date"
+                                className="bg-transparent outline-none text-[12px] text-slate-700 w-[104px]"
+                            />
+                        </label>
+                    </div>
+                    <div className="flex items-center gap-0.5">
+                        {PRIORITY_OPTS.map((p) => (
+                            <button
+                                key={p.id}
+                                type="button"
+                                onClick={() => setPriority(p.id)}
+                                className={`h-6 px-2 rounded text-[10.5px] font-medium inline-flex items-center gap-1 transition-colors ${
+                                    priority === p.id
+                                        ? "bg-slate-100 text-slate-900 ring-1 ring-slate-300"
+                                        : "text-slate-500 hover:text-slate-900"
+                                }`}
+                            >
+                                <span className={`size-1.5 rounded-full ${PRIORITY_DOT[p.id]}`} />
+                                {p.label}
+                            </button>
+                        ))}
+                    </div>
+                    <textarea
+                        value={desc}
+                        onChange={(e) => setDesc(e.target.value)}
+                        placeholder="Details (optional)"
+                        rows={2}
+                        className="w-full rounded-md border border-slate-200 px-2 py-1.5 text-[12px] text-slate-700 placeholder:text-slate-400 outline-none focus:border-sky-400 focus:ring-2 focus:ring-sky-100 resize-none"
+                    />
+                    <p className="text-[10px] text-slate-400 leading-snug">
+                        Linked to {contactName}
+                        {company ? ` · ${company}` : ""}
+                        {dealId ? " · open deal" : ""}.
+                    </p>
                     <button
                         type="button"
                         onClick={submit}
                         disabled={create.isPending}
-                        className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-60 shrink-0"
+                        className="w-full h-7 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center justify-center gap-1 transition-colors disabled:opacity-60"
                     >
                         {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
-                        Add
+                        Create task
                     </button>
                 </div>
             )}

--- a/web/src/components/app/unibox/ContactContextPanel.tsx
+++ b/web/src/components/app/unibox/ContactContextPanel.tsx
@@ -1,0 +1,623 @@
+// ContactContextPanel : the CRM rail of the unibox thread reader.
+//
+// Given the sender address of the open thread, it resolves the contact and
+// surfaces the customer-relationship context inline: who they are, which
+// campaign(s) they came from, their engagement, and their deals / tasks /
+// notes with one-click add. New deals stamp the originating campaign + the
+// mailbox the thread is on, so a reply turns into attributed pipeline without
+// leaving the inbox.
+
+import React from "react";
+import toast from "react-hot-toast";
+import {
+    BanIcon,
+    CheckIcon,
+    CircleDollarSignIcon,
+    ExternalLinkIcon,
+    Loader2Icon,
+    MailWarningIcon,
+    MegaphoneIcon,
+    PlusIcon,
+    StickyNoteIcon,
+    UserIcon,
+    UserXIcon,
+    CheckSquareIcon,
+    XIcon,
+} from "lucide-react";
+import { Link } from "react-router-dom";
+import { TextInput } from "@/components/ui/field";
+import useContactByEmail from "@/lib/api/hooks/app/contacts/useContactByEmail";
+import useContact from "@/lib/api/hooks/app/contacts/useContact";
+import useContactDeals from "@/lib/api/hooks/app/contacts/useContactDeals";
+import useContactNotes from "@/lib/api/hooks/app/contacts/useContactNotes";
+import useCreateContactNote from "@/lib/api/hooks/app/contacts/useCreateContactNote";
+import useCRMTasks from "@/lib/api/hooks/app/crm/tasks/useCRMTasks";
+import useCreateCRMTask from "@/lib/api/hooks/app/crm/tasks/useCreateCRMTask";
+import useCreateDeal from "@/lib/api/hooks/app/crm/deals/useCreateDeal";
+import usePipelines from "@/lib/api/hooks/app/crm/pipelines/usePipelines";
+import type Deal from "@/lib/api/models/app/crm/Deal";
+import type CRMTask from "@/lib/api/models/app/crm/CRMTask";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import buildError from "@/lib/helper/buildError";
+
+const DEAL_STATUS: Record<Deal["status"], { label: string; cls: string; dot: string }> = {
+    open: { label: "Open", cls: "text-slate-600", dot: "bg-slate-400" },
+    won: { label: "Won", cls: "text-emerald-700", dot: "bg-emerald-500" },
+    lost: { label: "Lost", cls: "text-red-700", dot: "bg-red-500" },
+};
+
+const PRIORITY_DOT: Record<CRMTask["priority"], string> = {
+    urgent: "bg-red-500",
+    high: "bg-amber-500",
+    medium: "bg-sky-500",
+    low: "bg-slate-400",
+};
+
+export default function ContactContextPanel({
+    email,
+    mailboxId,
+    onClose,
+}: {
+    email?: string;
+    mailboxId?: string;
+    onClose?: () => void;
+}) {
+    const lookup = useContactByEmail(email);
+    const contact = lookup.data ?? null;
+    const contactId = contact?.id;
+
+    const detailQ = useContact(contactId ?? "", !!contactId);
+    const detail = detailQ.data;
+    const dealsQ = useContactDeals(contactId ?? "");
+    const tasksQ = useCRMTasks({ contact_id: contactId, limit: 50 }, !!contactId);
+    const notesQ = useContactNotes(contactId ?? "");
+    const dealDefault = usePipelinesDefault();
+
+    const campaigns = detail?.campaigns ?? contact?.campaigns ?? [];
+    const eng = detail?.engagement;
+    const supp = detail?.suppression;
+
+    const name =
+        [contact?.first_name, contact?.last_name].filter(Boolean).join(" ").trim() ||
+        contact?.email ||
+        email ||
+        "";
+
+    return (
+        <aside className="hidden lg:flex w-80 shrink-0 flex-col border-l border-slate-200 bg-slate-50/40 min-h-0">
+            <div className="h-12 px-3 border-b border-slate-200 flex items-center gap-2 shrink-0 bg-white">
+                <UserIcon className="w-3.5 h-3.5 text-slate-400" />
+                <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                    Contact
+                </span>
+                {onClose && (
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Hide contact panel"
+                        className="ml-auto size-7 rounded-md text-slate-400 hover:text-slate-900 hover:bg-slate-100 inline-flex items-center justify-center transition-colors"
+                    >
+                        <XIcon className="w-3.5 h-3.5" />
+                    </button>
+                )}
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+                {lookup.isPending ? (
+                    <div className="flex items-center justify-center gap-2 py-10 text-[12px] text-slate-400">
+                        <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
+                        Resolving contact…
+                    </div>
+                ) : !contact ? (
+                    <NotAContact email={email} />
+                ) : (
+                    <div className="divide-y divide-slate-200/70">
+                        {/* Identity */}
+                        <div className="px-3 py-3">
+                            <div className="flex items-start gap-2.5">
+                                <div className="size-8 rounded-full bg-sky-100 text-sky-700 flex items-center justify-center text-[12px] font-semibold shrink-0">
+                                    {initials(name)}
+                                </div>
+                                <div className="min-w-0 flex-1">
+                                    <div className="text-[13px] font-semibold text-slate-900 truncate">{name}</div>
+                                    <div className="text-[11.5px] text-slate-500 truncate">{contact.email}</div>
+                                    {contact.company && (
+                                        <div className="text-[11px] text-slate-400 truncate mt-0.5">{contact.company}</div>
+                                    )}
+                                </div>
+                            </div>
+                            <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+                                {contact.subscribed ? (
+                                    <Badge tone="emerald" icon={<CheckIcon className="w-2.5 h-2.5" />}>Subscribed</Badge>
+                                ) : (
+                                    <Badge tone="slate" icon={<UserXIcon className="w-2.5 h-2.5" />}>Unsubscribed</Badge>
+                                )}
+                                {supp && (
+                                    <Badge tone="red" icon={<BanIcon className="w-2.5 h-2.5" />}>
+                                        Suppressed
+                                    </Badge>
+                                )}
+                                <Link
+                                    to="/app/contacts"
+                                    className="ml-auto inline-flex items-center gap-1 text-[10.5px] text-slate-400 hover:text-sky-700 transition-colors"
+                                >
+                                    Contacts
+                                    <ExternalLinkIcon className="w-2.5 h-2.5" />
+                                </Link>
+                            </div>
+                            {supp && (
+                                <div className="mt-2 rounded-md border border-red-200 bg-red-50/60 px-2 py-1.5 flex items-start gap-1.5">
+                                    <MailWarningIcon className="w-3 h-3 text-red-600 mt-px shrink-0" />
+                                    <span className="text-[10.5px] text-red-700/90 leading-snug">
+                                        {supp.reason || "Suppressed"} ({supp.source})
+                                    </span>
+                                </div>
+                            )}
+                        </div>
+
+                        {/* Lead source : campaigns */}
+                        <Section label="Campaigns" hint={campaigns.length ? undefined : "Not in any campaign"}>
+                            {campaigns.length > 0 && (
+                                <div className="flex flex-wrap gap-1.5">
+                                    {campaigns.map((c) => (
+                                        <Link
+                                            key={c.id}
+                                            to="/app/campaigns"
+                                            className="inline-flex items-center gap-1 h-5 px-1.5 rounded bg-white border border-slate-200 hover:border-sky-300 text-[10.5px] text-slate-600 hover:text-sky-700 transition-colors"
+                                        >
+                                            <MegaphoneIcon className="w-2.5 h-2.5 text-slate-400" />
+                                            <span className="truncate max-w-[140px]">{c.name}</span>
+                                        </Link>
+                                    ))}
+                                </div>
+                            )}
+                        </Section>
+
+                        {/* Engagement */}
+                        {eng && (
+                            <Section label="Engagement">
+                                <div className="grid grid-cols-4 gap-1.5">
+                                    <Metric label="Sent" value={eng.total_sent} />
+                                    <Metric label="Open" value={eng.total_opened} />
+                                    <Metric label="Click" value={eng.total_clicked} />
+                                    <Metric label="Reply" value={eng.total_replied} accent />
+                                </div>
+                            </Section>
+                        )}
+
+                        {/* Deals */}
+                        <DealsSection
+                            contactId={contact.id}
+                            deals={dealsQ.data ?? []}
+                            loading={dealsQ.isPending}
+                            defaultName={contact.company || name}
+                            campaignId={campaigns[0]?.id}
+                            mailboxId={mailboxId}
+                            pipelineId={dealDefault.pipelineId}
+                            stageId={dealDefault.stageId}
+                        />
+
+                        {/* Tasks */}
+                        <TasksSection
+                            contactId={contact.id}
+                            tasks={(tasksQ.data?.data ?? []).filter((t) => t.status !== "completed" && t.status !== "cancelled")}
+                            loading={tasksQ.isPending}
+                            defaultTitle={`Follow up with ${name}`}
+                        />
+
+                        {/* Notes */}
+                        <NotesSection contactId={contact.id} notes={notesQ.data ?? []} loading={notesQ.isPending} />
+                    </div>
+                )}
+            </div>
+        </aside>
+    );
+}
+
+// Resolve the org's first pipeline + its first stage, used as the default
+// target when creating a deal from the panel. Kept as a tiny hook so the deal
+// section stays declarative.
+function usePipelinesDefault() {
+    const pipelines = usePipelines();
+    const first = pipelines.data?.[0];
+    const stage = first ? [...(first.stages ?? [])].sort((a, b) => a.position - b.position)[0] : undefined;
+    return { pipelineId: first?.id, stageId: stage?.id };
+}
+
+function DealsSection({
+    contactId,
+    deals,
+    loading,
+    defaultName,
+    campaignId,
+    mailboxId,
+    pipelineId,
+    stageId,
+}: {
+    contactId: string;
+    deals: Deal[];
+    loading: boolean;
+    defaultName: string;
+    campaignId?: string;
+    mailboxId?: string;
+    pipelineId?: string;
+    stageId?: string;
+}) {
+    const create = useCreateDeal();
+    const [open, setOpen] = React.useState(false);
+    const [name, setName] = React.useState(defaultName);
+    const [value, setValue] = React.useState("");
+
+    React.useEffect(() => setName(defaultName), [defaultName]);
+
+    const canAdd = !!pipelineId && !!stageId;
+
+    async function submit() {
+        if (!name.trim()) {
+            toast.error("Deal name required");
+            return;
+        }
+        const data: Partial<Deal> = {
+            pipeline_id: pipelineId,
+            stage_id: stageId,
+            name: name.trim(),
+            contact_id: contactId,
+            currency: "USD",
+        };
+        if (value.trim()) {
+            const n = Number(value);
+            if (Number.isFinite(n)) data.value = n;
+        }
+        if (campaignId) data.campaign_id = campaignId;
+        if (mailboxId) data.source_mailbox_id = mailboxId;
+        try {
+            await toast.promise(create.mutateAsync(data), {
+                loading: "Creating deal…",
+                success: "Deal created",
+                error: (e: AppError) => buildError(e),
+            });
+            setOpen(false);
+            setValue("");
+        } catch {
+            /* surfaced */
+        }
+    }
+
+    return (
+        <Section
+            label="Deals"
+            action={
+                canAdd ? (
+                    <AddButton open={open} onClick={() => setOpen((o) => !o)} />
+                ) : (
+                    <Link to="/app/crm/pipelines" className="text-[10.5px] text-slate-400 hover:text-sky-700">
+                        Add a pipeline
+                    </Link>
+                )
+            }
+        >
+            {open && canAdd && (
+                <div className="mb-2 rounded-md border border-slate-200 bg-white p-2 space-y-1.5">
+                    <TextInput value={name} onChange={setName} placeholder="Deal name" className="w-full" autoFocus />
+                    <div className="flex items-center gap-1.5">
+                        <TextInput value={value} onChange={setValue} placeholder="Value (optional)" className="w-full" />
+                        <button
+                            type="button"
+                            onClick={submit}
+                            disabled={create.isPending}
+                            className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-60 shrink-0"
+                        >
+                            {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
+                            Add
+                        </button>
+                    </div>
+                    {(campaignId || mailboxId) && (
+                        <p className="text-[10px] text-slate-400 leading-snug">
+                            Attributed to this {campaignId ? "campaign" : ""}
+                            {campaignId && mailboxId ? " + " : ""}
+                            {mailboxId ? "mailbox" : ""}.
+                        </p>
+                    )}
+                </div>
+            )}
+            {loading ? (
+                <RowSkeleton />
+            ) : deals.length === 0 ? (
+                <Empty icon={<CircleDollarSignIcon className="w-3.5 h-3.5" />} text="No deals yet" />
+            ) : (
+                <div className="space-y-1">
+                    {deals.map((d) => {
+                        const st = DEAL_STATUS[d.status];
+                        return (
+                            <div
+                                key={d.id}
+                                className="rounded-md border border-slate-200 bg-white px-2 py-1.5 flex items-center gap-2"
+                            >
+                                <div className="min-w-0 flex-1">
+                                    <div className="text-[11.5px] font-medium text-slate-900 truncate">{d.name}</div>
+                                    <div className="flex items-center gap-1.5 mt-0.5">
+                                        <span className={`inline-flex items-center gap-1 text-[10px] ${st.cls}`}>
+                                            <span className={`size-1.5 rounded-full ${st.dot}`} />
+                                            {st.label}
+                                        </span>
+                                        {d.stage?.name && <span className="text-[10px] text-slate-400 truncate">· {d.stage.name}</span>}
+                                    </div>
+                                </div>
+                                {d.value != null && (
+                                    <span className="font-mono text-[10.5px] text-emerald-700 tabular-nums shrink-0">
+                                        {money(d.value, d.currency)}
+                                    </span>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </Section>
+    );
+}
+
+function TasksSection({
+    contactId,
+    tasks,
+    loading,
+    defaultTitle,
+}: {
+    contactId: string;
+    tasks: CRMTask[];
+    loading: boolean;
+    defaultTitle: string;
+}) {
+    const create = useCreateCRMTask();
+    const [open, setOpen] = React.useState(false);
+    const [title, setTitle] = React.useState(defaultTitle);
+
+    React.useEffect(() => setTitle(defaultTitle), [defaultTitle]);
+
+    async function submit() {
+        if (!title.trim()) {
+            toast.error("Task title required");
+            return;
+        }
+        try {
+            await toast.promise(
+                create.mutateAsync({ title: title.trim(), contact_id: contactId, priority: "medium" } as Partial<CRMTask>),
+                { loading: "Adding task…", success: "Task added", error: (e: AppError) => buildError(e) },
+            );
+            setOpen(false);
+        } catch {
+            /* surfaced */
+        }
+    }
+
+    return (
+        <Section label="Tasks" action={<AddButton open={open} onClick={() => setOpen((o) => !o)} />}>
+            {open && (
+                <div className="mb-2 rounded-md border border-slate-200 bg-white p-2 flex items-center gap-1.5">
+                    <TextInput value={title} onChange={setTitle} placeholder="Follow-up…" className="w-full" autoFocus />
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={create.isPending}
+                        className="h-7 px-2.5 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11.5px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-60 shrink-0"
+                    >
+                        {create.isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <CheckIcon className="w-3 h-3" />}
+                        Add
+                    </button>
+                </div>
+            )}
+            {loading ? (
+                <RowSkeleton />
+            ) : tasks.length === 0 ? (
+                <Empty icon={<CheckSquareIcon className="w-3.5 h-3.5" />} text="No open tasks" />
+            ) : (
+                <div className="space-y-1">
+                    {tasks.map((t) => (
+                        <div key={t.id} className="rounded-md border border-slate-200 bg-white px-2 py-1.5 flex items-center gap-2">
+                            <span className={`size-1.5 rounded-full shrink-0 ${PRIORITY_DOT[t.priority]}`} />
+                            <span className="text-[11.5px] text-slate-800 truncate flex-1">{t.title}</span>
+                            {t.due_date && (
+                                <span className="font-mono text-[10px] text-slate-400 tabular-nums shrink-0">
+                                    {fmtDate(t.due_date)}
+                                </span>
+                            )}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </Section>
+    );
+}
+
+function NotesSection({
+    contactId,
+    notes,
+    loading,
+}: {
+    contactId: string;
+    notes: { id: string; content: string; created_at: Date | string }[];
+    loading: boolean;
+}) {
+    const create = useCreateContactNote();
+    const [draft, setDraft] = React.useState("");
+
+    async function submit() {
+        if (!draft.trim()) return;
+        try {
+            await create.mutateAsync({ contactId, data: { content: draft.trim() } });
+            setDraft("");
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }
+
+    return (
+        <Section label="Notes">
+            <div className="mb-2 rounded-md border border-slate-200 bg-white p-2">
+                <textarea
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    placeholder="Add a note…"
+                    rows={2}
+                    className="w-full bg-transparent text-[11.5px] text-slate-900 placeholder:text-slate-400 outline-none resize-none"
+                />
+                <div className="flex justify-end">
+                    <button
+                        type="button"
+                        onClick={submit}
+                        disabled={create.isPending || !draft.trim()}
+                        className="h-6 px-2 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[11px] font-medium inline-flex items-center gap-1 transition-colors disabled:opacity-50"
+                    >
+                        {create.isPending ? <Loader2Icon className="w-2.5 h-2.5 animate-spin" /> : <PlusIcon className="w-2.5 h-2.5" />}
+                        Note
+                    </button>
+                </div>
+            </div>
+            {loading ? (
+                <RowSkeleton />
+            ) : notes.length === 0 ? (
+                <Empty icon={<StickyNoteIcon className="w-3.5 h-3.5" />} text="No notes yet" />
+            ) : (
+                <div className="space-y-1.5">
+                    {notes.slice(0, 5).map((n) => (
+                        <div key={n.id} className="rounded-md border border-slate-200 bg-white px-2 py-1.5">
+                            <p className="text-[11.5px] text-slate-700 leading-snug whitespace-pre-wrap break-words">{n.content}</p>
+                            <p className="text-[10px] text-slate-400 mt-1 font-mono">{fmtDate(n.created_at)}</p>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </Section>
+    );
+}
+
+// ── small presentational helpers ───────────────────────────────────
+
+function Section({
+    label,
+    hint,
+    action,
+    children,
+}: {
+    label: string;
+    hint?: string;
+    action?: React.ReactNode;
+    children?: React.ReactNode;
+}) {
+    return (
+        <div className="px-3 py-3">
+            <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{label}</span>
+                {action && <span className="ml-auto">{action}</span>}
+            </div>
+            {hint ? <p className="text-[11px] text-slate-400">{hint}</p> : children}
+        </div>
+    );
+}
+
+function AddButton({ open, onClick }: { open: boolean; onClick: () => void }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="h-6 px-1.5 rounded-md border border-slate-200 hover:border-slate-300 text-[10.5px] text-slate-600 hover:text-slate-900 inline-flex items-center gap-1 transition-colors"
+        >
+            {open ? <XIcon className="w-2.5 h-2.5" /> : <PlusIcon className="w-2.5 h-2.5" />}
+            {open ? "Cancel" : "Add"}
+        </button>
+    );
+}
+
+function Badge({
+    tone,
+    icon,
+    children,
+}: {
+    tone: "emerald" | "slate" | "red";
+    icon?: React.ReactNode;
+    children: React.ReactNode;
+}) {
+    const cls = {
+        emerald: "bg-emerald-50 text-emerald-700 border-emerald-100",
+        slate: "bg-slate-100 text-slate-600 border-slate-200",
+        red: "bg-red-50 text-red-700 border-red-100",
+    }[tone];
+    return (
+        <span className={`inline-flex items-center gap-1 h-5 px-1.5 rounded border text-[10px] font-medium ${cls}`}>
+            {icon}
+            {children}
+        </span>
+    );
+}
+
+function Metric({ label, value, accent }: { label: string; value: number; accent?: boolean }) {
+    return (
+        <div className="rounded-md border border-slate-200 bg-white px-1.5 py-1.5 text-center">
+            <div className={`text-[14px] font-light tabular-nums leading-none ${accent ? "text-sky-700" : "text-slate-900"}`}>
+                {value}
+            </div>
+            <div className="text-[9px] uppercase tracking-[0.08em] text-slate-400 mt-1">{label}</div>
+        </div>
+    );
+}
+
+function Empty({ icon, text }: { icon: React.ReactNode; text: string }) {
+    return (
+        <div className="flex items-center gap-1.5 text-[11px] text-slate-400 py-1">
+            <span className="text-slate-300">{icon}</span>
+            {text}
+        </div>
+    );
+}
+
+function RowSkeleton() {
+    return (
+        <div className="space-y-1">
+            {[0, 1].map((i) => (
+                <div key={i} className="h-8 rounded-md bg-slate-100 animate-pulse" />
+            ))}
+        </div>
+    );
+}
+
+function NotAContact({ email }: { email?: string }) {
+    return (
+        <div className="px-3 py-8 text-center">
+            <div className="mx-auto size-9 rounded-md bg-white border border-slate-200 flex items-center justify-center mb-2.5">
+                <UserIcon className="w-4 h-4 text-slate-400" />
+            </div>
+            <p className="text-[12px] font-medium text-slate-700 mb-0.5">Not a known contact</p>
+            {email && <p className="text-[11px] text-slate-400 break-all mb-3">{email}</p>}
+            <Link
+                to="/app/contacts"
+                className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-[11.5px] text-slate-700 hover:text-slate-900 transition-colors"
+            >
+                <PlusIcon className="w-3 h-3" />
+                Manage contacts
+            </Link>
+        </div>
+    );
+}
+
+function initials(name: string): string {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) return "?";
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}
+
+function money(n: number, currency = "USD") {
+    try {
+        return new Intl.NumberFormat("en-US", { style: "currency", currency: currency || "USD", maximumFractionDigits: 0 }).format(n);
+    } catch {
+        return `$${Math.round(n).toLocaleString()}`;
+    }
+}
+
+function fmtDate(d: string | Date) {
+    try {
+        return new Date(d).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+    } catch {
+        return "";
+    }
+}

--- a/web/src/components/app/unibox/ThreadView.tsx
+++ b/web/src/components/app/unibox/ThreadView.tsx
@@ -271,10 +271,19 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
   );
   const mailbox = accounts.find((a) => a.id === messages[0]?.account_id);
 
-  // The external party of the thread = the first participant address that
-  // isn't our own mailbox. Feeds the CRM panel's contact lookup.
+  // The external party of the thread = the first message address that isn't
+  // our own mailbox. Addresses arrive as "Name <addr>" or bare "addr"; reduce
+  // to the bare address so the comparison + the CRM panel lookup both work.
+  const mailboxEmail = mailbox?.email?.toLowerCase();
+  const bareAddr = (s: string) => {
+    const m = s.match(/<([^>]+)>/);
+    return (m ? m[1] : s).trim();
+  };
   const contactEmail =
-    [...participants].find((p) => p && p !== mailbox?.email) ?? messages[0]?.from;
+    messages
+      .map((m) => bareAddr(m.from))
+      .find((e) => e && e.toLowerCase() !== mailboxEmail) ??
+    bareAddr(messages[0]?.from ?? "");
 
   const submitCustomSnooze = () => {
     if (!customValue) return;

--- a/web/src/components/app/unibox/ThreadView.tsx
+++ b/web/src/components/app/unibox/ThreadView.tsx
@@ -33,6 +33,7 @@ import ContactContextPanel from "./ContactContextPanel";
 import { CategoryChip } from "@/components/app/contacts/CategoryPicker";
 import { SectionBar } from "@/components/layout/Page";
 import useThread from "@/lib/api/hooks/app/unibox/useThread";
+import useMarkSeen from "@/lib/api/hooks/app/unibox/useMarkSeen";
 import useThreadLabels from "@/lib/api/hooks/app/unibox/useThreadLabels";
 import useThreadScheduled from "@/lib/api/hooks/app/unibox/useThreadScheduled";
 import cancelScheduled from "@/lib/api/client/app/unibox/cancelScheduled";
@@ -197,6 +198,20 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
   React.useEffect(() => {
     setReplyState(null);
   }, [threadId]);
+
+  // Opening a thread marks its unseen messages as read. The hook invalidates
+  // ["unibox"], so the unread badge, the collapsed list, and the overview all
+  // refresh. Once everything is seen the id list is empty and this no-ops, so
+  // it self-terminates after the post-mark refetch (no loop).
+  const markSeen = useMarkSeen();
+  const markSeenMutate = markSeen.mutate;
+  React.useEffect(() => {
+    const unseenIds = (q.data?.data ?? [])
+      .filter((m) => !m.seen)
+      .map((m) => m.id);
+    if (unseenIds.length === 0) return;
+    markSeenMutate({ ids: unseenIds });
+  }, [threadId, q.data, markSeenMutate]);
 
   const snooze = useMutation({
     mutationFn: (until: Date) =>

--- a/web/src/components/app/unibox/ThreadView.tsx
+++ b/web/src/components/app/unibox/ThreadView.tsx
@@ -22,12 +22,14 @@ import {
   MoonIcon,
   SendIcon,
   TrashIcon,
+  UserIcon,
   XIcon,
 } from "lucide-react";
 
 import { MessageBubble } from "./MessageBubble";
 import { ReplyComposer, type ReplyMode } from "./ReplyComposer";
 import { ThreadLabelMenu } from "./ThreadLabelMenu";
+import ContactContextPanel from "./ContactContextPanel";
 import { CategoryChip } from "@/components/app/contacts/CategoryPicker";
 import { SectionBar } from "@/components/layout/Page";
 import useThread from "@/lib/api/hooks/app/unibox/useThread";
@@ -159,6 +161,10 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
   const threadLabels = useThreadLabels(threadId);
   const [labelMenuOpen, setLabelMenuOpen] = React.useState(false);
 
+  // CRM context rail (right side). Open by default on wide screens; the panel
+  // itself is hidden below `lg`, so the toggle only matters there.
+  const [crmOpen, setCrmOpen] = React.useState(true);
+
   // `c` opens the label menu while a thread is open — ignored while
   // typing into the composer / any input so it never eats keystrokes.
   React.useEffect(() => {
@@ -265,6 +271,11 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
   );
   const mailbox = accounts.find((a) => a.id === messages[0]?.account_id);
 
+  // The external party of the thread = the first participant address that
+  // isn't our own mailbox. Feeds the CRM panel's contact lookup.
+  const contactEmail =
+    [...participants].find((p) => p && p !== mailbox?.email) ?? messages[0]?.from;
+
   const submitCustomSnooze = () => {
     if (!customValue) return;
     const d = new Date(customValue);
@@ -284,7 +295,8 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
   };
 
   return (
-    <div className="flex flex-col h-full bg-white">
+    <div className="flex h-full min-h-0">
+      <div className="flex-1 flex flex-col min-w-0 bg-white">
       <div className="h-12 px-3 sm:px-5 border-b border-slate-200 flex items-center gap-2 sm:gap-3 shrink-0 bg-white">
         <span className="hidden sm:inline text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
           Thread
@@ -306,6 +318,19 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
           </span>
         )}
         <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setCrmOpen((o) => !o)}
+            aria-label={crmOpen ? "Hide contact panel" : "Show contact panel"}
+            className={
+              "hidden lg:inline-flex size-7 rounded-md items-center justify-center transition-colors " +
+              (crmOpen
+                ? "text-sky-700 bg-sky-50"
+                : "text-slate-500 hover:text-slate-900 hover:bg-slate-100")
+            }
+          >
+            <UserIcon className="w-3.5 h-3.5" />
+          </button>
           <ThreadLabelMenu
             threadId={threadId}
             open={labelMenuOpen}
@@ -507,6 +532,15 @@ export function ThreadView({ threadId, emailId }: ThreadViewProps) {
           </motion.div>
         )}
       </AnimatePresence>
+      </div>
+
+      {crmOpen && (
+        <ContactContextPanel
+          email={contactEmail}
+          mailboxId={mailbox?.id}
+          onClose={() => setCrmOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/layout/AppNav.tsx
+++ b/web/src/components/layout/AppNav.tsx
@@ -30,6 +30,7 @@ import { useAppStore } from "@/stores";
 import useFeatureAccess from "@/hooks/useFeatureAccess";
 import useCampaigns from "@/lib/api/hooks/app/campaigns/useCampaigns";
 import useEmails from "@/lib/api/hooks/app/emails/useEmails";
+import useCRMTasks from "@/lib/api/hooks/app/crm/tasks/useCRMTasks";
 import { UserNav } from "./UserNav";
 import { Logo } from "@/components/svg";
 import { cn } from "@/lib/utils";
@@ -44,9 +45,10 @@ interface NavItem {
     /** Role gate — when set, sidebar hides the row entirely for non-matching roles. */
     rolesAllowed?: "manage";
     /** Live indicator key — renders an ambient, realtime activity cluster.
-     *  Each key has its OWN motif (campaigns = dot-grid, accounts = flame) so
-     *  the rows stay visually distinct rather than a column of identical loaders. */
-    indicator?: "campaigns" | "accounts";
+     *  Each key has its OWN motif (campaigns = dot-grid, accounts = flame,
+     *  tasks = red attention dot) so the rows stay visually distinct rather
+     *  than a column of identical loaders. */
+    indicator?: "campaigns" | "accounts" | "tasks";
 }
 
 // Plan badge shown on locked sidebar rows. Plan names + colors come
@@ -90,7 +92,7 @@ const sections: NavSection[] = [
         items: [
             { title: "Pipelines", url: "/app/crm/pipelines", icon: GitBranchIcon },
             { title: "Deals", url: "/app/crm/deals", icon: CircleDollarSignIcon },
-            { title: "Tasks", url: "/app/crm/tasks", icon: CheckSquareIcon },
+            { title: "Tasks", url: "/app/crm/tasks", icon: CheckSquareIcon, indicator: "tasks" },
         ],
     },
     {
@@ -152,6 +154,7 @@ function NavRow({ item }: { item: NavItem }) {
             <span className="truncate flex-1">{item.title}</span>
             {item.indicator === "campaigns" && !locked && <CampaignActivity />}
             {item.indicator === "accounts" && !locked && <MailboxActivity />}
+            {item.indicator === "tasks" && !locked && <TasksOverdueActivity />}
             {planBadge ? (
                 <span
                     className={cn(
@@ -222,6 +225,45 @@ function MailboxActivity() {
             <FlameIcon className="w-3.5 h-3.5 flame-flicker" strokeWidth={2.2} />
             <span className="text-[10.5px] font-semibold tabular-nums leading-none text-orange-600">
                 {warming}
+            </span>
+        </span>
+    );
+}
+
+// TasksOverdueActivity is the Tasks-row indicator — its own motif again: a
+// subtle red attention dot (with a soft ping pulse) + a count of CRM tasks
+// that are past due and still open. "Overdue" = due_date in the past AND the
+// task is not completed or cancelled. Hidden when nothing is overdue, so the
+// row stays quiet until it actually needs attention. The count comes from the
+// shared, cached CRM tasks list, which the realtime layer invalidates on task
+// events, so it stays live without a manual refresh.
+function TasksOverdueActivity() {
+    const { data } = useCRMTasks();
+    const overdue = useMemo(() => {
+        const tasks = data?.data ?? [];
+        const now = Date.now();
+        return tasks.filter(
+            (t) =>
+                !!t.due_date &&
+                new Date(t.due_date).getTime() < now &&
+                t.status !== "completed" &&
+                t.status !== "cancelled",
+        ).length;
+    }, [data]);
+
+    if (overdue === 0) return null;
+
+    return (
+        <span
+            className="ml-auto inline-flex items-center gap-1.5 shrink-0 text-red-600"
+            title={`${overdue} overdue task${overdue === 1 ? "" : "s"}`}
+        >
+            <span className="relative inline-flex shrink-0">
+                <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                <span className="absolute inset-0 rounded-full bg-red-500/40 animate-ping" />
+            </span>
+            <span className="text-[10.5px] font-semibold tabular-nums leading-none">
+                {overdue > 99 ? "99+" : overdue}
             </span>
         </span>
     );

--- a/web/src/components/layout/AppNav.tsx
+++ b/web/src/components/layout/AppNav.tsx
@@ -25,15 +25,36 @@ import {
     UsersIcon,
     XIcon,
 } from "lucide-react";
-import { useMemo } from "react";
+import { type ReactNode, useMemo } from "react";
 import { useAppStore } from "@/stores";
 import useFeatureAccess from "@/hooks/useFeatureAccess";
 import useCampaigns from "@/lib/api/hooks/app/campaigns/useCampaigns";
 import useEmails from "@/lib/api/hooks/app/emails/useEmails";
-import useCRMTasks from "@/lib/api/hooks/app/crm/tasks/useCRMTasks";
+import useTasksSummary from "@/lib/api/hooks/app/crm/tasks/useTasksSummary";
+import useDealsSummary from "@/lib/api/hooks/app/crm/deals/useDealsSummary";
+import { EMPTY_TASK_SEARCH } from "@/lib/api/models/app/crm/SearchTasks";
+import { EMPTY_DEAL_SEARCH } from "@/lib/api/models/app/crm/SearchDeals";
+import useSearchContacts from "@/lib/api/hooks/app/contacts/useSearchContacts";
+import type SearchContacts from "@/lib/api/models/app/contacts/SearchContacts";
+import usePipelines from "@/lib/api/hooks/app/crm/pipelines/usePipelines";
+import useTemplates from "@/lib/api/hooks/app/templates/useTemplates";
+import useUsageOverview from "@/lib/api/hooks/app/analytics/useUsageOverview";
+import useAPIKeys from "@/lib/api/hooks/app/api-keys/useAPIKeys";
+import AnimatedNumber from "@/components/ui/AnimatedNumber";
 import { UserNav } from "./UserNav";
 import { Logo } from "@/components/svg";
 import { cn } from "@/lib/utils";
+
+// Stable (module-level) empty contacts search so the sidebar's contact-count
+// query key never changes identity between renders (which would refetch-loop).
+// limit 1 keeps the payload tiny — we only read pagination.total.
+const CONTACTS_COUNT_SEARCH: SearchContacts = {
+    query: "",
+    filters: [],
+    campaign_ids: [],
+    sort_by: "created_at",
+    reverse: false,
+};
 
 interface NavItem {
     title: string;
@@ -48,7 +69,16 @@ interface NavItem {
      *  Each key has its OWN motif (campaigns = dot-grid, accounts = flame,
      *  tasks = red attention dot) so the rows stay visually distinct rather
      *  than a column of identical loaders. */
-    indicator?: "campaigns" | "accounts" | "tasks";
+    indicator?:
+        | "campaigns"
+        | "accounts"
+        | "tasks"
+        | "contacts"
+        | "deals"
+        | "pipelines"
+        | "templates"
+        | "analytics"
+        | "apikeys";
 }
 
 // Plan badge shown on locked sidebar rows. Plan names + colors come
@@ -83,24 +113,24 @@ const sections: NavSection[] = [
         items: [
             { title: "Accounts", url: "/app/emails", icon: MailIcon, indicator: "accounts" },
             { title: "Campaigns", url: "/app/campaigns", icon: MegaphoneIcon, indicator: "campaigns" },
-            { title: "Contacts", url: "/app/contacts", icon: UsersIcon },
-            { title: "Analytics", url: "/app/analytics", icon: BarChart3Icon },
+            { title: "Contacts", url: "/app/contacts", icon: UsersIcon, indicator: "contacts" },
+            { title: "Analytics", url: "/app/analytics", icon: BarChart3Icon, indicator: "analytics" },
         ],
     },
     {
         label: "CRM",
         items: [
-            { title: "Pipelines", url: "/app/crm/pipelines", icon: GitBranchIcon },
-            { title: "Deals", url: "/app/crm/deals", icon: CircleDollarSignIcon },
+            { title: "Pipelines", url: "/app/crm/pipelines", icon: GitBranchIcon, indicator: "pipelines" },
+            { title: "Deals", url: "/app/crm/deals", icon: CircleDollarSignIcon, indicator: "deals" },
             { title: "Tasks", url: "/app/crm/tasks", icon: CheckSquareIcon, indicator: "tasks" },
         ],
     },
     {
         label: "Resources",
         items: [
-            { title: "Templates", url: "/app/templates", icon: FileTextIcon },
+            { title: "Templates", url: "/app/templates", icon: FileTextIcon, indicator: "templates" },
             { title: "Integrations", url: "/app/integrations", icon: CableIcon },
-            { title: "API Keys", url: "/app/api-keys", icon: KeyIcon },
+            { title: "API Keys", url: "/app/api-keys", icon: KeyIcon, indicator: "apikeys" },
             { title: "Audit log", url: "/app/audit", icon: ListChecksIcon, rolesAllowed: "manage" },
         ],
     },
@@ -151,10 +181,19 @@ function NavRow({ item }: { item: NavItem }) {
                 )}
                 strokeWidth={active ? 2 : 1.6}
             />
-            <span className="truncate flex-1">{item.title}</span>
+            {/* min-w-0 lets the label shrink/truncate so the count cluster (and its
+                separator) is never pushed off the row — longer labels like
+                "Campaigns"/"Accounts" used to clip it at narrower widths. */}
+            <span className="truncate flex-1 min-w-0">{item.title}</span>
             {item.indicator === "campaigns" && !locked && <CampaignActivity />}
             {item.indicator === "accounts" && !locked && <MailboxActivity />}
-            {item.indicator === "tasks" && !locked && <TasksOverdueActivity />}
+            {item.indicator === "tasks" && !locked && <TasksActivity />}
+            {item.indicator === "contacts" && !locked && <ContactsActivity />}
+            {item.indicator === "deals" && !locked && <DealsActivity />}
+            {item.indicator === "pipelines" && !locked && <PipelinesActivity />}
+            {item.indicator === "templates" && !locked && <TemplatesActivity />}
+            {item.indicator === "analytics" && !locked && <AnalyticsActivity />}
+            {item.indicator === "apikeys" && !locked && <ApiKeysActivity />}
             {planBadge ? (
                 <span
                     className={cn(
@@ -175,31 +214,113 @@ function NavRow({ item }: { item: NavItem }) {
     );
 }
 
-// CampaignActivity is the ambient, realtime indicator on the Campaigns nav
-// row: a small 3x3 dot-grid loader + a count of campaigns sending right now,
-// and nothing when none are sending. The count comes from the shared
-// campaigns-list cache, which the realtime layer invalidates on campaign
-// events, so it stays live without a refresh. Draft / paused / completed are
-// review states surfaced inside the Campaigns page, not here.
+// compactN renders large counts tersely (12.3k, 1.2M) so a headline number like
+// total emails sent fits a nav row.
+function compactN(n: number): string {
+    const v = Math.round(n);
+    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+    if (v >= 10_000) return `${Math.round(v / 1000)}k`;
+    if (v >= 1_000) return `${(v / 1000).toFixed(1)}k`;
+    return String(v);
+}
+
+// The "how many" total at the end of a nav row. Light slate so it reads as
+// ambient metadata (lifting a touch on row hover), but visible, and it tweens
+// (AnimatedNumber) on change. An optional `glyph` — a small coloured activity
+// motif (sending dot-grid, warming flame, overdue ping) — sits in front to flag
+// a live state without stealing the number, which stays the plain total. Hidden
+// only when there's truly nothing to show.
+const COUNT_LIGHT =
+    "text-[10.5px] font-medium tabular-nums leading-none text-slate-300 transition-colors group-hover:text-slate-500";
+
+function TabStat({
+    total,
+    glyph,
+    format = compactN,
+    title,
+}: {
+    total: number;
+    glyph?: ReactNode;
+    format?: (n: number) => string;
+    title?: string;
+}) {
+    // Always render the number (including 0) so every data tab visibly carries a
+    // count instead of going blank — it just tweens up as the query resolves.
+    return (
+        <span
+            className="ml-auto inline-flex items-center gap-1.5 shrink-0"
+            title={title}
+        >
+            {glyph}
+            <AnimatedNumber value={total} format={format} className={COUNT_LIGHT} />
+        </span>
+    );
+}
+
+// TabDualStat shows TWO numbers on a row: the light "how many in total" (the calm
+// baseline, e.g. all campaigns / all mailboxes) plus, when there's a live subset,
+// a coloured sub-count with its motif (e.g. how many are sending / warming). Both
+// tween. The total stays the faint baseline; the active subset is the coloured
+// attention.
+function TabDualStat({
+    total,
+    active,
+    activeGlyph,
+    activeClass,
+    title,
+}: {
+    total: number;
+    active: number;
+    activeGlyph: ReactNode;
+    activeClass: string;
+    title?: string;
+}) {
+    return (
+        <span
+            className="ml-auto inline-flex items-center gap-2.5 shrink-0"
+            title={title}
+        >
+            <AnimatedNumber value={total} format={compactN} className={COUNT_LIGHT} />
+            {/* Hairline divider so the light total and the active count read as two
+                separate values. Always present on a dual row so every one of them
+                (campaigns, accounts, tasks) shows both numbers consistently. */}
+            <span className="h-3 w-px shrink-0 bg-slate-200" aria-hidden />
+            <span
+                className={`inline-flex items-center gap-1 ${active > 0 ? activeClass : "text-slate-300"}`}
+            >
+                {/* The motif (sending dot-grid / warming flame / overdue ping) only
+                    appears when there's actually a live subset; at 0 it's a calm
+                    muted number. */}
+                {active > 0 && activeGlyph}
+                <AnimatedNumber
+                    value={active}
+                    format={compactN}
+                    className="text-[10.5px] font-semibold tabular-nums leading-none"
+                />
+            </span>
+        </span>
+    );
+}
+
+// CampaignActivity is the ambient, realtime indicator on the Campaigns nav row.
+// While campaigns are sending it escalates to a sky 3x3 dot-grid + a live count;
+// otherwise it shows a faint total of all campaigns. The counts come from the
+// shared campaigns-list cache, which the realtime layer invalidates on campaign
+// events, so it stays live without a refresh.
 function CampaignActivity() {
     const { campaigns } = useCampaigns({ query: "", folder: "" });
     const active = useMemo(
         () => campaigns.filter((c) => c.status === "active").length,
         [campaigns],
     );
-
-    if (active === 0) return null;
-
     return (
-        <span
-            className="ml-auto inline-flex items-center gap-1.5 shrink-0 text-sky-600"
-            title={`${active} campaign${active === 1 ? "" : "s"} sending now`}
-        >
-            <span className="campaign-grid" aria-hidden />
-            <span className="text-[10.5px] font-semibold tabular-nums leading-none">
-                {active}
-            </span>
-        </span>
+        <TabDualStat
+            total={campaigns.length}
+            active={active}
+            activeClass="text-sky-600"
+            activeGlyph={<span className="campaign-grid" aria-hidden />}
+            title={`${campaigns.length} campaign${campaigns.length === 1 ? "" : "s"}${active > 0 ? `, ${active} sending now` : ""}`}
+        />
     );
 }
 
@@ -214,58 +335,106 @@ function MailboxActivity() {
         () => emails.filter((e) => !!e.warmup && !e.warmup_paused_at).length,
         [emails],
     );
-
-    if (warming === 0) return null;
-
     return (
-        <span
-            className="ml-auto inline-flex items-center gap-1.5 shrink-0 text-orange-500"
-            title={`${warming} mailbox${warming === 1 ? "" : "es"} warming up`}
-        >
-            <FlameIcon className="w-3.5 h-3.5 flame-flicker" strokeWidth={2.2} />
-            <span className="text-[10.5px] font-semibold tabular-nums leading-none text-orange-600">
-                {warming}
-            </span>
-        </span>
+        <TabDualStat
+            total={emails.length}
+            active={warming}
+            activeClass="text-orange-500"
+            activeGlyph={
+                <FlameIcon className="w-3.5 h-3.5 flame-flicker" strokeWidth={2.2} />
+            }
+            title={`${emails.length} mailbox${emails.length === 1 ? "" : "es"}${warming > 0 ? `, ${warming} warming up` : ""}`}
+        />
     );
 }
 
-// TasksOverdueActivity is the Tasks-row indicator — its own motif again: a
-// subtle red attention dot (with a soft ping pulse) + a count of CRM tasks
-// that are past due and still open. "Overdue" = due_date in the past AND the
-// task is not completed or cancelled. Hidden when nothing is overdue, so the
-// row stays quiet until it actually needs attention. The count comes from the
-// shared, cached CRM tasks list, which the realtime layer invalidates on task
-// events, so it stays live without a manual refresh.
-function TasksOverdueActivity() {
-    const { data } = useCRMTasks();
-    const overdue = useMemo(() => {
-        const tasks = data?.data ?? [];
-        const now = Date.now();
-        return tasks.filter(
-            (t) =>
-                !!t.due_date &&
-                new Date(t.due_date).getTime() < now &&
-                t.status !== "completed" &&
-                t.status !== "cancelled",
-        ).length;
-    }, [data]);
-
-    if (overdue === 0) return null;
-
+// TasksActivity is the Tasks-row indicator — its own motif again. Overdue is the
+// urgent state (a soft red ping + count); when nothing is overdue it falls back
+// to a quiet count of open tasks (todo) so the row still tells you how much work
+// is waiting instead of going blank. Counts are SERVER aggregates (useTasksSummary)
+// so "how many" is correct over the whole set, not a truncated page, and the
+// realtime layer invalidates ["crm","tasks"] so they stay live. The number tweens
+// (AnimatedNumber) when it changes.
+function TasksActivity() {
+    const { data } = useTasksSummary(EMPTY_TASK_SEARCH);
+    const overdue = data?.overdue_count ?? 0;
+    const todo = (data?.pending_count ?? 0) + (data?.in_progress_count ?? 0);
     return (
-        <span
-            className="ml-auto inline-flex items-center gap-1.5 shrink-0 text-red-600"
-            title={`${overdue} overdue task${overdue === 1 ? "" : "s"}`}
-        >
-            <span className="relative inline-flex shrink-0">
-                <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
-                <span className="absolute inset-0 rounded-full bg-red-500/40 animate-ping" />
-            </span>
-            <span className="text-[10.5px] font-semibold tabular-nums leading-none">
-                {overdue > 99 ? "99+" : overdue}
-            </span>
-        </span>
+        <TabDualStat
+            total={todo}
+            active={overdue}
+            activeClass="text-red-600"
+            activeGlyph={
+                <span className="relative inline-flex shrink-0">
+                    <span className="w-1.5 h-1.5 rounded-full bg-red-500" />
+                    <span className="absolute inset-0 rounded-full bg-red-500/40 animate-ping" />
+                </span>
+            }
+            title={`${todo} open task${todo === 1 ? "" : "s"}${overdue > 0 ? `, ${overdue} overdue` : ""}`}
+        />
+    );
+}
+
+// Contacts row: total contacts. Reads pagination.total from a small search — the
+// limit MUST be >= the backend LimitMin (10) or validate.Limit rejects it (400)
+// and the whole count comes back as 0.
+function ContactsActivity() {
+    const { data } = useSearchContacts({ options: CONTACTS_COUNT_SEARCH, limit: 10 });
+    const total = data?.pages?.[0]?.pagination?.total ?? 0;
+    return <TabStat total={total} title={`${total.toLocaleString()} contacts`} />;
+}
+
+// Deals row: open (not won/lost) deals.
+function DealsActivity() {
+    const { data } = useDealsSummary(EMPTY_DEAL_SEARCH);
+    const open = data?.open_count ?? 0;
+    return (
+        <TabStat total={open} title={`${open} open deal${open === 1 ? "" : "s"}`} />
+    );
+}
+
+// Pipelines row: how many pipelines exist.
+function PipelinesActivity() {
+    const { data } = usePipelines();
+    const n = data?.length ?? 0;
+    return (
+        <TabStat total={n} title={`${n} pipeline${n === 1 ? "" : "s"}`} />
+    );
+}
+
+// Templates row: how many saved templates.
+function TemplatesActivity() {
+    const { data } = useTemplates();
+    const n = data?.length ?? 0;
+    return (
+        <TabStat total={n} title={`${n} template${n === 1 ? "" : "s"}`} />
+    );
+}
+
+// Analytics row: a live, compact tally of emails sent this period — the headline
+// throughput metric, surfaced right in the nav. From the org-wide usage overview.
+function AnalyticsActivity() {
+    const { data } = useUsageOverview();
+    const sent = data?.campaigns?.emails_sent ?? 0;
+    return (
+        <TabStat
+            total={sent}
+            format={compactN}
+            title={`${sent.toLocaleString()} emails sent this period`}
+        />
+    );
+}
+
+// API keys row: how many keys are currently active (not revoked / expired).
+function ApiKeysActivity() {
+    const { data } = useAPIKeys();
+    const active = (data?.data ?? []).filter((k) => k.status === "active").length;
+    return (
+        <TabStat
+            total={active}
+            format={(v) => String(Math.round(v))}
+            title={`${active} active API key${active === 1 ? "" : "s"}`}
+        />
     );
 }
 

--- a/web/src/components/ui/select-menu.tsx
+++ b/web/src/components/ui/select-menu.tsx
@@ -1,0 +1,99 @@
+// SelectMenu — the app's themed dropdown, replacing native <select> everywhere.
+// Built on the shared PopoverMenu primitives so it matches every other picker
+// (slate border, sky accent, rounded-md, h-7 density) and never shows the OS
+// dropdown chrome. Supports optional option groups (rendered as section labels)
+// while preserving declared order.
+//
+// (Distinct from the unused shadcn/Radix `select.tsx`, which has a different
+// theme + compound API.)
+
+import React from "react";
+import { ChevronDownIcon } from "lucide-react";
+import {
+    PopoverMenu,
+    PopoverMenuTrigger,
+    PopoverMenuContent,
+    PopoverMenuItem,
+} from "@/components/ui/popover-menu";
+
+export interface SelectOption {
+    value: string;
+    label: string;
+    /** Optional section header. Consecutive options sharing a group are grouped. */
+    group?: string;
+    disabled?: boolean;
+}
+
+export function SelectMenu({
+    value,
+    onChange,
+    options,
+    placeholder = "Select…",
+    className,
+    minWidth = 220,
+    align = "start",
+    disabled,
+    "aria-label": ariaLabel,
+}: {
+    value: string;
+    onChange: (value: string) => void;
+    options: SelectOption[];
+    placeholder?: string;
+    className?: string;
+    minWidth?: number;
+    align?: "start" | "end" | "center";
+    disabled?: boolean;
+    "aria-label"?: string;
+}) {
+    const [open, setOpen] = React.useState(false);
+    const current = options.find((o) => o.value === value);
+
+    // Group consecutive options that share a `group`, preserving order.
+    const groups: { group?: string; items: SelectOption[] }[] = [];
+    for (const o of options) {
+        const last = groups[groups.length - 1];
+        if (last && last.group === o.group) last.items.push(o);
+        else groups.push({ group: o.group, items: [o] });
+    }
+
+    return (
+        <PopoverMenu open={open} onOpenChange={setOpen} align={align}>
+            <PopoverMenuTrigger asChild>
+                <button
+                    type="button"
+                    disabled={disabled}
+                    aria-label={ariaLabel}
+                    className={`h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 bg-white text-[12px] text-slate-700 inline-flex items-center gap-1.5 transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${className ?? ""}`}
+                >
+                    <span className={`truncate flex-1 text-left ${current ? "" : "text-slate-400"}`}>
+                        {current?.label ?? placeholder}
+                    </span>
+                    <ChevronDownIcon className="w-3 h-3 text-slate-400 shrink-0" />
+                </button>
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={minWidth} className="max-h-72 overflow-y-auto">
+                {groups.map((grp, gi) => (
+                    <React.Fragment key={gi}>
+                        {grp.group && (
+                            <div className="px-2 pt-1.5 pb-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-slate-400">
+                                {grp.group}
+                            </div>
+                        )}
+                        {grp.items.map((o) => (
+                            <PopoverMenuItem
+                                key={o.value}
+                                disabled={o.disabled}
+                                selected={o.value === value}
+                                onSelect={() => onChange(o.value)}
+                            >
+                                {o.label}
+                            </PopoverMenuItem>
+                        ))}
+                    </React.Fragment>
+                ))}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+export default SelectMenu;

--- a/web/src/lib/api/client/app/contacts/lookupContact.ts
+++ b/web/src/lib/api/client/app/contacts/lookupContact.ts
@@ -1,0 +1,13 @@
+import type Contact from "@/lib/api/models/app/contacts/Contact";
+import Request from "../../Request";
+
+// Resolve a sender address to a contact in the current organization. Returns
+// null when the address isn't a known contact (a normal, non-error outcome).
+export default async function lookupContact(email: string): Promise<Contact | null> {
+    const res = await Request<{ contact: Contact | null }>({
+        method: "GET",
+        url: `/contacts/lookup?email=${encodeURIComponent(email)}`,
+        authorization: true,
+    });
+    return res?.contact ?? null;
+}

--- a/web/src/lib/api/client/app/crm/deals/dealsSummary.ts
+++ b/web/src/lib/api/client/app/crm/deals/dealsSummary.ts
@@ -1,0 +1,12 @@
+import type SearchDeals from "@/lib/api/models/app/crm/SearchDeals";
+import type DealsSummary from "@/lib/api/models/app/crm/DealsSummary";
+import Request from "../../../Request";
+
+export default async function dealsSummary(filters: SearchDeals): Promise<DealsSummary> {
+    return await Request<DealsSummary>({
+        method: "POST",
+        url: "/crm/deals/summary",
+        data: filters,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/deals/searchDeals.ts
+++ b/web/src/lib/api/client/app/crm/deals/searchDeals.ts
@@ -1,0 +1,21 @@
+import type SearchDeals from "@/lib/api/models/app/crm/SearchDeals";
+import type DealsSearchResult from "@/lib/api/models/app/crm/DealsSearchResult";
+import Request from "../../../Request";
+
+export default async function searchDeals(
+    filters: SearchDeals,
+    offset = 0,
+    limit = 50,
+): Promise<DealsSearchResult> {
+    const qs = new URLSearchParams();
+    if (offset) qs.set("offset", String(offset));
+    if (limit) qs.set("limit", String(limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+    return await Request<DealsSearchResult>({
+        method: "POST",
+        url: `/crm/deals/search${suffix}`,
+        data: filters,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/taskTypes/createTaskType.ts
+++ b/web/src/lib/api/client/app/crm/taskTypes/createTaskType.ts
@@ -1,0 +1,11 @@
+import type TaskType from "@/lib/api/models/app/crm/TaskType";
+import Request from "../../../Request";
+
+export default async function createTaskType(data: { name: string; color?: string }): Promise<TaskType> {
+    return await Request<TaskType>({
+        method: "POST",
+        url: "/crm/task-types",
+        data,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/taskTypes/deleteTaskType.ts
+++ b/web/src/lib/api/client/app/crm/taskTypes/deleteTaskType.ts
@@ -1,0 +1,9 @@
+import Request from "../../../Request";
+
+export default async function deleteTaskType(id: string): Promise<void> {
+    await Request<void>({
+        method: "DELETE",
+        url: `/crm/task-types/${id}`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/taskTypes/listTaskTypes.ts
+++ b/web/src/lib/api/client/app/crm/taskTypes/listTaskTypes.ts
@@ -1,0 +1,12 @@
+import type TaskType from "@/lib/api/models/app/crm/TaskType";
+import Request from "../../../Request";
+
+export default async function listTaskTypes(): Promise<TaskType[]> {
+    const res = await Request<{ data: TaskType[] } | TaskType[]>({
+        method: "GET",
+        url: "/crm/task-types",
+        authorization: true,
+    });
+    if (Array.isArray(res)) return res;
+    return res?.data ?? [];
+}

--- a/web/src/lib/api/client/app/crm/taskTypes/updateTaskType.ts
+++ b/web/src/lib/api/client/app/crm/taskTypes/updateTaskType.ts
@@ -1,0 +1,14 @@
+import type TaskType from "@/lib/api/models/app/crm/TaskType";
+import Request from "../../../Request";
+
+export default async function updateTaskType(
+    id: string,
+    data: { name?: string; color?: string; position?: number },
+): Promise<TaskType> {
+    return await Request<TaskType>({
+        method: "PATCH",
+        url: `/crm/task-types/${id}`,
+        data,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/tasks/searchTasks.ts
+++ b/web/src/lib/api/client/app/crm/tasks/searchTasks.ts
@@ -1,0 +1,21 @@
+import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
+import type TasksSearchResult from "@/lib/api/models/app/crm/TasksSearchResult";
+import Request from "../../../Request";
+
+export default async function searchTasks(
+    filters: SearchTasks,
+    offset = 0,
+    limit = 50,
+): Promise<TasksSearchResult> {
+    const qs = new URLSearchParams();
+    if (offset) qs.set("offset", String(offset));
+    if (limit) qs.set("limit", String(limit));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+    return await Request<TasksSearchResult>({
+        method: "POST",
+        url: `/crm/tasks/search${suffix}`,
+        data: filters,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/crm/tasks/tasksSummary.ts
+++ b/web/src/lib/api/client/app/crm/tasks/tasksSummary.ts
@@ -1,0 +1,12 @@
+import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
+import type { TasksSummary } from "@/lib/api/models/app/crm/TasksSearchResult";
+import Request from "../../../Request";
+
+export default async function tasksSummary(filters: SearchTasks): Promise<TasksSummary> {
+    return await Request<TasksSummary>({
+        method: "POST",
+        url: "/crm/tasks/summary",
+        data: filters,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/teams/addTeamMember.ts
+++ b/web/src/lib/api/client/app/teams/addTeamMember.ts
@@ -1,0 +1,11 @@
+import type Team from "@/lib/api/models/app/teams/Team";
+import Request from "../../Request";
+
+export default async function addTeamMember(id: string, userId: string): Promise<Team> {
+    return await Request<Team>({
+        method: "POST",
+        url: `/teams/${id}/members`,
+        data: { user_id: userId },
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/teams/createTeam.ts
+++ b/web/src/lib/api/client/app/teams/createTeam.ts
@@ -1,0 +1,11 @@
+import type Team from "@/lib/api/models/app/teams/Team";
+import Request from "../../Request";
+
+export default async function createTeam(data: { name: string; color?: string }): Promise<Team> {
+    return await Request<Team>({
+        method: "POST",
+        url: "/teams",
+        data,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/teams/deleteTeam.ts
+++ b/web/src/lib/api/client/app/teams/deleteTeam.ts
@@ -1,0 +1,9 @@
+import Request from "../../Request";
+
+export default async function deleteTeam(id: string): Promise<void> {
+    await Request<void>({
+        method: "DELETE",
+        url: `/teams/${id}`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/teams/listTeams.ts
+++ b/web/src/lib/api/client/app/teams/listTeams.ts
@@ -1,0 +1,12 @@
+import type Team from "@/lib/api/models/app/teams/Team";
+import Request from "../../Request";
+
+export default async function listTeams(): Promise<Team[]> {
+    const res = await Request<{ data: Team[] } | Team[]>({
+        method: "GET",
+        url: "/teams",
+        authorization: true,
+    });
+    if (Array.isArray(res)) return res;
+    return res?.data ?? [];
+}

--- a/web/src/lib/api/client/app/teams/removeTeamMember.ts
+++ b/web/src/lib/api/client/app/teams/removeTeamMember.ts
@@ -1,0 +1,9 @@
+import Request from "../../Request";
+
+export default async function removeTeamMember(id: string, userId: string): Promise<void> {
+    await Request<void>({
+        method: "DELETE",
+        url: `/teams/${id}/members/${userId}`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/teams/updateTeam.ts
+++ b/web/src/lib/api/client/app/teams/updateTeam.ts
@@ -1,0 +1,14 @@
+import type Team from "@/lib/api/models/app/teams/Team";
+import Request from "../../Request";
+
+export default async function updateTeam(
+    id: string,
+    data: { name?: string; color?: string },
+): Promise<Team> {
+    return await Request<Team>({
+        method: "PATCH",
+        url: `/teams/${id}`,
+        data,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/app/unibox/markSeen.ts
+++ b/web/src/lib/api/client/app/unibox/markSeen.ts
@@ -1,10 +1,15 @@
 import Request from "../../Request";
 
-export default async function markSeen(data: { ids: string[] }): Promise<void> {
+// PATCH /unibox/seen marks the given unibox emails seen/unseen. The backend body
+// is { email_ids, seen } (models.MarkSeen); callers pass { ids } and seen
+// defaults to true (mark as read). Sending the wrong field names makes the
+// server bind an empty list and silently no-op, which is why the unread bar
+// never cleared before.
+export default async function markSeen(data: { ids: string[]; seen?: boolean }): Promise<void> {
     return await Request<void>({
         method: "PATCH",
         url: `/unibox/seen`,
-        data,
+        data: { email_ids: data.ids, seen: data.seen ?? true },
         authorization: true,
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useContactByEmail.ts
+++ b/web/src/lib/api/hooks/app/contacts/useContactByEmail.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import lookupContact from "@/lib/api/client/app/contacts/lookupContact";
+
+// Resolves a sender email to a contact (or null) for the unibox CRM panel.
+export default function useContactByEmail(email: string | undefined, enabled = true) {
+    return useQuery({
+        queryKey: ["contacts", "by-email", email ?? ""],
+        queryFn: () => lookupContact(email as string),
+        enabled: enabled && !!email,
+        staleTime: 60_000,
+    });
+}

--- a/web/src/lib/api/hooks/app/contacts/useCreateContactNote.ts
+++ b/web/src/lib/api/hooks/app/contacts/useCreateContactNote.ts
@@ -8,8 +8,10 @@ export default function useCreateContactNote() {
         mutationFn: ({ contactId, data }: { contactId: string; data: { content: string } }) =>
             createContactNote(contactId, data),
         onSuccess: (_data, variables) => {
+            // Contact-scoped prefix so the notes list AND the 360 timeline /
+            // activity feed both reflect the new note.
             queryClient.invalidateQueries({
-                queryKey: ["contacts", variables.contactId, "notes"],
+                queryKey: ["contacts", variables.contactId],
             })
         }
     })

--- a/web/src/lib/api/hooks/app/contacts/useDeleteContact.ts
+++ b/web/src/lib/api/hooks/app/contacts/useDeleteContact.ts
@@ -27,6 +27,11 @@ export default function useDeleteContact(contact_id: string) {
             queryClient.invalidateQueries({
                 queryKey: ["contacts", contact_id]
             });
+            // The contacts table reads ["contacts","list",...]; without this the
+            // deleted row lingers until a manual reload.
+            queryClient.invalidateQueries({
+                queryKey: ["contacts", "list"]
+            });
         }
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useDeleteContactNote.ts
+++ b/web/src/lib/api/hooks/app/contacts/useDeleteContactNote.ts
@@ -9,7 +9,7 @@ export default function useDeleteContactNote() {
             deleteContactNote(contactId, noteId),
         onSuccess: (_data, variables) => {
             queryClient.invalidateQueries({
-                queryKey: ["contacts", variables.contactId, "notes"],
+                queryKey: ["contacts", variables.contactId],
             })
         }
     })

--- a/web/src/lib/api/hooks/app/contacts/useDeleteContacts.ts
+++ b/web/src/lib/api/hooks/app/contacts/useDeleteContacts.ts
@@ -29,6 +29,11 @@ export default function useDeleteContacts() {
                     queryKey: ["contacts", id]
                 });
             });
+            // The contacts table reads ["contacts","list",...]; refresh it so the
+            // deleted rows disappear without a manual reload.
+            queryClient.invalidateQueries({
+                queryKey: ["contacts", "list"]
+            });
         }
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useUpdateContactNote.ts
+++ b/web/src/lib/api/hooks/app/contacts/useUpdateContactNote.ts
@@ -10,7 +10,7 @@ export default function useUpdateContactNote() {
             updateContactNote(contactId, noteId, data),
         onSuccess: (_data, variables) => {
             queryClient.invalidateQueries({
-                queryKey: ["contacts", variables.contactId, "notes"],
+                queryKey: ["contacts", variables.contactId],
             })
         }
     })

--- a/web/src/lib/api/hooks/app/crm/deals/useCreateDeal.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useCreateDeal.ts
@@ -8,8 +8,10 @@ export default function useCreateDeal() {
     return useMutation({
         mutationFn: (data: Partial<Deal>) => createDeal(data),
         onSuccess: () => {
+            // Broad prefix so the board list, the cross-pipeline search table,
+            // and the summary aggregates all refresh.
             queryClient.invalidateQueries({
-                queryKey: ["crm", "deals", "list"],
+                queryKey: ["crm", "deals"],
             })
         }
     })

--- a/web/src/lib/api/hooks/app/crm/deals/useCreateDeal.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useCreateDeal.ts
@@ -7,12 +7,19 @@ export default function useCreateDeal() {
 
     return useMutation({
         mutationFn: (data: Partial<Deal>) => createDeal(data),
-        onSuccess: () => {
+        onSuccess: (_result, variables) => {
             // Broad prefix so the board list, the cross-pipeline search table,
             // and the summary aggregates all refresh.
             queryClient.invalidateQueries({
                 queryKey: ["crm", "deals"],
             })
+            // A deal created against a contact (e.g. from the unibox CRM panel)
+            // also lives under that contact's deal list + 360 timeline.
+            if (variables.contact_id) {
+                queryClient.invalidateQueries({
+                    queryKey: ["contacts", variables.contact_id],
+                })
+            }
         }
     })
 }

--- a/web/src/lib/api/hooks/app/crm/deals/useDealsSummary.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useDealsSummary.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import type SearchDeals from "@/lib/api/models/app/crm/SearchDeals";
+import dealsSummary from "@/lib/api/client/app/crm/deals/dealsSummary";
+
+// Server-aggregated totals for the same filter the table renders. Kept as a
+// separate query (not folded into the list) so the header stats and per-stage
+// board headers stay correct over the whole set while the rows page in.
+export default function useDealsSummary(filters: SearchDeals, enabled = true) {
+    return useQuery({
+        queryKey: ["crm", "deals", "summary", filters],
+        queryFn: () => dealsSummary(filters),
+        staleTime: 30_000,
+        enabled,
+    });
+}

--- a/web/src/lib/api/hooks/app/crm/deals/useDeleteDeal.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useDeleteDeal.ts
@@ -10,6 +10,10 @@ export default function useDeleteDeal() {
             queryClient.invalidateQueries({
                 queryKey: ["crm", "deals"],
             })
+            // Deals also render inside contacts (panel list + 360 timeline).
+            queryClient.invalidateQueries({
+                queryKey: ["contacts"],
+            })
         }
     })
 }

--- a/web/src/lib/api/hooks/app/crm/deals/useSearchDeals.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useSearchDeals.ts
@@ -1,0 +1,40 @@
+import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
+import type SearchDeals from "@/lib/api/models/app/crm/SearchDeals";
+import type DealsSearchResult from "@/lib/api/models/app/crm/DealsSearchResult";
+import searchDeals from "@/lib/api/client/app/crm/deals/searchDeals";
+
+interface UseSearchDealsProps {
+    filters: SearchDeals;
+    limit?: number;
+    enabled?: boolean;
+}
+
+// Cross-pipeline deals fetch. Offset-paginated (the backend uses offset rather
+// than a keyset cursor so nullable value/close-date sorts don't drop rows), so
+// the page param is the next offset. Pages flatten into a single `deals` list
+// and `total` comes straight off the server so the UI can show "N of M".
+export default function useSearchDeals({ filters, limit = 50, enabled = true }: UseSearchDealsProps) {
+    const queryResult = useInfiniteQuery<
+        DealsSearchResult,
+        Error,
+        InfiniteData<DealsSearchResult, number>,
+        [string, string, string, SearchDeals, number],
+        number
+    >({
+        queryKey: ["crm", "deals", "search", filters, limit],
+        queryFn: async ({ pageParam }) => searchDeals(filters, pageParam, limit),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) =>
+            lastPage.pagination.has_more ? (lastPage.pagination.next_offset ?? undefined) : undefined,
+        staleTime: 30_000,
+        enabled,
+    });
+
+    const deals = queryResult.data?.pages
+        .flatMap((p) => p.data ?? [])
+        .filter((d): d is NonNullable<typeof d> => d != null);
+
+    const total = queryResult.data?.pages[0]?.pagination.total ?? 0;
+
+    return { ...queryResult, deals, total };
+}

--- a/web/src/lib/api/hooks/app/crm/deals/useUpdateDeal.ts
+++ b/web/src/lib/api/hooks/app/crm/deals/useUpdateDeal.ts
@@ -11,6 +11,11 @@ export default function useUpdateDeal() {
             queryClient.invalidateQueries({
                 queryKey: ["crm", "deals"],
             })
+            // Deals also render inside contacts (panel list + 360 timeline), so
+            // a stage move / edit must refresh any active contact queries too.
+            queryClient.invalidateQueries({
+                queryKey: ["contacts"],
+            })
         }
     })
 }

--- a/web/src/lib/api/hooks/app/crm/taskTypes/useCreateTaskType.ts
+++ b/web/src/lib/api/hooks/app/crm/taskTypes/useCreateTaskType.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import createTaskType from "@/lib/api/client/app/crm/taskTypes/createTaskType";
+
+export default function useCreateTaskType() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: { name: string; color?: string }) => createTaskType(data),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["crm", "task-types"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/crm/taskTypes/useDeleteTaskType.ts
+++ b/web/src/lib/api/hooks/app/crm/taskTypes/useDeleteTaskType.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import deleteTaskType from "@/lib/api/client/app/crm/taskTypes/deleteTaskType";
+
+export default function useDeleteTaskType() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (id: string) => deleteTaskType(id),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["crm", "task-types"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/crm/taskTypes/useTaskTypes.ts
+++ b/web/src/lib/api/hooks/app/crm/taskTypes/useTaskTypes.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import listTaskTypes from "@/lib/api/client/app/crm/taskTypes/listTaskTypes";
+
+export default function useTaskTypes() {
+    return useQuery({
+        queryKey: ["crm", "task-types"],
+        queryFn: () => listTaskTypes(),
+        staleTime: 5 * 60 * 1000,
+    });
+}

--- a/web/src/lib/api/hooks/app/crm/taskTypes/useUpdateTaskType.ts
+++ b/web/src/lib/api/hooks/app/crm/taskTypes/useUpdateTaskType.ts
@@ -1,0 +1,11 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import updateTaskType from "@/lib/api/client/app/crm/taskTypes/updateTaskType";
+
+export default function useUpdateTaskType() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ id, data }: { id: string; data: { name?: string; color?: string; position?: number } }) =>
+            updateTaskType(id, data),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["crm", "task-types"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/crm/tasks/useCRMTasks.ts
+++ b/web/src/lib/api/hooks/app/crm/tasks/useCRMTasks.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import listCRMTasks, { type ListCRMTasksParams } from "@/lib/api/client/app/crm/tasks/listCRMTasks";
 
-export default function useCRMTasks(params: ListCRMTasksParams = {}) {
+export default function useCRMTasks(params: ListCRMTasksParams = {}, enabled = true) {
     return useQuery({
         queryKey: ["crm", "tasks", "list", params],
         queryFn: () => listCRMTasks(params),
         staleTime: 30_000,
+        enabled,
     });
 }

--- a/web/src/lib/api/hooks/app/crm/tasks/useCreateCRMTask.ts
+++ b/web/src/lib/api/hooks/app/crm/tasks/useCreateCRMTask.ts
@@ -8,8 +8,10 @@ export default function useCreateCRMTask() {
     return useMutation({
         mutationFn: (data: Partial<CRMTask>) => createCRMTask(data),
         onSuccess: () => {
+            // Broad prefix so the server-driven search list, the summary totals,
+            // and the sidebar overdue indicator all refresh on create.
             queryClient.invalidateQueries({
-                queryKey: ["crm", "tasks", "list"],
+                queryKey: ["crm", "tasks"],
             })
         }
     })

--- a/web/src/lib/api/hooks/app/crm/tasks/useSearchTasks.ts
+++ b/web/src/lib/api/hooks/app/crm/tasks/useSearchTasks.ts
@@ -1,0 +1,41 @@
+import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
+import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
+import type TasksSearchResult from "@/lib/api/models/app/crm/TasksSearchResult";
+import searchTasks from "@/lib/api/client/app/crm/tasks/searchTasks";
+
+interface UseSearchTasksProps {
+    filters: SearchTasks;
+    limit?: number;
+    enabled?: boolean;
+}
+
+// Server-driven tasks fetch that scales to thousands of rows. Offset-paginated
+// (the backend uses offset rather than a keyset cursor so nullable due-date
+// sorts don't drop rows), so the page param is the next offset. Pages flatten
+// into a single `tasks` list and `total` comes straight off the server so the
+// UI can show "N of M loaded".
+export default function useSearchTasks({ filters, limit = 50, enabled = true }: UseSearchTasksProps) {
+    const queryResult = useInfiniteQuery<
+        TasksSearchResult,
+        Error,
+        InfiniteData<TasksSearchResult, number>,
+        [string, string, string, SearchTasks, number],
+        number
+    >({
+        queryKey: ["crm", "tasks", "search", filters, limit],
+        queryFn: async ({ pageParam }) => searchTasks(filters, pageParam, limit),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage) =>
+            lastPage.pagination.has_more ? (lastPage.pagination.next_offset ?? undefined) : undefined,
+        staleTime: 30_000,
+        enabled,
+    });
+
+    const tasks = queryResult.data?.pages
+        .flatMap((p) => p.data ?? [])
+        .filter((t): t is NonNullable<typeof t> => t != null);
+
+    const total = queryResult.data?.pages[0]?.pagination.total ?? 0;
+
+    return { ...queryResult, tasks, total };
+}

--- a/web/src/lib/api/hooks/app/crm/tasks/useTasksSummary.ts
+++ b/web/src/lib/api/hooks/app/crm/tasks/useTasksSummary.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import type SearchTasks from "@/lib/api/models/app/crm/SearchTasks";
+import tasksSummary from "@/lib/api/client/app/crm/tasks/tasksSummary";
+
+// Server-aggregated totals for the same filter the table renders. Kept as a
+// separate query (not folded into the list) so the header stats stay correct
+// over the whole set while the rows page in.
+export default function useTasksSummary(filters: SearchTasks, enabled = true) {
+    return useQuery({
+        queryKey: ["crm", "tasks", "summary", filters],
+        queryFn: () => tasksSummary(filters),
+        staleTime: 30_000,
+        enabled,
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useAddTeamMember.ts
+++ b/web/src/lib/api/hooks/app/teams/useAddTeamMember.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import addTeamMember from "@/lib/api/client/app/teams/addTeamMember";
+
+export default function useAddTeamMember() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ id, userId }: { id: string; userId: string }) => addTeamMember(id, userId),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useCreateTeam.ts
+++ b/web/src/lib/api/hooks/app/teams/useCreateTeam.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import createTeam from "@/lib/api/client/app/teams/createTeam";
+
+export default function useCreateTeam() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: { name: string; color?: string }) => createTeam(data),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useDeleteTeam.ts
+++ b/web/src/lib/api/hooks/app/teams/useDeleteTeam.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import deleteTeam from "@/lib/api/client/app/teams/deleteTeam";
+
+export default function useDeleteTeam() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (id: string) => deleteTeam(id),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useRemoveTeamMember.ts
+++ b/web/src/lib/api/hooks/app/teams/useRemoveTeamMember.ts
@@ -1,0 +1,10 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import removeTeamMember from "@/lib/api/client/app/teams/removeTeamMember";
+
+export default function useRemoveTeamMember() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ id, userId }: { id: string; userId: string }) => removeTeamMember(id, userId),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useTeams.ts
+++ b/web/src/lib/api/hooks/app/teams/useTeams.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import listTeams from "@/lib/api/client/app/teams/listTeams";
+
+export default function useTeams() {
+    return useQuery({
+        queryKey: ["teams"],
+        queryFn: () => listTeams(),
+        staleTime: 5 * 60 * 1000,
+    });
+}

--- a/web/src/lib/api/hooks/app/teams/useUpdateTeam.ts
+++ b/web/src/lib/api/hooks/app/teams/useUpdateTeam.ts
@@ -1,0 +1,11 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import updateTeam from "@/lib/api/client/app/teams/updateTeam";
+
+export default function useUpdateTeam() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({ id, data }: { id: string; data: { name?: string; color?: string } }) =>
+            updateTeam(id, data),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ["teams"] }),
+    });
+}

--- a/web/src/lib/api/hooks/app/unibox/useMarkSeen.ts
+++ b/web/src/lib/api/hooks/app/unibox/useMarkSeen.ts
@@ -5,7 +5,7 @@ export default function useMarkSeen() {
     const queryClient = useQueryClient();
 
     return useMutation({
-        mutationFn: (data: { ids: string[] }) => markSeen(data),
+        mutationFn: (data: { ids: string[]; seen?: boolean }) => markSeen(data),
         onSuccess: () => {
             queryClient.invalidateQueries({
                 queryKey: ["unibox"],

--- a/web/src/lib/api/models/app/campaigns/sequences/Action.ts
+++ b/web/src/lib/api/models/app/campaigns/sequences/Action.ts
@@ -2,7 +2,14 @@
 // Stored in the sequence's `action` jsonb column. Spacing/delays are NOT actions:
 // per-step "wait before sending" (wait_after) covers that, so there is no
 // standalone wait node.
-export type SequenceActionType = "add_tag" | "remove_tag" | "unsubscribe" | "notify" | "create_task";
+export type SequenceActionType =
+    | "add_tag"
+    | "remove_tag"
+    | "unsubscribe"
+    | "notify"
+    | "create_task"
+    | "create_deal"
+    | "move_deal_stage";
 
 export interface SequenceAction {
     type: SequenceActionType;
@@ -17,4 +24,15 @@ export interface SequenceAction {
     task_priority?: "low" | "medium" | "high" | "urgent";
     task_assigned_to?: string | null;
     task_due_offset_days?: number | null;
+    // create_deal / move_deal_stage — CRM deal automation. create_deal opens a
+    // new deal for the contact in deal_pipeline_id/deal_stage_id; move_deal_stage
+    // moves the contact's most-recent OPEN deal in deal_pipeline_id to
+    // deal_stage_id (no-op when the contact has no open deal there).
+    deal_pipeline_id?: string;
+    deal_stage_id?: string;
+    // deal_name supports the same {{.FirstName}}/{{.Company}} templating other
+    // campaign copy uses. Only meaningful for create_deal.
+    deal_name?: string;
+    deal_value?: number;
+    deal_currency?: string; // ISO code, defaults to "USD"
 }

--- a/web/src/lib/api/models/app/campaigns/sequences/Action.ts
+++ b/web/src/lib/api/models/app/campaigns/sequences/Action.ts
@@ -2,7 +2,7 @@
 // Stored in the sequence's `action` jsonb column. Spacing/delays are NOT actions:
 // per-step "wait before sending" (wait_after) covers that, so there is no
 // standalone wait node.
-export type SequenceActionType = "add_tag" | "remove_tag" | "unsubscribe" | "notify";
+export type SequenceActionType = "add_tag" | "remove_tag" | "unsubscribe" | "notify" | "create_task";
 
 export interface SequenceAction {
     type: SequenceActionType;
@@ -11,4 +11,10 @@ export interface SequenceAction {
     // notify
     notify_event?: string;
     notify_data?: Record<string, unknown>;
+    // create_task — open a CRM task for the lead at this step
+    task_title?: string;
+    task_type?: string; // task type name (user-managed)
+    task_priority?: "low" | "medium" | "high" | "urgent";
+    task_assigned_to?: string | null;
+    task_due_offset_days?: number | null;
 }

--- a/web/src/lib/api/models/app/campaigns/sequences/Branching.ts
+++ b/web/src/lib/api/models/app/campaigns/sequences/Branching.ts
@@ -16,9 +16,29 @@ export type BranchField =
     | "not_opened"
     | "not_clicked"
     | "not_replied"
-    | "random";
+    | "random"
+    // Reply-classification routes. The contact's most-recent inbound reply was
+    // classified (see internal/app/replyclassify) and stored on
+    // campaign_contact_progress.reply_class. Operator is "ever" (no value).
+    // reply_automated == reply_class is auto_reply OR out_of_office.
+    | "reply_positive"
+    | "reply_negative"
+    | "reply_neutral"
+    | "reply_automated";
 
 export type BranchOperator = "within_days" | "ever" | "chance";
+
+// The reply-class fields are evaluated with operator "ever" and carry no value.
+export const REPLY_BRANCH_FIELDS: BranchField[] = [
+    "reply_positive",
+    "reply_negative",
+    "reply_neutral",
+    "reply_automated",
+];
+
+export function isReplyBranchField(field: BranchField): boolean {
+    return REPLY_BRANCH_FIELDS.includes(field);
+}
 
 export interface BranchCondition {
     field: BranchField;
@@ -48,4 +68,8 @@ export const BRANCH_FIELD_LABELS: Record<BranchField, string> = {
     not_clicked: "didn’t click",
     not_replied: "didn’t reply",
     random: "random split",
+    reply_positive: "replied: positive",
+    reply_negative: "replied: negative",
+    reply_neutral: "replied: neutral",
+    reply_automated: "auto-reply / out of office",
 };

--- a/web/src/lib/api/models/app/campaigns/sequences/Branching.ts
+++ b/web/src/lib/api/models/app/campaigns/sequences/Branching.ts
@@ -40,6 +40,29 @@ export function isReplyBranchField(field: BranchField): boolean {
     return REPLY_BRANCH_FIELDS.includes(field);
 }
 
+// Instant-capable fields are the "it happened" signals the backend can react to
+// the moment the event lands (a reply is recorded, or an open / click is
+// tracked), rather than at the next scheduled step boundary. That is the same
+// per-branch Instant toggle the reply paths use, generalized to engagement.
+//
+// Excluded on purpose: negative signals (not_opened / not_clicked / not_replied)
+// and "within N days" windows can only be resolved at a step boundary because
+// they assert something did NOT happen in a window; and random / always are not
+// event-driven at all. `replied` is also excluded here because it carries a day
+// window in this canvas; use the reply_* intent fields for an instant reply path.
+export const INSTANT_CAPABLE_FIELDS: BranchField[] = [
+    "reply_positive",
+    "reply_negative",
+    "reply_neutral",
+    "reply_automated",
+    "opened",
+    "clicked",
+];
+
+export function isInstantCapableField(field: BranchField): boolean {
+    return INSTANT_CAPABLE_FIELDS.includes(field);
+}
+
 export interface BranchCondition {
     field: BranchField;
     operator: BranchOperator;
@@ -53,6 +76,10 @@ export interface SequenceBranch {
     target_sequence_id: string | null;
     // ANDed conditions. An empty list is the catch-all "else" branch.
     conditions: BranchCondition[];
+    // For an instant-capable branch: whether its action chain fires the moment
+    // the signal lands. Absent/true = instant; false = route at the next step
+    // boundary. Ignored for fields that are not event-driven.
+    instant?: boolean;
 }
 
 // The full conditions payload carried on the sequence record + PATCH body.

--- a/web/src/lib/api/models/app/crm/CRMTask.ts
+++ b/web/src/lib/api/models/app/crm/CRMTask.ts
@@ -7,6 +7,7 @@ export default interface CRMTask {
     contact_id?: string;
     deal_id?: string;
     assigned_to?: string;
+    assigned_team_id?: string;
     created_by: string;
     title: string;
     description?: string;

--- a/web/src/lib/api/models/app/crm/CRMTask.ts
+++ b/web/src/lib/api/models/app/crm/CRMTask.ts
@@ -12,6 +12,8 @@ export default interface CRMTask {
     description?: string;
     due_date?: string;
     priority: CRMTaskPriority;
+    // The task type's name (user-managed; empty = no type).
+    type: string;
     status: CRMTaskStatus;
     completed_at?: string;
     created_at: string;

--- a/web/src/lib/api/models/app/crm/Deal.ts
+++ b/web/src/lib/api/models/app/crm/Deal.ts
@@ -15,6 +15,10 @@ export default interface Deal {
     lost_at?: string;
     lost_reason?: string;
     assigned_to?: string;
+    // Attribution: the campaign + sender mailbox that produced the originating
+    // reply. Nullable; editable. Lets won revenue trace back to outreach.
+    campaign_id?: string;
+    source_mailbox_id?: string;
     created_at: string;
     updated_at: string;
 
@@ -32,6 +36,7 @@ export default interface Deal {
         color: string;
         position: number;
     };
+    campaign_name?: string;
 }
 
 export interface DealsResult {

--- a/web/src/lib/api/models/app/crm/DealsSearchResult.ts
+++ b/web/src/lib/api/models/app/crm/DealsSearchResult.ts
@@ -1,0 +1,14 @@
+import type Deal from "@/lib/api/models/app/crm/Deal";
+
+export interface DealsSearchPagination {
+    total: number;
+    limit: number;
+    offset: number;
+    has_more: boolean;
+    next_offset?: number | null;
+}
+
+export default interface DealsSearchResult {
+    data: Deal[];
+    pagination: DealsSearchPagination;
+}

--- a/web/src/lib/api/models/app/crm/DealsSummary.ts
+++ b/web/src/lib/api/models/app/crm/DealsSummary.ts
@@ -1,0 +1,24 @@
+// Server-aggregated totals over a SearchDeals filter. Every number here is a
+// SUM/COUNT over the whole matching set — never a client reduce over a loaded
+// page — so the header stats and per-stage board headers stop lying at scale.
+
+export interface DealStageSummary {
+    stage_id: string;
+    count: number;
+    value: number;
+}
+
+export default interface DealsSummary {
+    total: number;
+    open_count: number;
+    open_value: number;
+    won_count: number;
+    won_value: number;
+    lost_count: number;
+    lost_value: number;
+    currency: string;
+    // True when the matched set spans more than one currency, in which case a
+    // single blended value total is not meaningful and the UI should say so.
+    mixed_currency: boolean;
+    stages: DealStageSummary[];
+}

--- a/web/src/lib/api/models/app/crm/SearchDeals.ts
+++ b/web/src/lib/api/models/app/crm/SearchDeals.ts
@@ -1,0 +1,39 @@
+// Filter body for POST /crm/deals/search and /crm/deals/summary. Every field
+// is optional; an empty body matches every deal in the org (the cross-pipeline
+// "All deals" default). The same body drives the rows and the summary totals,
+// so a header number always reflects the exact filter shown below it.
+
+export type DealSortBy =
+    | "created_at"
+    | "updated_at"
+    | "value"
+    | "expected_close_date"
+    | "name";
+
+export default interface SearchDeals {
+    query: string;
+    statuses: ("open" | "won" | "lost")[];
+    pipeline_ids: string[];
+    stage_ids: string[];
+    assigned_to: string[];
+    campaign_ids: string[];
+    min_value?: number;
+    max_value?: number;
+    close_after?: string;
+    close_before?: string;
+    created_after?: string;
+    created_before?: string;
+    sort_by: DealSortBy;
+    reverse: boolean;
+}
+
+export const EMPTY_DEAL_SEARCH: SearchDeals = {
+    query: "",
+    statuses: [],
+    pipeline_ids: [],
+    stage_ids: [],
+    assigned_to: [],
+    campaign_ids: [],
+    sort_by: "created_at",
+    reverse: false,
+};

--- a/web/src/lib/api/models/app/crm/SearchTasks.ts
+++ b/web/src/lib/api/models/app/crm/SearchTasks.ts
@@ -20,6 +20,10 @@ export default interface SearchTasks {
     types: string[];
     // User UUIDs (assigned_to). String-matched on the server.
     assigned_to: string[];
+    // Team UUIDs. Matches a task whose assigned_team_id is one of these, OR
+    // whose assigned_to is a member of one of these teams. The same predicate
+    // drives both the rows query and the summary aggregate.
+    team_ids: string[];
     contact_id?: string;
     deal_id?: string;
     due_after?: string;
@@ -37,6 +41,7 @@ export const EMPTY_TASK_SEARCH: SearchTasks = {
     priorities: [],
     types: [],
     assigned_to: [],
+    team_ids: [],
     sort_by: "created_at",
     reverse: false,
 };

--- a/web/src/lib/api/models/app/crm/SearchTasks.ts
+++ b/web/src/lib/api/models/app/crm/SearchTasks.ts
@@ -1,0 +1,42 @@
+// Filter body for POST /crm/tasks/search and /crm/tasks/summary. Every field
+// is optional; an empty body matches every task in the org (the "All tasks"
+// default). The same body drives the rows and the summary totals, so a header
+// number always reflects the exact filter shown below it.
+
+import type { CRMTaskPriority, CRMTaskStatus } from "@/lib/api/models/app/crm/CRMTask";
+
+export type TaskSortBy =
+    | "created_at"
+    | "updated_at"
+    | "due_date"
+    | "priority"
+    | "title";
+
+export default interface SearchTasks {
+    query: string;
+    statuses: CRMTaskStatus[];
+    priorities: CRMTaskPriority[];
+    // Task type NAMEs (crm_tasks.type), e.g. ["Call", "Email"].
+    types: string[];
+    // User UUIDs (assigned_to). String-matched on the server.
+    assigned_to: string[];
+    contact_id?: string;
+    deal_id?: string;
+    due_after?: string;
+    due_before?: string;
+    // due_date < now() AND status NOT IN ('completed','cancelled').
+    overdue?: boolean;
+    sort_by: TaskSortBy;
+    // false => DESC (default), true => ASC.
+    reverse: boolean;
+}
+
+export const EMPTY_TASK_SEARCH: SearchTasks = {
+    query: "",
+    statuses: [],
+    priorities: [],
+    types: [],
+    assigned_to: [],
+    sort_by: "created_at",
+    reverse: false,
+};

--- a/web/src/lib/api/models/app/crm/TaskType.ts
+++ b/web/src/lib/api/models/app/crm/TaskType.ts
@@ -1,0 +1,11 @@
+// A user-managed CRM task type (Call, Email, Meeting, or anything the user
+// creates). Org-scoped. Tasks reference a type by its name string.
+export default interface TaskType {
+    id: string;
+    organization_id: string;
+    name: string;
+    color: string;
+    position: number;
+    created_at: string;
+    updated_at: string;
+}

--- a/web/src/lib/api/models/app/crm/TasksSearchResult.ts
+++ b/web/src/lib/api/models/app/crm/TasksSearchResult.ts
@@ -1,0 +1,29 @@
+import type CRMTask from "@/lib/api/models/app/crm/CRMTask";
+
+export interface TasksSearchPagination {
+    total: number;
+    limit: number;
+    offset: number;
+    has_more: boolean;
+    next_offset?: number | null;
+}
+
+export default interface TasksSearchResult {
+    data: CRMTask[];
+    pagination: TasksSearchPagination;
+}
+
+// Server-aggregated totals over a SearchTasks filter. Every number here is a
+// COUNT over the whole matching set — never a client reduce over a loaded
+// page — so the header stats stay honest at scale.
+export interface TasksSummary {
+    total: number;
+    pending_count: number;
+    in_progress_count: number;
+    completed_count: number;
+    cancelled_count: number;
+    // due_date < now() AND status NOT IN ('completed','cancelled').
+    overdue_count: number;
+    // priority IN ('high','urgent').
+    high_priority_count: number;
+}

--- a/web/src/lib/api/models/app/organizations/OrganizationMember.ts
+++ b/web/src/lib/api/models/app/organizations/OrganizationMember.ts
@@ -7,8 +7,11 @@ export type OrganizationRole = "owner" | "admin" | "manager" | "member" | "viewe
 export default interface OrganizationMember {
     id: string;
     user_id: string;
-    email: string;
+    // Flattened from the joined user by the API (GET /organization/members).
+    // Optional + possibly-empty: always guard before calling string methods.
+    email?: string;
+    name?: string;
     role: OrganizationRole;
     permissions?: number;
-    joined_at: Date;
+    joined_at?: Date;
 }

--- a/web/src/lib/api/models/app/teams/Team.ts
+++ b/web/src/lib/api/models/app/teams/Team.ts
@@ -1,0 +1,19 @@
+// A team groups organization members under a named, colored label.
+// Org-scoped. Mirrors the backend Team JSON shape; `members` is always
+// present (never null) and hydrated on detail/mutation responses.
+export interface TeamMember {
+    user_id: string;
+    email: string;
+    name: string;
+    added_at: string;
+}
+
+export default interface Team {
+    id: string;
+    organization_id: string;
+    name: string;
+    color: string;
+    created_at: string;
+    updated_at: string;
+    members: TeamMember[];
+}

--- a/web/src/lib/helper/dueDate.ts
+++ b/web/src/lib/helper/dueDate.ts
@@ -1,0 +1,24 @@
+// Relative due-date helpers. Tasks are set as "due in N days" rather than an
+// absolute calendar date; these convert between that day offset and the ISO
+// timestamp the API stores.
+
+// Convert a day offset into an ISO timestamp at 9am local, N days from today.
+export function dueInDaysToISO(days: number): string {
+    const d = new Date();
+    d.setHours(9, 0, 0, 0);
+    d.setDate(d.getDate() + days);
+    return d.toISOString();
+}
+
+// Convert an existing absolute due date back into a whole-day offset from
+// today (used to seed the control when editing a task). Negative = overdue.
+export function isoToDueInDays(iso?: string): number | null {
+    if (!iso) return null;
+    const due = new Date(iso);
+    if (Number.isNaN(due.getTime())) return null;
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const dueDay = new Date(due);
+    dueDay.setHours(0, 0, 0, 0);
+    return Math.round((dueDay.getTime() - today.getTime()) / 86_400_000);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -32,6 +32,7 @@ import ProfileSettingsPage from './app/app/settings/profile/page';
 import NotificationsSettingsPage from './app/app/settings/notifications/page';
 import SecuritySettingsPage from './app/app/settings/security/page';
 import MembersSettingsPage from './app/app/settings/members/page';
+import TeamsSettingsPage from './app/app/settings/teams/page';
 import WorkspaceSettingsPage from './app/app/settings/workspace/page';
 import DangerSettingsPage from './app/app/settings/danger/page';
 import BillingSettingsPage from './app/app/settings/billing/page';
@@ -276,6 +277,7 @@ const router = createBrowserRouter([
               { path: "notifications", element: <NotificationsSettingsPage /> },
               { path: "security", element: <SecuritySettingsPage /> },
               { path: "members", element: <MembersSettingsPage /> },
+              { path: "teams", element: <TeamsSettingsPage /> },
               { path: "workspace", element: <WorkspaceSettingsPage /> },
               { path: "billing", element: <BillingSettingsPage /> },
               { path: "limits", element: <LimitsSettingsPage /> },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -291,7 +291,9 @@ const router = createBrowserRouter([
             element: <Navigate to="/app/settings/billing" replace />,
           },
           {
-            path: "unibox",
+            // Path-based, readable inbox URLs: /app/unibox/<scope>[/<threadId>].
+            // Both segments optional, so /app/unibox is the default "all" view.
+            path: "unibox/:scope?/:threadId?",
             element: <UniboxPage />,
           },
           {


### PR DESCRIPTION
## Summary
- add instant campaign branch execution for reply, open, and click signals, including stop-on-reply handling
- expand CRM workflows with task team assignment/filtering, deal/task UI improvements, and sidebar activity counts
- improve unibox path routing and seen state updates

## Verification
- gofmt -l clean
- make lint
- pnpm typecheck (web)
- pnpm lint (web, 99 warnings / 0 errors)