### PR TITLE
iOS realtime parity, richer sequence preview, and mobile push notifications

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -72,6 +72,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/worker_orchestrator"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/events"
+	"github.com/warmbly/warmbly/internal/infrastructure/apns"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/cloudprovider"
 	"github.com/warmbly/warmbly/internal/infrastructure/cloudprovider/hetzner"
@@ -970,6 +971,17 @@ func main() {
 		// here too).
 		notificationService = notification.NewService(repository.NewNotificationRepository(primaryDB.Pool), streamingPublisher)
 		notificationService.WireDelivery(emailNotificationService, integrationServiceForHandler, userRepostory)
+		// Mobile push (APNs): device registration always works; delivery only
+		// activates when the APNS_* env is configured. The Redis client backs
+		// the shared immediate-then-digest push window. The sender stays a nil
+		// interface (not a typed-nil *apns.Client) when unconfigured.
+		var pushSender notification.PushSender
+		if apnsClient, aerr := apns.FromEnv(); aerr != nil {
+			log.Printf("Warning: APNs push disabled: %v", aerr)
+		} else if apnsClient != nil {
+			pushSender = apnsClient
+		}
+		notificationService.WirePush(pushSender, repository.NewDeviceTokenRepository(primaryDB.Pool), cache.Client)
 		advancedService.WireNotifier(notificationService)
 		// New-device sign-in alerts: the token service fires this on session
 		// creation from an unrecognized device, delivered as a security

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -21,6 +21,7 @@ import (
 	workerapp "github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/events"
+	"github.com/warmbly/warmbly/internal/infrastructure/apns"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/codec"
 	"github.com/warmbly/warmbly/internal/infrastructure/db"
@@ -283,6 +284,17 @@ func main() {
 		}
 	}
 	notificationService.WireDelivery(notifEmail, integrationServiceC, repository.NewUserRepostory(primaryDB, kmsClient))
+	// Mobile push (APNs) fires from THIS process too: reply/bounce/complaint
+	// notifications are created here. Redis backs the immediate-then-digest
+	// window shared with the backend. The sender stays a nil interface (not a
+	// typed-nil *apns.Client) when unconfigured.
+	var pushSender notification.PushSender
+	if apnsClient, aerr := apns.FromEnv(); aerr != nil {
+		log.Printf("Warning: APNs push disabled: %v", aerr)
+	} else if apnsClient != nil {
+		pushSender = apnsClient
+	}
+	notificationService.WirePush(pushSender, repository.NewDeviceTokenRepository(primaryDB.Pool), redisCache.Client)
 	advancedService.WireNotifier(notificationService)
 	// Reply pulses fire in THIS process too (inbox ingest classifies replies).
 	advancedService.WireRealtime(streamingPublisher)

--- a/docs/content/docs/api/account-and-organization.mdx
+++ b/docs/content/docs/api/account-and-organization.mdx
@@ -532,12 +532,12 @@ Auth: Session only (not available to API keys).
 ```json
 {
   "preferences": {
-    "inbound_reply": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } }
+    "inbound_reply": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } }
   }
 }
 ```
@@ -554,17 +554,17 @@ Auth: Session only (not available to API keys).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `preferences` | object | yes | The complete preferences object. Each of the six categories has `enabled` plus a `channels` object (`in_app`, `email`, `slack`). |
+| `preferences` | object | yes | The complete preferences object. Each of the six categories has `enabled` plus a `channels` object (`in_app`, `email`, `slack`, `push`). |
 
 ```json
 {
   "preferences": {
-    "inbound_reply": { "enabled": true, "channels": { "in_app": true, "email": true, "slack": false } },
-    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } }
+    "inbound_reply": { "enabled": true, "channels": { "in_app": true, "email": true, "slack": false, "push": true } },
+    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } }
   }
 }
 ```
@@ -632,6 +632,50 @@ Auth: Session only (not available to API keys).
 | Parameter | In | Type | Description |
 |-----------|----|------|-------------|
 | `id` | path | uuid | The notification id. |
+
+#### Response
+
+```json
+{ "ok": true }
+```
+
+### Register a device token
+
+`POST /auth/me/device-tokens`
+
+Registers an APNs device token for mobile push delivery. The mobile app calls this automatically after the user allows notifications; it is an upsert, so repeating it on every launch is safe. A token already registered by another account moves to the caller (the device changed accounts). Delivery of enabled notifications follows the `push` channel in the preferences above, batched server-side: the first event in a quiet stretch pushes immediately, later events inside the batching window arrive as one summary.
+
+Auth: Session only (not available to API keys).
+
+#### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `token` | string | yes | The hex APNs device token. |
+| `platform` | string | no | Only `ios` today (the default). |
+| `environment` | string | no | `production` (default) or `development` for sandbox builds. |
+
+```json
+{ "token": "a1b2c3...", "platform": "ios", "environment": "production" }
+```
+
+#### Response
+
+```json
+{ "ok": true }
+```
+
+### Delete a device token
+
+`DELETE /auth/me/device-tokens/:token`
+
+Removes one of the caller's device tokens. The mobile app calls this on sign-out so the device stops receiving the account's pushes.
+
+Auth: Session only (not available to API keys).
+
+| Parameter | In | Type | Description |
+|-----------|----|------|-------------|
+| `token` | path | string | The hex device token to remove. |
 
 #### Response
 

--- a/docs/content/docs/api/reference/account-org.mdx
+++ b/docs/content/docs/api/reference/account-org.mdx
@@ -477,12 +477,12 @@ Auth: Session only (not available to API keys).
 ```json
 {
   "preferences": {
-    "inbound_reply": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } }
+    "inbound_reply": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } }
   }
 }
 ```
@@ -499,17 +499,17 @@ Auth: Session only (not available to API keys).
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `preferences` | object | yes | The complete preferences object. Each of the six categories has `enabled` plus a `channels` object (`in_app`, `email`, `slack`). |
+| `preferences` | object | yes | The complete preferences object. Each of the six categories has `enabled` plus a `channels` object (`in_app`, `email`, `slack`, `push`). |
 
 ```json
 {
   "preferences": {
-    "inbound_reply": { "enabled": true, "channels": { "in_app": true, "email": true, "slack": false } },
-    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } },
-    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false } }
+    "inbound_reply": { "enabled": true, "channels": { "in_app": true, "email": true, "slack": false, "push": true } },
+    "inbound_out_of_office": { "enabled": false, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_bounce": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_complaint": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "health_worker_downtime": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } },
+    "security_new_signin": { "enabled": true, "channels": { "in_app": true, "email": false, "slack": false, "push": true } }
   }
 }
 ```
@@ -577,6 +577,50 @@ Auth: Session only (not available to API keys).
 | Parameter | In | Type | Description |
 |-----------|----|------|-------------|
 | `id` | path | uuid | The notification id. |
+
+#### Response
+
+```json
+{ "ok": true }
+```
+
+### Register a device token
+
+`POST /auth/me/device-tokens`
+
+Registers an APNs device token for mobile push delivery. The mobile app calls this automatically after the user allows notifications; it is an upsert, so repeating it on every launch is safe. A token already registered by another account moves to the caller (the device changed accounts). Delivery of enabled notifications follows the `push` channel in the preferences above, batched server-side: the first event in a quiet stretch pushes immediately, later events inside the batching window arrive as one summary.
+
+Auth: Session only (not available to API keys).
+
+#### Request body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `token` | string | yes | The hex APNs device token. |
+| `platform` | string | no | Only `ios` today (the default). |
+| `environment` | string | no | `production` (default) or `development` for sandbox builds. |
+
+```json
+{ "token": "a1b2c3...", "platform": "ios", "environment": "production" }
+```
+
+#### Response
+
+```json
+{ "ok": true }
+```
+
+### Delete a device token
+
+`DELETE /auth/me/device-tokens/:token`
+
+Removes one of the caller's device tokens. The mobile app calls this on sign-out so the device stops receiving the account's pushes.
+
+Auth: Session only (not available to API keys).
+
+| Parameter | In | Type | Description |
+|-----------|----|------|-------------|
+| `token` | path | string | The hex device token to remove. |
 
 #### Response
 

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -73,6 +73,16 @@ WORKER_AWS_ACCESS_KEY_ID=...
 WORKER_AWS_SECRET_ACCESS_KEY=...
 ```
 
+Mobile push via APNs (optional; omit to disable push delivery while device registration keeps working). Set on the backend and the consumer; the digest window controls how push bursts are batched (first event immediate, the rest summarized when the window closes):
+
+```
+APNS_KEY_PATH=/etc/warmbly/AuthKey_ABC123.p8   # or APNS_KEY with the PEM contents inline
+APNS_KEY_ID=ABC123DEFG
+APNS_TEAM_ID=TEAM123456
+APNS_TOPIC=com.warmbly.app
+NOTIFICATION_PUSH_WINDOW=5h                    # optional, default 5h
+```
+
 Release auto-update (optional; safe to omit on a fresh install):
 
 ```

--- a/docs/content/docs/guides/notifications.mdx
+++ b/docs/content/docs/guides/notifications.mdx
@@ -22,7 +22,7 @@ The feed updates live. When a notification is raised, it appears in your feed an
 
 ## Categories
 
-Warmbly notifies on a fixed set of categories, grouped by what they tell you. They fall into two groups: inbound activity and health.
+Warmbly notifies on a fixed set of categories, grouped by what they tell you: inbound activity, health, and security.
 
 ### Inbound activity
 
@@ -41,6 +41,10 @@ These are deliverability and infrastructure alerts. They are about your sending 
 
 For more on what bounces and complaints mean for your reputation, and the thresholds Warmbly acts on, see [Deliverability](/guides/deliverability).
 
+### Security
+
+- **New sign-in**: your account was accessed from a device you have not used before, with the browser, OS, and approximate location in the notification body.
+
 ## Per-category preferences
 
 You control notifications per category from **Settings → Notifications**. Each category has its own toggle, so you can keep the ones that matter to you and silence the rest.
@@ -49,8 +53,9 @@ The settings page groups the toggles the same way as above:
 
 - **Inbound activity** Reply received, Out-of-office detected.
 - **Health** Bounce detected, Spam complaint, Worker downtime.
+- **Security** New sign-in.
 
-Changes are not saved as you click. When you flip a toggle, a **Save** and a **Discard** action appear; your changes only take effect once you press Save. Discard returns the toggles to their last saved state.
+Toggles save automatically as you flip them; the save indicator next to the page title confirms each change has persisted.
 
 ## Defaults
 
@@ -61,6 +66,7 @@ The defaults are chosen to be useful without being noisy. The shipped defaults a
 | Bounce detected | Health | On |
 | Spam complaint | Health | On |
 | Worker downtime | Health | On |
+| New sign-in | Security | On |
 | Reply received | Inbound | Off |
 | Out-of-office detected | Inbound | Off |
 
@@ -77,6 +83,7 @@ Even with the reply notification off, you never miss responses. Every reply stil
 The settings page controls where enabled notifications are delivered. The channel toggles apply across every category above.
 
 - **In-app**: the bell in the dashboard. Always on, controlled by the per-category toggles above.
+- **Mobile push**: alerts on devices signed in with the Warmbly iOS app. Registration happens automatically when you allow notifications in the app, and signing out on a device stops its pushes. Push is batched so a burst never pings you once per event: the first notification in a quiet stretch is delivered immediately, and anything else that arrives inside the batching window (five hours by default) is held and sent as a single summary, like "3 new replies", when the window closes.
 - **Email**: delivery to your account email. Turn it on to also receive each enabled notification as an email with a link back into the app.
 - **Slack**: posts each enabled notification to your connected Slack, on the channel you have configured for Slack in the [Integrations](/guides/integrations) tab. Connect Slack and set up a channel there first; until a Slack channel is configured the toggle saves but nothing is delivered.
 

--- a/internal/api/handler/device_token.go
+++ b/internal/api/handler/device_token.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"net/http"
+	"regexp"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// APNs tokens are hex; allow generous length for future formats.
+var deviceTokenPattern = regexp.MustCompile(`^[0-9a-fA-F]{16,512}$`)
+
+// RegisterDeviceToken stores an APNs device token for the caller. Upserts, so
+// retries and re-registrations on app launch are naturally safe.
+func (h *Handler) RegisterDeviceToken(c *gin.Context) {
+	uid, ok := notifActor(c)
+	if !ok {
+		return
+	}
+	var req models.RegisterDeviceTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid payload"))
+		return
+	}
+	if !deviceTokenPattern.MatchString(req.Token) {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid device token"))
+		return
+	}
+	if req.Platform == "" {
+		req.Platform = "ios"
+	}
+	if req.Platform != "ios" {
+		errx.JSON(c, errx.New(errx.BadRequest, "unsupported platform"))
+		return
+	}
+	if req.Environment == "" {
+		req.Environment = "production"
+	}
+	if req.Environment != "production" && req.Environment != "development" {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid environment"))
+		return
+	}
+	if err := h.NotificationService.RegisterDevice(c.Request.Context(), uid, req.Platform, req.Token, req.Environment); err != nil {
+		errx.JSON(c, errx.InternalError())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}
+
+// DeleteDeviceToken removes one of the caller's device tokens (sign-out).
+func (h *Handler) DeleteDeviceToken(c *gin.Context) {
+	uid, ok := notifActor(c)
+	if !ok {
+		return
+	}
+	token := c.Param("token")
+	if !deviceTokenPattern.MatchString(token) {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid device token"))
+		return
+	}
+	if err := h.NotificationService.UnregisterDevice(c.Request.Context(), uid, token); err != nil {
+		errx.JSON(c, errx.InternalError())
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -234,6 +234,10 @@ func Run(
 		protectedAuth.PUT("/me/notifications", h.MarkAllNotificationsRead)
 		protectedAuth.POST("/me/notifications/:id/read", h.MarkNotificationRead)
 
+		// APNs device registration for mobile push (user-scoped).
+		protectedAuth.POST("/me/device-tokens", h.RegisterDeviceToken)
+		protectedAuth.DELETE("/me/device-tokens/:token", h.DeleteDeviceToken)
+
 		// 2FA enrollment + management (user-scoped, behind a live session).
 		protectedAuth.GET("/2fa/status", h.TwoFAStatus)
 		protectedAuth.POST("/2fa/enroll/start", h.TwoFAEnrollStart)

--- a/internal/app/notification/push.go
+++ b/internal/app/notification/push.go
@@ -1,0 +1,242 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/apns"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// PushSender delivers one alert to a device token. Satisfied by *apns.Client.
+type PushSender interface {
+	Push(ctx context.Context, deviceToken, environment string, n apns.Notification) error
+}
+
+// Push batching: the first notification in a quiet period is pushed
+// immediately; everything else that arrives inside the window (default 5h,
+// NOTIFICATION_PUSH_WINDOW) is coalesced into one digest push sent when the
+// window closes ("3 new replies"). State lives in Redis so backend + consumer
+// share one window per (user, category), and a ZSET claim keeps replicas from
+// double-sending the digest.
+const (
+	defaultPushWindow = 5 * time.Hour
+	pushKeyPrefix     = "notifpush"
+	digestPollEvery   = 30 * time.Second
+)
+
+type pendingPush struct {
+	Title string `json:"title"`
+	Body  string `json:"body,omitempty"`
+	Link  string `json:"link,omitempty"`
+}
+
+func pushWindow() time.Duration {
+	if raw := os.Getenv("NOTIFICATION_PUSH_WINDOW"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultPushWindow
+}
+
+// WirePush attaches the APNs sender, device-token storage, and the Redis
+// client backing the digest window, then starts the digest loop. Token storage
+// works with just the repository (devices can register before APNs is
+// configured); delivery needs all three.
+func (s *service) WirePush(sender PushSender, tokens repository.DeviceTokenRepository, rdb *redis.Client) {
+	if tokens != nil {
+		s.deviceTokens = tokens
+	}
+	if sender == nil || tokens == nil || rdb == nil {
+		return
+	}
+	s.push = sender
+	s.pushRedis = rdb
+	go s.digestLoop()
+}
+
+func (s *service) RegisterDevice(ctx context.Context, userID uuid.UUID, platform, token, environment string) error {
+	if s.deviceTokens == nil {
+		return errors.New("push not configured")
+	}
+	return s.deviceTokens.Upsert(ctx, userID, platform, token, environment)
+}
+
+func (s *service) UnregisterDevice(ctx context.Context, userID uuid.UUID, token string) error {
+	if s.deviceTokens == nil {
+		return errors.New("push not configured")
+	}
+	return s.deviceTokens.Delete(ctx, userID, token)
+}
+
+func pushMember(userID uuid.UUID, category models.NotificationCategory) string {
+	return userID.String() + "|" + string(category)
+}
+
+func lastKey(member string) string    { return pushKeyPrefix + ":last:{" + member + "}" }
+func pendingKey(member string) string { return pushKeyPrefix + ":pending:{" + member + "}" }
+func dueKey() string                  { return pushKeyPrefix + ":due" }
+
+// deliverPush is the per-notification ingress (detached, best-effort). First
+// event in a quiet window pushes right away; the rest queue for the digest.
+func (s *service) deliverPush(userID uuid.UUID, category models.NotificationCategory, title, body, link string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	member := pushMember(userID, category)
+	window := pushWindow()
+
+	ok, err := s.pushRedis.SetNX(ctx, lastKey(member), "1", window).Result()
+	if err != nil {
+		return
+	}
+	if ok {
+		s.sendPush(ctx, userID, category, apnsAlert(category, title, body, link, 1))
+		return
+	}
+
+	// Inside the window: queue and make sure a digest fires when it closes.
+	item, merr := json.Marshal(pendingPush{Title: title, Body: body, Link: link})
+	if merr != nil {
+		return
+	}
+	if err := s.pushRedis.RPush(ctx, pendingKey(member), item).Err(); err != nil {
+		return
+	}
+	due := time.Now().Add(window)
+	if ttl, terr := s.pushRedis.PTTL(ctx, lastKey(member)).Result(); terr == nil && ttl > 0 {
+		due = time.Now().Add(ttl)
+	}
+	s.pushRedis.ZAddNX(ctx, dueKey(), redis.Z{Score: float64(due.Unix()), Member: member})
+}
+
+// digestLoop drains due digest windows. ZRem is the cross-replica claim: only
+// the process that removes the member sends its digest.
+func (s *service) digestLoop() {
+	ticker := time.NewTicker(digestPollEvery)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.flushDueDigests()
+	}
+}
+
+func (s *service) flushDueDigests() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	members, err := s.pushRedis.ZRangeByScore(ctx, dueKey(), &redis.ZRangeBy{
+		Min: "-inf",
+		Max: fmt.Sprintf("%d", time.Now().Unix()),
+	}).Result()
+	if err != nil {
+		return
+	}
+	for _, member := range members {
+		removed, rerr := s.pushRedis.ZRem(ctx, dueKey(), member).Result()
+		if rerr != nil || removed == 0 {
+			continue // another replica claimed it
+		}
+		s.sendDigest(ctx, member)
+	}
+}
+
+func (s *service) sendDigest(ctx context.Context, member string) {
+	parts := strings.SplitN(member, "|", 2)
+	if len(parts) != 2 {
+		return
+	}
+	userID, err := uuid.Parse(parts[0])
+	if err != nil {
+		return
+	}
+	category := models.NotificationCategory(parts[1])
+
+	raw, lerr := s.pushRedis.LRange(ctx, pendingKey(member), 0, -1).Result()
+	if lerr != nil {
+		return
+	}
+	s.pushRedis.Del(ctx, pendingKey(member))
+	if len(raw) == 0 {
+		return
+	}
+	// Restart the window so the next burst digests again instead of streaming.
+	s.pushRedis.Set(ctx, lastKey(member), "1", pushWindow())
+
+	items := make([]pendingPush, 0, len(raw))
+	for _, r := range raw {
+		var p pendingPush
+		if json.Unmarshal([]byte(r), &p) == nil {
+			items = append(items, p)
+		}
+	}
+	if len(items) == 0 {
+		return
+	}
+	if len(items) == 1 {
+		s.sendPush(ctx, userID, category, apnsAlert(category, items[0].Title, items[0].Body, items[0].Link, 1))
+		return
+	}
+	last := items[len(items)-1]
+	n := apnsAlert(category, digestTitle(category, len(items)), "Latest: "+last.Title, last.Link, len(items))
+	n.CollapseID = "digest:" + string(category)
+	s.sendPush(ctx, userID, category, n)
+}
+
+func apnsAlert(category models.NotificationCategory, title, body, link string, count int) apns.Notification {
+	custom := map[string]any{"category": string(category), "count": count}
+	if link != "" {
+		custom["link"] = link
+	}
+	return apns.Notification{
+		Title:    title,
+		Body:     body,
+		ThreadID: string(category),
+		Custom:   custom,
+	}
+}
+
+func digestTitle(category models.NotificationCategory, n int) string {
+	switch category {
+	case models.NotifInboundReply:
+		return fmt.Sprintf("%d new replies", n)
+	case models.NotifInboundOOO:
+		return fmt.Sprintf("%d out-of-office replies", n)
+	case models.NotifHealthBounce:
+		return fmt.Sprintf("%d new bounces", n)
+	case models.NotifHealthComplaint:
+		return fmt.Sprintf("%d new spam complaints", n)
+	case models.NotifWorkerDowntime:
+		return fmt.Sprintf("%d worker alerts", n)
+	case models.NotifSecuritySignIn:
+		return fmt.Sprintf("%d new sign-ins", n)
+	default:
+		return fmt.Sprintf("%d new notifications", n)
+	}
+}
+
+// sendPush fans one alert out to every device the user registered, dropping
+// tokens APNs reports as gone. The badge is the user's unread feed count.
+func (s *service) sendPush(ctx context.Context, userID uuid.UUID, category models.NotificationCategory, n apns.Notification) {
+	tokens, err := s.deviceTokens.ListByUser(ctx, userID)
+	if err != nil || len(tokens) == 0 {
+		return
+	}
+	if unread, cerr := s.repo.CountUnread(ctx, userID); cerr == nil {
+		n.Badge = &unread
+	}
+	for _, t := range tokens {
+		if perr := s.push.Push(ctx, t.Token, t.Environment, n); errors.Is(perr, apns.ErrUnregistered) {
+			_ = s.deviceTokens.DeleteToken(ctx, t.Token)
+		}
+	}
+}

--- a/internal/app/notification/service.go
+++ b/internal/app/notification/service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
@@ -53,6 +54,14 @@ type Service interface {
 	// the email/Slack channels (wired post-construction in both mains). Any
 	// may be nil — the matching channel is then skipped.
 	WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup)
+
+	// WirePush attaches APNs + device-token storage + the Redis digest window
+	// and starts the digest loop. Any nil dependency leaves push disabled.
+	WirePush(sender PushSender, tokens repository.DeviceTokenRepository, rdb *redis.Client)
+
+	// RegisterDevice / UnregisterDevice manage the caller's APNs tokens.
+	RegisterDevice(ctx context.Context, userID uuid.UUID, platform, token, environment string) error
+	UnregisterDevice(ctx context.Context, userID uuid.UUID, token string) error
 }
 
 type service struct {
@@ -61,6 +70,10 @@ type service struct {
 	email     EmailSender
 	slack     SlackNotifier
 	users     UserLookup
+
+	push         PushSender
+	deviceTokens repository.DeviceTokenRepository
+	pushRedis    *redis.Client
 }
 
 func (s *service) WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup) {
@@ -162,6 +175,11 @@ func (s *service) Notify(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID
 			defer cancel()
 			_ = s.slack.NotifySlack(ctx, org, title, body)
 		}()
+	}
+
+	// Push: immediate on a quiet window, digest-batched inside one (detached).
+	if cat.Channels.Push && s.push != nil && s.deviceTokens != nil && s.pushRedis != nil {
+		go s.deliverPush(userID, category, title, body, link)
 	}
 }
 

--- a/internal/infrastructure/apns/client.go
+++ b/internal/infrastructure/apns/client.go
@@ -1,0 +1,197 @@
+// Package apns is a minimal APNs provider: token-based (p8) auth over the
+// HTTP/2 API, no third-party APNs dependency. The stdlib http.Transport
+// negotiates HTTP/2 with api.push.apple.com automatically.
+package apns
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// ErrUnregistered means APNs no longer knows the device token (app deleted,
+// token rotated). Callers should drop the token from storage.
+var ErrUnregistered = errors.New("apns: device token unregistered")
+
+const (
+	hostProduction  = "https://api.push.apple.com"
+	hostDevelopment = "https://api.sandbox.push.apple.com"
+	// Apple wants provider tokens refreshed every 20-60 minutes.
+	tokenTTL = 45 * time.Minute
+)
+
+// Notification is one alert push.
+type Notification struct {
+	Title string
+	Body  string
+	// Badge, when non-nil, sets the app icon badge count.
+	Badge *int
+	// ThreadID groups alerts in the notification center (we use the category).
+	ThreadID string
+	// CollapseID makes a later push replace an earlier one with the same id.
+	CollapseID string
+	// Custom keys delivered alongside aps (link, category, notification id).
+	Custom map[string]any
+}
+
+// Client sends alert pushes with a cached ES256 provider token.
+type Client struct {
+	key    *ecdsa.PrivateKey
+	keyID  string
+	teamID string
+	topic  string
+	http   *http.Client
+
+	mu       sync.Mutex
+	bearer   string
+	bearerAt time.Time
+}
+
+// FromEnv builds a client from APNS_KEY (PEM contents) or APNS_KEY_PATH, plus
+// APNS_KEY_ID, APNS_TEAM_ID, and APNS_TOPIC (the app bundle id). Returns nil
+// when unconfigured so callers can treat push as absent.
+func FromEnv() (*Client, error) {
+	keyPEM := os.Getenv("APNS_KEY")
+	if keyPEM == "" {
+		if path := os.Getenv("APNS_KEY_PATH"); path != "" {
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("apns: read key: %w", err)
+			}
+			keyPEM = string(raw)
+		}
+	}
+	keyID := os.Getenv("APNS_KEY_ID")
+	teamID := os.Getenv("APNS_TEAM_ID")
+	topic := os.Getenv("APNS_TOPIC")
+	if keyPEM == "" && keyID == "" && teamID == "" && topic == "" {
+		return nil, nil // push not configured
+	}
+	if keyPEM == "" || keyID == "" || teamID == "" || topic == "" {
+		return nil, errors.New("apns: partial config; need APNS_KEY (or APNS_KEY_PATH), APNS_KEY_ID, APNS_TEAM_ID, APNS_TOPIC")
+	}
+	key, err := parseP8(keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		key:    key,
+		keyID:  keyID,
+		teamID: teamID,
+		topic:  topic,
+		http:   &http.Client{Timeout: 10 * time.Second},
+	}, nil
+}
+
+func parseP8(pemStr string) (*ecdsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return nil, errors.New("apns: key is not PEM")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("apns: parse key: %w", err)
+	}
+	key, ok := parsed.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, errors.New("apns: key is not ECDSA (expected an Apple .p8)")
+	}
+	return key, nil
+}
+
+func (c *Client) providerToken() (string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.bearer != "" && time.Since(c.bearerAt) < tokenTTL {
+		return c.bearer, nil
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodES256, jwt.MapClaims{
+		"iss": c.teamID,
+		"iat": time.Now().Unix(),
+	})
+	tok.Header["kid"] = c.keyID
+	signed, err := tok.SignedString(c.key)
+	if err != nil {
+		return "", fmt.Errorf("apns: sign provider token: %w", err)
+	}
+	c.bearer = signed
+	c.bearerAt = time.Now()
+	return signed, nil
+}
+
+// Push delivers one alert to a device token. environment selects the sandbox
+// or production APNs host (per-token, matching how the device was built).
+func (c *Client) Push(ctx context.Context, deviceToken, environment string, n Notification) error {
+	bearer, err := c.providerToken()
+	if err != nil {
+		return err
+	}
+
+	aps := map[string]any{
+		"alert": map[string]string{"title": n.Title, "body": n.Body},
+		"sound": "default",
+	}
+	if n.Badge != nil {
+		aps["badge"] = *n.Badge
+	}
+	if n.ThreadID != "" {
+		aps["thread-id"] = n.ThreadID
+	}
+	payload := map[string]any{"aps": aps}
+	for k, v := range n.Custom {
+		payload[k] = v
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	host := hostProduction
+	if environment == "development" {
+		host = hostDevelopment
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, host+"/3/device/"+deviceToken, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("authorization", "bearer "+bearer)
+	req.Header.Set("apns-topic", c.topic)
+	req.Header.Set("apns-push-type", "alert")
+	req.Header.Set("apns-priority", "10")
+	if n.CollapseID != "" {
+		req.Header.Set("apns-collapse-id", n.CollapseID)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	var apiErr struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.Unmarshal(raw, &apiErr)
+	if resp.StatusCode == http.StatusGone ||
+		apiErr.Reason == "Unregistered" || apiErr.Reason == "BadDeviceToken" || apiErr.Reason == "DeviceTokenNotForTopic" {
+		return ErrUnregistered
+	}
+	return fmt.Errorf("apns: %d %s", resp.StatusCode, strings.TrimSpace(apiErr.Reason))
+}

--- a/internal/infrastructure/db/migrations/000056_device_tokens.down.sql
+++ b/internal/infrastructure/db/migrations/000056_device_tokens.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS device_tokens;

--- a/internal/infrastructure/db/migrations/000056_device_tokens.up.sql
+++ b/internal/infrastructure/db/migrations/000056_device_tokens.up.sql
@@ -1,0 +1,14 @@
+-- APNs device tokens for mobile push delivery. One row per device; a token is
+-- globally unique and re-registering it moves it to the signing-in user (the
+-- device changed accounts). Environment picks the APNs host (sandbox vs prod).
+CREATE TABLE device_tokens (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    platform     TEXT NOT NULL DEFAULT 'ios' CHECK (platform IN ('ios')),
+    token        TEXT NOT NULL UNIQUE,
+    environment  TEXT NOT NULL DEFAULT 'production' CHECK (environment IN ('development', 'production')),
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_device_tokens_user ON device_tokens (user_id);

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -20,12 +20,13 @@ const (
 	NotifSecuritySignIn  NotificationCategory = "security_new_signin"
 )
 
-// ChannelPrefs is the per-category delivery toggles. Only InApp is delivered
-// today across in-app, email, and a connected Slack workspace.
+// ChannelPrefs is the per-category delivery toggles: in-app feed, account
+// email, a connected Slack workspace, and mobile push (APNs).
 type ChannelPrefs struct {
 	InApp bool `json:"in_app"`
 	Email bool `json:"email"`
 	Slack bool `json:"slack"`
+	Push  bool `json:"push"`
 }
 
 // CategoryPref is the enable flag + channel toggles for one category.
@@ -48,9 +49,12 @@ type NotificationPreferences struct {
 // DefaultNotificationPreferences is the merge base. Health categories default ON
 // (operationally important + low volume); inbound categories default OFF (a big
 // campaign would otherwise flood the feed with a notification per recipient).
+// Push defaults on: it only fires for devices the user explicitly registered by
+// granting the OS notification permission, and enabled categories should reach
+// those devices without a second opt-in.
 func DefaultNotificationPreferences() NotificationPreferences {
-	on := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true}}
-	off := CategoryPref{Enabled: false, Channels: ChannelPrefs{InApp: true}}
+	on := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true}}
+	off := CategoryPref{Enabled: false, Channels: ChannelPrefs{InApp: true, Push: true}}
 	return NotificationPreferences{
 		InboundReply:    off,
 		InboundOOO:      off,
@@ -98,4 +102,22 @@ type Notification struct {
 // UpdateNotificationPreferencesRequest is the PUT payload.
 type UpdateNotificationPreferencesRequest struct {
 	Preferences NotificationPreferences `json:"preferences"`
+}
+
+// DeviceToken is one push-capable device registration (APNs).
+type DeviceToken struct {
+	ID          uuid.UUID `json:"id"`
+	UserID      uuid.UUID `json:"user_id"`
+	Platform    string    `json:"platform"`
+	Token       string    `json:"token"`
+	Environment string    `json:"environment"`
+	CreatedAt   time.Time `json:"created_at"`
+	LastSeenAt  time.Time `json:"last_seen_at"`
+}
+
+// RegisterDeviceTokenRequest is the POST payload from the mobile app.
+type RegisterDeviceTokenRequest struct {
+	Token       string `json:"token" binding:"required"`
+	Platform    string `json:"platform"`
+	Environment string `json:"environment"`
 }

--- a/internal/repository/pg_device_token.go
+++ b/internal/repository/pg_device_token.go
@@ -1,0 +1,76 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DeviceTokenRepository stores APNs device registrations for mobile push.
+type DeviceTokenRepository interface {
+	// Upsert registers a token, moving it to userID when the device switched
+	// accounts (token is globally unique).
+	Upsert(ctx context.Context, userID uuid.UUID, platform, token, environment string) error
+	// Delete removes one of the user's tokens (sign-out on that device).
+	Delete(ctx context.Context, userID uuid.UUID, token string) error
+	// DeleteToken removes a token regardless of owner (APNs said Unregistered).
+	DeleteToken(ctx context.Context, token string) error
+	// ListByUser returns every registered device for a user.
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]models.DeviceToken, error)
+}
+
+type deviceTokenRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewDeviceTokenRepository(db *pgxpool.Pool) DeviceTokenRepository {
+	return &deviceTokenRepository{db: db}
+}
+
+func (r *deviceTokenRepository) Upsert(ctx context.Context, userID uuid.UUID, platform, token, environment string) error {
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO device_tokens (user_id, platform, token, environment)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (token) DO UPDATE
+		SET user_id = EXCLUDED.user_id,
+		    platform = EXCLUDED.platform,
+		    environment = EXCLUDED.environment,
+		    last_seen_at = now()`,
+		userID, platform, token, environment)
+	return err
+}
+
+func (r *deviceTokenRepository) Delete(ctx context.Context, userID uuid.UUID, token string) error {
+	_, err := r.db.Exec(ctx, `DELETE FROM device_tokens WHERE user_id = $1 AND token = $2`, userID, token)
+	return err
+}
+
+func (r *deviceTokenRepository) DeleteToken(ctx context.Context, token string) error {
+	_, err := r.db.Exec(ctx, `DELETE FROM device_tokens WHERE token = $1`, token)
+	return err
+}
+
+func (r *deviceTokenRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]models.DeviceToken, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT id, user_id, platform, token, environment, created_at, last_seen_at
+		FROM device_tokens
+		WHERE user_id = $1
+		ORDER BY created_at`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.DeviceToken
+	for rows.Next() {
+		var t models.DeviceToken
+		if err := rows.Scan(&t.ID, &t.UserID, &t.Platform, &t.Token, &t.Environment, &t.CreatedAt, &t.LastSeenAt); err != nil {
+			return nil, err
+		}
+		out = append(out, t)
+	}
+	return out, rows.Err()
+}

--- a/ios/Warmbly/Core/AppEnvironment.swift
+++ b/ios/Warmbly/Core/AppEnvironment.swift
@@ -21,13 +21,16 @@ final class AppEnvironment {
         self.api = api
         session = SessionStore(api: api)
         realtime = RealtimeService(api: api)
+        PushManager.shared.configure(api: api)
 
         session.onReady = { [weak self] userID, orgID in
             self?.realtime.connect(userID: userID, orgID: orgID)
+            PushManager.shared.sessionReady()
         }
         session.onLoggedOut = { [weak self] in
             self?.realtime.disconnect()
             self?.badges.uniboxUnread = 0
+            PushManager.shared.sessionEnded()
         }
     }
 }

--- a/ios/Warmbly/Core/Push/PushManager.swift
+++ b/ios/Warmbly/Core/Push/PushManager.swift
@@ -1,0 +1,142 @@
+import SwiftUI
+import UIKit
+import UserNotifications
+import os
+
+/// APNs registration + device-token sync with the backend.
+///
+/// The OS permission prompt fires once after login; the resulting token is
+/// POSTed to `auth/me/device-tokens` (an upsert, safe to repeat every launch)
+/// and DELETEd on logout so a shared device stops receiving the previous
+/// account's pushes. Batching lives server-side (first event pushes
+/// immediately, the rest digest at the window edge), so the client stays
+/// simple: register, unregister, mirror the unread badge.
+@MainActor
+@Observable
+final class PushManager: NSObject {
+    static let shared = PushManager()
+
+    private(set) var authorization: UNAuthorizationStatus = .notDetermined
+
+    private var api: APIClient?
+    private let log = Logger(subsystem: "com.warmbly.app", category: "push")
+
+    private var storedToken: String {
+        get { UserDefaults.standard.string(forKey: "push.deviceToken") ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: "push.deviceToken") }
+    }
+
+    /// Debug builds carry the sandbox aps-environment; the backend routes the
+    /// token to the matching APNs host.
+    private var apnsEnvironment: String {
+        #if DEBUG
+        "development"
+        #else
+        "production"
+        #endif
+    }
+
+    func configure(api: APIClient) {
+        self.api = api
+    }
+
+    /// Call once a session is live: asks for permission (first time only) and
+    /// (re)registers with APNs. Server-side registration is an upsert.
+    func sessionReady() {
+        Task { await requestAndRegister() }
+    }
+
+    func refreshAuthorization() async {
+        authorization = await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+    }
+
+    private func requestAndRegister() async {
+        let center = UNUserNotificationCenter.current()
+        var status = await center.notificationSettings().authorizationStatus
+        if status == .notDetermined {
+            let granted = (try? await center.requestAuthorization(options: [.alert, .badge, .sound])) ?? false
+            status = granted ? .authorized : .denied
+        }
+        authorization = status
+        guard status == .authorized || status == .provisional || status == .ephemeral else { return }
+        UIApplication.shared.registerForRemoteNotifications()
+    }
+
+    /// Sign-out: the backend forgets this device, then local state clears.
+    func sessionEnded() {
+        let token = storedToken
+        storedToken = ""
+        guard !token.isEmpty, let api else { return }
+        Task {
+            let _: MoreOkResponse? = try? await api.delete("auth/me/device-tokens/\(token)")
+        }
+    }
+
+    /// Mirror the server-tracked unread feed count onto the app icon.
+    func setBadge(_ count: Int) {
+        UNUserNotificationCenter.current().setBadgeCount(count, withCompletionHandler: nil)
+    }
+
+    // MARK: AppDelegate entry points
+
+    func didRegister(deviceToken: Data) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        storedToken = token
+        guard let api else { return }
+        let environment = apnsEnvironment
+        Task {
+            struct Body: Encodable {
+                let token: String
+                let platform: String
+                let environment: String
+            }
+            let _: MoreOkResponse? = try? await api.post(
+                "auth/me/device-tokens",
+                body: Body(token: token, platform: "ios", environment: environment)
+            )
+        }
+    }
+
+    func didFailToRegister(_ error: Error) {
+        log.warning("APNs registration failed: \(error.localizedDescription)")
+    }
+}
+
+extension PushManager: UNUserNotificationCenterDelegate {
+    /// Foreground pushes stay quiet — realtime already updates the feed and
+    /// badge counts in-app; only the icon badge is applied.
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.badge])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        completionHandler()
+    }
+}
+
+/// Bridges the UIKit launch + APNs callbacks into PushManager.
+final class PushAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = PushManager.shared
+        return true
+    }
+
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        Task { @MainActor in PushManager.shared.didRegister(deviceToken: deviceToken) }
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        Task { @MainActor in PushManager.shared.didFailToRegister(error) }
+    }
+}

--- a/ios/Warmbly/Core/Realtime/PhoenixClient.swift
+++ b/ios/Warmbly/Core/Realtime/PhoenixClient.swift
@@ -164,6 +164,29 @@ final class PhoenixSocket: NSObject, URLSessionWebSocketDelegate, @unchecked Sen
         scheduleReconnect()
     }
 
+    /// Fast-path recovery after app foregrounding: sockets die during
+    /// suspension, and the watchdog/backoff can take ~30s to notice on their
+    /// own. Verifies a live socket with an immediate heartbeat, or reconnects
+    /// right away instead of waiting out the scheduled backoff.
+    func nudge() {
+        let (running, connected) = locked { (shouldRun, state == .connected && task != nil) }
+        guard running else { return }
+        if connected {
+            let ref = nextRef()
+            locked { heartbeatAwaitingRef = ref }
+            sendFrame(topic: "phoenix", event: "heartbeat", payload: [:], ref: ref, joinRef: nil)
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 8_000_000_000)
+                guard let self else { return }
+                let stillWaiting = self.locked { self.heartbeatAwaitingRef == ref }
+                if stillWaiting { self.forceReconnect() }
+            }
+        } else {
+            locked { reconnectAttempt = 0 }
+            Task { await openSocket() }
+        }
+    }
+
     // MARK: - URLSessionWebSocketDelegate
 
     func urlSession(

--- a/ios/Warmbly/Core/Realtime/RealtimeService.swift
+++ b/ios/Warmbly/Core/Realtime/RealtimeService.swift
@@ -214,6 +214,13 @@ final class RealtimeService {
         socket.connect()
     }
 
+    /// Foreground kick: recheck the socket immediately instead of letting the
+    /// heartbeat watchdog discover a suspension-killed connection ~30s late.
+    func nudge() {
+        guard userID != nil else { return }
+        socket.nudge()
+    }
+
     func disconnect() {
         socket.disconnect()
         presence.reset()
@@ -319,7 +326,7 @@ final class RealtimeService {
         "step": [.campaigns],
         "email_account": [.emailAccounts, .analytics],
         "api_key": [.apiKeys],
-        "webhook": [.settings],
+        "webhook": [.settings, .integrations],
         "template": [.templates],
         "organization": [.team, .settings],
         "organization_member": [.team],
@@ -340,7 +347,7 @@ final class RealtimeService {
         "crm_stage": [.crm],
         "crm_deal": [.crm],
         "crm_task": [.crm],
-        "warmup_routing_rule": [.emailAccounts],
+        "warmup_routing_rule": [.emailAccounts, .analytics],
         "folder": [.me, .campaigns],
         "tag": [.me, .emailAccounts, .unibox],
         "category": [.me, .contacts],
@@ -348,19 +355,25 @@ final class RealtimeService {
 
     private static func domains(forEventName name: String) -> [RealtimeDomain] {
         if name.contains("NOTIFICATION") { return [.notifications] }
-        if name.contains("INBOX") || name == "EMAIL_RECEIVED" || name == "EMAIL_UPDATED" || name == "EMAIL_DELETED" {
-            return [.unibox]
+        if name.contains("INBOX") || name == "EMAIL_RECEIVED" {
+            return [.unibox, .analytics, .emailAccounts]
         }
+        if name == "EMAIL_UPDATED" || name == "EMAIL_DELETED" { return [.unibox, .analytics] }
         if name == "EMAIL_REPLIED" { return [.campaigns, .analytics, .unibox] }
         if name == "EMAIL_SENT" || name == "EMAIL_OPENED" || name == "EMAIL_CLICKED"
             || name == "EMAIL_FAILED" || name == "EMAIL_BOUNCED" || name.contains("TASK_PROGRESS") {
             return [.campaigns, .analytics]
         }
+        if name == "EMAIL_STATUS" || name == "EMAIL_ERROR" { return [.emailAccounts, .analytics] }
         if name.contains("CAMPAIGN") { return [.campaigns, .analytics] }
-        if name.contains("CONTACT") { return [.contacts] }
+        if name.contains("CONTACT") { return [.contacts, .campaigns, .analytics] }
         if name.contains("ACCOUNT") || name.contains("WARMUP") { return [.emailAccounts, .analytics] }
         if name.contains("BULK") { return [.contacts] }
-        if name.contains("MEETING") { return [.meetings, .crm] }
+        if name.contains("MEETING") || name.contains("BOOKING") { return [.meetings, .crm] }
+        if name.contains("DEAL") { return [.crm, .contacts] }
+        if name.contains("SUBSCRIPTION") || name.contains("PLAN") || name.contains("BILLING") || name.contains("LIMIT") {
+            return [.billing, .me]
+        }
         if name.contains("AUTOMATION") { return [.automations] }
         if name.contains("TASK") { return [.campaigns] }
         return []

--- a/ios/Warmbly/Features/Campaigns/CampaignDetailPages.swift
+++ b/ios/Warmbly/Features/Campaigns/CampaignDetailPages.swift
@@ -130,9 +130,9 @@ struct CampaignSequencePage: View {
                 List {
                     ForEach(store.steps) { step in
                         NavigationLink {
-                            CampaignStepReader(step: step)
+                            CampaignStepReader(step: step, all: store.steps)
                         } label: {
-                            CampaignStepRow(step: step)
+                            CampaignStepRow(step: step, all: store.steps)
                         }
                     }
                     WebHandoffBanner(text: "Writing and rearranging steps needs the full sequence editor. Open this campaign in Warmbly on the web to edit it.")
@@ -152,8 +152,136 @@ struct CampaignSequencePage: View {
     }
 }
 
+/// Read-only presentation for sequence step nodes: kind icon/tone, action
+/// summaries, and human-readable branch routes (mirrors the web editor's copy).
+enum StepMeta {
+    static func tone(_ step: CampaignStep) -> Tone {
+        switch step.stepKind {
+        case "wait": return .amber
+        case "action": return .indigo
+        default: return .sky
+        }
+    }
+
+    static func icon(_ step: CampaignStep) -> String {
+        switch step.stepKind {
+        case "wait": return "hourglass"
+        case "action": return actionIcon(step.action?.type)
+        default: return "envelope.fill"
+        }
+    }
+
+    static func title(_ step: CampaignStep) -> String {
+        if let name = step.name, !name.isEmpty { return name }
+        switch step.stepKind {
+        case "wait": return "Wait"
+        case "action": return "Action"
+        default: return "Step"
+        }
+    }
+
+    private static func actionIcon(_ type: String?) -> String {
+        switch type {
+        case "wait": return "hourglass"
+        case "add_tag", "remove_tag": return "tag.fill"
+        case "label_email": return "tray.full.fill"
+        case "unsubscribe": return "person.fill.xmark"
+        case "notify": return "bell.fill"
+        case "create_task": return "checklist"
+        case "create_deal", "move_deal_stage": return "briefcase.fill"
+        case "run_automation": return "gearshape.2.fill"
+        case "fire_event": return "dot.radiowaves.left.and.right"
+        case "end": return "stop.circle.fill"
+        default: return "bolt.fill"
+        }
+    }
+
+    /// One-line summary of what a non-email node does when a contact hits it.
+    static func actionSummary(_ step: CampaignStep) -> String {
+        let action = step.action
+        switch action?.type {
+        case "wait":
+            if let minutes = action?.waitMinutes, minutes > 0 { return "Waits \(duration(minutes))" }
+            return "Waits before the next step"
+        case "add_tag": return "Adds a tag to the contact"
+        case "remove_tag": return "Removes a tag from the contact"
+        case "label_email": return "Labels the reply conversation"
+        case "unsubscribe": return "Unsubscribes the contact"
+        case "notify": return "Notifies your team"
+        case "create_task":
+            if let title = action?.taskTitle, !title.isEmpty { return "Creates task \"\(title)\"" }
+            return "Creates a CRM task"
+        case "create_deal":
+            if let name = action?.dealName, !name.isEmpty { return "Creates deal \"\(name)\"" }
+            return "Creates a CRM deal"
+        case "move_deal_stage": return "Moves the contact's deal to another stage"
+        case "run_automation": return "Runs an automation"
+        case "fire_event":
+            if let name = action?.eventName, !name.isEmpty { return "Fires event \"\(name)\"" }
+            return "Fires a custom event"
+        case "end": return "Ends the sequence"
+        default:
+            if step.stepKind == "wait" { return "Waits before the next step" }
+            return "Runs an action"
+        }
+    }
+
+    static func duration(_ minutes: Int) -> String {
+        if minutes % 1440 == 0 {
+            let days = minutes / 1440
+            return "\(days) day\(days == 1 ? "" : "s")"
+        }
+        if minutes % 60 == 0 {
+            let hours = minutes / 60
+            return "\(hours) hour\(hours == 1 ? "" : "s")"
+        }
+        return "\(minutes) min"
+    }
+
+    static func conditionText(_ cond: StepBranchCondition) -> String {
+        let field = cond.field ?? ""
+        if field == "random" {
+            if let value = cond.value { return "random split (\(value)%)" }
+            return "random split"
+        }
+        let label: String
+        switch field {
+        case "opened": label = "opened the email"
+        case "clicked": label = "clicked a link"
+        case "replied": label = "replied"
+        case "not_opened": label = "didn't open"
+        case "not_clicked": label = "didn't click"
+        case "not_replied": label = "didn't reply"
+        case "reply_positive": label = "replied: positive"
+        case "reply_negative": label = "replied: negative"
+        case "reply_neutral": label = "replied: neutral"
+        case "reply_automated": label = "auto-reply / out of office"
+        default: label = field.replacingOccurrences(of: "_", with: " ")
+        }
+        if cond.op == "within_days", let value = cond.value {
+            return "\(label) within \(value) day\(value == 1 ? "" : "s")"
+        }
+        return label
+    }
+
+    /// "If opened the email within 3 days → Step 4" / "Otherwise → stops".
+    static func branchText(_ branch: StepBranch, in all: [CampaignStep]) -> String {
+        let conditions = (branch.conditions ?? []).map(conditionText)
+        let lhs = conditions.isEmpty ? "Otherwise" : "If " + conditions.joined(separator: " and ")
+        let rhs: String
+        if let target = branch.targetStepID,
+           let step = all.first(where: { $0.id == target }) {
+            rhs = "goes to step \(step.position ?? 0)"
+        } else {
+            rhs = "stops the sequence"
+        }
+        return "\(lhs), \(rhs)"
+    }
+}
+
 struct CampaignStepRow: View {
     let step: CampaignStep
+    let all: [CampaignStep]
 
     private var waitLine: String? {
         guard let wait = step.waitAfter, wait > 0 else { return nil }
@@ -163,13 +291,23 @@ struct CampaignStepRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
             HStack(spacing: 10) {
-                Text("\(step.position ?? 0)")
-                    .font(.footnote.weight(.semibold))
-                    .monospacedDigit()
-                    .foregroundStyle(Tone.sky.color)
-                    .frame(width: 28, height: 28)
-                    .background(Tone.sky.background, in: RoundedRectangle(cornerRadius: 8))
-                Text(step.name ?? "Step")
+                ZStack(alignment: .bottomTrailing) {
+                    Text("\(step.position ?? 0)")
+                        .font(.footnote.weight(.semibold))
+                        .monospacedDigit()
+                        .foregroundStyle(StepMeta.tone(step).color)
+                        .frame(width: 28, height: 28)
+                        .background(StepMeta.tone(step).background, in: RoundedRectangle(cornerRadius: 8))
+                    if !step.isEmail {
+                        Image(systemName: StepMeta.icon(step))
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundStyle(.white)
+                            .frame(width: 13, height: 13)
+                            .background(StepMeta.tone(step).color, in: Circle())
+                            .offset(x: 4, y: 4)
+                    }
+                }
+                Text(StepMeta.title(step))
                     .font(.body.weight(.medium))
                     .lineLimit(1)
                 Spacer(minLength: 8)
@@ -180,28 +318,49 @@ struct CampaignStepRow: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            if let subject = step.subject, !subject.isEmpty {
-                Text(subject)
-                    .font(.subheadline.weight(.medium))
+            if step.isEmail {
+                if let subject = step.subject, !subject.isEmpty {
+                    Text(subject)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                let preview = step.bodyPreview
+                if !preview.isEmpty {
+                    Text(preview)
+                        .font(.subheadline)
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(2)
+                }
+            } else {
+                Text(StepMeta.actionSummary(step))
+                    .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
-            let preview = step.bodyPreview
-            if !preview.isEmpty {
-                Text(preview)
-                    .font(.subheadline)
-                    .foregroundStyle(.tertiary)
-                    .lineLimit(2)
+            ForEach(Array(step.branches.enumerated()), id: \.offset) { _, branch in
+                HStack(alignment: .firstTextBaseline, spacing: 5) {
+                    Image(systemName: "arrow.triangle.branch")
+                        .font(.caption2)
+                        .foregroundStyle(Tone.indigo.color)
+                    Text(StepMeta.branchText(branch, in: all))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
         }
         .padding(.vertical, 6)
     }
 }
 
-/// Read-only step viewer: subject line and the full body exactly as it sends
-/// (HTML through the shared webview, plain text as a fallback).
+/// Read-only step viewer. Email nodes show the subject and the full body
+/// exactly as it sends (HTML through the shared webview, plain text as a
+/// fallback); action/wait nodes show what fires, and every node lists its
+/// branch routes.
 struct CampaignStepReader: View {
     let step: CampaignStep
+    let all: [CampaignStep]
 
     @State private var bodyHeight: CGFloat = 120
 
@@ -212,29 +371,65 @@ struct CampaignStepReader: View {
                     HStack(spacing: 8) {
                         Text("Step \(step.position ?? 0)")
                             .font(.caption.weight(.semibold))
-                            .foregroundStyle(Tone.sky.color)
+                            .foregroundStyle(StepMeta.tone(step).color)
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
-                            .background(Tone.sky.background, in: Capsule())
+                            .background(StepMeta.tone(step).background, in: Capsule())
                         if let wait = step.waitAfter, wait > 0 {
-                            Text("sends \(wait) day\(wait == 1 ? "" : "s") after the previous step")
+                            Text("\(step.isEmail ? "sends" : "runs") \(wait) day\(wait == 1 ? "" : "s") after the previous step")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
                     }
-                    if let subject = step.subject, !subject.isEmpty {
+                    if step.isEmail, let subject = step.subject, !subject.isEmpty {
                         Text(subject)
                             .font(.title3.weight(.semibold))
                     }
                 }
                 Divider()
-                if step.bodyHTML?.isEmpty == false || step.bodyPlain?.isEmpty == false {
-                    UniboxWebView(html: step.bodyHTML, plain: step.bodyPlain, height: $bodyHeight)
-                        .frame(height: bodyHeight)
+                if step.isEmail {
+                    if step.bodyHTML?.isEmpty == false || step.bodyPlain?.isEmpty == false {
+                        UniboxWebView(html: step.bodyHTML, plain: step.bodyPlain, height: $bodyHeight)
+                            .frame(height: bodyHeight)
+                    } else {
+                        Text("This step has no body yet.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                 } else {
-                    Text("This step has no body yet.")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                    HStack(spacing: 12) {
+                        IconTile(symbol: StepMeta.icon(step), tone: StepMeta.tone(step), size: 34)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(StepMeta.actionSummary(step))
+                                .font(.body.weight(.medium))
+                            Text(step.stepKind == "wait" ? "Delay step, nothing is sent." : "Runs automatically, nothing is sent.")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                if !step.branches.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("BRANCHING")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.tertiary)
+                            .kerning(1.1)
+                        ForEach(Array(step.branches.enumerated()), id: \.offset) { _, branch in
+                            HStack(alignment: .firstTextBaseline, spacing: 7) {
+                                Image(systemName: "arrow.triangle.branch")
+                                    .font(.caption)
+                                    .foregroundStyle(Tone.indigo.color)
+                                Text(StepMeta.branchText(branch, in: all))
+                                    .font(.subheadline)
+                                    .foregroundStyle(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                            }
+                        }
+                        Text("If no branch matches, the contact continues to the next step.")
+                            .font(.footnote)
+                            .foregroundStyle(.tertiary)
+                    }
+                    .padding(.top, 4)
                 }
                 WebHandoffBanner(text: "Edit this step in the sequence editor in Warmbly on the web.")
                     .padding(.top, 6)
@@ -242,7 +437,7 @@ struct CampaignStepReader: View {
             .padding(16)
         }
         .background(Color(.systemBackground))
-        .navigationTitle(step.name ?? "Step")
+        .navigationTitle(StepMeta.title(step))
         .navigationBarTitleDisplayMode(.inline)
     }
 }

--- a/ios/Warmbly/Features/Campaigns/CampaignModels.swift
+++ b/ios/Warmbly/Features/Campaigns/CampaignModels.swift
@@ -371,11 +371,13 @@ struct CampaignStep: Codable, Identifiable, Sendable {
     var waitAfter: Int?
     var position: Int?
     var kind: String?
+    var conditions: StepBranchConditions?
+    var action: StepActionConfig?
     var updatedAt: Date?
     var createdAt: Date?
 
     enum CodingKeys: String, CodingKey {
-        case id, name, subject, kind
+        case id, name, subject, kind, conditions, action
         case bodyPlain = "body_plain"
         case bodyHTML = "body_html"
         case waitAfter = "wait_after"
@@ -383,6 +385,16 @@ struct CampaignStep: Codable, Identifiable, Sendable {
         case updatedAt = "updated_at"
         case createdAt = "created_at"
     }
+
+    /// Older rows persist an empty kind; treat it as the email default.
+    var stepKind: String {
+        if let kind, !kind.isEmpty { return kind }
+        return "email"
+    }
+
+    var isEmail: Bool { stepKind == "email" }
+
+    var branches: [StepBranch] { conditions?.branches ?? [] }
 
     /// Plaintext preview: body_plain first, else tags stripped from body_html.
     var bodyPreview: String {
@@ -403,6 +415,55 @@ struct CampaignStep: Codable, Identifiable, Sendable {
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
+    }
+}
+
+/// The per-step branching tree (sequences.conditions jsonb). Branches are
+/// evaluated in order; the first branch whose conditions all match routes the
+/// contact, a nil target means stop, no match falls through linearly.
+struct StepBranchConditions: Codable, Sendable {
+    var branches: [StepBranch]?
+}
+
+struct StepBranch: Codable, Sendable {
+    var branchID: String?
+    var targetStepID: String?
+    var conditions: [StepBranchCondition]?
+    var instant: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case branchID = "branch_id"
+        case targetStepID = "target_step_id"
+        case conditions, instant
+    }
+}
+
+struct StepBranchCondition: Codable, Sendable {
+    var field: String?
+    var op: String?
+    var value: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case field, value
+        case op = "operator"
+    }
+}
+
+/// The non-email node config (sequences.action jsonb); only the fields the
+/// read-only preview summarizes.
+struct StepActionConfig: Codable, Sendable {
+    var type: String?
+    var waitMinutes: Int?
+    var taskTitle: String?
+    var dealName: String?
+    var eventName: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case waitMinutes = "wait_minutes"
+        case taskTitle = "task_title"
+        case dealName = "deal_name"
+        case eventName = "event_name"
     }
 }
 

--- a/ios/Warmbly/Features/More/MoreModels.swift
+++ b/ios/Warmbly/Features/More/MoreModels.swift
@@ -225,9 +225,10 @@ struct MoreChannelPrefs: Codable, Sendable {
     var inApp: Bool?
     var email: Bool?
     var slack: Bool?
+    var push: Bool?
 
     enum CodingKeys: String, CodingKey {
-        case email, slack
+        case email, slack, push
         case inApp = "in_app"
     }
 }

--- a/ios/Warmbly/Features/More/NotificationsView.swift
+++ b/ios/Warmbly/Features/More/NotificationsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 @MainActor
 @Observable
@@ -22,6 +23,7 @@ final class MoreNotificationsStore {
             )
             items = feed.notifications ?? []
             unread = feed.unread ?? 0
+            PushManager.shared.setBadge(unread)
             let envelope: MoreNotificationPreferencesEnvelope = try await api.get("auth/me/notification-preferences")
             preferences = envelope.preferences?.categories ?? [:]
             loadedOnce = true
@@ -35,6 +37,7 @@ final class MoreNotificationsStore {
         guard let index = items.firstIndex(where: { $0.id == id }), items[index].isUnread else { return }
         items[index].readAt = Date()
         unread = max(0, unread - 1)
+        PushManager.shared.setBadge(unread)
         let _: MoreOkResponse? = try? await api.post("auth/me/notifications/\(id)/read")
     }
 
@@ -44,19 +47,44 @@ final class MoreNotificationsStore {
             items[index].readAt = now
         }
         unread = 0
+        PushManager.shared.setBadge(0)
         // PUT on the collection marks everything read; the handler ignores the body.
         let _: MoreOkResponse? = try? await api.put("auth/me/notifications", body: EmptyBody())
     }
 
     /// Autosaves the full preferences object, mirroring the web settings page.
     func setEnabled(_ key: String, _ enabled: Bool, _ api: APIClient) async {
-        let previous = preferences[key]
-        var pref = previous ?? MoreCategoryPref(
+        let previous = preferences
+        var pref = preferences[key] ?? MoreCategoryPref(
             enabled: enabled,
-            channels: MoreChannelPrefs(inApp: true, email: false, slack: false)
+            channels: MoreChannelPrefs(inApp: true, email: false, slack: false, push: true)
         )
         pref.enabled = enabled
         preferences[key] = pref
+        await persist(previous: previous, api)
+    }
+
+    /// Global channel state, like the web settings page: a channel reads "on"
+    /// only when every category delivers to it.
+    func channelOn(_ channel: WritableKeyPath<MoreChannelPrefs, Bool?>) -> Bool {
+        !preferences.isEmpty && preferences.values.allSatisfy { $0.channels?[keyPath: channel] == true }
+    }
+
+    /// Flips a delivery channel across every category at once (the web has the
+    /// same all-or-nothing toggle; per-category channel splits stay web/API-only).
+    func setChannel(_ channel: WritableKeyPath<MoreChannelPrefs, Bool?>, _ on: Bool, _ api: APIClient) async {
+        let previous = preferences
+        for key in preferences.keys {
+            var pref = preferences[key] ?? MoreCategoryPref(enabled: false, channels: nil)
+            var channels = pref.channels ?? MoreChannelPrefs(inApp: true, email: false, slack: false, push: true)
+            channels[keyPath: channel] = on
+            pref.channels = channels
+            preferences[key] = pref
+        }
+        await persist(previous: previous, api)
+    }
+
+    private func persist(previous: [String: MoreCategoryPref], _ api: APIClient) async {
         do {
             let body = MorePreferencesBody(preferences: NotificationPreferences(categories: preferences))
             let echoed: MoreNotificationPreferencesEnvelope = try await api.put(
@@ -67,7 +95,7 @@ final class MoreNotificationsStore {
                 preferences = categories
             }
         } catch {
-            preferences[key] = previous
+            preferences = previous
             actionError = error.localizedDescription
         }
     }
@@ -162,7 +190,10 @@ struct NotificationsView: View {
                 }
             }
         }
-        .task { await store.load(env.api) }
+        .task {
+            await store.load(env.api)
+            await PushManager.shared.refreshAuthorization()
+        }
         .onChange(of: env.realtime.pulse(for: .notifications)) {
             Task { await store.load(env.api) }
         }
@@ -291,7 +322,68 @@ struct NotificationsView: View {
                     preferenceRow(key)
                 }
             }
-            Text("Only in-app delivery is live today. Email and Slack channels are coming.")
+            MoreFlatSectionHeader("Channels")
+            channelRow(
+                symbol: "app.badge.fill",
+                tone: .sky,
+                label: "In-app",
+                caption: "The feed above; always on for enabled categories."
+            ) {
+                Text("On")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Tone.emerald.color)
+            }
+            channelRow(
+                symbol: "iphone.gen3.radiowaves.left.and.right",
+                tone: .rose,
+                label: "Push",
+                caption: "Alerts on this device. The first event pushes right away; bursts arrive as one summary instead of a ping per event."
+            ) {
+                Toggle("", isOn: channelBinding(\.push))
+                    .labelsHidden()
+                    .tint(WTheme.accent)
+                    .disabled(PushManager.shared.authorization == .denied)
+            }
+            if PushManager.shared.authorization == .denied {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.caption)
+                        .foregroundStyle(Tone.amber.color)
+                    Text("Notifications are off for Warmbly in iOS Settings.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer(minLength: 8)
+                    Button("Open Settings") {
+                        if let url = URL(string: UIApplication.openNotificationSettingsURLString) {
+                            UIApplication.shared.open(url)
+                        }
+                    }
+                    .font(.footnote.weight(.medium))
+                }
+                .padding(.vertical, 6)
+                .moreFlatRow(textLeading: MoreFlatMetrics.tileTextLeading)
+            }
+            channelRow(
+                symbol: "envelope.fill",
+                tone: .indigo,
+                label: "Email",
+                caption: "Delivery to your account email."
+            ) {
+                Toggle("", isOn: channelBinding(\.email))
+                    .labelsHidden()
+                    .tint(WTheme.accent)
+            }
+            channelRow(
+                symbol: "bubble.left.and.bubble.right.fill",
+                tone: .emerald,
+                label: "Slack",
+                caption: "Posts to the Slack channel set up in Integrations on the web."
+            ) {
+                Toggle("", isOn: channelBinding(\.slack))
+                    .labelsHidden()
+                    .tint(WTheme.accent)
+            }
+            Text("Channels apply across every enabled category above.")
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 16)
@@ -335,5 +427,37 @@ struct NotificationsView: View {
                 Task { await store.setEnabled(key, newValue, env.api) }
             }
         )
+    }
+
+    private func channelBinding(_ channel: WritableKeyPath<MoreChannelPrefs, Bool?>) -> Binding<Bool> {
+        Binding(
+            get: { store.channelOn(channel) },
+            set: { newValue in
+                Task { await store.setChannel(channel, newValue, env.api) }
+            }
+        )
+    }
+
+    private func channelRow(
+        symbol: String,
+        tone: Tone,
+        label: String,
+        caption: String,
+        @ViewBuilder trailing: () -> some View
+    ) -> some View {
+        HStack(spacing: 12) {
+            IconTile(symbol: symbol, tone: tone, size: 34)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(.body.weight(.medium))
+                Text(caption)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            trailing()
+        }
+        .padding(.vertical, 9)
+        .moreFlatRow(textLeading: MoreFlatMetrics.tileTextLeading)
     }
 }

--- a/ios/Warmbly/Warmbly.entitlements
+++ b/ios/Warmbly/Warmbly.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/ios/Warmbly/WarmblyApp.swift
+++ b/ios/Warmbly/WarmblyApp.swift
@@ -2,13 +2,18 @@ import SwiftUI
 
 @main
 struct WarmblyApp: App {
+    @UIApplicationDelegateAdaptor(PushAppDelegate.self) private var pushDelegate
     @State private var env = AppEnvironment()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environment(env)
                 .tint(WTheme.accent)
+        }
+        .onChange(of: scenePhase) { _, phase in
+            if phase == .active { env.realtime.nudge() }
         }
     }
 }

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -61,9 +61,9 @@ export default function NotificationsSettingsPage() {
         "security_new_signin",
     ];
     // Channels present globally: "on" when every category carries the channel.
-    const channelOn = (ch: "email" | "slack") =>
+    const channelOn = (ch: "email" | "slack" | "push") =>
         !!draft && CATEGORY_KEYS.every((k) => draft[k].channels[ch]);
-    const setChannel = (ch: "email" | "slack", on: boolean) =>
+    const setChannel = (ch: "email" | "slack" | "push", on: boolean) =>
         setDraft((d) => {
             if (!d) return d;
             const next = { ...d };
@@ -105,6 +105,12 @@ export default function NotificationsSettingsPage() {
                     <Section eyebrow="Channels" description="Where enabled notifications are delivered. Applies across every category above.">
                         <Row label="In-app" description="The bell in the dashboard chrome (controlled per category above).">
                             <span className="text-[11px] font-medium text-emerald-600">On</span>
+                        </Row>
+                        <Row
+                            label="Mobile push"
+                            description="Alerts on devices signed in with the Warmbly iOS app. The first event pushes right away; bursts arrive as one summary instead of a ping per event."
+                        >
+                            <Toggle on={channelOn("push")} onChange={(v) => setChannel("push", v)} />
                         </Row>
                         <Row label="Email" description="Delivery to your account email.">
                             <Toggle on={channelOn("email")} onChange={(v) => setChannel("email", v)} />

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -4,6 +4,7 @@ export interface ChannelPrefs {
     in_app: boolean;
     email: boolean;
     slack: boolean;
+    push: boolean;
 }
 
 export interface CategoryPref {


### PR DESCRIPTION
## What this does

Three related pieces of work bringing the iOS app in line with the dashboard and adding full push notification support.

### iOS realtime parity
The iOS `RealtimeService` mirrored the web spine but dropped several event families on the floor. Now routed like the web client:
- `EMAIL_STATUS` / `EMAIL_ERROR` (mailbox health) refresh mailboxes + analytics
- `SUBSCRIPTION` / `PLAN` / `BILLING` / `LIMIT` refresh billing + profile
- `DEAL` refreshes CRM, `BOOKING` behaves like `MEETING`
- inbox arrivals also refresh analytics + mailbox counters; `CONTACT` events also refresh campaigns/analytics; spine fixes for `warmup_routing_rule` and `webhook`
- new foreground socket nudge: iOS kills the websocket during suspension and the heartbeat watchdog could take ~30s to notice on resume; on `scenePhase == .active` the app now verifies the socket with an immediate heartbeat or reconnects right away (a reconnect already bumps every domain, so screens catch up on missed events)

### Campaign sequence preview
The steps page treated every node as an email row. The steps endpoint already returns `kind`, the branching tree, and action configs; iOS now decodes them and renders:
- wait/action nodes with icons and plain-language summaries ("Waits 2 days", "Creates task \"Follow up call\"")
- per-step branch routes using the web editor's wording ("If opened the email within 3 days, goes to step 4", "Otherwise, stops the sequence"), including random splits and reply-classification branches
- a branching section in the read-only step reader; the "edit on web" handoff stays

### Mobile push notifications
- **Backend**: dependency-free APNs client (p8 provider-token auth over stdlib HTTP/2), `device_tokens` table (migration 000056) with session-scoped `POST/DELETE /auth/me/device-tokens`, a `push` channel in notification preferences, and Redis-backed batching: the first event in a quiet period pushes immediately, everything else inside the window (default 5h, `NOTIFICATION_PUSH_WINDOW`) coalesces into one summary push ("3 new replies"). State is shared between backend and consumer; a ZSET claim prevents replica double-sends. Dead tokens (APNs 410/BadDeviceToken) are dropped automatically. Registration works without APNs configured; delivery activates when `APNS_*` env is set.
- **iOS**: permission prompt after login, token registration on launch (idempotent upsert), token deletion on sign-out, app-icon badge synced to the unread feed count, and a Push toggle in notification settings with an Open Settings recovery row when the OS permission is denied. Push entitlement added.
- **Web**: Mobile push toggle in Settings → Notifications.
- **Docs**: notifications guide (channel + batching), both API reference pages (channel shape + new endpoints), deployment guide (`APNS_*` env block). Also fixed two stale spots on the notifications guide: it claimed settings need a manual Save (they autosave) and omitted the Security category.

## Verification
- Go: `gofmt` clean, builds, `make lint` passes
- iOS: full `xcodebuild` against the iOS simulator succeeds (Xcode 27)
- Docs: `fumadocs-mdx` + `tsc --noEmit` + eslint pass
- Web: **typecheck not run locally** — fresh `pnpm install` of `web/` fails because the lockfile pins `vite@7.1.14`, which has been unpublished from npm (404). That breakage is pre-existing and unrelated to this PR (the web diff is three additive lines mirroring the existing Email/Slack rows). If web CI installs from a warm store it will pass; if it resolves from the registry it will fail for any PR until the lockfile is regenerated.

## Notes for deployment
Push delivery needs an APNs Auth Key (.p8) and the Push Notifications capability on the app bundle ID; set `APNS_KEY`/`APNS_KEY_PATH`, `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_TOPIC` on backend and consumer. Without them everything ships inert (registration works, delivery skipped).