### PR TITLE
Microsoft mailboxes on Graph + working account load/send/sync + warmup categorization

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -813,6 +813,10 @@ func main() {
 				EventBusProvider:         os.Getenv("EVENTBUS_PROVIDER"),
 				NATSURL:                  os.Getenv("NATS_URL"),
 				CodecProvider:            os.Getenv("CODEC_PROVIDER"),
+				BoxGoogleClientID:        os.Getenv("BOX_GOOGLE_CLIENT_ID"),
+				BoxGoogleClientSecret:    os.Getenv("BOX_GOOGLE_CLIENT_SECRET"),
+				BoxOutlookClientID:       os.Getenv("BOX_OUTLOOK_CLIENT_ID"),
+				BoxOutlookClientSecret:   os.Getenv("BOX_OUTLOOK_CLIENT_SECRET"),
 			},
 			getenvDefault("WORKER_INSTALLER_PATH", "/app/scripts/install-worker.sh"),
 		)
@@ -854,6 +858,8 @@ func main() {
 		// only the prod backend has a real cache; jobs / tests build
 		// emailService without one.
 		emailService.WireThrottle(dailyThrottleService)
+		// Seed Graph delta cursors when the reconciler reloads mailboxes.
+		emailService.WireGraphDelta(repository.NewEmailGraphDeltaRepository(primaryDB))
 		analyticsRepository := repository.NewAnalyticsRepository(primaryDB)
 		emailAccountErrorRepository := repository.NewEmailAccountErrorRepository(primaryDB)
 		analyticsService = analytics.NewService(analyticsRepository, emailRepostory, campaignRepostory, emailAccountErrorRepository, warmupRepository)
@@ -995,6 +1001,11 @@ func main() {
 		// crash between send and enqueue). Campaigns have no other bootstrap once
 		// started, so without this a stranded campaign stops sending forever.
 		go tasksService.StartCampaignReconciler(ctx, 5*time.Minute)
+
+		// Worker reconciler: assign + (re)load every active mailbox onto its
+		// worker. Workers hold accounts in memory only, so this is what makes a
+		// freshly onboarded account send/sync and re-seeds a restarted worker.
+		go emailService.StartWorkerReconciler(ctx, 60*time.Second)
 
 		// Danger zone: schedule + execute delayed deletions (orgs, accounts).
 		dangerZoneRepository := repository.NewDangerZoneRepository(primaryDB.Pool)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -186,6 +186,7 @@ func main() {
 	uniboxRepo := repository.NewUniboxRepository(primaryDB)
 	mailboxRepo := repository.NewMailboxRepository(primaryDB)
 	emailHistoryIDRepo := repository.NewEmailHistoryIDRepository(primaryDB)
+	emailGraphDeltaRepo := repository.NewEmailGraphDeltaRepository(primaryDB)
 	emailAccountErrorRepo := repository.NewEmailAccountErrorRepository(primaryDB)
 	warmupRepo := repository.NewWarmupRepository(primaryDB.Pool)
 	warmupService := warmupapp.NewService(warmupRepo)
@@ -298,6 +299,7 @@ func main() {
 		MailboxRepository:           mailboxRepo,
 		EmailRepository:             emailRepo,
 		EmailHistoryIDRepository:    emailHistoryIDRepo,
+		EmailGraphDeltaRepository:   emailGraphDeltaRepo,
 		EmailAccountErrorRepository: emailAccountErrorRepo,
 		WarmupRepo:                  warmupRepo,
 		WarmupContentRepo:           repository.NewWarmupContentRepository(primaryDB.Pool),

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -150,6 +150,21 @@ func main() {
 
 	workerTopic := kafka.GetWorkerTopic(workerID.String())
 
+	// Provider OAuth configs for local token refresh. Cfg is not shipped in the
+	// AddWorkerEmail payload (avro-excluded), so the worker rebuilds it from
+	// these (reads BOX_GOOGLE_* / BOX_OUTLOOK_* from the worker env). RedirectURL
+	// is unused for refresh, so the base URL is irrelevant here.
+	oauthInbox := config.LoadOauth2Inbox("")
+	// Token refresh needs the provider client credentials in the worker env.
+	// Warn loudly if they're missing: the initial token still works, but refresh
+	// fails silently once it expires (~1h), stalling the mailbox.
+	if oauthInbox.Outlook == nil || oauthInbox.Outlook.ClientID == "" || oauthInbox.Outlook.ClientSecret == "" {
+		log.Println("WARNING: BOX_OUTLOOK_CLIENT_ID/SECRET not set; Microsoft Graph mailbox token refresh will fail on expiry")
+	}
+	if oauthInbox.Google == nil || oauthInbox.Google.ClientID == "" || oauthInbox.Google.ClientSecret == "" {
+		log.Println("WARNING: BOX_GOOGLE_CLIENT_ID/SECRET not set; Gmail mailbox token refresh will fail on expiry")
+	}
+
 	// WorkerService
 	workerService := &worker.WorkerService{
 		ID:                        workerID.String(),
@@ -159,6 +174,7 @@ func main() {
 		Cache:                     redisCache,
 		Storage:                   s3Client,
 		EmailMessageMapRepository: emailMessageMapRepo,
+		OauthInbox:                &oauthInbox,
 	}
 
 	if err := workerService.Init(); err != nil {

--- a/docs/content/docs/guides/mailboxes.mdx
+++ b/docs/content/docs/guides/mailboxes.mdx
@@ -16,6 +16,8 @@ Open the **Accounts** page in the dashboard and choose **Add account**. Warmbly 
 
 For Google (Gmail / Google Workspace) and Microsoft (Outlook / Microsoft 365), Warmbly uses OAuth. You authorize Warmbly directly with your provider, and we receive a token instead of your password.
 
+Both OAuth providers connect through the provider's native API rather than IMAP or SMTP: Gmail over the Gmail API, and Microsoft over the Microsoft Graph API. Sending and inbox sync both run over that API, so the consent screen asks to send mail and to read and organize your mailbox. Nothing goes over IMAP or SMTP for these accounts.
+
 The flow is:
 
 1. Pick the provider. The dashboard starts an OAuth round trip and sends you to your provider's consent screen.
@@ -53,7 +55,7 @@ If your provider requires an app password (common when two-factor authentication
 | Provider | Method | Notes |
 |----------|--------|-------|
 | Gmail / Google Workspace | OAuth (`gmail`) | Recommended. No password stored. |
-| Outlook / Microsoft 365 | OAuth (`outlook`) | Recommended. No password stored. |
+| Outlook / Microsoft 365 | OAuth (`outlook`) | Recommended. No password stored. Runs on Microsoft Graph. |
 | Any IMAP/SMTP server | IMAP + SMTP (`smtp_imap`) | Use for custom domains, self-hosted, or providers without OAuth. |
 
 ## How many mailboxes you can connect

--- a/docs/content/docs/guides/warmup.mdx
+++ b/docs/content/docs/guides/warmup.mdx
@@ -78,6 +78,10 @@ Real inboxes do not only send. They also reply. Warmup mimics this with a config
 
 A portion of the time, instead of starting a new message, a mailbox will reply to an existing warmup thread it received. The reply stays on the same topic as the original message and threads correctly with a real `Re:` subject and reply headers, so the exchange looks like a genuine back-and-forth rather than a one-way blast. Replies are tracked separately in your warmup stats as a healthy-engagement signal.
 
+## Keeping warmup out of your inbox
+
+Warmup traffic should build reputation without cluttering the mailbox you actually read. When a warmup message is received, Warmbly recognizes it by its verification token and files it away automatically: the message is moved out of the inbox into a dedicated `Warmbly` folder and marked as read, and anything that landed in spam is rescued back to the inbox first so providers record a positive placement signal. This works across Gmail, Outlook (via Microsoft Graph), and generic IMAP mailboxes, and warmup mail never appears in your unified inbox. The engagement (open, read, occasional reply, importance) still happens, so providers see the healthy signals while you see a clean inbox.
+
 ## Pool safety and abuse protection
 
 Shared warmup pools only work if every participant behaves. Warmbly continuously evaluates each mailbox's behavior and removes risky ones before they can harm the pool's reputation.

--- a/internal/app/consumer/event_graph_delta_update.go
+++ b/internal/app/consumer/event_graph_delta_update.go
@@ -1,0 +1,21 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// HandleGraphDeltaUpdate persists the opaque per-folder Microsoft Graph delta
+// cursor relayed by the worker, so the mailbox resumes from its last position on
+// the next (re)assignment instead of re-priming.
+func (s *JobsService) HandleGraphDeltaUpdate(ctx context.Context, e *models.JobEventGraphDeltaUpdate) error {
+	if s.EmailGraphDeltaRepository == nil {
+		return nil
+	}
+	if err := s.EmailGraphDeltaRepository.Put(ctx, e.UserID, e.EmailID, e.Folder, e.DeltaLink); err != nil {
+		CaptureError(e.UserID, e.EmailID, err)
+		return err
+	}
+	return nil
+}

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -187,6 +187,9 @@ func (s *JobsService) performWarmupActions(ctx context.Context, e *models.JobEve
 		GmailID:            e.Message.GmailID,
 		UID:                e.Message.UID,
 		MailboxUIDValidity: e.Message.Mailbox,
+		// Stable key so Graph accounts re-resolve the live message id at action
+		// time (Graph ids change on move).
+		RFCMessageID: e.Message.MessageID,
 	}
 
 	// Resolve the receiving mailbox's worker once.

--- a/internal/app/consumer/events.go
+++ b/internal/app/consumer/events.go
@@ -28,6 +28,7 @@ func (w *JobsService) InitEvents() {
 	Register(w, models.JobEventTypeMailboxUpdate, w.HandleMailboxUpdate)
 	Register(w, models.JobEventTypeMailboxDelete, w.HandleMailboxDelete)
 	Register(w, models.JobEventTypeHistoryIDUpdate, w.HandleHistoryIDUpdate)
+	Register(w, models.JobEventTypeGraphDeltaUpdate, w.HandleGraphDeltaUpdate)
 	Register(w, models.JobEventTypeTokenUpdate, w.HandleTokenUpdate)
 
 	// Email error handlers

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -20,6 +20,7 @@ type JobsService struct {
 	MailboxRepository           repository.MailboxRepository
 	EmailRepository             repository.EmailRepository
 	EmailHistoryIDRepository    repository.EmailHistoryIDRepository
+	EmailGraphDeltaRepository   repository.EmailGraphDeltaRepository
 	EmailAccountErrorRepository repository.EmailAccountErrorRepository
 	WarmupRepo                  repository.WarmupRepository
 	WarmupContentRepo           repository.WarmupContentRepository

--- a/internal/app/email/loader.go
+++ b/internal/app/email/loader.go
@@ -1,0 +1,199 @@
+package email
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+	"golang.org/x/oauth2"
+)
+
+// WireGraphDelta attaches the Graph delta-cursor repository so the reconciler can
+// seed a Graph mailbox's saved per-folder cursors when (re)loading it. Optional;
+// when unset, Graph mailboxes prime from empty on load.
+func (s *emailService) WireGraphDelta(repo repository.EmailGraphDeltaRepository) {
+	s.graphDelta = repo
+}
+
+// StartWorkerReconciler periodically ensures every active mailbox is assigned to
+// a worker and loaded onto it. Workers hold accounts in memory only, so this is
+// what makes onboarding, worker restarts, and reassignment converge: a fresh
+// account gets picked up within one interval, and a restarted worker is
+// re-seeded. PublishAddEmail is idempotent worker-side (already-loaded accounts
+// are skipped), so re-publishing every tick is safe.
+func (s *emailService) StartWorkerReconciler(ctx context.Context, interval time.Duration) {
+	s.reconcileWorkerAccounts(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcileWorkerAccounts(ctx)
+		}
+	}
+}
+
+func (s *emailService) reconcileWorkerAccounts(ctx context.Context) {
+	ids, err := s.emailRepository.ListActiveWorkerAccounts(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("worker reconciler: list active accounts failed")
+		return
+	}
+	for _, id := range ids {
+		if err := s.LoadAccountOntoWorker(ctx, id); err != nil {
+			log.Warn().Err(err).Str("email_id", id.String()).Msg("worker reconciler: load account failed")
+		}
+	}
+}
+
+// loadAccountBestEffort loads a freshly onboarded account onto its worker without
+// blocking or failing the onboarding response; the reconciler is the safety net.
+func (s *emailService) loadAccountBestEffort(ctx context.Context, accountID uuid.UUID) {
+	if err := s.LoadAccountOntoWorker(ctx, accountID); err != nil {
+		log.Warn().Err(err).Str("email_id", accountID.String()).Msg("initial account load onto worker failed")
+	}
+}
+
+// LoadAccountOntoWorker assigns a worker if the account has none, rebuilds the
+// account's decrypted credentials into an AddWorkerEmail payload, and publishes
+// it so the worker loads the account into memory. Safe to call repeatedly.
+func (s *emailService) LoadAccountOntoWorker(ctx context.Context, accountID uuid.UUID) error {
+	acc, xerr := s.emailRepository.GetByID(ctx, accountID)
+	if xerr != nil {
+		return xerr
+	}
+	if acc == nil {
+		return nil
+	}
+
+	workerID := acc.WorkerID
+	if workerID == nil {
+		// No worker yet: assign one now (OAuth onboarding never assigned).
+		if acc.OrganizationID == nil || s.workerAssignment == nil {
+			log.Warn().
+				Str("email_id", acc.ID.String()).
+				Bool("has_org", acc.OrganizationID != nil).
+				Msg("cannot load mailbox onto a worker: missing organization or assignment service; account will not send or sync")
+			return nil
+		}
+		assigned, err := s.workerAssignment.AssignWorkerToEmail(ctx, acc.ID, *acc.OrganizationID)
+		if err != nil {
+			return err
+		}
+		workerID = assigned
+	}
+	if workerID == nil {
+		return nil
+	}
+
+	payload, err := s.buildAddWorkerEmail(ctx, acc)
+	if err != nil {
+		return err
+	}
+	if payload == nil {
+		return nil
+	}
+	return s.publisher.PublishAddEmail(ctx, *workerID, payload)
+}
+
+// buildAddWorkerEmail reconstructs the worker payload for an account, decrypting
+// its credentials and attaching the provider-specific data. Cfg is intentionally
+// left zero: it is avro-excluded and the worker rebuilds it locally from its own
+// oauth config.
+func (s *emailService) buildAddWorkerEmail(ctx context.Context, acc *models.Email) (*models.AddWorkerEmail, error) {
+	userID, err := uuid.Parse(acc.UserID)
+	if err != nil {
+		return nil, err
+	}
+	first, last := splitName(acc.Name)
+	provider := models.InboxProvider(acc.Provider)
+
+	out := &models.AddWorkerEmail{
+		ID:        acc.ID,
+		UserID:    userID,
+		Email:     acc.Email,
+		FirstName: first,
+		LastName:  last,
+		Type:      provider,
+	}
+
+	switch provider {
+	case models.InboxProviderGoogle:
+		creds, cerr := s.emailRepository.GetOAuthCredentials(ctx, acc.ID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		var lastHistory uint64
+		if acc.LastID != nil && *acc.LastID > 0 {
+			lastHistory = uint64(*acc.LastID)
+		}
+		out.Google = &models.AddWorkerEmailGoogleData{
+			Token:         oauthToken(creds),
+			LastHistoryID: lastHistory,
+		}
+	case models.InboxProviderOutlook:
+		creds, cerr := s.emailRepository.GetOAuthCredentials(ctx, acc.ID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		out.Graph = &models.AddWorkerEmailGraphData{
+			Token:      oauthToken(creds),
+			DeltaLinks: s.deltaLinksFor(ctx, userID, acc.ID),
+		}
+	case models.InboxProviderSMTPIMAP:
+		creds, cerr := s.emailRepository.GetSMTPCredentials(ctx, acc.ID)
+		if cerr != nil {
+			return nil, cerr
+		}
+		out.ImapSync = true
+		out.SmtpImap = &models.AddWorkerEmailSmtpImapData{
+			Credentials: &models.SmtpImap{
+				SMTP: &models.Service{Host: creds.SMTPHost, Port: creds.SMTPPort, Username: creds.SMTPUser, Password: creds.SMTPPassword},
+				IMAP: &models.Service{Host: creds.IMAPHost, Port: creds.IMAPPort, Username: creds.IMAPUser, Password: creds.IMAPPassword},
+			},
+		}
+	default:
+		return nil, nil
+	}
+
+	return out, nil
+}
+
+func (s *emailService) deltaLinksFor(ctx context.Context, userID, emailID uuid.UUID) map[string]string {
+	if s.graphDelta == nil {
+		return nil
+	}
+	links, err := s.graphDelta.Get(ctx, userID, emailID)
+	if err != nil {
+		return nil
+	}
+	return links
+}
+
+func oauthToken(c *repository.OAuthCredentials) *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  c.AccessToken,
+		RefreshToken: c.RefreshToken,
+		Expiry:       c.ExpiresAt,
+		TokenType:    "Bearer",
+	}
+}
+
+func splitName(name string) (firstName, lastName string) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", ""
+	}
+	parts := strings.SplitN(name, " ", 2)
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], strings.TrimSpace(parts[1])
+}

--- a/internal/app/email/onboarding.go
+++ b/internal/app/email/onboarding.go
@@ -165,6 +165,9 @@ func (s *emailService) OAuthFinish(ctx context.Context, userID, code, state stri
 		s.syncWarmupPoolMembership(ctx, acc)
 		s.publishAccountEvent(ctx, pubsub.EventAccountConnected, acc)
 		s.dispatchAccountConnected(ctx, sess.OrganizationID, acc)
+		// Assign a worker and load the mailbox so it starts sending/syncing
+		// immediately; the reconciler is the fallback if this fails.
+		s.loadAccountBestEffort(ctx, acc.ID)
 	}
 	return acc, xerr
 }
@@ -229,6 +232,9 @@ func (s *emailService) OnboardSMTPIMAP(ctx context.Context, userID string, orgID
 	s.syncWarmupPoolMembership(ctx, acc)
 	s.publishAccountEvent(ctx, pubsub.EventAccountConnected, acc)
 	s.dispatchAccountConnected(ctx, orgID, acc)
+	// Load the mailbox onto its assigned worker so it starts sending/syncing
+	// immediately; the reconciler is the fallback if this fails.
+	s.loadAccountBestEffort(ctx, acc.ID)
 	return acc, nil
 }
 

--- a/internal/app/email/service.go
+++ b/internal/app/email/service.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/cipher"
@@ -39,6 +40,12 @@ type EmailService interface {
 	// set, account-lifecycle events fan out to customer webhook endpoints.
 	WireWebhooks(w webhook.Service)
 	WireThrottle(t dailythrottle.Service)
+	// WireGraphDelta attaches the Graph delta-cursor repository so the worker
+	// reconciler can seed a mailbox's saved cursors when loading it.
+	WireGraphDelta(repo repository.EmailGraphDeltaRepository)
+	// StartWorkerReconciler periodically ensures every active mailbox is
+	// assigned to a worker and loaded onto it (blocks until ctx is cancelled).
+	StartWorkerReconciler(ctx context.Context, interval time.Duration)
 }
 
 type emailService struct {
@@ -53,6 +60,7 @@ type emailService struct {
 	oauthInbox         *config.Oauth2Inbox
 	workerAssignment   worker.WorkerAssignmentService
 	throttle           dailythrottle.Service
+	graphDelta         repository.EmailGraphDeltaRepository
 	// webhookService is optional. When non-nil, account lifecycle events
 	// (email_account.connected, email_account.removed) are dispatched to
 	// subscribed customer webhooks.

--- a/internal/app/worker/event_add_email.go
+++ b/internal/app/worker/event_add_email.go
@@ -26,8 +26,9 @@ func (w *WorkerService) HandleAddEmail(ctx context.Context, e *models.AddWorkerE
 	// cancelled when the account is removed or terminates, so we don't leak goroutines.
 	mail := w.mailManager.Get(e.ID)
 	if mail != nil {
-		// Skip IMAP if not requested for SMTP/IMAP providers
-		if e.Type != models.InboxProviderGoogle && !e.ImapSync {
+		// Gmail (history) and Outlook/Graph (delta) always sync. Only generic
+		// SMTP/IMAP mailboxes are opt-in via ImapSync.
+		if e.Type == models.InboxProviderSMTPIMAP && !e.ImapSync {
 			log.Info().Str("email_id", e.ID.String()).Str("email", e.Email).Msg("email account added (no sync)")
 			return nil
 		}

--- a/internal/app/worker/event_warmup_action.go
+++ b/internal/app/worker/event_warmup_action.go
@@ -49,6 +49,8 @@ func (w *WorkerService) HandleWarmupAction(ctx context.Context, body any) error 
 	switch {
 	case mail.GoogleData != nil && mail.GoogleData.Client != nil:
 		w.runGoogleWarmupActions(ctx, mail, action)
+	case mail.GraphData != nil && mail.GraphData.Client != nil:
+		w.runGraphWarmupActions(ctx, mail, action)
 	case mail.SmtpImapData != nil && mail.SmtpImapData.ImapClient != nil:
 		w.runImapWarmupActions(ctx, mail, action)
 	default:
@@ -81,6 +83,61 @@ func (w *WorkerService) runGoogleWarmupActions(ctx context.Context, mail *wmail.
 		case "star":
 			if err := mail.GoogleData.Client.AddStar(ctx, action.GmailID); err != nil {
 				log.Error().Err(err).Str("gmail_id", action.GmailID).Msg("Failed to star warmup message")
+			}
+		default:
+			log.Warn().Str("action", act).Msg("Unknown warmup action")
+		}
+	}
+}
+
+// runGraphWarmupActions applies recipient-side warmup engagement to a Microsoft
+// Graph mailbox. action.GmailID carries the Graph message id (the provider id
+// field is provider-agnostic). Star maps to the follow-up flag, the closest
+// Outlook equivalent of a Gmail star.
+func (w *WorkerService) runGraphWarmupActions(ctx context.Context, mail *wmail.WMail, action models.WarmupEmailAction) {
+	client := mail.GraphData.Client
+
+	// A Graph message id changes whenever the message is moved (copy+delete), so
+	// resolve the live id from the immutable RFC Message-ID before acting. This
+	// leg may run after an earlier leg already moved the message to Warmbly.
+	msgID := action.GmailID
+	if action.RFCMessageID != "" {
+		if resolved, err := client.ResolveMessageID(ctx, action.RFCMessageID); err == nil && resolved != "" {
+			msgID = resolved
+		}
+	}
+
+	for _, act := range action.Actions {
+		switch act {
+		case "move_to_warmbly":
+			newID, err := client.MoveToFolder(ctx, msgID, imap.WarmupFolderName)
+			if err != nil {
+				log.Error().Err(err).Str("graph_id", msgID).Msg("Failed to move to Warmbly folder (Graph)")
+				continue
+			}
+			if newID != "" {
+				msgID = newID // subsequent actions target the moved copy
+			}
+		case "mark_read":
+			if err := client.MarkAsRead(ctx, msgID); err != nil {
+				log.Error().Err(err).Str("graph_id", msgID).Msg("Failed to mark as read (Graph)")
+			}
+		case "remove_from_spam":
+			newID, err := client.RemoveFromSpam(ctx, msgID)
+			if err != nil {
+				log.Error().Err(err).Str("graph_id", msgID).Msg("Failed to rescue from junk (Graph)")
+				continue
+			}
+			if newID != "" {
+				msgID = newID
+			}
+		case "mark_important":
+			if err := client.MarkImportant(ctx, msgID); err != nil {
+				log.Error().Err(err).Str("graph_id", msgID).Msg("Failed to mark important (Graph)")
+			}
+		case "star":
+			if err := client.AddFlag(ctx, msgID); err != nil {
+				log.Error().Err(err).Str("graph_id", msgID).Msg("Failed to flag warmup message (Graph)")
 			}
 		default:
 			log.Warn().Str("action", act).Msg("Unknown warmup action")

--- a/internal/app/worker/mailmanager/add_email.go
+++ b/internal/app/worker/mailmanager/add_email.go
@@ -14,6 +14,10 @@ func (m *MailManager) AddWMail(
 	m.Lock()
 	defer m.Unlock()
 
+	// Cfg is avro-excluded from the payload, so rebuild it from the worker's
+	// local oauth config for token refresh (no-op for smtp_imap).
+	data.Cfg = m.cfgFor(data.Type)
+
 	newMail, err := wmail.NewWMail(
 		data,
 		m.OnEvent,

--- a/internal/app/worker/mailmanager/manager.go
+++ b/internal/app/worker/mailmanager/manager.go
@@ -6,10 +6,12 @@ import (
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/worker/wmail"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/storage"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
+	"golang.org/x/oauth2"
 )
 
 type MailManager struct {
@@ -20,6 +22,7 @@ type MailManager struct {
 	storage                   storage.Store
 	emailMessageMapRepository repository.EmailMessageMapRepository
 	cipherService             cipher.CipherService
+	oauthInbox                *config.Oauth2Inbox
 }
 
 func NewMailManager(
@@ -28,6 +31,7 @@ func NewMailManager(
 	storage storage.Store,
 	emailMessageMapRepository repository.EmailMessageMapRepository,
 	cipherService cipher.CipherService,
+	oauthInbox *config.Oauth2Inbox,
 ) *MailManager {
 	return &MailManager{
 		Emails:                    make(map[uuid.UUID]*wmail.WMail),
@@ -36,7 +40,28 @@ func NewMailManager(
 		storage:                   storage,
 		emailMessageMapRepository: emailMessageMapRepository,
 		cipherService:             cipherService,
+		oauthInbox:                oauthInbox,
 	}
+}
+
+// cfgFor returns the OAuth config the worker uses to refresh a provider's
+// delegated token. Cfg is not carried in the AddWorkerEmail payload (avro
+// excludes it), so it is rebuilt here from the worker's local oauth config.
+func (m *MailManager) cfgFor(t models.InboxProvider) oauth2.Config {
+	if m.oauthInbox == nil {
+		return oauth2.Config{}
+	}
+	switch t {
+	case models.InboxProviderGoogle:
+		if m.oauthInbox.Google != nil {
+			return *m.oauthInbox.Google
+		}
+	case models.InboxProviderOutlook:
+		if m.oauthInbox.Outlook != nil {
+			return *m.oauthInbox.Outlook
+		}
+	}
+	return oauth2.Config{}
 }
 
 // Get returns a WMail by ID, or nil if not present

--- a/internal/app/worker/service.go
+++ b/internal/app/worker/service.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/worker/mailmanager"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/codec"
 	"github.com/warmbly/warmbly/internal/infrastructure/eventbus"
@@ -25,6 +26,11 @@ type WorkerService struct {
 	Cache                     *cache.Cache
 	Storage                   storage.Store
 	EmailMessageMapRepository repository.EmailMessageMapRepository
+
+	// OauthInbox supplies the provider OAuth configs (client id/secret +
+	// endpoint) the worker needs to refresh delegated tokens locally. Cfg is not
+	// serialized in the AddWorkerEmail payload, so the worker rebuilds it here.
+	OauthInbox *config.Oauth2Inbox
 
 	mailManager *mailmanager.MailManager
 
@@ -54,6 +60,7 @@ func (s *WorkerService) Init() error {
 		s.Storage,
 		s.EmailMessageMapRepository,
 		s.CipherService,
+		s.OauthInbox,
 	)
 
 	return nil

--- a/internal/app/worker/wmail/event_graph.go
+++ b/internal/app/worker/wmail/event_graph.go
@@ -1,0 +1,159 @@
+package wmail
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/emsg"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// onGraphMessageAdd mirrors onGoogleMessageAdd: dedupe by RFC Message-ID, store
+// the body, record the messageId map entry, and emit a NEW_EMAIL event. The
+// opaque Graph message id rides in GmailID (the provider-message-id field).
+func (w *WMail) onGraphMessageAdd(ctx context.Context, msg *models.EmailMessageData) error {
+	// The messageId map is keyed by the provider message id (the Graph id lives
+	// in GmailID), so dedup and the remove/flag lookups below all use the same
+	// key even though delta only ever gives us the Graph id.
+	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, msg.GmailID)
+	if err != nil {
+		return err
+	}
+
+	if internalMessage != nil {
+		return nil
+	}
+
+	if rateLimitErr := w.CheckAndRecordSync(ctx, 1); rateLimitErr != nil {
+		return rateLimitErr
+	}
+
+	msg.ID = uuid.New()
+	now := time.Now()
+
+	data := &models.EmailMessageStoreData{
+		ID:           msg.ID,
+		EmailID:      w.ID,
+		Mailbox:      0,
+		ThreadID:     msg.ThreadID,
+		MessageID:    msg.MessageID,
+		GmailID:      msg.GmailID,
+		ParentID:     msg.ParentID,
+		UID:          msg.UID,
+		ModSeq:       msg.ModSeq,
+		Flags:        msg.Flags,
+		BCC:          msg.BCC,
+		CC:           msg.CC,
+		FromAddr:     msg.From,
+		InReplyTo:    msg.InReplyTo,
+		ReplyTo:      msg.ReplyTo,
+		ToAddr:       msg.To,
+		Subject:      msg.Subject,
+		Size:         msg.Size,
+		InternalDate: msg.InternalDate,
+		SentDate:     msg.Date,
+		Snippet:      msg.Snippet,
+		Seen:         false,
+		UpdatedAt:    now,
+		CreatedAt:    now,
+	}
+
+	if err := w.EmailMessageMapRepository.Add(ctx, repository.EmailMessageData{
+		UserID:    w.UserID.String(),
+		EmailID:   w.ID.String(),
+		MessageID: msg.GmailID,
+		ID:        msg.ID.String(),
+		ThreadID:  msg.ThreadID,
+	}); err != nil {
+		return err
+	}
+
+	if err := w.StoreBody(ctx, msg.ID, &emsg.EmailBlob{
+		HTMLBody:  []byte(msg.BodyHTML),
+		PlainText: []byte(msg.BodyPlain),
+	}); err != nil {
+		return err
+	}
+
+	return w.onEvent(models.JobEventTypeNewEmail, data)
+}
+
+// onGraphMessageRemove emits REMOVE_EMAIL for a message deleted or moved out of a
+// tracked folder. providerID is the Graph message id.
+func (w *WMail) onGraphMessageRemove(ctx context.Context, providerID string) error {
+	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, providerID)
+	if err != nil {
+		return err
+	}
+	if internalMessage == nil {
+		return nil
+	}
+
+	internalID, err := uuid.Parse(internalMessage.ID)
+	if err != nil {
+		return err
+	}
+
+	return w.onEvent(models.JobEventTypeRemoveEmail, &models.JobEventRemoveEmail{
+		UserID:  w.UserID,
+		EmailID: w.ID,
+		ID:      internalID,
+	})
+}
+
+// onGraphFlagsChange keeps read state in sync: Graph delta reports isRead, which
+// we map to the \Seen flag add/remove the unibox already understands. No-op when
+// the message isn't tracked yet (the add path sets the initial flags).
+func (w *WMail) onGraphFlagsChange(ctx context.Context, providerID string, seen bool) error {
+	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, providerID)
+	if err != nil {
+		return err
+	}
+	if internalMessage == nil {
+		return nil
+	}
+
+	internalID, err := uuid.Parse(internalMessage.ID)
+	if err != nil {
+		return err
+	}
+
+	eventType := models.JobEventTypeFlagsRemove
+	if seen {
+		eventType = models.JobEventTypeFlagsAdd
+	}
+
+	return w.onEvent(eventType, &models.JobEventFlags{
+		UserID:  w.UserID,
+		EmailID: w.ID,
+		ID:      internalID,
+		Flags:   []string{"\\Seen"},
+	})
+}
+
+// onGraphDelta relays the opaque per-folder delta cursor to the control plane for
+// durable persistence (the worker is disposable and must not be the source of
+// truth for the cursor).
+func (w *WMail) onGraphDelta(_ context.Context, folder, deltaLink string) error {
+	return w.onEvent(models.JobEventTypeGraphDeltaUpdate, &models.JobEventGraphDeltaUpdate{
+		UserID:    w.UserID,
+		EmailID:   w.ID,
+		Folder:    folder,
+		DeltaLink: deltaLink,
+	})
+}
+
+// cloneStringMap returns a shallow copy so the worker's live cursor map is never
+// aliased to the deserialized event payload.
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/internal/app/worker/wmail/send.go
+++ b/internal/app/worker/wmail/send.go
@@ -2,11 +2,13 @@ package wmail
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/client/goog"
+	"github.com/warmbly/warmbly/internal/client/msgraph"
 	"github.com/warmbly/warmbly/internal/client/smtpimap/smtp"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
@@ -89,7 +91,9 @@ func (w *WMail) Send(ctx context.Context, req *SendRequest) *SendResult {
 		switch w.EmailType {
 		case models.InboxProviderGoogle:
 			result = w.sendViaGmail(ctx, req, bodyHTML)
-		case models.InboxProviderOutlook, models.InboxProviderSMTPIMAP:
+		case models.InboxProviderOutlook:
+			result = w.sendViaGraph(ctx, req, bodyHTML)
+		case models.InboxProviderSMTPIMAP:
 			result = w.sendViaSMTP(ctx, req, bodyHTML)
 		default:
 			result.Error = errx.MError(
@@ -197,6 +201,78 @@ func (w *WMail) sendViaGmail(ctx context.Context, req *SendRequest, bodyHTML str
 	return result
 }
 
+// sendViaGraph sends an email through Microsoft Graph (RAW MIME sendMail).
+// sendMail returns 202 with no provider id, so ProviderMsgID is the RFC
+// Message-ID we minted, mirroring the SMTP path.
+func (w *WMail) sendViaGraph(ctx context.Context, req *SendRequest, bodyHTML string) *SendResult {
+	result := &SendResult{
+		Success: false,
+		SentAt:  time.Now(),
+	}
+
+	if w.GraphData == nil || w.GraphData.Client == nil {
+		result.Error = errx.MError(
+			errx.MailErrorCritical,
+			errx.MailErrorCodeAuthenticationFailed,
+			"Microsoft Graph client not initialized",
+			errx.MailErrorResolveMethodReload,
+		)
+		return result
+	}
+
+	// Build parent reference for replies. Warmup replies often only have the RFC
+	// Message-ID from the token flow, not a local provider thread record.
+	var parent *models.EmailMessageData
+	if req.InReplyTo != "" && req.Parent != nil {
+		parent = &models.EmailMessageData{
+			MessageID: req.Parent.MessageID,
+			ThreadID:  req.Parent.ThreadID,
+		}
+	} else if req.InReplyTo != "" {
+		parent = &models.EmailMessageData{
+			MessageID: strings.Trim(req.InReplyTo, "<>"),
+		}
+	}
+
+	// Warmup token + RFC 8058 one-click unsubscribe headers; RAW MIME carries
+	// them verbatim (the JSON message shape cannot).
+	customHeaders := buildSendHeaders(req)
+	attachments := toGraphAttachments(req.Attachments)
+
+	err := w.GraphData.Client.SendMessage(
+		ctx,
+		req.To,
+		req.Cc,
+		req.Bcc,
+		req.MessageID,
+		req.Subject,
+		req.BodyPlain,
+		bodyHTML,
+		parent,
+		attachments,
+		customHeaders,
+	)
+	if err != nil {
+		var mailErr *errx.MailError
+		if errors.As(err, &mailErr) {
+			result.Error = mailErr
+		} else {
+			result.Error = errx.MError(
+				errx.MailErrorWarning,
+				errx.MailErrorCodeServerUnreachable,
+				err.Error(),
+				errx.MailErrorResolveMethodRetry,
+			)
+		}
+		return result
+	}
+
+	result.Success = true
+	result.MessageID = req.MessageID
+	result.ProviderMsgID = req.MessageID // Graph sendMail returns no id
+	return result
+}
+
 // sendViaSMTP sends an email using SMTP
 func (w *WMail) sendViaSMTP(ctx context.Context, req *SendRequest, bodyHTML string) *SendResult {
 	result := &SendResult{
@@ -253,6 +329,22 @@ func toGoogAttachments(in []Attachment) []goog.Attachment {
 	out := make([]goog.Attachment, 0, len(in))
 	for _, a := range in {
 		out = append(out, goog.Attachment{
+			Filename: a.Filename,
+			MimeType: a.MimeType,
+			Data:     a.Data,
+		})
+	}
+	return out
+}
+
+// toGraphAttachments maps wmail attachments to the Graph transport shape.
+func toGraphAttachments(in []Attachment) []msgraph.Attachment {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]msgraph.Attachment, 0, len(in))
+	for _, a := range in {
+		out = append(out, msgraph.Attachment{
 			Filename: a.Filename,
 			MimeType: a.MimeType,
 			Data:     a.Data,

--- a/internal/app/worker/wmail/sync_graph.go
+++ b/internal/app/worker/wmail/sync_graph.go
@@ -1,0 +1,23 @@
+package wmail
+
+import (
+	"context"
+	"errors"
+
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// SyncGraph walks the Microsoft Graph delta stream for the mailbox. It is the
+// Graph analogue of SyncGoogle: a critical MailError (auth/disabled) is returned
+// so the sync loop stops and the account is flagged for re-auth; anything else is
+// captured and swallowed so a transient blip doesn't tear down the account.
+func (w *WMail) SyncGraph(ctx context.Context) *errx.MailError {
+	if err := w.GraphData.Client.Sync(ctx); err != nil {
+		var mailErr *errx.MailError
+		if errors.As(err, &mailErr) {
+			return mailErr
+		}
+		w.CaptureError(err)
+	}
+	return nil
+}

--- a/internal/app/worker/wmail/sync_mail.go
+++ b/internal/app/worker/wmail/sync_mail.go
@@ -11,7 +11,9 @@ func (w *WMail) SyncMail(ctx context.Context) *errx.MailError {
 	switch w.EmailType {
 	case models.InboxProviderGoogle:
 		return w.SyncGoogle(ctx)
-	case models.InboxProviderOutlook, models.InboxProviderSMTPIMAP:
+	case models.InboxProviderOutlook:
+		return w.SyncGraph(ctx)
+	case models.InboxProviderSMTPIMAP:
 		return w.Sync(ctx)
 	default:
 		return nil

--- a/internal/app/worker/wmail/wmail.go
+++ b/internal/app/worker/wmail/wmail.go
@@ -6,13 +6,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/client/goog"
+	"github.com/warmbly/warmbly/internal/client/msgraph"
 	"github.com/warmbly/warmbly/internal/client/smtpimap/imap"
 	"github.com/warmbly/warmbly/internal/client/smtpimap/smtp"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/storage"
 	"github.com/warmbly/warmbly/internal/models"
-	"github.com/warmbly/warmbly/internal/pkg/stoken"
 	"github.com/warmbly/warmbly/internal/repository"
 	"golang.org/x/oauth2"
 )
@@ -31,6 +31,10 @@ type OutlookService struct {
 type GoogleData struct {
 	Client        *goog.Client
 	LastHistoryID uint64
+}
+
+type GraphData struct {
+	Client *msgraph.Client
 }
 
 type SmtpImapData struct {
@@ -53,6 +57,7 @@ type WMail struct {
 	EmailType models.InboxProvider
 
 	GoogleData   *GoogleData
+	GraphData    *GraphData
 	SmtpImapData *SmtpImapData
 
 	Cache                     *cache.Cache
@@ -101,6 +106,14 @@ func NewWMail(
 
 	switch data.Type {
 	case models.InboxProviderGoogle:
+		if data.Google == nil {
+			return nil, errx.MError(
+				errx.MailErrorCritical,
+				errx.MailErrorCodeAuthenticationFailed,
+				"missing Google credentials in add-email payload",
+				errx.MailErrorResolveMethodReload,
+			)
+		}
 		mail.GoogleData = &GoogleData{
 			Client: &goog.Client{
 				Email:     data.Email,
@@ -119,55 +132,59 @@ func NewWMail(
 		if err := mail.GoogleData.Client.Init(mailCtx, data.Google.Token, data.Cfg); err != nil {
 			return nil, err
 		}
-	default:
+	case models.InboxProviderOutlook:
+		// Microsoft/Outlook mailboxes run entirely on Microsoft Graph: RAW MIME
+		// sendMail plus delta-based inbound sync. There is no IMAP/SMTP path.
+		if data.Graph == nil {
+			return nil, errx.MError(
+				errx.MailErrorCritical,
+				errx.MailErrorCodeAuthenticationFailed,
+				"missing Microsoft Graph credentials in add-email payload",
+				errx.MailErrorResolveMethodReload,
+			)
+		}
+		token := data.Graph.Token
+		deltaLinks := data.Graph.DeltaLinks
+
+		mail.GraphData = &GraphData{
+			Client: &msgraph.Client{
+				Email:     data.Email,
+				FirstName: data.FirstName,
+				LastName:  data.LastName,
+
+				Cache:      mail.Cache,
+				DeltaLinks: cloneStringMap(deltaLinks),
+
+				OnMessageAdd:    mail.onGraphMessageAdd,
+				OnMessageRemove: mail.onGraphMessageRemove,
+				OnFlagsChange:   mail.onGraphFlagsChange,
+				OnDelta:         mail.onGraphDelta,
+				OnTokenRefresh: func(_ context.Context, t *oauth2.Token) error {
+					return mail.onTokenUpdate(t)
+				},
+			},
+		}
+
+		if err := mail.GraphData.Client.Init(mailCtx, token, data.Cfg); err != nil {
+			return nil, err
+		}
+	case models.InboxProviderSMTPIMAP:
+		// Generic SMTP/IMAP with plain-auth credentials (arbitrary providers).
+		if data.SmtpImap == nil || data.SmtpImap.Credentials == nil {
+			return nil, errx.MError(
+				errx.MailErrorCritical,
+				errx.MailErrorCodeInvalidCredentials,
+				"missing SMTP/IMAP credentials in add-email payload",
+				errx.MailErrorResolveMethodReload,
+			)
+		}
 		mail.SmtpImapData = &SmtpImapData{}
-		var smtpOauth2 *models.Oauth2Service
-		var imapOauth2 *models.Oauth2Service
-
-		var authType models.AuthType
-
-		switch data.Type {
-		case models.InboxProviderOutlook:
-			imapOauth2 = &models.Oauth2Service{
-				Host: "outlook.office365.com",
-				Port: 993,
-			}
-			smtpOauth2 = &models.Oauth2Service{
-				Host: "smtp-mail.outlook.com",
-				Port: 587,
-			}
-			authType = models.AuthOAuth2
-		case models.InboxProviderSMTPIMAP:
-			authType = models.AuthPlain
-		}
-
-		if data.SmtpImap.Token != nil {
-			ts := data.Cfg.TokenSource(mailCtx, data.SmtpImap.Token)
-			ts = oauth2.ReuseTokenSource(data.SmtpImap.Token, ts)
-			ts = stoken.New(ts, func(token *oauth2.Token) error {
-				return mail.onTokenUpdate(token)
-			})
-
-			tk := stoken.New(ts, mail.onTokenUpdate)
-
-			if imapOauth2 != nil {
-				imapOauth2.Token = tk
-			}
-			if smtpOauth2 != nil {
-				smtpOauth2.Token = tk
-			}
-		}
 
 		if data.ImapSync {
-			var imapCredentials *models.Service
-			if authType == models.AuthPlain {
-				imapCredentials = data.SmtpImap.Credentials.IMAP
-			}
 			mail.SmtpImapData.ImapClient = &imap.Client{
 				Email:       data.Email,
-				AuthType:    authType,
-				Credentials: imapCredentials,
-				Oauth2:      imapOauth2,
+				AuthType:    models.AuthPlain,
+				Credentials: data.SmtpImap.Credentials.IMAP,
 
 				OnUpdate: mail.onImapEmailUpdate,
 			}
@@ -180,10 +197,16 @@ func NewWMail(
 			FirstName:   data.FirstName,
 			LastName:    data.LastName,
 			Email:       data.Email,
-			AuthType:    authType,
+			AuthType:    models.AuthPlain,
 			Credentials: data.SmtpImap.Credentials.SMTP,
-			Oauth2:      smtpOauth2,
 		}
+	default:
+		return nil, errx.MError(
+			errx.MailErrorCritical,
+			errx.MailErrorCodeUnsupported,
+			"Unsupported email provider",
+			errx.MailErrorResolveMethodReload,
+		)
 	}
 
 	return mail, nil

--- a/internal/app/worker_orchestrator/orchestrator.go
+++ b/internal/app/worker_orchestrator/orchestrator.go
@@ -64,6 +64,13 @@ type WorkerEnvConfig struct {
 	EventBusProvider string
 	NATSURL          string
 	CodecProvider    string
+
+	// Provider OAuth client credentials the worker needs to refresh delegated
+	// mailbox tokens locally (Cfg is not shipped in the AddWorkerEmail payload).
+	BoxGoogleClientID      string
+	BoxGoogleClientSecret  string
+	BoxOutlookClientID     string
+	BoxOutlookClientSecret string
 }
 
 type Orchestrator struct {
@@ -622,6 +629,10 @@ func (o *Orchestrator) renderEnvFile(ctx context.Context, workerID uuid.UUID) (e
 	write("EVENTBUS_PROVIDER", env.EventBusProvider)
 	write("NATS_URL", env.NATSURL)
 	write("CODEC_PROVIDER", env.CodecProvider)
+	write("BOX_GOOGLE_CLIENT_ID", env.BoxGoogleClientID)
+	write("BOX_GOOGLE_CLIENT_SECRET", env.BoxGoogleClientSecret)
+	write("BOX_OUTLOOK_CLIENT_ID", env.BoxOutlookClientID)
+	write("BOX_OUTLOOK_CLIENT_SECRET", env.BoxOutlookClientSecret)
 	return b.String(), image, nil
 }
 

--- a/internal/client/goog/message.go
+++ b/internal/client/goog/message.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/models"
 	"google.golang.org/api/gmail/v1"
 )
@@ -40,7 +41,9 @@ func getAddressList(headers []*gmail.MessagePartHeader, name string) []string {
 
 func getSingleHeader(headers []*gmail.MessagePartHeader, name string) string {
 	for _, h := range headers {
-		if h.Name == name {
+		// RFC 5322 header names are case-insensitive; match accordingly so the
+		// warmup token (and other headers) resolve regardless of provider casing.
+		if strings.EqualFold(h.Name, name) {
 			return h.Value
 		}
 	}
@@ -91,6 +94,18 @@ func GmailMessageToEmailData(msg *gmail.Message) *models.EmailMessageData {
 					flags = append(flags, "\\Important")
 				case "DRAFT":
 					flags = append(flags, "\\Draft")
+				}
+			}
+			// Surface the warmup verification token as a pseudo-flag so the
+			// consumer can categorize warmup mail into the Warmbly folder.
+			if tok := getSingleHeader(headers, config.WarmupVerifyHeader); tok != "" {
+				flags = append(flags, config.WarmupVerifyHeader+":"+tok)
+			}
+			// Surface machine-reply / DSN-bounce markers so the consumer's
+			// reply/bounce classifier can read them.
+			for _, name := range config.InboundClassificationHeaders {
+				if v := strings.TrimSpace(getSingleHeader(headers, name)); v != "" {
+					flags = append(flags, name+":"+v)
 				}
 			}
 			return flags

--- a/internal/client/msgraph/actions.go
+++ b/internal/client/msgraph/actions.go
@@ -1,0 +1,134 @@
+package msgraph
+
+import (
+	"context"
+	"net/url"
+	"strings"
+)
+
+// Warmup mailbox actions. These mirror the goog/imap warmup actions so the
+// recipient side generates the same natural-looking engagement signals.
+//
+// Note: Graph's move is a copy+delete that returns a NEW message id in the
+// destination folder (the old id shows up @removed in the next delta). The
+// warmup engagement flow is fire-and-forget per message, so we don't thread the
+// new id back here; the messageId map self-heals on the next sync.
+
+// MarkAsRead sets isRead on the message.
+func (c *Client) MarkAsRead(ctx context.Context, messageID string) error {
+	return c.doJSON(ctx, "PATCH", c.messageURL(messageID), map[string]any{"isRead": true}, nil)
+}
+
+// MarkImportant raises the message importance to high, the closest Outlook
+// equivalent of Gmail's IMPORTANT label.
+func (c *Client) MarkImportant(ctx context.Context, messageID string) error {
+	return c.doJSON(ctx, "PATCH", c.messageURL(messageID), map[string]any{"importance": "high"}, nil)
+}
+
+// AddFlag sets the follow-up flag on the message, a deliberate positive signal
+// analogous to a Gmail star.
+func (c *Client) AddFlag(ctx context.Context, messageID string) error {
+	body := map[string]any{"flag": map[string]any{"flagStatus": "flagged"}}
+	return c.doJSON(ctx, "PATCH", c.messageURL(messageID), body, nil)
+}
+
+// RemoveFromSpam rescues a message out of Junk Email back into the Inbox.
+// Graph has no stable v1.0 "not junk" action (markAsNotJunk is retired), so the
+// move is the reliable primitive. Returns the message's new id (move is a
+// copy+delete, so the id changes).
+func (c *Client) RemoveFromSpam(ctx context.Context, messageID string) (string, error) {
+	return c.move(ctx, messageID, FolderInbox)
+}
+
+// MoveToFolder moves the message into a named folder, creating it if needed.
+// Used for the "Warmbly" sorting folder. Returns the message's new id.
+func (c *Client) MoveToFolder(ctx context.Context, messageID, folderName string) (string, error) {
+	folderID, err := c.ensureFolder(ctx, folderName)
+	if err != nil {
+		return "", err
+	}
+	return c.move(ctx, messageID, folderID)
+}
+
+// move relocates a message and returns the new id from the destination folder
+// (Graph move is copy+delete; the source id is invalidated).
+func (c *Client) move(ctx context.Context, messageID, destinationID string) (string, error) {
+	body := map[string]any{"destinationId": destinationID}
+	var moved struct {
+		ID string `json:"id"`
+	}
+	if err := c.doJSON(ctx, "POST", c.messageURL(messageID)+"/move", body, &moved); err != nil {
+		return "", err
+	}
+	return moved.ID, nil
+}
+
+// ResolveMessageID returns the current Graph message id for the message with the
+// given immutable RFC 5322 internetMessageId, searching across folders. Graph
+// ids change on move, so warmup actions re-resolve against this stable key.
+// Returns an empty string (no error) when the message can't be found.
+func (c *Client) ResolveMessageID(ctx context.Context, internetMessageID string) (string, error) {
+	filter := "internetMessageId eq '" + strings.ReplaceAll(internetMessageID, "'", "''") + "'"
+	u := graphBase + "/me/messages?$select=id&$top=1&$filter=" + url.QueryEscape(filter)
+	var resp struct {
+		Value []struct {
+			ID string `json:"id"`
+		} `json:"value"`
+	}
+	if err := c.doJSON(ctx, "GET", u, nil, &resp); err != nil {
+		return "", err
+	}
+	if len(resp.Value) == 0 {
+		return "", nil
+	}
+	return resp.Value[0].ID, nil
+}
+
+func (c *Client) messageURL(messageID string) string {
+	return graphBase + "/me/messages/" + url.PathEscape(messageID)
+}
+
+// ensureFolder resolves a top-level mail folder id by display name, creating the
+// folder on first use. The id is cached for the mailbox's lifetime.
+func (c *Client) ensureFolder(ctx context.Context, name string) (string, error) {
+	c.mu.Lock()
+	if id, ok := c.folderIDs[name]; ok {
+		c.mu.Unlock()
+		return id, nil
+	}
+	c.mu.Unlock()
+
+	// Look for an existing folder with this display name.
+	listURL := graphBase + "/me/mailFolders?$select=id,displayName&$top=100"
+	var list struct {
+		Value []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"displayName"`
+		} `json:"value"`
+	}
+	if err := c.doJSON(ctx, "GET", listURL, nil, &list); err != nil {
+		return "", err
+	}
+	for _, f := range list.Value {
+		if f.DisplayName == name {
+			c.cacheFolder(name, f.ID)
+			return f.ID, nil
+		}
+	}
+
+	// Create it.
+	var created struct {
+		ID string `json:"id"`
+	}
+	if err := c.doJSON(ctx, "POST", graphBase+"/me/mailFolders", map[string]any{"displayName": name}, &created); err != nil {
+		return "", err
+	}
+	c.cacheFolder(name, created.ID)
+	return created.ID, nil
+}
+
+func (c *Client) cacheFolder(name, id string) {
+	c.mu.Lock()
+	c.folderIDs[name] = id
+	c.mu.Unlock()
+}

--- a/internal/client/msgraph/delta.go
+++ b/internal/client/msgraph/delta.go
@@ -1,0 +1,123 @@
+package msgraph
+
+import (
+	"context"
+	"net/url"
+)
+
+// deltaSelect keeps delta pages light: we only need the id, read state, and the
+// @removed marker to decide add/update vs remove. Full envelope + body + headers
+// are hydrated per added message via fetchMessage.
+const deltaSelect = "id,isRead"
+
+// msgSelect is the property set fetched for each new message: enough to build a
+// complete EmailMessageData (envelope, threading, body) plus internetMessageHeaders
+// so the warmup verification token survives into sync.
+const msgSelect = "id,internetMessageId,conversationId,subject,bodyPreview,isRead," +
+	"receivedDateTime,from,sender,toRecipients,ccRecipients,bccRecipients,replyTo,body,internetMessageHeaders"
+
+// deltaPage is one page of a messages/delta response.
+type deltaPage struct {
+	Value     []graphMessage `json:"value"`
+	NextLink  string         `json:"@odata.nextLink"`
+	DeltaLink string         `json:"@odata.deltaLink"`
+}
+
+// Sync walks the delta stream for the tracked folders (inbox + junk) and drives
+// the OnMessage* callbacks. It is the Graph equivalent of goog.FetchHistory and
+// fits the disposable worker natively: no webhook endpoint, no subscription
+// lifecycle, just a cursor the control plane persists via OnDelta.
+func (c *Client) Sync(ctx context.Context) error {
+	for _, folder := range []string{FolderInbox, FolderJunk} {
+		if err := c.syncFolder(ctx, folder); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Client) syncFolder(ctx context.Context, folder string) error {
+	next := c.DeltaLinks[folder]
+
+	// First run for this folder: there is no cursor yet. We page to the end
+	// purely to capture a deltaLink representing "now" and do NOT import the
+	// mailbox's existing history, mirroring how the Gmail path starts from the
+	// history id captured at connect time rather than backfilling everything.
+	priming := next == ""
+	if priming {
+		next = graphBase + "/me/mailFolders/" + folder + "/messages/delta?$select=" + url.QueryEscape(deltaSelect)
+	}
+
+	for {
+		var page deltaPage
+		if err := c.doJSON(ctx, "GET", next, nil, &page); err != nil {
+			return err
+		}
+
+		if !priming {
+			for i := range page.Value {
+				if err := c.applyDelta(ctx, &page.Value[i]); err != nil {
+					return err
+				}
+			}
+		}
+
+		switch {
+		case page.NextLink != "":
+			next = page.NextLink
+		case page.DeltaLink != "":
+			c.DeltaLinks[folder] = page.DeltaLink
+			if c.OnDelta != nil {
+				if err := c.OnDelta(ctx, folder, page.DeltaLink); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return nil
+		}
+	}
+}
+
+// applyDelta turns one delta item into the right callback. Removed items (delete
+// or move-out) fire OnMessageRemove; live items are hydrated and fire
+// OnMessageAdd (the wmail layer dedupes by Message-ID) plus OnFlagsChange to keep
+// read state fresh for messages that already exist.
+func (c *Client) applyDelta(ctx context.Context, item *graphMessage) error {
+	if item.Removed != nil {
+		if c.OnMessageRemove != nil {
+			return c.OnMessageRemove(ctx, item.ID)
+		}
+		return nil
+	}
+
+	full, err := c.fetchMessage(ctx, item.ID)
+	if err != nil {
+		return err
+	}
+	if full == nil {
+		return nil
+	}
+
+	if c.OnMessageAdd != nil {
+		if err := c.OnMessageAdd(ctx, full.toEmailData()); err != nil {
+			return err
+		}
+	}
+	if c.OnFlagsChange != nil {
+		if err := c.OnFlagsChange(ctx, item.ID, full.IsRead); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// fetchMessage hydrates a single message with the full property set.
+func (c *Client) fetchMessage(ctx context.Context, id string) (*graphMessage, error) {
+	u := graphBase + "/me/messages/" + url.PathEscape(id) + "?$select=" + url.QueryEscape(msgSelect)
+	var msg graphMessage
+	if err := c.doJSON(ctx, "GET", u, nil, &msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}

--- a/internal/client/msgraph/error.go
+++ b/internal/client/msgraph/error.go
@@ -1,0 +1,47 @@
+package msgraph
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// graphErrorEnvelope is Graph's standard error shape.
+type graphErrorEnvelope struct {
+	Error struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// HandleError maps a non-2xx Graph response to a MailError. It classifies by
+// HTTP status so the send/sync retry loop can tell transient (retryable) from
+// critical (needs re-auth / stop) failures:
+//   - 401 -> authentication failed (token expired/revoked, re-consent)
+//   - 403 -> authorization failed (missing scope / mailbox disabled)
+//   - 429 -> sending too fast (throttled; Retry-After honored by the caller loop)
+//   - 5xx / other -> server unreachable (retry)
+func HandleError(resp *http.Response) *errx.MailError {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	var env graphErrorEnvelope
+	_ = json.Unmarshal(body, &env)
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return errx.ErrMailAuthenticationFailed
+	case http.StatusForbidden:
+		return errx.ErrMailAuthorizationFailed
+	case http.StatusTooManyRequests:
+		return errx.ErrMailSendingTooFast
+	default:
+		log.Debug().
+			Int("status", resp.StatusCode).
+			Str("code", env.Error.Code).
+			Str("message", env.Error.Message).
+			Msg("Graph API error")
+		return errx.ErrMailServerUnreachable
+	}
+}

--- a/internal/client/msgraph/helper.go
+++ b/internal/client/msgraph/helper.go
@@ -1,0 +1,11 @@
+package msgraph
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetAddress renders the mailbox's RFC 5322 From value ("First Last <email>").
+func (c *Client) GetAddress() string {
+	return fmt.Sprintf("%s <%s>", strings.TrimSpace(c.FirstName+" "+c.LastName), c.Email)
+}

--- a/internal/client/msgraph/message.go
+++ b/internal/client/msgraph/message.go
@@ -1,0 +1,161 @@
+package msgraph
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// graphMessage is the subset of the Graph message resource we read. Delta pages
+// return a light shape (id, isRead, @removed); a follow-up $select GET fills in
+// the envelope, body, and headers.
+type graphMessage struct {
+	ID                     string           `json:"id"`
+	InternetMessageID      string           `json:"internetMessageId"`
+	ConversationID         string           `json:"conversationId"`
+	Subject                string           `json:"subject"`
+	BodyPreview            string           `json:"bodyPreview"`
+	IsRead                 bool             `json:"isRead"`
+	ReceivedDateTime       time.Time        `json:"receivedDateTime"`
+	From                   *graphRecipient  `json:"from"`
+	Sender                 *graphRecipient  `json:"sender"`
+	ToRecipients           []graphRecipient `json:"toRecipients"`
+	CcRecipients           []graphRecipient `json:"ccRecipients"`
+	BccRecipients          []graphRecipient `json:"bccRecipients"`
+	ReplyTo                []graphRecipient `json:"replyTo"`
+	Body                   *graphItemBody   `json:"body"`
+	InternetMessageHeaders []graphHeader    `json:"internetMessageHeaders"`
+
+	// Removed is set (with a reason) on delta items that were deleted or moved
+	// out of the tracked folder.
+	Removed *graphRemoved `json:"@removed"`
+}
+
+type graphRecipient struct {
+	EmailAddress graphEmailAddress `json:"emailAddress"`
+}
+
+type graphEmailAddress struct {
+	Name    string `json:"name"`
+	Address string `json:"address"`
+}
+
+type graphItemBody struct {
+	ContentType string `json:"contentType"` // "html" | "text"
+	Content     string `json:"content"`
+}
+
+type graphHeader struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type graphRemoved struct {
+	Reason string `json:"reason"`
+}
+
+// header returns the first internet header matching name (case-insensitive).
+func (m *graphMessage) header(name string) string {
+	for _, h := range m.InternetMessageHeaders {
+		if strings.EqualFold(h.Name, name) {
+			return h.Value
+		}
+	}
+	return ""
+}
+
+// toEmailData maps a fully-hydrated Graph message onto the internal
+// EmailMessageData. The opaque Graph message id is carried in GmailID (the
+// provider-message-id field), and ConversationID stands in for the thread id.
+func (m *graphMessage) toEmailData() *models.EmailMessageData {
+	var plain, html string
+	if m.Body != nil {
+		if strings.EqualFold(m.Body.ContentType, "html") {
+			html = m.Body.Content
+		} else {
+			plain = m.Body.Content
+		}
+	}
+
+	flags := []string{}
+	if m.IsRead {
+		flags = append(flags, "\\Seen")
+	}
+
+	// Surface the warmup verification token as a pseudo-flag ("Header:value").
+	// The consumer's warmup detector reads it from Flags to identify warmup mail
+	// and file it into the Warmbly folder instead of the inbox.
+	if tok := m.header(config.WarmupVerifyHeader); tok != "" {
+		flags = append(flags, config.WarmupVerifyHeader+":"+tok)
+	}
+	// Surface machine-reply / DSN-bounce markers as pseudo-flags so the
+	// consumer's reply/bounce classifier can read them (the sync model has no
+	// arbitrary-header field).
+	for _, name := range config.InboundClassificationHeaders {
+		if v := strings.TrimSpace(m.header(name)); v != "" {
+			flags = append(flags, name+":"+v)
+		}
+	}
+
+	return &models.EmailMessageData{
+		GmailID:      m.ID,
+		ThreadID:     m.ConversationID,
+		MessageID:    m.InternetMessageID,
+		Snippet:      m.BodyPreview,
+		Subject:      m.Subject,
+		From:         recipients(oneRecipient(m.From)),
+		Sender:       recipients(oneRecipient(m.Sender)),
+		To:           recipients(m.ToRecipients),
+		CC:           recipients(m.CcRecipients),
+		BCC:          recipients(m.BccRecipients),
+		ReplyTo:      recipients(m.ReplyTo),
+		InReplyTo:    splitHeaderList(m.header("In-Reply-To")),
+		Date:         m.ReceivedDateTime,
+		InternalDate: m.ReceivedDateTime,
+		Flags:        flags,
+		BodyPlain:    plain,
+		BodyHTML:     html,
+	}
+}
+
+func oneRecipient(r *graphRecipient) []graphRecipient {
+	if r == nil {
+		return nil
+	}
+	return []graphRecipient{*r}
+}
+
+// recipients renders Graph recipients as RFC 5322 address strings, matching the
+// "Name <addr>" shape the Gmail path produces.
+func recipients(in []graphRecipient) []string {
+	var out []string
+	for _, r := range in {
+		addr := r.EmailAddress.Address
+		if addr == "" {
+			continue
+		}
+		if r.EmailAddress.Name != "" {
+			out = append(out, fmt.Sprintf("%s <%s>", r.EmailAddress.Name, addr))
+		} else {
+			out = append(out, addr)
+		}
+	}
+	return out
+}
+
+func splitHeaderList(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/client/msgraph/mime.go
+++ b/internal/client/msgraph/mime.go
@@ -1,0 +1,158 @@
+package msgraph
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/textproto"
+)
+
+// Attachment is a fully-resolved file the worker has already fetched from object
+// storage, ready to be MIME-encoded.
+type Attachment struct {
+	Filename string
+	MimeType string
+	Data     []byte
+}
+
+type hdr struct{ name, value string }
+
+// buildMIME assembles a complete RFC 5322 message from the given top-level
+// headers and bodies. This is the only reliable way to control Message-ID,
+// In-Reply-To/References, and custom warmup/unsubscribe headers on Graph, which
+// the JSON sendMail shape cannot set. Body HTML (already carrying the tracking
+// pixel + rewritten links) is preserved verbatim. Shapes emitted:
+//   - text/plain only          -> single text/plain part (warmup sends)
+//   - text/plain + text/html   -> multipart/alternative
+//   - + attachments            -> multipart/mixed(alternative, files...)
+func buildMIME(hdrs []hdr, bodyPlain, bodyHTML string, attachments []Attachment) ([]byte, error) {
+	var buf bytes.Buffer
+	writeHeaders := func(extra ...hdr) {
+		for _, h := range hdrs {
+			fmt.Fprintf(&buf, "%s: %s\r\n", h.name, h.value)
+		}
+		for _, h := range extra {
+			fmt.Fprintf(&buf, "%s: %s\r\n", h.name, h.value)
+		}
+	}
+
+	// Plain-only: no multipart wrapper needed.
+	if len(attachments) == 0 && bodyHTML == "" {
+		writeHeaders(hdr{"Content-Type", "text/plain; charset=UTF-8"}, hdr{"Content-Transfer-Encoding", "quoted-printable"})
+		buf.WriteString("\r\n")
+		if err := writeQuotedPrintable(&buf, bodyPlain); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), nil
+	}
+
+	// Text + HTML with no attachments: a single multipart/alternative.
+	if len(attachments) == 0 {
+		alt := multipart.NewWriter(&buf)
+		writeHeaders(hdr{"Content-Type", fmt.Sprintf("multipart/alternative; boundary=%s", alt.Boundary())})
+		buf.WriteString("\r\n")
+		if err := writeAltBodies(alt, bodyPlain, bodyHTML); err != nil {
+			return nil, err
+		}
+		return buf.Bytes(), alt.Close()
+	}
+
+	// Attachments present: multipart/mixed wrapping the alternative + one part
+	// per file.
+	mixed := multipart.NewWriter(&buf)
+	writeHeaders(hdr{"Content-Type", fmt.Sprintf("multipart/mixed; boundary=%s", mixed.Boundary())})
+	buf.WriteString("\r\n")
+
+	var altBuf bytes.Buffer
+	alt := multipart.NewWriter(&altBuf)
+	if err := writeAltBodies(alt, bodyPlain, bodyHTML); err != nil {
+		return nil, err
+	}
+	if err := alt.Close(); err != nil {
+		return nil, err
+	}
+	altPart, err := mixed.CreatePart(textproto.MIMEHeader{
+		"Content-Type": {fmt.Sprintf("multipart/alternative; boundary=%s", alt.Boundary())},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if _, err := altPart.Write(altBuf.Bytes()); err != nil {
+		return nil, err
+	}
+
+	for _, a := range attachments {
+		mimeType := a.MimeType
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+		fn := mime.QEncoding.Encode("utf-8", a.Filename)
+		part, perr := mixed.CreatePart(textproto.MIMEHeader{
+			"Content-Type":              {fmt.Sprintf("%s; name=%q", mimeType, fn)},
+			"Content-Transfer-Encoding": {"base64"},
+			"Content-Disposition":       {fmt.Sprintf("attachment; filename=%q", fn)},
+		})
+		if perr != nil {
+			return nil, perr
+		}
+		if werr := writeBase64Wrapped(part, a.Data); werr != nil {
+			return nil, werr
+		}
+	}
+
+	return buf.Bytes(), mixed.Close()
+}
+
+// writeAltBodies writes the text/plain (and optional text/html) parts of a
+// multipart/alternative body, quoted-printable encoded.
+func writeAltBodies(w *multipart.Writer, bodyPlain, bodyHTML string) error {
+	if err := writeTextPart(w, "text/plain; charset=UTF-8", bodyPlain); err != nil {
+		return err
+	}
+	if bodyHTML != "" {
+		if err := writeTextPart(w, "text/html; charset=UTF-8", bodyHTML); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeTextPart(w *multipart.Writer, contentType, body string) error {
+	part, err := w.CreatePart(textproto.MIMEHeader{
+		"Content-Type":              {contentType},
+		"Content-Transfer-Encoding": {"quoted-printable"},
+	})
+	if err != nil {
+		return err
+	}
+	return writeQuotedPrintable(part, body)
+}
+
+func writeQuotedPrintable(w io.Writer, body string) error {
+	qp := quotedprintable.NewWriter(w)
+	if _, err := qp.Write([]byte(body)); err != nil {
+		return err
+	}
+	return qp.Close()
+}
+
+// writeBase64Wrapped writes data as base64 hard-wrapped at 76 columns per RFC
+// 2045 so strict MTAs accept the message.
+func writeBase64Wrapped(w io.Writer, data []byte) error {
+	encoded := base64.StdEncoding.EncodeToString(data)
+	const lineLen = 76
+	for i := 0; i < len(encoded); i += lineLen {
+		end := i + lineLen
+		if end > len(encoded) {
+			end = len(encoded)
+		}
+		if _, err := w.Write([]byte(encoded[i:end] + "\r\n")); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/client/msgraph/msgraph.go
+++ b/internal/client/msgraph/msgraph.go
@@ -1,0 +1,125 @@
+// Package msgraph is a thin Microsoft Graph mail client for Warmbly's
+// Outlook/Microsoft 365 mailboxes. It mirrors the shape of internal/client/goog
+// (the Gmail API client): a per-mailbox Client with OnMessage* callbacks, an
+// OAuth2 token source that persists refreshes, RAW MIME sending, delta-based
+// inbound sync, and warmup mailbox actions. It deliberately hand-rolls a small
+// REST surface (~a dozen endpoints) instead of pulling in the very large
+// official SDK, which would bloat the disposable worker binary and slow CI.
+package msgraph
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/infrastructure/cache"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/stoken"
+	"golang.org/x/oauth2"
+)
+
+const (
+	// graphBase is the Microsoft Graph v1.0 root. All mail calls are made
+	// against the signed-in user (/me) using the delegated token.
+	graphBase = "https://graph.microsoft.com/v1.0"
+
+	// Well-known mail folder ids Graph accepts directly in a path or as a
+	// move destinationId, so we never have to resolve them to opaque ids.
+	FolderInbox = "inbox"
+	FolderJunk  = "junkemail"
+)
+
+// Client is a single Microsoft 365 mailbox reached over Graph.
+type Client struct {
+	Email     string
+	FirstName string
+	LastName  string
+
+	hc    *http.Client
+	Cache *cache.Cache
+
+	// DeltaLinks holds the opaque per-folder delta cursor (well-known folder
+	// name -> deltaLink URL). Seeded from persisted state on init and advanced
+	// as sync runs; OnDelta persists each new value off the disposable worker.
+	DeltaLinks map[string]string
+
+	// folderIDs caches resolved folder ids (e.g. the created "Warmbly" folder)
+	// so we don't re-list on every warmup action.
+	folderIDs map[string]string
+	mu        sync.Mutex
+
+	OnMessageAdd    func(ctx context.Context, msg *models.EmailMessageData) error
+	OnMessageRemove func(ctx context.Context, providerID string) error
+	OnFlagsChange   func(ctx context.Context, providerID string, seen bool) error
+	OnDelta         func(ctx context.Context, folder, deltaLink string) error
+	OnTokenRefresh  func(ctx context.Context, token *oauth2.Token) error
+}
+
+// Init builds the auto-refreshing OAuth2 HTTP client. It mirrors goog.Client.Init:
+// the token source reuses the current token until expiry, then refreshes through
+// cfg and persists the new token via OnTokenRefresh (the worker relays it back to
+// the control plane, which owns the encrypted credential store).
+func (c *Client) Init(ctx context.Context, token *oauth2.Token, cfg oauth2.Config) *errx.MailError {
+	ts := cfg.TokenSource(ctx, token)
+	ts = oauth2.ReuseTokenSource(token, ts)
+	ts = stoken.New(ts, func(t *oauth2.Token) error {
+		return c.OnTokenRefresh(context.Background(), t)
+	})
+
+	c.hc = oauth2.NewClient(ctx, ts)
+	if c.DeltaLinks == nil {
+		c.DeltaLinks = map[string]string{}
+	}
+	c.folderIDs = map[string]string{}
+	return nil
+}
+
+// do issues a single authenticated request. body may be nil.
+func (c *Client) do(ctx context.Context, method, url, contentType string, body []byte) (*http.Response, error) {
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, r)
+	if err != nil {
+		return nil, err
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return c.hc.Do(req)
+}
+
+// doJSON marshals in (if non-nil), issues the request, maps any non-2xx status to
+// a MailError, and decodes the response into out (if non-nil).
+func (c *Client) doJSON(ctx context.Context, method, url string, in, out any) error {
+	var body []byte
+	contentType := ""
+	if in != nil {
+		b, err := json.Marshal(in)
+		if err != nil {
+			return err
+		}
+		body = b
+		contentType = "application/json"
+	}
+
+	resp, err := c.do(ctx, method, url, contentType, body)
+	if err != nil {
+		return errx.ErrMailServerUnreachable
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return HandleError(resp)
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/internal/client/msgraph/send.go
+++ b/internal/client/msgraph/send.go
@@ -1,0 +1,76 @@
+package msgraph
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// SendMessage sends a message through Graph's MIME sendMail endpoint. We build a
+// full RFC 5322 message ourselves and POST it base64-encoded with
+// Content-Type: text/plain, because only the MIME path lets us set a custom
+// Message-ID, In-Reply-To/References for threading, and arbitrary headers (the
+// warmup verification token, RFC 8058 one-click unsubscribe) that the JSON
+// message shape restricts. Graph auto-files the message in Sent Items.
+//
+// sendMail returns 202 with no id, so there is no provider message id to return;
+// callers record the RFC Message-ID they supplied (inbound correlation keys on
+// that anyway). customHeaders is variadic to mirror goog.Client.SendMessage.
+func (c *Client) SendMessage(
+	ctx context.Context,
+	to, cc, bcc []string,
+	messageID,
+	subject, bodyPlain, bodyHTML string,
+	parent *models.EmailMessageData,
+	attachments []Attachment,
+	customHeaders ...map[string]string,
+) error {
+	hdrs := []hdr{
+		{"From", c.GetAddress()},
+		{"To", strings.Join(to, ", ")},
+		{"Subject", subject},
+		{"Message-ID", messageID},
+		{"MIME-Version", "1.0"},
+	}
+	if len(cc) > 0 {
+		hdrs = append(hdrs, hdr{"Cc", strings.Join(cc, ", ")})
+	}
+	if len(bcc) > 0 {
+		hdrs = append(hdrs, hdr{"Bcc", strings.Join(bcc, ", ")})
+	}
+	if parent != nil && parent.MessageID != "" {
+		// Trim any existing <...> before re-wrapping so we never emit <<id>>,
+		// which won't match the original Message-ID and breaks threading.
+		mid := "<" + strings.Trim(parent.MessageID, "<>") + ">"
+		hdrs = append(hdrs, hdr{"In-Reply-To", mid}, hdr{"References", mid})
+	}
+	if len(customHeaders) > 0 {
+		for k, v := range customHeaders[0] {
+			hdrs = append(hdrs, hdr{k, v})
+		}
+	}
+
+	raw, err := buildMIME(hdrs, bodyPlain, bodyHTML, attachments)
+	if err != nil {
+		return fmt.Errorf("build mime: %w", err)
+	}
+
+	// MIME sendMail: the request body is the base64 of the RFC 5322 message.
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	resp, err := c.do(ctx, http.MethodPost, graphBase+"/me/sendMail", "text/plain", []byte(encoded))
+	if err != nil {
+		return errx.ErrMailServerUnreachable
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return HandleError(resp)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -133,3 +133,19 @@ const (
 	// Future: per-plan ceiling lookup. Today: single backstop.
 	MaxPendingScheduledSendsPerUser = 10000
 )
+
+// InboundClassificationHeaders are the internet headers the API-based inbound
+// sync (Gmail, Microsoft Graph) surfaces into EmailMessageData.Flags as
+// "Header:value" pseudo-flags. The sync model carries no arbitrary-header field,
+// so this is how the consumer's reply/bounce classifier (replyclassify via
+// buildReplyHeaders) sees the machine-reply and delivery-status-report markers.
+// From/Subject already ride the envelope; these add the high-signal headers.
+var InboundClassificationHeaders = []string{
+	"Auto-Submitted",
+	"Precedence",
+	"Content-Type",
+	"Return-Path",
+	"X-Autoreply",
+	"X-Autorespond",
+	"X-Auto-Response-Suppress",
+}

--- a/internal/config/inbox.go
+++ b/internal/config/inbox.go
@@ -30,6 +30,13 @@ func GoogleOauth2Inbox(baseURL string) *oauth2.Config {
 	}
 }
 
+// OutlookOauth2Inbox configures delegated Microsoft Graph access for Outlook /
+// Microsoft 365 mailboxes. Graph is the transport now (RAW MIME sendMail + delta
+// sync), so we request Graph scopes rather than the legacy IMAP/SMTP scopes:
+// Mail.Send (send), Mail.ReadWrite (delta sync + warmup move/mark/flag),
+// User.Read (resolve the mailbox owner via /me), and offline_access (refresh
+// token). None require tenant admin consent by default and all work on personal
+// Outlook.com accounts.
 func OutlookOauth2Inbox(baseURL string) *oauth2.Config {
 	return &oauth2.Config{
 		ClientID:     os.Getenv("BOX_OUTLOOK_CLIENT_ID"),
@@ -39,10 +46,10 @@ func OutlookOauth2Inbox(baseURL string) *oauth2.Config {
 			"openid",
 			"email",
 			"profile",
-			"https://outlook.office.com/IMAP.AccessAsUser.All",
-			"https://outlook.office.com/SMTP.Send",
-			"https://outlook.office.com/Mail.Send",
 			"offline_access",
+			"https://graph.microsoft.com/User.Read",
+			"https://graph.microsoft.com/Mail.Send",
+			"https://graph.microsoft.com/Mail.ReadWrite",
 		},
 		Endpoint: oauth2.Endpoint{
 			AuthURL:  "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",

--- a/internal/infrastructure/db/migrations/000054_graph_delta_links.down.sql
+++ b/internal/infrastructure/db/migrations/000054_graph_delta_links.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS public.email_delta_links;

--- a/internal/infrastructure/db/migrations/000054_graph_delta_links.up.sql
+++ b/internal/infrastructure/db/migrations/000054_graph_delta_links.up.sql
@@ -1,0 +1,14 @@
+-- graph_delta_links: the consumer's per-mailbox, per-folder Microsoft Graph
+-- delta cursor. Unlike the Gmail history id (a small monotonic int stored on
+-- email_history_ids), a Graph deltaLink is a long opaque URL, so it is stored
+-- per (email, folder) rather than in the email row. The worker relays each new
+-- deltaLink via the GRAPH_DELTA_UPDATE job event; the disposable worker never
+-- owns this cursor.
+CREATE TABLE public.email_delta_links (
+    user_id uuid NOT NULL,
+    email_id uuid NOT NULL,
+    folder text NOT NULL,
+    delta_link text NOT NULL,
+    last_updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    PRIMARY KEY (user_id, email_id, folder)
+);

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -26,8 +26,9 @@ const (
 	JobEventTypeMailboxUpdate JobEventType = "UPDATE_MAILBOX"
 	JobEventTypeMailboxDelete JobEventType = "DELETE_MAILBOX"
 
-	JobEventTypeTokenUpdate     JobEventType = "TOKEN_UPDATE"
-	JobEventTypeHistoryIDUpdate JobEventType = "HISTORY_ID_UPDATE"
+	JobEventTypeTokenUpdate      JobEventType = "TOKEN_UPDATE"
+	JobEventTypeHistoryIDUpdate  JobEventType = "HISTORY_ID_UPDATE"
+	JobEventTypeGraphDeltaUpdate JobEventType = "GRAPH_DELTA_UPDATE"
 
 	// Task result events from worker
 	JobEventTypeEmailSent   JobEventType = "EMAIL_SENT"

--- a/internal/models/event_w_graph.go
+++ b/internal/models/event_w_graph.go
@@ -1,0 +1,14 @@
+package models
+
+import "github.com/google/uuid"
+
+// JobEventGraphDeltaUpdate carries the opaque per-folder Microsoft Graph delta
+// cursor back to the control plane for persistence. Unlike the Gmail history id
+// (a small monotonic int stored on the email row), a deltaLink is a long opaque
+// URL, so it is stored per (email, folder) in its own table.
+type JobEventGraphDeltaUpdate struct {
+	UserID    uuid.UUID `json:"user_id"`
+	EmailID   uuid.UUID `json:"email_id"`
+	Folder    string    `json:"folder"`
+	DeltaLink string    `json:"delta_link"`
+}

--- a/internal/models/warmup.go
+++ b/internal/models/warmup.go
@@ -35,7 +35,11 @@ type WarmupEmailAction struct {
 	GmailID            string    `json:"gmail_id"`
 	UID                uint32    `json:"uid"`
 	MailboxUIDValidity uint32    `json:"mailbox_uid_validity"`
-	Actions            []string  `json:"actions"` // "move_to_warmbly", "mark_read", "remove_from_spam", "mark_important"
+	// RFCMessageID is the immutable RFC 5322 Message-ID. Graph provider ids
+	// change when a message is moved (copy+delete), so the worker re-resolves
+	// the live Graph id from this stable key at action time.
+	RFCMessageID string   `json:"rfc_message_id,omitempty"`
+	Actions      []string `json:"actions"` // "move_to_warmbly", "mark_read", "remove_from_spam", "mark_important"
 
 	// DelaySeconds is retained for wire compatibility but is now always 0: the
 	// recipient-side "dwell" is owned by the consumer's durable schedule

--- a/internal/models/worker.go
+++ b/internal/models/worker.go
@@ -201,6 +201,15 @@ type AddWorkerEmailSmtpImapData struct {
 	Credentials *SmtpImap     `json:"credentials" avro:"credentials"`
 }
 
+// AddWorkerEmailGraphData seeds a Microsoft Graph mailbox on the worker: the
+// delegated OAuth token and the opaque per-folder delta cursors persisted by the
+// control plane (empty on first connect, which primes the cursor without
+// backfilling history).
+type AddWorkerEmailGraphData struct {
+	Token      *oauth2.Token     `json:"token" avro:"token"`
+	DeltaLinks map[string]string `json:"delta_links" avro:"delta_links"`
+}
+
 type AddWorkerEmail struct {
 	ID        uuid.UUID                   `json:"id" avro:"id"`
 	UserID    uuid.UUID                   `json:"user_id" avro:"user_id"`
@@ -211,6 +220,7 @@ type AddWorkerEmail struct {
 	Type      InboxProvider               `json:"type" avro:"type"`
 	Google    *AddWorkerEmailGoogleData   `json:"google" avro:"google"`
 	SmtpImap  *AddWorkerEmailSmtpImapData `json:"smtp_imap" avro:"smtp_imap"`
+	Graph     *AddWorkerEmailGraphData    `json:"graph" avro:"graph"`
 
 	Cfg oauth2.Config `json:"-" avro:"-"`
 }

--- a/internal/repository/pg_email.go
+++ b/internal/repository/pg_email.go
@@ -82,6 +82,11 @@ type EmailRepository interface {
 	// actively warming, or backing a live campaign (the health-check lane).
 	// Used by the warmup reconciler to (re)seed chains.
 	ListWarmupScheduleCandidates(ctx context.Context, limit int) ([]uuid.UUID, error)
+
+	// ListActiveWorkerAccounts returns the ids of every active mailbox. The
+	// worker reconciler uses it to (re)load accounts onto their assigned workers
+	// after onboarding, worker restarts, or reassignment.
+	ListActiveWorkerAccounts(ctx context.Context) ([]uuid.UUID, error)
 }
 
 type emailRepository struct {
@@ -130,6 +135,25 @@ func (r *emailRepository) ListWarmupScheduleCandidates(ctx context.Context, limi
 		LIMIT $1`
 
 	rows, err := r.DB.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (r *emailRepository) ListActiveWorkerAccounts(ctx context.Context) ([]uuid.UUID, error) {
+	const query = `SELECT id FROM email_accounts WHERE status = 'active'`
+	rows, err := r.DB.Query(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/pg_graph_delta.go
+++ b/internal/repository/pg_graph_delta.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+)
+
+// EmailGraphDeltaRepository persists the per-mailbox, per-folder Microsoft Graph
+// delta cursor. Like EmailHistoryIDRepository (the Gmail equivalent) it lives in
+// the consumer's Postgres; the disposable worker relays cursors over Kafka and
+// never touches the DB. Get returns the folder->deltaLink map used to seed the
+// worker when the mailbox is (re)assigned.
+type EmailGraphDeltaRepository interface {
+	Put(ctx context.Context, userID, emailID uuid.UUID, folder, deltaLink string) error
+	Get(ctx context.Context, userID, emailID uuid.UUID) (map[string]string, error)
+}
+
+type pgEmailGraphDeltaRepository struct {
+	db *db.DB
+}
+
+func NewEmailGraphDeltaRepository(d *db.DB) EmailGraphDeltaRepository {
+	return &pgEmailGraphDeltaRepository{db: d}
+}
+
+func (r *pgEmailGraphDeltaRepository) Put(ctx context.Context, userID, emailID uuid.UUID, folder, deltaLink string) error {
+	const q = `
+		INSERT INTO email_delta_links (user_id, email_id, folder, delta_link, last_updated_at)
+		VALUES ($1, $2, $3, $4, now())
+		ON CONFLICT (user_id, email_id, folder)
+		DO UPDATE SET delta_link = EXCLUDED.delta_link, last_updated_at = now()
+	`
+	if _, err := r.db.Exec(ctx, q, userID, emailID, folder, deltaLink); err != nil {
+		return fmt.Errorf("email_delta_links: put: %w", err)
+	}
+	return nil
+}
+
+func (r *pgEmailGraphDeltaRepository) Get(ctx context.Context, userID, emailID uuid.UUID) (map[string]string, error) {
+	const q = `
+		SELECT folder, delta_link
+		FROM email_delta_links
+		WHERE user_id = $1 AND email_id = $2
+	`
+	rows, err := r.db.Query(ctx, q, userID, emailID)
+	if err != nil {
+		return nil, fmt.Errorf("email_delta_links: get: %w", err)
+	}
+	defer rows.Close()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var folder, deltaLink string
+		if err := rows.Scan(&folder, &deltaLink); err != nil {
+			return nil, fmt.Errorf("email_delta_links: scan: %w", err)
+		}
+		out[folder] = deltaLink
+	}
+	return out, rows.Err()
+}


### PR DESCRIPTION
## What this does

Moves Microsoft/Outlook mailboxes off OAuth-over-IMAP/SMTP and onto the **Microsoft Graph API**, and — because the mailbox→worker load path turned out to be unimplemented for every provider — wires up the full control loop so accounts actually **load, send, sync, and warm up** end to end.

There is no prod deployment yet, so this replaces the Outlook transport rather than dual-running it. Gmail stays on the Gmail API; the generic `smtp_imap` provider is untouched.

## Highlights

- **`internal/client/msgraph`** — a thin, hand-rolled Graph client (no bloated official SDK): RAW MIME `sendMail` (keeps our `Message-ID`, threading, `X-Mailtrace-Verify`, tracking pixel/links), delta sync of inbox + junk, warmup move/mark/flag actions, and throttling-aware error mapping. Mirrors `internal/client/goog`.
- **Outlook = Graph** in the worker dispatch (`wmail`): send/sync/new-email/warmup all route to Graph; delegated Graph OAuth scopes (`Mail.Send`, `Mail.ReadWrite`, `User.Read`, `offline_access`) replace the IMAP/SMTP scopes.
- **Delta cursor persistence** — new `email_delta_links` table + repo + `GRAPH_DELTA_UPDATE` consumer handler (the opaque per-folder deltaLink doesn't fit the int `email_history_ids` column).
- **Account loader** — a backend reconciler + on-onboarding load that assigns a worker, decrypts the account's credentials, and publishes `AddWorkerEmail`. Previously `AssignWorkerToEmail` only set `worker_id` in the DB and nothing ever told the worker, so **nothing sent or synced for any provider**. This fixes Gmail, Outlook, and SMTP/IMAP.
- **Worker token refresh** — `Cfg` is `avro:"-"`, so the worker now rebuilds the provider oauth2 config locally from `BOX_*` env (plumbed through the orchestrator), and warns if it's missing. Also previously broken for Gmail.
- **Warmup categorization** — warmup mail is detected via its verify token and filed into a dedicated **Warmbly** folder + marked read (kept out of the unibox), the way MailReach/Instantly do it. Robust to Graph's id-changes-on-move by re-resolving the live id from the immutable RFC Message-ID.
- **Inbound classification** — Gmail + Graph sync now surface machine-reply/DSN headers into flags so the existing reply/bounce classifier correctly gates `replied_at` (auto-replies/OOO never count as human replies for stop-on-reply / branching).
- Docs updated (mailboxes + warmup guides).

## New migration

`000054_graph_delta_links` — run before deploy.

## Verification

`go build ./...`, `gofmt -l`, and `go vet` all clean. A 22-agent adversarial review ran over the new integration; all 7 confirmed bugs are fixed in-branch (nil-guards in `NewWMail`, the stale-id-after-move fix, silent-failure logging, case-insensitive header matching, missing-creds warning). Not runtime-verified against a live M365 tenant (per repo policy that's manual), and the new Avro event shapes ride the same schema-registry path as existing events but weren't smoke-tested here.

## Deliberately out of scope: NDR bounce suppression

Recording bounces from inbound NDRs needs to distinguish hard (permanent, 5.x.x) from soft (transient, 4.x.x) failures — which requires parsing the machine-readable delivery-status part of the DSN. Graph's `message.body` doesn't expose that reliably (needs a raw-MIME `$value` fetch), and getting it wrong over-suppresses valid recipients on temporary failures. Shipping unverified suppression logic that can harm deliverability isn't worth it; this is left as a dedicated follow-up (worker parses the DSN it already has → emits a permanent-only bounce event → consumer resolves the task via `GetTaskByMessageID` and records via `IngestDeliverabilityEvent`, idempotently).

## Follow-up recommendations: yes, the Gmail and SMTP/IMAP paths need attention too

**Gmail:**
1. **messageId-map key mismatch (latent bug):** `onGoogleMessageAdd` keys the worker map by the RFC `Message-ID`, but `onGoogleMessageRemove` / label handlers look it up by the **Gmail id** → mismatch → removes and read/label syncs silently no-op. Mirror the Graph fix and key the map by the provider id consistently.
2. **history sync fetches metadata-only messages:** `FetchHistory` maps the message straight out of the Gmail history response, which is typically just `{id, threadId, labelIds}` — no payload/headers/body. So the warmup-token + classification-header extraction added here (and bodies/subjects) will often be empty. Fetch the full message (`Users.Messages.Get(id, format=metadata|full)`) for added ids before mapping.
3. Together these mean Gmail warmup categorization + reply/bounce classification are still unreliable until fixed; worth a dedicated PR.

**SMTP/IMAP:**
1. **SMTP Message-ID gap (bug):** `sendViaSMTP` records `req.MessageID` as the provider id, but the SMTP client never writes a `Message-ID:` header — the receiving server assigns one — so the recorded id doesn't match what was actually sent, breaking reply/bounce correlation and threading. Have the SMTP client set the header from the caller's value, like Gmail/Graph do.
2. **no custom headers surfaced:** IMAP sync fetches ENVELOPE + FLAGS only, so the warmup token + classification headers aren't injected into flags (unlike Graph/Gmail now). Fetch them via `BODY.PEEK[HEADER.FIELDS (...)]` and inject the same way so warmup categorization + reply/bounce classification work for IMAP mailboxes.

**All providers:**
- NDR bounce suppression (above).
- The reconciler republishes every active account each interval (idempotent but chatty); a worker "loaded" heartbeat would let it skip already-loaded accounts.
