### PR TITLE
feat: deliverability score + per-provider/per-domain inbox placement on the dashboard

### DIFF
--- a/docs/content/docs/api/reference/analytics.mdx
+++ b/docs/content/docs/api/reference/analytics.mdx
@@ -75,7 +75,7 @@ Returns the main dashboard overview for the active organization: aggregate stats
 
 `GET /analytics/deliverability`
 
-Returns the organization's deliverability posture for a time window: bounce, complaint, open, click, and reply counts and rates, suppression and dead-letter pressure, reply-intent breakdown, seed inbox-placement, an overall health band (from the documented thresholds), a daily timeseries, and per-mailbox and per-campaign breakdowns. Requires an organization context. Auth: **Scope** `READ_ANALYTICS` · **Org permission** `view_analytics`.
+Returns the organization's deliverability posture for a time window: bounce, complaint, open, click, and reply counts and rates, suppression and dead-letter pressure, reply-intent breakdown, seed inbox-placement (overall and per recipient provider), warmup-derived placement per recipient domain, an overall health band and a `0-100` composite score (both from the documented thresholds), a daily timeseries, and per-mailbox and per-campaign breakdowns. Requires an organization context. Auth: **Scope** `READ_ANALYTICS` · **Org permission** `view_analytics`.
 
 | Parameter | In | Type | Description |
 | --- | --- | --- | --- |
@@ -112,6 +112,7 @@ Returns the organization's deliverability posture for a time window: bounce, com
   "inbox_placement_rate": 93.5,
   "placement_samples": 40,
   "band": "healthy",
+  "score": 91,
   "timeseries": [
     {
       "date": "2026-06-05",
@@ -147,11 +148,33 @@ Returns the organization's deliverability posture for a time window: bounce, com
       "complaint_rate": 0.12,
       "band": "watch"
     }
+  ],
+  "by_provider": [
+    {
+      "provider": "gmail",
+      "samples": 24,
+      "inbox": 22,
+      "promotions": 1,
+      "spam": 1,
+      "other": 0,
+      "inbox_rate": 91.67,
+      "spam_rate": 4.17
+    }
+  ],
+  "warmup_placement": [
+    {
+      "provider": "outlook",
+      "domain": "outlook.com",
+      "delivered": 132,
+      "spam": 6,
+      "inbox_rate": 95.45,
+      "spam_rate": 4.55
+    }
   ]
 }
 ```
 
-`spam_placement_rate` and `inbox_placement_rate` are omitted when there are no seed samples in the window.
+`spam_placement_rate` and `inbox_placement_rate` are omitted when there are no seed samples in the window. `by_provider` rolls the same seed samples up per recipient provider; `warmup_placement` is the continuous warmup signal per recipient domain, where `delivered` counts verified warmup arrivals and `spam` the subset the recipient's provider filed into junk. `score` starts at `100` and subtracts saturating penalties for bounce rate (up to `40` points, maxed at `10%`), complaint rate (up to `30` points, maxed at `0.30%`), and spam placement (up to `40` points, maxed at `40%`).
 
 ## Get warmup analytics
 

--- a/docs/content/docs/guides/deliverability.mdx
+++ b/docs/content/docs/guides/deliverability.mdx
@@ -17,8 +17,9 @@ You can scope the whole dashboard to a time window with the range tabs: `7d`, `3
 
 ### Headline rates
 
-At the top of the page are four headline numbers for the selected window:
+At the top of the page are five headline numbers for the selected window:
 
+- **Deliverability score**: a `0-100` composite for the window, shown with its health band chip. The score starts at `100` and subtracts a penalty per signal: bounce rate costs up to `40` points (maxed at a `10%` bounce rate), complaint rate up to `30` points (maxed at `0.30%`), and spam placement up to `40` points (maxed at `40%` spam placement). It shows a dash until the window has any activity.
 - **Bounce rate**: the share of sent emails that bounced, shown as a percentage along with the raw counts (for example, bounces out of total sent). This number is highlighted when it reaches `5%` or higher.
 - **Complaint rate**: the share of recipients who marked your mail as spam. This number is highlighted when it reaches `0.1%` or higher.
 - **Spam placement**: the share of monitored test deliveries that landed in spam or junk, based on seed inbox samples. If there is no seed data yet, this shows a dash.
@@ -42,11 +43,27 @@ Seed placement is the most direct signal you have. Bounces and complaints tell y
 Spam placement and inbox placement only appear once there is enough seed data. A small number of samples can be noisy, so treat a low sample count as a hint, not a verdict. Warmbly only starts acting on placement once it has a meaningful sample (see the bands below).
 </Callout>
 
+### Placement by provider
+
+Seed placement results are also broken down per recipient provider (Gmail, Outlook, IMAP/SMTP). Each row shows a stacked bar of where your test mail landed (inbox, promotions, spam, or another folder), the inbox and spam rates, and the number of samples behind them.
+
+This is the view to check before scaling up a campaign: an aggregate placement rate can look fine while one provider is quietly junking everything. If Gmail shows `95%` inbox but Outlook shows `40%`, the problem is provider-specific (often authentication or content), not general volume.
+
+### Warmup placement by domain
+
+While seed tests are point-in-time probes, warmup gives you a continuous placement signal for free: every verified warmup delivery reports whether it arrived in the recipient's inbox or was filed into spam. The dashboard rolls this up per recipient domain, showing deliveries, inbox rate, and spam rate for each, with a status dot that turns amber at `10%` spam and red at `20%`.
+
+Because warmup partners are real monitored mailboxes across providers, this section keeps updating as long as warmup runs, so placement drift shows up here first, before it shows up as complaints on a campaign.
+
 ### Mailboxes and campaigns at risk
 
 Below the charts, two lists rank the mailboxes and campaigns that have bounce or complaint activity in the window, worst first. Each row shows how many emails were sent, the bounce rate, the complaint (spam) rate, and a colored health band chip.
 
 Clicking a campaign row opens that campaign. From the mailboxes list you can jump to **All mailboxes** to manage individual senders.
+
+### Customizing the dashboard
+
+Use the **Customize** menu in the top bar to choose which sections are visible: the over-time chart, window totals, placement by provider, warmup placement by domain, and the two at-risk lists. Your section choices and the selected time window are remembered per browser, so the dashboard opens the way you left it.
 
 ## Health bands
 
@@ -64,7 +81,7 @@ The four bands you see on the dashboard are:
 Warmup is a paid feature, and these pool actions apply to the shared paid warmup pool that healthy paying customers depend on. Protecting that shared reputation is the reason the bands exist. For how warmup itself works, see the [Warmup](/guides/warmup) guide.
 
 <Callout type="info" title="Different metrics, different failure modes">
-Warmbly does not roll everything into one score. It tracks complaint rate, spam-folder placement, and bounce rate as separate signals, because they fail for different reasons. Any one of them crossing a threshold can move a mailbox into a worse band.
+The deliverability score is a headline summary, but Warmbly never acts on the composite alone. It tracks complaint rate, spam-folder placement, and bounce rate as separate signals, because they fail for different reasons. Any one of them crossing a threshold can move a mailbox into a worse band, even while the overall score still looks acceptable.
 </Callout>
 
 ### Sample floors
@@ -147,10 +164,11 @@ When a message can't be delivered, the recipient's mail server sends back a boun
 
 A practical way to use the page:
 
-1. Check the four headline rates first. Bounce rate at or above `5%` and complaint rate at or above `0.1%` are the two highlighted danger lines.
+1. Check the headline numbers first. The score and its band chip give you the one-glance answer; bounce rate at or above `5%` and complaint rate at or above `0.1%` are the two highlighted danger lines.
 2. If a rate looks off, switch the "Over time" chart to that metric and find the day it spiked. That usually points you at one campaign or one imported list.
-3. Scroll to **Mailboxes at risk** and **Campaigns at risk**. The band chips tell you which senders Warmbly is already acting on.
-4. For any mailbox in Watch, slow it down and let it recover before pushing more volume. For Quarantine or Blocked, leave it out of sending and let it requalify.
+3. Check **Placement by provider** and **Warmup placement by domain** to see whether mail is actually reaching inboxes, and whether a problem is concentrated at one provider.
+4. Scroll to **Mailboxes at risk** and **Campaigns at risk**. The band chips tell you which senders Warmbly is already acting on.
+5. For any mailbox in Watch, slow it down and let it recover before pushing more volume. For Quarantine or Blocked, leave it out of sending and let it requalify.
 
 The single most important habit: keep complaint rate and spam placement low. A clean reputation with modest volume beats high volume with a rising complaint rate every time.
 

--- a/internal/models/advanced_outreach.go
+++ b/internal/models/advanced_outreach.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"math"
 	"time"
 
 	"github.com/google/uuid"
@@ -276,10 +277,17 @@ type DeliverabilityDashboard struct {
 
 	// Overall health band for the org window (from the documented thresholds).
 	Band string `json:"band"`
+	// Score is the 0-100 composite deliverability score for the window.
+	Score int `json:"score"`
 
 	Timeseries []DeliverabilityDailyPoint `json:"timeseries"`
 	ByMailbox  []MailboxDeliverability    `json:"by_mailbox"`
 	ByCampaign []CampaignDeliverability   `json:"by_campaign"`
+	// ByProvider breaks seed placement results down per recipient provider.
+	ByProvider []ProviderPlacement `json:"by_provider"`
+	// WarmupPlacement is the continuous warmup-derived placement signal per
+	// recipient domain (inbox = verified arrivals not flagged spam).
+	WarmupPlacement []WarmupDomainPlacement `json:"warmup_placement"`
 }
 
 // DeliverabilityDailyPoint is one UTC day in the deliverability timeseries.
@@ -318,6 +326,30 @@ type CampaignDeliverability struct {
 	Band          string    `json:"band"`
 }
 
+// ProviderPlacement is one recipient provider's seed placement rollup in the
+// window (from placement_results; folders mirror the table CHECK constraint).
+type ProviderPlacement struct {
+	Provider   string  `json:"provider"`
+	Samples    int     `json:"samples"`
+	Inbox      int     `json:"inbox"`
+	Promotions int     `json:"promotions"`
+	Spam       int     `json:"spam"`
+	Other      int     `json:"other"`
+	InboxRate  float64 `json:"inbox_rate"`
+	SpamRate   float64 `json:"spam_rate"`
+}
+
+// WarmupDomainPlacement is one recipient domain's warmup placement rollup:
+// Delivered counts verified warmup arrivals, Spam the ones flagged into junk.
+type WarmupDomainPlacement struct {
+	Provider  string  `json:"provider"`
+	Domain    string  `json:"domain"`
+	Delivered int     `json:"delivered"`
+	Spam      int     `json:"spam"`
+	InboxRate float64 `json:"inbox_rate"`
+	SpamRate  float64 `json:"spam_rate"`
+}
+
 // DeliverabilityBand maps bounce%/complaint%/spam-placement% to a health band
 // using the documented shared-pool thresholds (see CLAUDE.md). Rates are on the
 // percent scale (0-100), so complaintRate>=0.03 means 0.03% (3 basis points),
@@ -333,6 +365,20 @@ func DeliverabilityBand(bounceRate, complaintRate, spamRate float64) string {
 	default:
 		return "healthy"
 	}
+}
+
+// DeliverabilityScore folds the same three rates the band uses into a 0-100
+// score: each penalty saturates at the "blocked" threshold of its metric, so
+// any single metric in the blocked band alone costs its full weight.
+func DeliverabilityScore(bounceRate, complaintRate, spamRate float64) int {
+	penalty := math.Min(40, bounceRate*4) + // 10% bounce = full 40
+		math.Min(30, complaintRate*100) + // 0.30% complaints = full 30
+		math.Min(40, spamRate) // 40% spam placement = full 40
+	score := int(math.Round(100 - penalty))
+	if score < 0 {
+		return 0
+	}
+	return score
 }
 
 // Rate is a divide-by-zero-safe percentage (count/total*100).

--- a/internal/repository/pg_advanced_outreach.go
+++ b/internal/repository/pg_advanced_outreach.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -534,29 +535,56 @@ func (r *advancedOutreachRepository) GetDeliverabilityDashboard(ctx context.Cont
 	out.ByCampaign = r.deliverabilityByCampaign(ctx, organizationID, from, to)
 	out.ByMailbox = r.deliverabilityByMailbox(ctx, organizationID, from, to)
 
-	// Seed inbox-placement (optional — nil rates when there are no seed samples).
+	// Seed inbox-placement per provider (optional — nil rates when there are no
+	// seed samples). The flat org totals are derived from the same rows.
 	var spam, inbox, placementTotal int
+	byProvider := map[string]*models.ProviderPlacement{}
 	placementQuery := `
-		SELECT pr.folder, COUNT(*)
+		SELECT pr.provider, pr.folder, COUNT(*)
 		FROM placement_results pr JOIN placement_tests pt ON pt.id = pr.test_id
 		WHERE pt.organization_id = $1 AND pr.detected_at >= $2 AND pr.detected_at <= $3 AND pr.folder <> 'pending'
-		GROUP BY pr.folder`
+		GROUP BY pr.provider, pr.folder`
 	if rows, perr := r.db.Query(ctx, placementQuery, organizationID, from, to); perr == nil {
 		for rows.Next() {
-			var folder string
+			var provider, folder string
 			var n int
-			if rows.Scan(&folder, &n) == nil {
+			if rows.Scan(&provider, &folder, &n) == nil {
 				placementTotal += n
+				p := byProvider[provider]
+				if p == nil {
+					p = &models.ProviderPlacement{Provider: provider}
+					byProvider[provider] = p
+				}
+				p.Samples += n
 				switch folder {
 				case "spam":
-					spam = n
+					spam += n
+					p.Spam += n
 				case "inbox":
-					inbox = n
+					inbox += n
+					p.Inbox += n
+				case "promotions":
+					p.Promotions += n
+				default:
+					p.Other += n
 				}
 			}
 		}
 		rows.Close()
 	}
+	out.ByProvider = make([]models.ProviderPlacement, 0, len(byProvider))
+	for _, p := range byProvider {
+		p.InboxRate = models.Rate(p.Inbox, p.Samples)
+		p.SpamRate = models.Rate(p.Spam, p.Samples)
+		out.ByProvider = append(out.ByProvider, *p)
+	}
+	sort.Slice(out.ByProvider, func(i, j int) bool {
+		if out.ByProvider[i].Samples != out.ByProvider[j].Samples {
+			return out.ByProvider[i].Samples > out.ByProvider[j].Samples
+		}
+		return out.ByProvider[i].Provider < out.ByProvider[j].Provider
+	})
+
 	out.PlacementSamples = placementTotal
 	spamRate := 0.0
 	if placementTotal > 0 {
@@ -567,8 +595,83 @@ func (r *advancedOutreachRepository) GetDeliverabilityDashboard(ctx context.Cont
 		spamRate = sr
 	}
 
+	out.WarmupPlacement = r.warmupPlacementByDomain(ctx, organizationID, from, to)
+
 	out.Band = models.DeliverabilityBand(out.BounceRate, out.ComplaintRate, spamRate)
+	out.Score = models.DeliverabilityScore(out.BounceRate, out.ComplaintRate, spamRate)
 	return out, nil
+}
+
+// warmupPlacementByDomain rolls the continuous warmup placement signal up per
+// recipient domain: delivered = verified warmup arrivals at partner mailboxes
+// (warmup_received), spam = the subset the recipient's provider filed into
+// junk (warmup_spam_reports, report_type=spam_placement). Org scope is the
+// sending account. Best-effort: an error returns an empty list.
+func (r *advancedOutreachRepository) warmupPlacementByDomain(ctx context.Context, orgID uuid.UUID, from, to time.Time) []models.WarmupDomainPlacement {
+	out := []models.WarmupDomainPlacement{}
+	byDomain := map[string]*models.WarmupDomainPlacement{}
+
+	deliveredQ := `
+		SELECT rcpt.provider, split_part(lower(rcpt.email), '@', 2), COUNT(*)
+		FROM warmup_received wr
+		JOIN email_accounts snd ON snd.id = wr.sender_account_id
+		JOIN email_accounts rcpt ON rcpt.id = wr.email_account_id
+		WHERE snd.organization_id = $1 AND wr.created_at >= $2 AND wr.created_at <= $3
+		GROUP BY 1, 2`
+	if rows, err := r.db.Query(ctx, deliveredQ, orgID, from, to); err == nil {
+		for rows.Next() {
+			var provider, domain string
+			var n int
+			if rows.Scan(&provider, &domain, &n) == nil && domain != "" {
+				byDomain[domain] = &models.WarmupDomainPlacement{Provider: provider, Domain: domain, Delivered: n}
+			}
+		}
+		rows.Close()
+	}
+
+	spamQ := `
+		SELECT sr.recipient_provider, sr.recipient_domain, COUNT(*)
+		FROM warmup_spam_reports sr
+		JOIN email_accounts snd ON snd.id = sr.reported_account_id
+		WHERE snd.organization_id = $1 AND sr.report_type = 'spam_placement'
+		  AND sr.created_at >= $2 AND sr.created_at <= $3 AND sr.recipient_domain <> ''
+		GROUP BY 1, 2`
+	if rows, err := r.db.Query(ctx, spamQ, orgID, from, to); err == nil {
+		for rows.Next() {
+			var provider, domain string
+			var n int
+			if rows.Scan(&provider, &domain, &n) == nil {
+				p := byDomain[domain]
+				if p == nil {
+					p = &models.WarmupDomainPlacement{Provider: provider, Domain: domain}
+					byDomain[domain] = p
+				}
+				p.Spam += n
+				// A spam-flagged arrival can be reported without (or before) its
+				// warmup_received row; keep delivered >= spam so rates stay sane.
+				if p.Delivered < p.Spam {
+					p.Delivered = p.Spam
+				}
+			}
+		}
+		rows.Close()
+	}
+
+	for _, p := range byDomain {
+		p.InboxRate = models.Rate(p.Delivered-p.Spam, p.Delivered)
+		p.SpamRate = models.Rate(p.Spam, p.Delivered)
+		out = append(out, *p)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Delivered != out[j].Delivered {
+			return out[i].Delivered > out[j].Delivered
+		}
+		return out[i].Domain < out[j].Domain
+	})
+	if len(out) > 25 {
+		out = out[:25]
+	}
+	return out
 }
 
 // deliverabilityTimeseries returns gap-filled UTC daily points for the window.

--- a/web/src/app/app/deliverability/page.tsx
+++ b/web/src/app/app/deliverability/page.tsx
@@ -2,17 +2,27 @@
 // signals the platform already collects, with health bands tied to the
 // documented shared-pool thresholds (see CLAUDE.md). Live-updating: the query
 // is keyed under ["analytics", ...] which useRealtimeEvents already invalidates.
+// The visible sections and the time window are user-customizable and persisted.
 
 import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangleIcon, ArrowUpRightIcon, RefreshCcwIcon } from "lucide-react";
+import { AlertTriangleIcon, ArrowUpRightIcon, CheckIcon, RefreshCcwIcon, SlidersHorizontalIcon } from "lucide-react";
 import { EmptyBlock, Page, PageBody, PageTopbar, SectionBar, Stat, StatStrip } from "@/components/layout/Page";
 import { DailyBars, type ChartPoint } from "@/components/ui/charts";
+import {
+    PopoverMenu,
+    PopoverMenuContent,
+    PopoverMenuItem,
+    PopoverMenuLabel,
+    PopoverMenuTrigger,
+    SelectButton,
+} from "@/components/ui/popover-menu";
 import useDeliverability from "@/lib/api/hooks/app/analytics/useDeliverability";
-import type { DeliverabilityBand } from "@/lib/api/models/app/analytics/Deliverability";
+import type { DeliverabilityBand, ProviderPlacement, WarmupDomainPlacement } from "@/lib/api/models/app/analytics/Deliverability";
 
 type Range = "7d" | "30d" | "90d";
 type Metric = "bounces" | "complaints" | "opens" | "replies" | "sent";
+type SectionKey = "chart" | "totals" | "providers" | "warmup" | "mailboxes" | "campaigns";
 
 const RANGE_LABEL: Record<Range, string> = {
     "7d": "Last 7 days",
@@ -26,6 +36,15 @@ const METRICS: { key: Metric; label: string; bar: string }[] = [
     { key: "opens", label: "Opens", bar: "bg-emerald-500" },
     { key: "replies", label: "Replies", bar: "bg-sky-500" },
     { key: "sent", label: "Sent", bar: "bg-slate-400" },
+];
+
+const SECTIONS: { key: SectionKey; label: string }[] = [
+    { key: "chart", label: "Over time" },
+    { key: "totals", label: "Window totals" },
+    { key: "providers", label: "Placement by provider" },
+    { key: "warmup", label: "Warmup placement by domain" },
+    { key: "mailboxes", label: "Mailboxes at risk" },
+    { key: "campaigns", label: "Campaigns at risk" },
 ];
 
 const BAND_CHIP: Record<DeliverabilityBand, string> = {
@@ -47,11 +66,45 @@ const BAND_LABEL: Record<DeliverabilityBand, string> = {
     blocked: "Blocked",
 };
 
+const PROVIDER_LABEL: Record<string, string> = {
+    gmail: "Gmail",
+    outlook: "Outlook",
+    smtp_imap: "IMAP / SMTP",
+};
+
+function providerLabel(p: string): string {
+    return PROVIDER_LABEL[p] ?? (p ? p : "Other");
+}
+
 function pct(v: number | null | undefined): string {
     return v == null ? "—" : `${v.toFixed(2)}%`;
 }
 function num(v: number | undefined): string {
     return (v ?? 0).toLocaleString();
+}
+
+// View preferences (window + hidden sections), persisted per browser.
+const VIEW_KEY = "warmbly:deliverability-view";
+
+interface ViewPrefs {
+    range: Range;
+    hidden: SectionKey[];
+}
+
+function loadView(): ViewPrefs {
+    try {
+        const raw = localStorage.getItem(VIEW_KEY);
+        if (raw) {
+            const v = JSON.parse(raw) as Partial<ViewPrefs>;
+            return {
+                range: v.range === "30d" || v.range === "90d" ? v.range : "7d",
+                hidden: Array.isArray(v.hidden) ? v.hidden.filter((k): k is SectionKey => SECTIONS.some((s) => s.key === k)) : [],
+            };
+        }
+    } catch {
+        // Corrupt or unavailable storage falls back to defaults.
+    }
+    return { range: "7d", hidden: [] };
 }
 
 function BandChip({ band }: { band: DeliverabilityBand }) {
@@ -63,23 +116,55 @@ function BandChip({ band }: { band: DeliverabilityBand }) {
 }
 
 export default function DeliverabilityPage() {
-    const [range, setRange] = useState<Range>("7d");
+    const [view, setView] = useState<ViewPrefs>(loadView);
     const [metric, setMetric] = useState<Metric>("bounces");
-    const q = useDeliverability(range);
+    const q = useDeliverability(view.range);
     const d = q.data;
+
+    const updateView = (next: ViewPrefs) => {
+        setView(next);
+        try {
+            localStorage.setItem(VIEW_KEY, JSON.stringify(next));
+        } catch {
+            // Persisting is best-effort; the in-memory view still applies.
+        }
+    };
+    const show = (k: SectionKey) => !view.hidden.includes(k);
+    const toggleSection = (k: SectionKey) =>
+        updateView({ ...view, hidden: show(k) ? [...view.hidden, k] : view.hidden.filter((h) => h !== k) });
 
     const series: ChartPoint[] = useMemo(
         () => (d?.timeseries ?? []).map((p) => ({ label: p.date, value: p[metric] ?? 0 })),
         [d?.timeseries, metric],
     );
 
+    // The score is meaningless before any signal exists; show a dash instead
+    // of a perfect 100 on an empty window.
+    const hasActivity =
+        !!d && (d.emails_sent > 0 || d.events_total > 0 || d.placement_samples > 0 || (d.warmup_placement?.length ?? 0) > 0);
+
     return (
         <Page>
-            <PageTopbar eyebrow="Deliverability" subtitle="Bounce, complaint, and inbox-placement health across your mailboxes">
-                <RangeTabs value={range} onChange={setRange} />
+            <PageTopbar eyebrow="Deliverability" subtitle="Inbox placement, bounce, and complaint health across your mailboxes">
+                <CustomizeMenu hidden={view.hidden} onToggle={toggleSection} />
+                <RangeTabs value={view.range} onChange={(range) => updateView({ ...view, range })} />
             </PageTopbar>
 
-            <StatStrip cols={4}>
+            <StatStrip cols={5}>
+                <Stat
+                    label="Deliverability score"
+                    value={
+                        hasActivity ? (
+                            <span className="inline-flex items-center gap-2">
+                                {d!.score}
+                                <BandChip band={d!.band} />
+                            </span>
+                        ) : (
+                            "—"
+                        )
+                    }
+                    sub={hasActivity ? "out of 100" : "no activity in this window"}
+                />
                 <Stat
                     label="Bounce rate"
                     value={pct(d?.bounce_rate)}
@@ -101,131 +186,259 @@ export default function DeliverabilityPage() {
                 </PageBody>
             ) : (
                 <>
-                    <div className="grid lg:grid-cols-[1fr_320px] min-h-0 flex-1">
-                        <section className="flex flex-col min-h-0 lg:border-r lg:border-slate-200">
-                            <SectionBar label="Over time">
-                                <div className="inline-flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5 max-w-full overflow-x-auto">
-                                    {METRICS.map((m) => (
-                                        <button
-                                            key={m.key}
-                                            onClick={() => setMetric(m.key)}
-                                            className={`h-6 px-2 rounded text-[11px] font-medium transition-colors ${
-                                                metric === m.key ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-900"
-                                            }`}
-                                        >
-                                            {m.label}
-                                        </button>
-                                    ))}
-                                </div>
-                            </SectionBar>
-                            <div className="flex-1 px-5 py-4">
-                                {q.isPending ? (
-                                    <div className="h-52 rounded-md bg-slate-50 animate-pulse" />
-                                ) : (
-                                    <DailyBars
-                                        points={series}
-                                        height={220}
-                                        barClass={METRICS.find((m) => m.key === metric)?.bar}
-                                        emptyLabel="No activity in this window yet"
-                                    />
-                                )}
-                            </div>
-                        </section>
-
-                        <aside className="flex flex-col min-h-0 bg-slate-50/40">
-                            <SectionBar label="Window totals" />
-                            <div className="divide-y divide-slate-200/60">
-                                {[
-                                    { label: "Sent", value: d?.emails_sent, dot: "bg-slate-400" },
-                                    { label: "Opens", value: d?.open_count, dot: "bg-emerald-500" },
-                                    { label: "Clicks", value: d?.click_count, dot: "bg-violet-500" },
-                                    { label: "Replies", value: d?.reply_count, dot: "bg-sky-500" },
-                                    { label: "Bounces", value: d?.bounce_count, dot: "bg-rose-500" },
-                                    { label: "Complaints", value: d?.complaint_count, dot: "bg-amber-500" },
-                                    { label: "Unsubscribes", value: d?.unsubscribe_count, dot: "bg-orange-500" },
-                                ].map((row) => (
-                                    <div key={row.label} className="h-9 px-4 flex items-center gap-2">
-                                        <span className={`size-1.5 rounded-full ${row.dot}`} />
-                                        <span className="text-[12px] text-slate-700">{row.label}</span>
-                                        <span className="ml-auto font-mono text-[11px] text-slate-500 tabular-nums">{q.isPending ? "—" : num(row.value)}</span>
-                                    </div>
-                                ))}
-                            </div>
-                            {d?.placement_samples ? (
-                                <>
-                                    <SectionBar label="Inbox placement" />
-                                    <div className="px-4 py-3 grid grid-cols-2 gap-2 text-center">
-                                        <div>
-                                            <div className="text-[18px] font-semibold text-emerald-600 tabular-nums">{pct(d.inbox_placement_rate)}</div>
-                                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Inbox</div>
+                    {(show("chart") || show("totals")) && (
+                        <div className={`grid min-h-0 ${show("chart") && show("totals") ? "lg:grid-cols-[1fr_320px]" : ""}`}>
+                            {show("chart") && (
+                                <section className="flex flex-col min-h-0 lg:border-r lg:border-slate-200">
+                                    <SectionBar label="Over time">
+                                        <div className="inline-flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5 max-w-full overflow-x-auto">
+                                            {METRICS.map((m) => (
+                                                <button
+                                                    key={m.key}
+                                                    onClick={() => setMetric(m.key)}
+                                                    className={`h-6 px-2 rounded text-[11px] font-medium transition-colors ${
+                                                        metric === m.key ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-900"
+                                                    }`}
+                                                >
+                                                    {m.label}
+                                                </button>
+                                            ))}
                                         </div>
-                                        <div>
-                                            <div className="text-[18px] font-semibold text-rose-600 tabular-nums">{pct(d.spam_placement_rate)}</div>
-                                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Spam</div>
-                                        </div>
+                                    </SectionBar>
+                                    <div className="flex-1 px-5 py-4">
+                                        {q.isPending ? (
+                                            <div className="h-52 rounded-md bg-slate-50 animate-pulse" />
+                                        ) : (
+                                            <DailyBars
+                                                points={series}
+                                                height={220}
+                                                barClass={METRICS.find((m) => m.key === metric)?.bar}
+                                                emptyLabel="No activity in this window yet"
+                                            />
+                                        )}
                                     </div>
-                                </>
-                            ) : null}
-                        </aside>
-                    </div>
+                                </section>
+                            )}
 
-                    <SectionBar label="Mailboxes at risk" count={d?.by_mailbox?.length || undefined}>
-                        <Link to="/app/emails" className="inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-900 transition-colors">
-                            All mailboxes
-                            <ArrowUpRightIcon className="w-3 h-3" />
-                        </Link>
-                    </SectionBar>
-                    {q.isPending ? (
-                        <SkeletonRows />
-                    ) : (d?.by_mailbox?.length ?? 0) === 0 ? (
-                        <EmptyBlock title="No bounce or complaint activity" body="Mailboxes with bounces or complaints in this window will show up here, ranked by risk." />
-                    ) : (
-                        <div className="divide-y divide-slate-200/60">
-                            {d!.by_mailbox.map((m) => (
-                                <div key={m.email_account_id} className="h-11 px-5 flex items-center gap-3">
-                                    <span className={`size-1.5 rounded-full shrink-0 ${BAND_DOT[m.band]}`} />
-                                    <span className="text-[12.5px] font-medium text-slate-900 truncate max-w-[36%]">{m.email}</span>
-                                    <span className="ml-auto flex items-center gap-2 md:gap-4 font-mono text-[11px] text-slate-500 tabular-nums shrink-0">
-                                        <span title="Sent" className="hidden md:inline">{num(m.sent)} sent</span>
-                                        <span title="Bounce rate" className="text-rose-600">{pct(m.bounce_rate)} bounce</span>
-                                        <span title="Complaint rate" className="hidden md:inline text-amber-600">{pct(m.complaint_rate)} spam</span>
-                                    </span>
-                                    <BandChip band={m.band} />
-                                </div>
-                            ))}
+                            {show("totals") && (
+                                <aside className="flex flex-col min-h-0 bg-slate-50/40">
+                                    <SectionBar label="Window totals" />
+                                    <div className="divide-y divide-slate-200/60">
+                                        {[
+                                            { label: "Sent", value: d?.emails_sent, dot: "bg-slate-400" },
+                                            { label: "Opens", value: d?.open_count, dot: "bg-emerald-500" },
+                                            { label: "Clicks", value: d?.click_count, dot: "bg-violet-500" },
+                                            { label: "Replies", value: d?.reply_count, dot: "bg-sky-500" },
+                                            { label: "Bounces", value: d?.bounce_count, dot: "bg-rose-500" },
+                                            { label: "Complaints", value: d?.complaint_count, dot: "bg-amber-500" },
+                                            { label: "Unsubscribes", value: d?.unsubscribe_count, dot: "bg-orange-500" },
+                                        ].map((row) => (
+                                            <div key={row.label} className="h-9 px-4 flex items-center gap-2">
+                                                <span className={`size-1.5 rounded-full ${row.dot}`} />
+                                                <span className="text-[12px] text-slate-700">{row.label}</span>
+                                                <span className="ml-auto font-mono text-[11px] text-slate-500 tabular-nums">{q.isPending ? "—" : num(row.value)}</span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                    {d?.placement_samples ? (
+                                        <>
+                                            <SectionBar label="Inbox placement" />
+                                            <div className="px-4 py-3 grid grid-cols-2 gap-2 text-center">
+                                                <div>
+                                                    <div className="text-[18px] font-semibold text-emerald-600 tabular-nums">{pct(d.inbox_placement_rate)}</div>
+                                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Inbox</div>
+                                                </div>
+                                                <div>
+                                                    <div className="text-[18px] font-semibold text-rose-600 tabular-nums">{pct(d.spam_placement_rate)}</div>
+                                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Spam</div>
+                                                </div>
+                                            </div>
+                                        </>
+                                    ) : null}
+                                </aside>
+                            )}
                         </div>
                     )}
 
-                    <SectionBar label="Campaigns at risk" count={d?.by_campaign?.length || undefined} />
+                    {show("providers") && (
+                        <>
+                            <SectionBar label="Placement by provider" count={d?.by_provider?.length || undefined} />
+                            {q.isPending ? (
+                                <SkeletonRows />
+                            ) : (d?.by_provider?.length ?? 0) === 0 ? (
+                                <EmptyBlock
+                                    title="No placement test samples in this window"
+                                    body="Run a seed placement test to see where your mail lands (inbox, promotions, or spam) at each provider."
+                                />
+                            ) : (
+                                <div className="divide-y divide-slate-200/60">
+                                    {d!.by_provider.map((p) => (
+                                        <ProviderRow key={p.provider} p={p} />
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    )}
+
+                    {show("warmup") && (
+                        <>
+                            <SectionBar label="Warmup placement by domain" count={d?.warmup_placement?.length || undefined} />
+                            {q.isPending ? (
+                                <SkeletonRows />
+                            ) : (d?.warmup_placement?.length ?? 0) === 0 ? (
+                                <EmptyBlock
+                                    title="No warmup deliveries in this window"
+                                    body="Once warmup is running, every verified delivery reports whether it reached the inbox or the spam folder, broken down by the recipient's domain."
+                                />
+                            ) : (
+                                <div className="divide-y divide-slate-200/60">
+                                    {d!.warmup_placement.map((w) => (
+                                        <WarmupDomainRow key={w.domain} w={w} />
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    )}
+
+                    {show("mailboxes") && (
+                        <>
+                            <SectionBar label="Mailboxes at risk" count={d?.by_mailbox?.length || undefined}>
+                                <Link to="/app/emails" className="inline-flex items-center gap-1 text-[11px] text-slate-500 hover:text-slate-900 transition-colors">
+                                    All mailboxes
+                                    <ArrowUpRightIcon className="w-3 h-3" />
+                                </Link>
+                            </SectionBar>
+                            {q.isPending ? (
+                                <SkeletonRows />
+                            ) : (d?.by_mailbox?.length ?? 0) === 0 ? (
+                                <EmptyBlock title="No bounce or complaint activity" body="Mailboxes with bounces or complaints in this window will show up here, ranked by risk." />
+                            ) : (
+                                <div className="divide-y divide-slate-200/60">
+                                    {d!.by_mailbox.map((m) => (
+                                        <div key={m.email_account_id} className="h-11 px-5 flex items-center gap-3">
+                                            <span className={`size-1.5 rounded-full shrink-0 ${BAND_DOT[m.band]}`} />
+                                            <span className="text-[12.5px] font-medium text-slate-900 truncate max-w-[36%]">{m.email}</span>
+                                            <span className="ml-auto flex items-center gap-2 md:gap-4 font-mono text-[11px] text-slate-500 tabular-nums shrink-0">
+                                                <span title="Sent" className="hidden md:inline">{num(m.sent)} sent</span>
+                                                <span title="Bounce rate" className="text-rose-600">{pct(m.bounce_rate)} bounce</span>
+                                                <span title="Complaint rate" className="hidden md:inline text-amber-600">{pct(m.complaint_rate)} spam</span>
+                                            </span>
+                                            <BandChip band={m.band} />
+                                        </div>
+                                    ))}
+                                </div>
+                            )}
+                        </>
+                    )}
+
+                    {show("campaigns") && (
+                        <SectionBar label="Campaigns at risk" count={d?.by_campaign?.length || undefined} />
+                    )}
                     <PageBody>
-                        {q.isPending ? (
-                            <SkeletonRows />
-                        ) : (d?.by_campaign?.length ?? 0) === 0 ? (
-                            <EmptyBlock title="No campaign deliverability issues" body="Campaigns with bounces or complaints in this window will appear here." />
-                        ) : (
-                            <div className="divide-y divide-slate-200/60">
-                                {d!.by_campaign.map((c) => (
-                                    <Link
-                                        key={c.campaign_id}
-                                        to={`/app/campaigns/${c.campaign_id}`}
-                                        className="group h-11 px-5 flex items-center gap-3 hover:bg-slate-50 transition-colors"
-                                    >
-                                        <span className={`size-1.5 rounded-full shrink-0 ${BAND_DOT[c.band]}`} />
-                                        <span className="text-[12.5px] font-medium text-slate-900 truncate max-w-[36%]">{c.name}</span>
-                                        <span className="ml-auto flex items-center gap-2 md:gap-4 font-mono text-[11px] text-slate-500 tabular-nums shrink-0">
-                                            <span title="Sent" className="hidden md:inline">{num(c.sent)} sent</span>
-                                            <span title="Bounce rate" className="text-rose-600">{pct(c.bounce_rate)} bounce</span>
-                                            <span title="Complaint rate" className="hidden md:inline text-amber-600">{pct(c.complaint_rate)} spam</span>
-                                        </span>
-                                        <BandChip band={c.band} />
-                                    </Link>
-                                ))}
-                            </div>
-                        )}
+                        {show("campaigns") &&
+                            (q.isPending ? (
+                                <SkeletonRows />
+                            ) : (d?.by_campaign?.length ?? 0) === 0 ? (
+                                <EmptyBlock title="No campaign deliverability issues" body="Campaigns with bounces or complaints in this window will appear here." />
+                            ) : (
+                                <div className="divide-y divide-slate-200/60">
+                                    {d!.by_campaign.map((c) => (
+                                        <Link
+                                            key={c.campaign_id}
+                                            to={`/app/campaigns/${c.campaign_id}`}
+                                            className="group h-11 px-5 flex items-center gap-3 hover:bg-slate-50 transition-colors"
+                                        >
+                                            <span className={`size-1.5 rounded-full shrink-0 ${BAND_DOT[c.band]}`} />
+                                            <span className="text-[12.5px] font-medium text-slate-900 truncate max-w-[36%]">{c.name}</span>
+                                            <span className="ml-auto flex items-center gap-2 md:gap-4 font-mono text-[11px] text-slate-500 tabular-nums shrink-0">
+                                                <span title="Sent" className="hidden md:inline">{num(c.sent)} sent</span>
+                                                <span title="Bounce rate" className="text-rose-600">{pct(c.bounce_rate)} bounce</span>
+                                                <span title="Complaint rate" className="hidden md:inline text-amber-600">{pct(c.complaint_rate)} spam</span>
+                                            </span>
+                                            <BandChip band={c.band} />
+                                        </Link>
+                                    ))}
+                                </div>
+                            ))}
                     </PageBody>
                 </>
             )}
         </Page>
+    );
+}
+
+// One provider's seed placement rollup: a stacked inbox/promotions/spam/other
+// bar plus the two rates that matter.
+function ProviderRow({ p }: { p: ProviderPlacement }) {
+    const segments = [
+        { n: p.inbox, cls: "bg-emerald-500", label: "Inbox" },
+        { n: p.promotions, cls: "bg-violet-400", label: "Promotions" },
+        { n: p.spam, cls: "bg-rose-500", label: "Spam" },
+        { n: p.other, cls: "bg-slate-300", label: "Other" },
+    ].filter((s) => s.n > 0);
+    return (
+        <div className="h-11 px-5 flex items-center gap-3">
+            <span className="text-[12.5px] font-medium text-slate-900 w-28 shrink-0 truncate">{providerLabel(p.provider)}</span>
+            <div className="flex h-1.5 flex-1 min-w-16 rounded-full overflow-hidden bg-slate-100" title={segments.map((s) => `${s.label} ${s.n}`).join(" · ")}>
+                {segments.map((s) => (
+                    <span key={s.label} className={s.cls} style={{ width: `${(s.n / p.samples) * 100}%` }} />
+                ))}
+            </div>
+            <span className="flex items-center gap-2 md:gap-4 font-mono text-[11px] tabular-nums shrink-0">
+                <span title="Inbox rate" className="text-emerald-600">{pct(p.inbox_rate)} inbox</span>
+                <span title="Spam rate" className="text-rose-600">{pct(p.spam_rate)} spam</span>
+                <span title="Samples" className="hidden md:inline text-slate-500">{num(p.samples)} samples</span>
+            </span>
+        </div>
+    );
+}
+
+// One recipient domain's continuous warmup placement signal.
+function WarmupDomainRow({ w }: { w: WarmupDomainPlacement }) {
+    return (
+        <div className="h-11 px-5 flex items-center gap-3">
+            <span className={`size-1.5 rounded-full shrink-0 ${w.spam_rate >= 20 ? "bg-rose-500" : w.spam_rate >= 10 ? "bg-amber-500" : "bg-emerald-500"}`} />
+            <span className="text-[12.5px] font-medium text-slate-900 truncate max-w-[36%]">{w.domain}</span>
+            <span className="hidden md:inline text-[11px] text-slate-400">{providerLabel(w.provider)}</span>
+            <span className="ml-auto flex items-center gap-2 md:gap-4 font-mono text-[11px] tabular-nums shrink-0">
+                <span title="Warmup deliveries" className="hidden md:inline text-slate-500">{num(w.delivered)} delivered</span>
+                <span title="Inbox rate" className="text-emerald-600">{pct(w.inbox_rate)} inbox</span>
+                <span title="Spam rate" className="text-rose-600">{pct(w.spam_rate)} spam</span>
+            </span>
+        </div>
+    );
+}
+
+function CustomizeMenu({ hidden, onToggle }: { hidden: SectionKey[]; onToggle: (k: SectionKey) => void }) {
+    return (
+        <PopoverMenu align="end">
+            <PopoverMenuTrigger asChild>
+                <SelectButton icon={<SlidersHorizontalIcon className="w-3.5 h-3.5" />} label="Customize" />
+            </PopoverMenuTrigger>
+            <PopoverMenuContent minWidth={230}>
+                <PopoverMenuLabel>Visible sections</PopoverMenuLabel>
+                {SECTIONS.map((s) => {
+                    const on = !hidden.includes(s.key);
+                    return (
+                        <PopoverMenuItem key={s.key} closeOnSelect={false} onSelect={() => onToggle(s.key)} trailing={<CheckSquare on={on} />}>
+                            {s.label}
+                        </PopoverMenuItem>
+                    );
+                })}
+            </PopoverMenuContent>
+        </PopoverMenu>
+    );
+}
+
+function CheckSquare({ on }: { on: boolean }) {
+    return (
+        <span
+            className={`inline-flex size-3.5 items-center justify-center rounded-[3px] border transition-colors ${
+                on ? "bg-sky-600 border-sky-600 text-white" : "border-slate-300 bg-white text-transparent"
+            }`}
+        >
+            <CheckIcon className="w-2.5 h-2.5" strokeWidth={3} />
+        </span>
     );
 }
 

--- a/web/src/lib/api/models/app/analytics/Deliverability.ts
+++ b/web/src/lib/api/models/app/analytics/Deliverability.ts
@@ -36,6 +36,26 @@ export interface CampaignDeliverability {
     band: DeliverabilityBand;
 }
 
+export interface ProviderPlacement {
+    provider: string;
+    samples: number;
+    inbox: number;
+    promotions: number;
+    spam: number;
+    other: number;
+    inbox_rate: number;
+    spam_rate: number;
+}
+
+export interface WarmupDomainPlacement {
+    provider: string;
+    domain: string;
+    delivered: number;
+    spam: number;
+    inbox_rate: number;
+    spam_rate: number;
+}
+
 export default interface DeliverabilityDashboard {
     from: string;
     to: string;
@@ -67,8 +87,11 @@ export default interface DeliverabilityDashboard {
     placement_samples: number;
 
     band: DeliverabilityBand;
+    score: number;
 
     timeseries: DeliverabilityDailyPoint[];
     by_mailbox: MailboxDeliverability[];
     by_campaign: CampaignDeliverability[];
+    by_provider: ProviderPlacement[];
+    warmup_placement: WarmupDomainPlacement[];
 }


### PR DESCRIPTION
## What

Extends `GET /analytics/deliverability` (additive, no contract break) and the Deliverability dashboard:

- **`score`**: 0-100 composite deliverability score. Starts at 100 and subtracts saturating penalties aligned with the documented band thresholds: bounce rate up to 40 pts (maxed at 10%), complaint rate up to 30 pts (maxed at 0.30%), spam placement up to 40 pts (maxed at 40%).
- **`by_provider`**: seed placement results rolled up per recipient provider (inbox / promotions / spam / other counts and rates). Previously the dashboard collapsed `placement_results` into one flat rate.
- **`warmup_placement`**: continuous warmup-derived placement per recipient domain (delivered = verified arrivals in `warmup_received`, spam = `warmup_spam_reports` with `report_type='spam_placement'`), org-scoped via the sending account, top 25 domains.

Dashboard (`web/src/app/app/deliverability/page.tsx`):

- Deliverability score headline stat with band chip (dash on an empty window instead of a misleading 100)
- Placement by provider section with stacked inbox/promotions/spam bars
- Warmup placement by domain section (status dot: amber at 10% spam, red at 20%)
- Customize menu: toggle any section; section choices + time window persist per browser
- Stays live through the existing `["analytics", ...]` realtime invalidation

Docs: `guides/deliverability.mdx` (score formula, both placement sections, customization) and `api/reference/analytics.mdx` (new response fields + examples); reworded the old "no single score" callout since enforcement still acts per-signal but a composite headline now exists.

## Verification

- `make fmt` + `make lint` clean
- `tsc` + `eslint` clean in `web/`
- `fumadocs-mdx` + `tsc` clean in `docs/`