### PR TITLE
Fix Gmail and SMTP/IMAP sync/send bugs; bring both to parity with the Graph path

### DIFF
--- a/internal/app/worker/wmail/event_google.go
+++ b/internal/app/worker/wmail/event_google.go
@@ -11,7 +11,11 @@ import (
 )
 
 func (w *WMail) onGoogleMessageAdd(ctx context.Context, msg *models.EmailMessageData) error {
-	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, msg.MessageID)
+	// The messageId map is keyed by the Gmail message id: it is the only
+	// identifier the history feed reports on remove/label events, so add must
+	// key the same way for those lookups to ever match (same principle as the
+	// Graph path).
+	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, msg.GmailID)
 	if err != nil {
 		return err
 	}
@@ -58,7 +62,7 @@ func (w *WMail) onGoogleMessageAdd(ctx context.Context, msg *models.EmailMessage
 	if err := w.EmailMessageMapRepository.Add(ctx, repository.EmailMessageData{
 		UserID:    w.UserID.String(),
 		EmailID:   w.ID.String(),
-		MessageID: data.MessageID,
+		MessageID: msg.GmailID,
 		ID:        msg.ID.String(),
 		ThreadID:  msg.ThreadID,
 	}); err != nil {
@@ -105,34 +109,44 @@ func (w *WMail) onGoogleMessageRemove(ctx context.Context, messageID string) err
 	return nil
 }
 
+// translateGmailLabels maps a Gmail label transition onto internal flag
+// add/remove sets. Gmail models read state inversely (the UNREAD label marks
+// unread mail), so gaining UNREAD removes \Seen and losing it adds \Seen.
+// Unmapped labels pass through in the transition's own direction.
+func translateGmailLabels(labelIDs []string, added bool) (addFlags, removeFlags []string) {
+	for _, label := range labelIDs {
+		var flag string
+		inverted := false
+		switch label {
+		case "UNREAD":
+			flag, inverted = "\\Seen", true
+		case "STARRED":
+			flag = "\\Flagged"
+		case "IMPORTANT":
+			flag = "\\Important"
+		case "DRAFT":
+			flag = "\\Draft"
+		default:
+			flag = label
+		}
+		if added != inverted {
+			addFlags = append(addFlags, flag)
+		} else {
+			removeFlags = append(removeFlags, flag)
+		}
+	}
+	return addFlags, removeFlags
+}
+
 func (w *WMail) onGoogleMessageLabelsAdded(ctx context.Context, messageID string, labelIDs []string) error {
-	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, messageID)
-	if err != nil {
-		return err
-	}
-
-	if internalMessage == nil {
-		return nil
-	}
-
-	internalID, err := uuid.Parse(internalMessage.ID)
-	if err != nil {
-		return err
-	}
-
-	if err := w.onEvent(models.JobEventTypeFlagsAdd, &models.JobEventFlags{
-		UserID:  w.UserID,
-		EmailID: w.ID,
-		ID:      internalID,
-		Flags:   labelIDs,
-	}); err != nil {
-		return err
-	}
-
-	return nil
+	return w.emitGoogleFlagEvents(ctx, messageID, labelIDs, true)
 }
 
 func (w *WMail) onGoogleMessageLabelsRemoved(ctx context.Context, messageID string, labelIDs []string) error {
+	return w.emitGoogleFlagEvents(ctx, messageID, labelIDs, false)
+}
+
+func (w *WMail) emitGoogleFlagEvents(ctx context.Context, messageID string, labelIDs []string, added bool) error {
 	internalMessage, err := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, messageID)
 	if err != nil {
 		return err
@@ -147,13 +161,27 @@ func (w *WMail) onGoogleMessageLabelsRemoved(ctx context.Context, messageID stri
 		return err
 	}
 
-	if err := w.onEvent(models.JobEventTypeFlagsRemove, &models.JobEventFlags{
-		UserID:  w.UserID,
-		EmailID: w.ID,
-		ID:      internalID,
-		Flags:   labelIDs,
-	}); err != nil {
-		return err
+	addFlags, removeFlags := translateGmailLabels(labelIDs, added)
+
+	if len(addFlags) > 0 {
+		if err := w.onEvent(models.JobEventTypeFlagsAdd, &models.JobEventFlags{
+			UserID:  w.UserID,
+			EmailID: w.ID,
+			ID:      internalID,
+			Flags:   addFlags,
+		}); err != nil {
+			return err
+		}
+	}
+	if len(removeFlags) > 0 {
+		if err := w.onEvent(models.JobEventTypeFlagsRemove, &models.JobEventFlags{
+			UserID:  w.UserID,
+			EmailID: w.ID,
+			ID:      internalID,
+			Flags:   removeFlags,
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/app/worker/wmail/event_imap.go
+++ b/internal/app/worker/wmail/event_imap.go
@@ -36,7 +36,16 @@ func (w *WMail) onImapEmailUpdate(ctx context.Context, msg *models.EmailMessageD
 		if parentID != "" {
 			internalParent, _ := w.EmailMessageMapRepository.Get(ctx, w.UserID, w.ID, parentID)
 			if internalParent != nil {
-				threadID = internalParent.ID
+				// Join the parent's thread; using the parent's internal id here
+				// forked a new thread at every reply depth.
+				threadID = internalParent.ThreadID
+				if threadID == "" {
+					threadID = parentID
+				}
+			} else {
+				// Parent unknown (e.g. reply to a pre-connect message): root a
+				// thread on the parent's RFC id so siblings still group.
+				threadID = parentID
 			}
 		} else {
 			threadID = msg.MessageID

--- a/internal/app/worker/wmail/send.go
+++ b/internal/app/worker/wmail/send.go
@@ -303,6 +303,7 @@ func (w *WMail) sendViaSMTP(ctx context.Context, req *SendRequest, bodyHTML stri
 		req.To,
 		req.Cc,
 		req.Bcc,
+		req.MessageID,
 		req.Subject,
 		req.BodyPlain,
 		bodyHTML,

--- a/internal/client/goog/error.go
+++ b/internal/client/goog/error.go
@@ -7,6 +7,9 @@ import (
 )
 
 func HandleError(err error) *errx.MailError {
+	if err == nil {
+		return nil
+	}
 	if gerr, ok := err.(*googleapi.Error); ok {
 		switch gerr.Code {
 		case 401:
@@ -22,5 +25,9 @@ func HandleError(err error) *errx.MailError {
 		}
 	}
 
-	return nil
+	// Non-API failures (DNS, TLS, timeouts) are transient transport errors.
+	// Returning nil here would silently swallow them and leave callers holding
+	// a typed-nil *MailError in an error interface.
+	log.Debug().Err(err).Msg("Google transport error")
+	return errx.ErrMailServerUnreachable
 }

--- a/internal/client/goog/history.go
+++ b/internal/client/goog/history.go
@@ -1,6 +1,10 @@
 package goog
 
-import "context"
+import (
+	"context"
+
+	"google.golang.org/api/googleapi"
+)
 
 func (c *Client) FetchHistory(ctx context.Context, lastHistoryID uint64) (uint64, error) {
 	call := c.srv.Users.History.List("me").MaxResults(500).StartHistoryId(lastHistoryID) // It does not include the record that has that exact HistoryID
@@ -15,7 +19,19 @@ func (c *Client) FetchHistory(ctx context.Context, lastHistoryID uint64) (uint64
 
 		for _, h := range resp.History {
 			for _, m := range h.MessagesAdded {
-				msg := GmailMessageToEmailData(m.Message)
+				// History entries carry only id/threadId/labelIds — no envelope,
+				// headers, or body — so hydrate the full message before mapping.
+				// A 404 means the message was deleted between the history event
+				// and now; skip it rather than failing the whole sync.
+				full, ferr := c.srv.Users.Messages.Get("me", m.Message.Id).Format("full").Context(ctx).Do()
+				if ferr != nil {
+					if gerr, ok := ferr.(*googleapi.Error); ok && gerr.Code == 404 {
+						continue
+					}
+					return newLastHistoryID, HandleError(ferr)
+				}
+
+				msg := GmailMessageToEmailData(full)
 				if err := c.OnMessageAdd(ctx, msg); err != nil {
 					return newLastHistoryID, err
 				}

--- a/internal/client/goog/message.go
+++ b/internal/client/goog/message.go
@@ -52,12 +52,13 @@ func getSingleHeader(headers []*gmail.MessagePartHeader, name string) string {
 
 func extractBody(parts []*gmail.MessagePart) (plain, html string) {
 	for _, p := range parts {
+		if p == nil {
+			continue
+		}
 		if p.MimeType == "text/plain" && p.Body != nil && p.Body.Data != "" {
-			decoded, _ := base64.URLEncoding.DecodeString(p.Body.Data)
-			plain += string(decoded)
+			plain += decodeBase64URL(p.Body.Data)
 		} else if p.MimeType == "text/html" && p.Body != nil && p.Body.Data != "" {
-			decoded, _ := base64.URLEncoding.DecodeString(p.Body.Data)
-			html += string(decoded)
+			html += decodeBase64URL(p.Body.Data)
 		} else if len(p.Parts) > 0 {
 			pPlain, pHTML := extractBody(p.Parts)
 			plain += pPlain
@@ -65,6 +66,16 @@ func extractBody(parts []*gmail.MessagePart) (plain, html string) {
 		}
 	}
 	return
+}
+
+// decodeBase64URL decodes Gmail body data, which is base64url and usually
+// unpadded (padded URLEncoding rejects it, which silently emptied bodies).
+func decodeBase64URL(data string) string {
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(data, "="))
+	if err != nil {
+		return ""
+	}
+	return string(decoded)
 }
 
 func parseGmailDate(dateText string) time.Time {
@@ -76,7 +87,15 @@ func parseGmailDate(dateText string) time.Time {
 }
 
 func GmailMessageToEmailData(msg *gmail.Message) *models.EmailMessageData {
-	headers := msg.Payload.Headers
+	var headers []*gmail.MessagePartHeader
+	if msg.Payload != nil {
+		headers = msg.Payload.Headers
+	}
+
+	// Walk from the payload itself, not payload.Parts: single-part messages
+	// (most plaintext mail) carry their body directly on the payload and have
+	// no parts at all.
+	plain, html := extractBody([]*gmail.MessagePart{msg.Payload})
 
 	return &models.EmailMessageData{
 		GmailID:  msg.Id,
@@ -84,17 +103,33 @@ func GmailMessageToEmailData(msg *gmail.Message) *models.EmailMessageData {
 		ThreadID: msg.ThreadId,
 		Flags: func() []string {
 			flags := []string{}
+			// Gmail models read state inversely: the UNREAD label is present on
+			// unread mail, so \Seen applies only when UNREAD is absent.
+			seen := true
 			for _, label := range msg.LabelIds {
 				switch label {
 				case "UNREAD":
-					flags = append(flags, "\\Seen")
+					seen = false
 				case "STARRED":
 					flags = append(flags, "\\Flagged")
 				case "IMPORTANT":
 					flags = append(flags, "\\Important")
 				case "DRAFT":
 					flags = append(flags, "\\Draft")
+				case "SPAM":
+					// Drives warmup spam-placement detection and placement
+					// tests (containsSpamFlag matches "SPAM").
+					flags = append(flags, "SPAM")
+				default:
+					// CATEGORY_* tab labels feed placement classification
+					// (promotions tab detection).
+					if strings.HasPrefix(label, "CATEGORY_") {
+						flags = append(flags, label)
+					}
 				}
+			}
+			if seen {
+				flags = append(flags, "\\Seen")
 			}
 			// Surface the warmup verification token as a pseudo-flag so the
 			// consumer can categorize warmup mail into the Warmbly folder.
@@ -123,13 +158,8 @@ func GmailMessageToEmailData(msg *gmail.Message) *models.EmailMessageData {
 		Size:         msg.SizeEstimate,
 		InternalDate: time.Unix(msg.InternalDate/1000, 0),
 		ModSeq:       msg.HistoryId,
-		BodyPlain: func() string {
-			plain, _ := extractBody(msg.Payload.Parts)
-			return plain
-		}(),
-		BodyHTML: func() string {
-			_, html := extractBody(msg.Payload.Parts)
-			return html
-		}(),
+		Snippet:      msg.Snippet,
+		BodyPlain:    plain,
+		BodyHTML:     html,
 	}
 }

--- a/internal/client/msgraph/delta.go
+++ b/internal/client/msgraph/delta.go
@@ -56,7 +56,7 @@ func (c *Client) syncFolder(ctx context.Context, folder string) error {
 
 		if !priming {
 			for i := range page.Value {
-				if err := c.applyDelta(ctx, &page.Value[i]); err != nil {
+				if err := c.applyDelta(ctx, folder, &page.Value[i]); err != nil {
 					return err
 				}
 			}
@@ -83,7 +83,7 @@ func (c *Client) syncFolder(ctx context.Context, folder string) error {
 // or move-out) fire OnMessageRemove; live items are hydrated and fire
 // OnMessageAdd (the wmail layer dedupes by Message-ID) plus OnFlagsChange to keep
 // read state fresh for messages that already exist.
-func (c *Client) applyDelta(ctx context.Context, item *graphMessage) error {
+func (c *Client) applyDelta(ctx context.Context, folder string, item *graphMessage) error {
 	if item.Removed != nil {
 		if c.OnMessageRemove != nil {
 			return c.OnMessageRemove(ctx, item.ID)
@@ -100,7 +100,13 @@ func (c *Client) applyDelta(ctx context.Context, item *graphMessage) error {
 	}
 
 	if c.OnMessageAdd != nil {
-		if err := c.OnMessageAdd(ctx, full.toEmailData()); err != nil {
+		data := full.toEmailData()
+		// Junk-folder arrivals carry a spam flag so warmup spam-placement
+		// detection and placement tests see where the message landed.
+		if folder == FolderJunk {
+			data.Flags = append(data.Flags, "\\Junk")
+		}
+		if err := c.OnMessageAdd(ctx, data); err != nil {
 			return err
 		}
 	}

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -1,11 +1,15 @@
 package imap
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/textproto"
+	"strings"
 	"sync"
 
 	"github.com/emersion/go-imap/v2"
@@ -18,6 +22,13 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 	"golang.org/x/oauth2"
 )
+
+// headerFetchFields are the internet headers fetched alongside each changed
+// message (BODY.PEEK[HEADER.FIELDS ...]) and surfaced into Flags as
+// "Header:value" pseudo-flags: the warmup verification token plus the
+// machine-reply/DSN markers the consumer's reply/bounce classifier reads.
+// The IMAP ENVELOPE carries none of these.
+var headerFetchFields = append([]string{config.WarmupVerifyHeader}, config.InboundClassificationHeaders...)
 
 type Client struct {
 	Email       string
@@ -166,12 +177,20 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.Mail
 		ModSeq:       true,
 		InternalDate: true,
 		ChangedSince: lastModSeq,
+		BodySection: []*imap.FetchItemBodySection{{
+			Specifier:    imap.PartSpecifierHeader,
+			HeaderFields: headerFetchFields,
+			Peek:         true,
+		}},
 	})
 	for em := cmd.Next(); em != nil; em = cmd.Next() {
 		var email models.EmailMessageData
 		var euid imap.UID
 
 		var bodyStructure imap.BodyStructure
+		// Collected separately: the FLAGS item resets email.Flags and item
+		// order is server-dependent, so appending inline could be wiped.
+		var headerFlags []string
 
 		for item := em.Next(); item != nil; item = em.Next() {
 			switch item := item.(type) {
@@ -202,9 +221,12 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.Mail
 				email.ModSeq = item.ModSeq
 			case imapclient.FetchItemDataBodyStructure:
 				bodyStructure = item.BodyStructure
+			case imapclient.FetchItemDataBodySection:
+				headerFlags = parseHeaderFlags(item.Literal)
 			}
 		}
 
+		email.Flags = append(email.Flags, headerFlags...)
 		email.BodyPlain, email.BodyHTML = fetchTextParts(c.client, euid, bodyStructure)
 
 		if err := c.OnUpdate(ctx, &email); err != nil {
@@ -218,4 +240,25 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.Mail
 	}
 
 	return nil
+}
+
+// parseHeaderFlags reads a HEADER.FIELDS literal and renders the fetched
+// headers as "Header:value" pseudo-flags, using the canonical names from
+// headerFetchFields so the consumer's prefix matching always hits.
+func parseHeaderFlags(lit io.Reader) []string {
+	if lit == nil {
+		return nil
+	}
+	tp := textproto.NewReader(bufio.NewReader(io.LimitReader(lit, 32*1024)))
+	hdr, err := tp.ReadMIMEHeader()
+	if len(hdr) == 0 && err != nil {
+		return nil
+	}
+	var out []string
+	for _, name := range headerFetchFields {
+		if v := strings.TrimSpace(hdr.Get(name)); v != "" {
+			out = append(out, name+":"+v)
+		}
+	}
+	return out
 }

--- a/internal/client/smtpimap/smtp/client.go
+++ b/internal/client/smtpimap/smtp/client.go
@@ -50,6 +50,7 @@ type Attachment struct {
 func (c *Client) Send(
 	ctx context.Context,
 	to, cc, bcc []string,
+	messageID,
 	subject, bodyPlain, bodyHTML,
 	inReplyTo string,
 	attachments []Attachment,
@@ -64,6 +65,12 @@ func (c *Client) Send(
 		"Subject":      subject,
 		"Date":         time.Now().Format(time.RFC1123Z),
 		"MIME-Version": "1.0",
+	}
+	if messageID != "" {
+		// Write the caller's Message-ID so the id we record matches what was
+		// actually sent; without it the receiving server assigns its own and
+		// reply/bounce correlation and threading break.
+		headers["Message-ID"] = "<" + strings.Trim(messageID, "<>") + ">"
 	}
 	if len(cc) > 0 {
 		headers["Cc"] = strings.Join(cc, ", ")
@@ -213,7 +220,8 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 	}
 	defer conn.Close()
 
-	client, err := smtp.NewClient(conn, c.Credentials.Host)
+	// Use the resolved host: c.Credentials is nil for OAuth2-configured clients.
+	client, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return errx.ErrMailServerUnreachable
 	}
@@ -256,7 +264,10 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 	}
 	for _, r := range to {
 		if err := client.Rcpt(r); err != nil {
-			return errx.ErrMailServerUnreachable
+			// A refused RCPT is a recipient problem (bad address, policy
+			// rejection), not a dead server; classifying it as unreachable
+			// hid rejections from bounce accounting.
+			return errx.ErrMailRecipientRejected
 		}
 	}
 	w, err := client.Data()


### PR DESCRIPTION
## What this does

Fixes every real bug found in the Gmail and SMTP/IMAP mail paths during the Graph migration review, and brings both up to parity with the Graph path (warmup categorization, reply/bounce classification, spam-placement detection).

Stacked on #57 (base: `feature/mailbox-graph-api`).

## Gmail

- **History sync mapped id-only stubs.** History responses carry just `{id, threadId, labelIds}` — no envelope, headers, or body — so synced Gmail messages had empty subjects, bodies, and headers, and the warmup token could never be read. Each added message is now hydrated with a full `Users.Messages.Get` (404s from in-flight deletions are skipped).
- **Read state was inverted.** The mapper turned the `UNREAD` label into `\Seen` — unread messages were recorded as read. `\Seen` now applies when `UNREAD` is absent.
- **messageId-map key mismatch.** Adds were keyed by RFC `Message-ID`, but remove/label lookups used the Gmail id, so removes and read/label syncs silently no-oped forever. The map is now keyed by the Gmail id end to end (same principle as the Graph path: key by the id the provider's change feed reports).
- **Label events passed raw Gmail labels.** `UNREAD` added now emits FLAGS_REMOVE `\Seen` (and vice versa); `STARRED`/`IMPORTANT`/`DRAFT` translate to their internal flags; unknown labels pass through.
- **Spam placement never fired.** The `SPAM` label was dropped by the mapper, so warmup spam-placement health had no signal on Gmail. `SPAM` and `CATEGORY_*` labels now flow into flags (`CATEGORY_PROMOTIONS` also unblocks the placement-test promotions detection flagged as a follow-up in `placement/service.go`).
- **Bodies were empty even when present**: `extractBody` only walked `payload.parts` (single-part messages carry the body on the payload itself) and used padded base64 decoding against Gmail's unpadded base64url. Both fixed; `Snippet` is now populated from the API.
- **Silent transport errors.** `goog.HandleError` returned nil for non-`googleapi` errors (DNS/TLS/timeouts), swallowing them and leaving callers with a typed-nil `*MailError`. Now mapped to a retryable server-unreachable error.

## SMTP / IMAP

- **SMTP never wrote `Message-ID`.** The recorded id didn't match the wire message (the receiving server assigned its own), breaking reply/bounce correlation and threading. The client now writes the caller's Message-ID, mirroring the Gmail/Graph signature.
- **Refused recipients were "server unreachable".** A rejected `RCPT` is now classified as recipient-rejected so bounce accounting sees it (and retries don't hammer a dead address).
- **OAuth2-config nil-deref** in the SMTP handshake (`smtp.NewClient` used `c.Credentials.Host`, nil for OAuth2 configs); now uses the resolved host.
- **IMAP surfaced no custom headers.** Sync fetched ENVELOPE + FLAGS only, so the warmup verify token and machine-reply/DSN markers never reached the consumer — warmup categorization and reply/bounce classification were dead on IMAP mailboxes. The changed-message fetch now includes `BODY.PEEK[HEADER.FIELDS (…)]` and surfaces them as the same `Header:value` pseudo-flags the Graph/Gmail paths use (collected order-independently, since the FLAGS item resets the flag slice).
- **Threads forked at every reply depth.** A reply's thread id was set to the parent's *internal UUID* rather than the parent's *thread*, so three-message chains produced three "threads". Replies now join the parent's thread, with a sensible root when the parent predates connect.

## Graph (same bug family)

- Junk-folder delta arrivals now carry a `\Junk` flag so warmup spam-placement detection and placement tests see where the message landed (previously no spam signal on Graph either).

## Verification

`go build ./...`, `gofmt -l`, `go vet` clean. Not runtime-verified against live Gmail/IMAP servers (per repo policy, manual verification against the dev stack); the IMAP `HEADER.FIELDS` fetch and Gmail full-message hydration are the two spots most worth a live smoke test.
