### PR TITLE
One-command local dev: make dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Event codec: `CODEC_PROVIDER=json` is required wherever workers are exercised (t
 
 Infra runs in docker; the Go services and frontends run natively on the host for fast iteration — no docker image rebuilds when you change app code. Targets live in the `Makefile`.
 
+- `make dev` — the one-command stack: brings up the docker infra and waits for readiness (postgres, kafka topics, KMS/S3 init), applies migrations, loads seed fixtures (skip with `SEED=false`), installs web deps on first run, then starts backend + consumer + both shared workers + the dashboard in one terminal. Login: dev@warmbly.com / password123. Ctrl-C stops the app; infra stays up.
 - `make infra` — start the backing services in docker (postgres, redis, kafka, schema-registry, mailpit, localstack + init, cloud-tasks, stripe-mock). Run once; leave running.
 - `make backend` — run the API natively on `:8080` (applies the embedded migrations on boot against the docker postgres).
 - `make consumer` / `make worker` / `make worker-premium` — run those Go services natively, each in its own terminal. Two native workers exist because tier placement is strict: free-trial orgs place onto the free-tier worker (`make worker`), paid orgs onto the premium one (`make worker-premium`). The workers read encrypted DEKs through the backend's `/internal/dek` endpoint (the prod `http` provider, no worker DB), so `make backend` must be running and their `INTERNAL_API_TOKEN` must match (the targets are pre-wired to match).

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PROTO_GEN_FILES := $(PROTO_DIR)/tasks.pb.go
 .PHONY: setup-tools fmt lint proto check-proto \
         up sim seed seed-plan sandbox sandbox-seed reset logs status stop down tools test-seed \
         restart restart-go restart-all infra infra-down app app-down app-logs \
-        backend consumer worker worker-premium run tracking realtime web \
+        backend consumer worker worker-premium run dev tracking realtime web \
         admin site docs grant-admin revoke-admin
 
 setup-tools:
@@ -491,6 +491,51 @@ run:
 	$(MAKE) --no-print-directory consumer & \
 	$(MAKE) --no-print-directory worker & \
 	$(MAKE) --no-print-directory worker-premium & \
+	wait
+
+# ─── one-command dev stack ───────────────────────────────────────────────
+#
+# `make dev` is the "just make it work" target for a fresh clone or a fresh
+# morning: brings up the docker infra, waits until it is actually ready
+# (postgres accepting connections, kafka topics + KMS/S3 init one-shots
+# done), applies migrations, loads the seed fixtures (idempotent), installs
+# web deps on first run, then starts backend + consumer + both shared
+# workers + the dashboard together in this terminal. Ctrl-C stops the app;
+# infra stays up for next time (`make infra-down` stops it too).
+#
+#   make dev                      # everything; dashboard on :5173
+#   make dev SEED=false           # skip fixture seeding
+#   make dev AI_PROVIDER=ollama   # with the AI assistant on (see AI env above)
+#
+# Log in with dev@warmbly.com / password123 (from the seed fixtures).
+# Tracking (:3000) and realtime (:4000) stay separate — `make tracking` /
+# `make realtime` — because they need the cargo / elixir toolchains.
+SEED ?= true
+dev:
+	@command -v docker >/dev/null || { echo "docker is required: https://docs.docker.com/get-docker/"; exit 1; }
+	@command -v go >/dev/null || { echo "go 1.25+ is required: https://go.dev/dl/"; exit 1; }
+	@command -v pnpm >/dev/null || { echo "pnpm is required: https://pnpm.io/installation"; exit 1; }
+	$(DEV_COMPOSE) up -d $(INFRA_SVCS)
+	@echo "Waiting for infra to be ready (postgres, kafka topics, KMS/S3 init)..."
+	@until $(COMPOSE) exec -T postgres pg_isready -U warmbly >/dev/null 2>&1; do sleep 1; done
+	@for svc in kafka-init schema-registry-init localstack-init; do \
+		until [ "$$($(COMPOSE) ps -a --format '{{.State}}' $$svc 2>/dev/null | head -1)" = "exited" ]; do sleep 1; done; \
+		code=$$($(COMPOSE) ps -a --format '{{.ExitCode}}' $$svc | head -1); \
+		if [ "$$code" != "0" ]; then echo "$$svc failed (exit $$code); check: make logs $$svc"; exit 1; fi; \
+	done
+	$(GO_DEV_ENV) go run ./cmd/migrate
+	@if [ "$(SEED)" = "true" ]; then $(GO_DEV_ENV) SEED_RICH=true SEED_FULL=true go run ./cmd/seed; fi
+	@if [ ! -d web/node_modules ]; then echo "Installing web dependencies (first run)..."; cd web && pnpm install; fi
+	@echo ""
+	@echo "Starting backend + consumer + both workers + dashboard. Ctrl-C stops them (infra stays up)."
+	@echo "Dashboard: http://localhost:5173    Login: dev@warmbly.com / password123"
+	@echo ""
+	@trap 'kill 0' INT TERM; \
+	$(MAKE) --no-print-directory backend & \
+	$(MAKE) --no-print-directory consumer & \
+	$(MAKE) --no-print-directory worker & \
+	$(MAKE) --no-print-directory worker-premium & \
+	$(MAKE) --no-print-directory web & \
 	wait
 
 # ─── other native services (Rust tracking, Elixir realtime) ──────────────

--- a/README.md
+++ b/README.md
@@ -122,24 +122,21 @@ premium pools are kept separate.
 
 You need Docker, Go 1.25, and pnpm.
 
-Run the whole stack with Docker:
-
 ```bash
 git clone https://github.com/warmbly/warmbly && cd warmbly
-make up
+make dev
 ```
 
-That starts every service against local infra. The dashboard comes up at
-`http://localhost:5173`.
+That one command brings up the backing services in Docker, waits for them to be
+ready, applies migrations, seeds demo data, and starts the backend, consumer,
+both workers, and the dashboard together in your terminal. Open
+`http://localhost:5173` and log in with `dev@warmbly.com` / `password123`.
+Ctrl-C stops the app; the Docker infra stays up so the next `make dev` is fast.
 
-For day-to-day development, skip the Docker app images and run the Go services on
-the host instead. It recompiles in a second or two on save:
-
-```bash
-make infra   # backing services in Docker, run once and leave up
-make run     # backend, consumer, and worker in one terminal
-make web     # dashboard dev server
-```
+The Go services run natively (recompiling in a second or two on save), so the
+same command is also the day-to-day loop. If you prefer separate terminals, the
+stack splits into `make infra` + `make run` + `make web`. To run everything in
+Docker instead, use `make up`.
 
 The first admin account cannot be created from the UI. Sign up through the
 dashboard, then promote yourself from the host with

--- a/docs/content/docs/development/local-development.mdx
+++ b/docs/content/docs/development/local-development.mdx
@@ -9,21 +9,49 @@ The whole stack runs locally via a single `docker-compose.yml` at the repo root.
 
 - Docker (20.10+) and Docker Compose v2
 - Git
-
-For native development (running services outside Docker against the containerized infra), also install:
-
 - Go 1.25+
+- Node 22+ and pnpm (for web)
+
+Optional, only for the two auxiliary services when run natively:
+
 - Rust (for tracking)
 - Elixir 1.18+ (for realtime)
-- Node 22+ and pnpm (for web)
+
+## One command
+
+```bash
+make dev
+```
+
+This is the whole setup for a fresh clone. It brings up the Docker infra
+(postgres, redis, kafka, mailpit, dovecot, localstack, and friends), waits until
+everything is actually ready, applies migrations, loads the seed fixtures,
+installs web dependencies on first run, and then starts the backend, consumer,
+both shared workers, and the dashboard together in your terminal.
+
+Open `http://localhost:5173` and log in with `dev@warmbly.com` / `password123`.
+
+Ctrl-C stops the app services; the Docker infra stays up, so the next `make dev`
+skips straight to starting the app. The Go services run natively with `go run`,
+so a code change plus Ctrl-C and re-run recompiles in a second or two. Variants:
+
+```bash
+make dev SEED=false           # skip fixture seeding
+make dev AI_PROVIDER=ollama   # with the AI assistant on (see the AI provider section)
+```
+
+Tracking (`:3000`) and realtime (`:4000`) are deliberately not part of `make dev`;
+start them with `make tracking` / `make realtime` when you need pixels, click
+redirects, or live dashboard updates. They need the Rust and Elixir toolchains.
 
 ## Make targets
 
 Day-one:
 
 ```bash
+make dev        # one command: infra + migrations + seed + backend/consumer/workers + dashboard
 make infra      # postgres, redis, kafka, mailpit, dovecot, localstack, etc. (leave running)
-make app        # backend, consumer, worker, tracking, realtime, web (hot reload)
+make app        # backend, consumer, worker, tracking, realtime, web (hot reload, in Docker)
 make sim        # adds premium + dedicated workers; full simulation (prod-image flow)
 make seed       # load rich fixtures (3 orgs, 6 mailboxes, a campaign)
 make sandbox    # fully working demo environment (see /development/sandbox/)
@@ -154,55 +182,36 @@ External clients can use:
 
 ## Running services natively
 
-If you want hot reload, run a service natively and point it at the docker infra.
-
-### Backend (Go)
+`make dev` already runs the Go services and the dashboard natively against the
+Docker infra. When you want them in separate terminals instead of one, each has
+its own target with the full dev environment pre-wired (no manual env exports):
 
 ```bash
-make infra && make app  # in another terminal, leave running
-
-# Install air for hot reload
-go install github.com/cosmtrek/air@latest
-
-# Point at containerized infra
-export PRIMARY_DB="postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable"
-export REDIS="redis://localhost:16379"
-export KAFKA_BOOTSTRAP_SERVERS="localhost:9092"
-export SCHEMA_REGISTRY_URL="http://localhost:8081"
-export AWS_ENDPOINT_URL="http://localhost:4566"
-export AWS_REGION="us-east-1"
-export AWS_ACCESS_KEY_ID="test"
-export AWS_SECRET_ACCESS_KEY="test"
-# ... rest of env, see deploy/config/env.example
-
-air -c .air.toml
+make infra            # once: the backing services in Docker
+make backend          # API on :8080 (applies migrations on boot)
+make consumer         # kafka -> postgres consumer
+make worker           # free-tier shared worker
+make worker-premium   # premium shared worker (paid orgs place here)
+make run              # all four of the above in one terminal
+make web              # dashboard dev server on :5173
+make admin            # admin app on :5174
+make site             # marketing site on :4321
 ```
 
-### Web (React)
+Each target sets the same env you would otherwise export by hand (see
+`deploy/config/env.example` for the full reference). Saving a Go file and
+re-running the target recompiles in a second or two against the warm build
+cache.
 
-The web service in compose already mounts `./web` and runs `pnpm dev`. To run it locally instead:
+### Tracking (Rust) and realtime (Elixir)
 
-```bash
-docker compose stop web
-cd web
-pnpm install
-pnpm dev
-```
-
-### Tracking (Rust)
+Deliberately kept out of `make dev` and `make run` because they need their own
+toolchains (cargo, elixir + mix). Start them when you need open/click tracking
+or live dashboard updates:
 
 ```bash
-docker compose stop tracking
-cd tracking
-cargo run
-```
-
-### Realtime (Elixir)
-
-```bash
-docker compose stop realtime
-cd realtime
-mix deps.get && mix phx.server
+make tracking   # tracking pixel + click redirect service on :3000
+make realtime   # Phoenix websocket fanout on :4000
 ```
 
 ## AI provider

--- a/docs/content/docs/development/sandbox.mdx
+++ b/docs/content/docs/development/sandbox.mdx
@@ -10,11 +10,9 @@ The sandbox turns a local stack into a living product demo. It seeds a paid show
 Run each in its own terminal:
 
 ```bash
-make infra      # postgres, kafka, mailpit, dovecot, localstack, ... (once)
-make run        # backend + consumer + both shared workers
+make dev        # infra + backend + consumer + workers + dashboard, one command
 make tracking   # open/click tracking (Rust; needs cargo + cmake)
 make realtime   # websocket fanout (Elixir; optional but recommended)
-make web        # dashboard on http://localhost:5173
 make sandbox    # seed the showcase org + run the simulator (foreground)
 ```
 


### PR DESCRIPTION
## What

Adds a single \`make dev\` target that takes a fresh clone to a working, seeded, logged-in-able stack in one terminal, and updates every doc that described the old multi-terminal flow.

\`make dev\`:

1. Checks for docker / go / pnpm with install links if missing.
2. Brings up the docker infra and waits for real readiness: \`pg_isready\`, plus the kafka-topics, schema-registry, and localstack (KMS/S3) init one-shots polled to completion. A failed init aborts with a \`make logs <svc>\` hint instead of starting a broken stack.
3. Applies migrations (\`cmd/migrate\`) and loads the rich seed fixtures (idempotent; \`SEED=false\` skips).
4. Runs \`pnpm install\` in \`web/\` on first run only.
5. Starts backend + consumer + both shared workers + the dashboard together. Ctrl-C stops the app; infra stays up so the next \`make dev\` is fast. \`AI_PROVIDER=...\` passes through as with the existing targets.

Login: \`dev@warmbly.com\` / \`password123\`, dashboard on http://localhost:5173.

Tracking and realtime stay separate (\`make tracking\` / \`make realtime\`) since they need the cargo / elixir toolchains, matching the existing \`make run\` policy.

## Docs

- README quick start now leads with \`make dev\` (infra/run/web split and all-docker \`make up\` kept as alternatives)
- local-development: new "One command" section, Rust/Elixir moved to optional prerequisites, and the stale manual-env + air "Running services natively" section rewritten around the pre-wired make targets
- sandbox quick start collapsed from six commands to four
- AGENTS.md local development targets updated

## Verified

Ran end to end on a machine in the true first-run state (no \`web/node_modules\`): infra up, migrate + seed complete, backend 200 on \`/health\`, dashboard 200 on :5173, both workers heartbeating through Kafka, and \`POST /v1/auth/login\` with the seeded credentials returns a session. Shutdown leaves no stray processes. Docs tree passes \`types:check\` and eslint.