### PR TITLE
Digest-first notifications: fewer emails, targeted audiences, one shared email per team event

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1099,7 +1099,7 @@ func main() {
 		// onto the backend's advanced service (deliverability webhooks can ingest
 		// here too).
 		notificationService = notification.NewService(repository.NewNotificationRepository(primaryDB.Pool), streamingPublisher)
-		notificationService.WireDelivery(emailNotificationService, integrationServiceForHandler, userRepostory)
+		notificationService.WireDelivery(emailNotificationService, integrationServiceForHandler, userRepostory, organizationRepoForHandler)
 		// Mobile push (APNs): device registration always works; delivery only
 		// activates when the APNS_* env is configured. The Redis client backs
 		// the shared immediate-then-digest push window. The sender stays a nil
@@ -1174,6 +1174,7 @@ func main() {
 
 		// Start trial expiration job in background
 		trialExpirationJob := jobs.NewTrialExpirationJobWithDB(subscriptionRepository, primaryDB.Pool, emailNotificationService)
+		trialExpirationJob.WireNotifier(notificationService)
 		trialScheduler := jobs.NewTrialExpirationScheduler(trialExpirationJob, 1*time.Hour)
 		go trialScheduler.Start(ctx)
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -324,7 +324,7 @@ func main() {
 			notifEmail = ses
 		}
 	}
-	notificationService.WireDelivery(notifEmail, integrationServiceC, repository.NewUserRepostory(primaryDB, kmsClient))
+	notificationService.WireDelivery(notifEmail, integrationServiceC, repository.NewUserRepostory(primaryDB, kmsClient), orgRepoConsumer)
 	// Mobile push (APNs) fires from THIS process too: reply/bounce/complaint
 	// notifications are created here. Redis backs the immediate-then-digest
 	// window shared with the backend. The sender stays a nil interface (not a
@@ -396,6 +396,7 @@ func main() {
 		Cache:                       redisCache,
 		AdminRepo:                   repository.NewAdminRepository(primaryDB.Pool),
 		AssignmentService:           workerAssignmentSvc,
+		Notifier:                    notificationService,
 	}
 
 	jobsService.InitEvents()

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -82,6 +82,14 @@ APNS_TOPIC=com.warmbly.app
 NOTIFICATION_PUSH_WINDOW=5h                    # optional, default 5h
 ```
 
+Notification email delivery (optional; set on the backend and the consumer). Notification emails batch on a per-user digest cadence, and two cost guards exist because hosted deployments pay per email: the per-event instant cadence is hidden unless you opt in, and each user has a rolling 24h budget for non-security notification emails. Self-hosted deployments running their own SMTP can loosen both:
+
+```
+NOTIFICATION_EMAIL_ALLOW_INSTANT=true          # optional, default false; offers the instant cadence in settings
+NOTIFICATION_EMAIL_DAILY_CAP=0                 # optional, default 25; 0 disables the per-user daily budget
+NOTIFICATION_EMAIL_SMART_HOLD=15m              # optional, default 15m; the smart cadence hold window
+```
+
 Release auto-update (optional; safe to omit on a fresh install):
 
 ```

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -82,12 +82,10 @@ APNS_TOPIC=com.warmbly.app
 NOTIFICATION_PUSH_WINDOW=5h                    # optional, default 5h
 ```
 
-Notification email delivery (optional; set on the backend and the consumer). Notification emails batch on a per-user digest cadence, and two cost guards exist because hosted deployments pay per email: the per-event instant cadence is hidden unless you opt in, and each user has a rolling 24h budget for non-security notification emails. Self-hosted deployments running their own SMTP can loosen both:
+Notification email delivery (optional; set on the backend and the consumer). Notification emails bundle on a per-user window (30 minutes minimum, up to daily; there is no per-event mode), and each user additionally has a rolling 24h budget for non-security notification emails:
 
 ```
-NOTIFICATION_EMAIL_ALLOW_INSTANT=true          # optional, default false; offers the instant cadence in settings
 NOTIFICATION_EMAIL_DAILY_CAP=0                 # optional, default 25; 0 disables the per-user daily budget
-NOTIFICATION_EMAIL_SMART_HOLD=15m              # optional, default 15m; the smart cadence hold window
 ```
 
 Release auto-update (optional; safe to omit on a fresh install):

--- a/docs/content/docs/guides/notifications.mdx
+++ b/docs/content/docs/guides/notifications.mdx
@@ -110,18 +110,11 @@ Email notifications are designed to cost you as few emails as possible. Nothing 
 - **One email, not a stream.** When the hold expires, everything still unread goes out as a single bundled email, with each item linked back into the app.
 - **Shared events share one email.** When the same event concerns several teammates (a worker outage, a trial expiring), Warmbly sends one email with all of them together in To, instead of a copy per person. Everyone sees who else was told.
 
-The cadence is yours to pick in **Settings → Notifications**, under Email delivery:
+The window is yours to pick in **Settings → Notifications**, under Email delivery: presets from every 30 minutes up to once a day, or a custom window anywhere in that range. The default is every 30 minutes. There is deliberately no per-event option; 30 minutes is the floor, so the email channel can never turn into one email per alert.
 
-| Cadence | Behavior |
-| --- | --- |
-| Smart (default) | Waits 15 minutes, then bundles whatever you have not read into one email |
-| Hourly | At most one bundled email per hour |
-| Daily | At most one bundled email per day |
-| Instant | Every alert is its own email, sent right away. Self-hosted deployments only |
+Security sign-in alerts ignore the window and always send immediately: if someone signs in to your account from a new device, waiting is not an option.
 
-Security sign-in alerts ignore the cadence and always send immediately: if someone signs in to your account from a new device, waiting an hour is not an option.
-
-Two limits keep the email channel bounded. The per-event **Instant** cadence only appears on self-hosted deployments that enable it (`NOTIFICATION_EMAIL_ALLOW_INSTANT`); on Warmbly cloud the smart hold is the fastest cadence. And outside of security alerts, each person has a rolling 24 hour budget of notification emails (25 by default, configurable when self-hosting). Past the budget, alerts stay in the in-app feed instead of emailing. With bundling on any cadence, normal use never gets near it; it exists so a very high-volume day cannot turn the email channel into a firehose.
+On top of the window, each person has a rolling 24 hour budget of notification emails (25 by default, configurable when self-hosting). Past the budget, alerts stay in the in-app feed instead of emailing. With bundling, normal use never gets near it; it exists so even the busiest day stays a handful of emails.
 
 For richer, event-specific routing (custom messages, branching, multiple destinations), use [Automations](/guides/automations) instead: they can route events like replies, bookings, and record changes to outside tools with full control.
 

--- a/docs/content/docs/guides/notifications.mdx
+++ b/docs/content/docs/guides/notifications.mdx
@@ -114,12 +114,14 @@ The cadence is yours to pick in **Settings → Notifications**, under Email deli
 
 | Cadence | Behavior |
 | --- | --- |
-| Instant | Every alert is its own email, sent right away |
 | Smart (default) | Waits 15 minutes, then bundles whatever you have not read into one email |
 | Hourly | At most one bundled email per hour |
 | Daily | At most one bundled email per day |
+| Instant | Every alert is its own email, sent right away. Self-hosted deployments only |
 
 Security sign-in alerts ignore the cadence and always send immediately: if someone signs in to your account from a new device, waiting an hour is not an option.
+
+Two limits keep the email channel bounded. The per-event **Instant** cadence only appears on self-hosted deployments that enable it (`NOTIFICATION_EMAIL_ALLOW_INSTANT`); on Warmbly cloud the smart hold is the fastest cadence. And outside of security alerts, each person has a rolling 24 hour budget of notification emails (25 by default, configurable when self-hosting). Past the budget, alerts stay in the in-app feed instead of emailing. With bundling on any cadence, normal use never gets near it; it exists so a very high-volume day cannot turn the email channel into a firehose.
 
 For richer, event-specific routing (custom messages, branching, multiple destinations), use [Automations](/guides/automations) instead: they can route events like replies, bookings, and record changes to outside tools with full control.
 

--- a/docs/content/docs/guides/notifications.mdx
+++ b/docs/content/docs/guides/notifications.mdx
@@ -44,6 +44,18 @@ For more on what bounces and complaints mean for your reputation, and the thresh
 
 - **New sign-in**: your account was accessed from a device you have not used before, with the browser, OS, and approximate location in the notification body.
 
+### Billing
+
+- **Billing alerts**: your trial expired or your workspace's sending was paused for billing reasons. These go to the members who can act on them, the ones with the manage billing permission, not to everyone in the workspace.
+
+### Team
+
+- **Teammate joined**: someone accepted an invitation to your workspace. Goes to members with the manage team permission; the person who joined is not notified about themselves.
+
+<Callout type="info" title="Who gets notified">
+Workspace-level events never fan out to the whole organization. Warmbly notifies the people a thing concerns: reply and bounce alerts go to the owner of the mailbox or campaign, worker downtime goes to members who can manage mailboxes, billing to members who can manage billing, and team changes to members who can manage the team.
+</Callout>
+
 ## Per-category preferences
 
 You control notifications per category from **Settings → Notifications**. Each category has its own toggle, so you can keep the ones that matter to you and silence the rest.
@@ -53,6 +65,8 @@ The settings page groups the toggles the same way as above:
 - **Inbound activity** Reply received, Out-of-office detected.
 - **Health** Bounce detected, Spam complaint, Worker downtime.
 - **Security** New sign-in.
+- **Billing** Billing alerts.
+- **Team** Teammate joined.
 
 Toggles save automatically as you flip them; the save indicator next to the page title confirms each change has persisted.
 
@@ -66,6 +80,8 @@ The defaults are chosen to be useful without being noisy. The shipped defaults a
 | Spam complaint | Health | On |
 | Worker downtime | Health | On |
 | New sign-in | Security | On |
+| Billing alerts | Billing | On, including email |
+| Teammate joined | Team | On |
 | Reply received | Inbound | Off |
 | Out-of-office detected | Inbound | Off |
 
@@ -83,8 +99,27 @@ The settings page controls where enabled notifications are delivered. The channe
 
 - **In-app**: the bell in the dashboard. Always on, controlled by the per-category toggles above.
 - **Mobile push**: alerts on devices signed in with the Warmbly iOS app. Registration happens automatically when you allow notifications in the app, and signing out on a device stops its pushes. Push is batched so a burst never pings you once per event: the first notification in a quiet stretch is delivered immediately, and anything else that arrives inside the batching window (five hours by default) is held and sent as a single summary, like "3 new replies", when the window closes.
-- **Email**: delivery to your account email. Turn it on to also receive each enabled notification as an email with a link back into the app.
+- **Email**: delivery to your account email, batched by the digest cadence described below rather than one email per event.
 - **Slack**: posts each enabled notification to your connected Slack, on the channel you have configured for Slack in the [Integrations](/guides/integrations) tab. Connect Slack and set up a channel there first; until a Slack channel is configured the toggle saves but nothing is delivered.
+
+## Email digest
+
+Email notifications are designed to cost you as few emails as possible. Nothing is emailed the moment it happens. Each alert with the email channel on waits on a short hold, and what actually reaches your inbox follows three rules:
+
+- **Read means no email.** Anything you read in the dashboard or the mobile app before the hold expires is never emailed. If you live in the dashboard, the email channel stays almost silent.
+- **One email, not a stream.** When the hold expires, everything still unread goes out as a single bundled email, with each item linked back into the app.
+- **Shared events share one email.** When the same event concerns several teammates (a worker outage, a trial expiring), Warmbly sends one email with all of them together in To, instead of a copy per person. Everyone sees who else was told.
+
+The cadence is yours to pick in **Settings → Notifications**, under Email delivery:
+
+| Cadence | Behavior |
+| --- | --- |
+| Instant | Every alert is its own email, sent right away |
+| Smart (default) | Waits 15 minutes, then bundles whatever you have not read into one email |
+| Hourly | At most one bundled email per hour |
+| Daily | At most one bundled email per day |
+
+Security sign-in alerts ignore the cadence and always send immediately: if someone signs in to your account from a new device, waiting an hour is not an option.
 
 For richer, event-specific routing (custom messages, branching, multiple destinations), use [Automations](/guides/automations) instead: they can route events like replies, bookings, and record changes to outside tools with full control.
 

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -8,9 +8,19 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/notification"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
+
+// emailDeliveryInfo tells clients what the deployment's email channel offers,
+// so pickers can hide the instant cadence on hosted deploys.
+func emailDeliveryInfo() gin.H {
+	return gin.H{
+		"instant_allowed": notification.InstantEmailAllowed(),
+		"daily_cap":       notification.EmailDailyCap(),
+	}
+}
 
 func notifActor(c *gin.Context) (uuid.UUID, bool) {
 	id, err := uuid.Parse(middleware.GetUserID(c))
@@ -33,7 +43,7 @@ func (h *Handler) GetNotificationPreferences(c *gin.Context) {
 		errx.JSON(c, xerr)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"preferences": prefs})
+	c.JSON(http.StatusOK, gin.H{"preferences": prefs, "email_delivery": emailDeliveryInfo()})
 }
 
 // UpdateNotificationPreferences replaces the caller's notification preferences.
@@ -54,11 +64,15 @@ func (h *Handler) UpdateNotificationPreferences(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "email_digest must be one of instant, smart, hourly, daily"))
 		return
 	}
+	if req.Preferences.EmailDigest == models.EmailDigestInstant && !notification.InstantEmailAllowed() {
+		errx.JSON(c, errx.New(errx.BadRequest, "the instant email cadence is only available on self-hosted deployments"))
+		return
+	}
 	if xerr := h.NotificationService.UpdatePreferences(c.Request.Context(), uid, &req.Preferences); xerr != nil {
 		errx.JSON(c, xerr)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"preferences": req.Preferences})
+	c.JSON(http.StatusOK, gin.H{"preferences": req.Preferences, "email_delivery": emailDeliveryInfo()})
 }
 
 // ListNotifications returns the caller's recent feed + the unread count.

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -47,6 +47,13 @@ func (h *Handler) UpdateNotificationPreferences(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "invalid payload"))
 		return
 	}
+	if req.Preferences.EmailDigest == "" {
+		req.Preferences.EmailDigest = models.EmailDigestSmart
+	}
+	if !models.ValidEmailDigest(req.Preferences.EmailDigest) {
+		errx.JSON(c, errx.New(errx.BadRequest, "email_digest must be one of instant, smart, hourly, daily"))
+		return
+	}
 	if xerr := h.NotificationService.UpdatePreferences(c.Request.Context(), uid, &req.Preferences); xerr != nil {
 		errx.JSON(c, xerr)
 		return

--- a/internal/api/handler/notification.go
+++ b/internal/api/handler/notification.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -9,16 +10,18 @@ import (
 
 	"github.com/warmbly/warmbly/internal/api/middleware"
 	"github.com/warmbly/warmbly/internal/app/notification"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-// emailDeliveryInfo tells clients what the deployment's email channel offers,
-// so pickers can hide the instant cadence on hosted deploys.
+// emailDeliveryInfo tells clients the email-channel bounds so the window
+// control renders the right range without hardcoding it.
 func emailDeliveryInfo() gin.H {
 	return gin.H{
-		"instant_allowed": notification.InstantEmailAllowed(),
-		"daily_cap":       notification.EmailDailyCap(),
+		"min_minutes": config.NotificationEmailWindowMinMinutes,
+		"max_minutes": config.NotificationEmailWindowMaxMinutes,
+		"daily_cap":   notification.EmailDailyCap(),
 	}
 }
 
@@ -57,15 +60,14 @@ func (h *Handler) UpdateNotificationPreferences(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "invalid payload"))
 		return
 	}
-	if req.Preferences.EmailDigest == "" {
-		req.Preferences.EmailDigest = models.EmailDigestSmart
+	if req.Preferences.EmailDigestMinutes == 0 {
+		req.Preferences.EmailDigestMinutes = config.NotificationEmailWindowDefaultMinutes
 	}
-	if !models.ValidEmailDigest(req.Preferences.EmailDigest) {
-		errx.JSON(c, errx.New(errx.BadRequest, "email_digest must be one of instant, smart, hourly, daily"))
-		return
-	}
-	if req.Preferences.EmailDigest == models.EmailDigestInstant && !notification.InstantEmailAllowed() {
-		errx.JSON(c, errx.New(errx.BadRequest, "the instant email cadence is only available on self-hosted deployments"))
+	if req.Preferences.EmailDigestMinutes < config.NotificationEmailWindowMinMinutes ||
+		req.Preferences.EmailDigestMinutes > config.NotificationEmailWindowMaxMinutes {
+		errx.JSON(c, errx.New(errx.BadRequest, fmt.Sprintf(
+			"email_digest_minutes must be between %d and %d",
+			config.NotificationEmailWindowMinMinutes, config.NotificationEmailWindowMaxMinutes)))
 		return
 	}
 	if xerr := h.NotificationService.UpdatePreferences(c.Request.Context(), uid, &req.Preferences); xerr != nil {

--- a/internal/api/handler/organization.go
+++ b/internal/api/handler/organization.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -431,6 +434,27 @@ func (h *Handler) AcceptInvitation(c *gin.Context) {
 	}
 
 	h.auditOrg(c, models.AuditActionCreate, models.AuditEntityOrganizationMember, &member.UserID, nil, map[string]string{"via": "invitation"})
+
+	// Tell the members who manage the team (not the whole org, and not the
+	// joiner). Detached + best-effort: a notification hiccup must not fail
+	// the accept.
+	if h.NotificationService != nil {
+		joiner := strings.TrimSpace(strings.TrimSpace(user.FirstName) + " " + strings.TrimSpace(user.LastName))
+		if joiner == "" {
+			joiner = user.Email
+		}
+		orgID, joinerID := member.OrganizationID, member.UserID
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			h.NotificationService.NotifyOrg(ctx, orgID, models.PermManageTeam, joinerID,
+				models.NotifTeamActivity,
+				joiner+" joined your workspace",
+				user.Email+" accepted their invitation.",
+				"/app/settings/members", nil,
+				"member_joined:"+joinerID.String())
+		}()
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"message": "invitation accepted",

--- a/internal/app/consumer/dead_worker.go
+++ b/internal/app/consumer/dead_worker.go
@@ -10,6 +10,46 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// OrgNotifier raises a permission-targeted org notification (in-app feed +
+// each member's enabled channels, email digest-coalesced). Satisfied by
+// *notification.Service; local interface to avoid an import cycle.
+type OrgNotifier interface {
+	NotifyOrg(ctx context.Context, orgID uuid.UUID, perm models.OrganizationPermission, exclude uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any, groupKey string)
+}
+
+// notifyWorkerDown tells each affected org's manage_emails members about a
+// dead worker, at most once per worker incident: detection reruns every
+// interval while the worker stays down, and the SetNX guard keeps that from
+// re-alerting. The shared group key coalesces an org's recipients into one
+// email with everyone in To.
+func (s *JobsService) notifyWorkerDown(ctx context.Context, workerID uuid.UUID, orgs map[uuid.UUID]int, reassigned bool) {
+	if s.Notifier == nil || len(orgs) == 0 {
+		return
+	}
+	ok, err := s.Cache.SetNX(ctx, "worker:downnotify:"+workerID.String(), "1", 6*time.Hour).Result()
+	if err != nil || !ok {
+		return
+	}
+	for orgID, n := range orgs {
+		noun := fmt.Sprintf("%d of your mailboxes were", n)
+		if n == 1 {
+			noun = "One of your mailboxes was"
+		}
+		body := noun + " on a sending worker that stopped responding. "
+		if reassigned {
+			body += "They were moved to a healthy worker automatically; no action is needed."
+			if n == 1 {
+				body = noun + " on a sending worker that stopped responding. It was moved to a healthy worker automatically; no action is needed."
+			}
+		} else {
+			body += "Sending from them is paused until a replacement worker is available."
+		}
+		s.Notifier.NotifyOrg(ctx, orgID, models.PermManageEmails, uuid.Nil, models.NotifWorkerDowntime,
+			"Sending worker went offline", body, "/app/emails", nil,
+			"worker_down:"+workerID.String())
+	}
+}
+
 // StartDeadWorkerDetection periodically checks for workers whose heartbeat has
 // expired and reassigns their email accounts to healthy workers.
 // Runs every interval until the context is cancelled.
@@ -70,11 +110,13 @@ func (s *JobsService) detectDeadWorkers(ctx context.Context) {
 		replacement, err := s.findHealthyWorker(ctx, w)
 		if err != nil || replacement == nil {
 			log.Warn().Str("worker_id", w.ID.String()).Msg("no healthy replacement worker found")
+			s.notifyWorkerDown(ctx, w.ID, s.accountOrgs(ctx, accountIDs), false)
 			continue
 		}
 
 		// Reassign accounts to the healthy worker
 		reassigned := 0
+		affectedOrgs := map[uuid.UUID]int{}
 		for _, accountID := range accountIDs {
 			if err := s.WorkerRepo.UpdateEmailAccountWorker(ctx, accountID, replacement.ID); err != nil {
 				log.Error().Err(err).Str("account_id", accountID.String()).Msg("failed to reassign email account")
@@ -82,19 +124,24 @@ func (s *JobsService) detectDeadWorkers(ctx context.Context) {
 			}
 			reassigned++
 
+			account, aerr := s.EmailRepository.GetByID(ctx, accountID)
+			if aerr != nil || account == nil {
+				continue
+			}
+			if account.OrganizationID != nil {
+				affectedOrgs[*account.OrganizationID]++
+			}
+
 			// Publish AddEmail event to the new worker so it picks up the account
 			if s.Publisher != nil {
-				account, aerr := s.EmailRepository.GetByID(ctx, accountID)
-				if aerr == nil && account != nil {
-					userUUID, _ := uuid.Parse(account.UserID)
-					_ = s.Publisher.PublishAddEmail(ctx, replacement.ID, &models.AddWorkerEmail{
-						ID:       account.ID,
-						UserID:   userUUID,
-						Email:    account.Email,
-						Type:     models.InboxProvider(account.Provider),
-						ImapSync: true,
-					})
-				}
+				userUUID, _ := uuid.Parse(account.UserID)
+				_ = s.Publisher.PublishAddEmail(ctx, replacement.ID, &models.AddWorkerEmail{
+					ID:       account.ID,
+					UserID:   userUUID,
+					Email:    account.Email,
+					Type:     models.InboxProvider(account.Provider),
+					ImapSync: true,
+				})
 			}
 		}
 
@@ -125,8 +172,21 @@ func (s *JobsService) detectDeadWorkers(ctx context.Context) {
 					CreatedAt: time.Now(),
 				})
 			}
+
+			s.notifyWorkerDown(ctx, w.ID, affectedOrgs, true)
 		}
 	}
+}
+
+// accountOrgs resolves which orgs own the given accounts (org -> count).
+func (s *JobsService) accountOrgs(ctx context.Context, accountIDs []uuid.UUID) map[uuid.UUID]int {
+	orgs := map[uuid.UUID]int{}
+	for _, id := range accountIDs {
+		if account, err := s.EmailRepository.GetByID(ctx, id); err == nil && account != nil && account.OrganizationID != nil {
+			orgs[*account.OrganizationID]++
+		}
+	}
+	return orgs
 }
 
 func (s *JobsService) findHealthyWorker(ctx context.Context, deadWorker models.Worker) (*models.Worker, error) {

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -52,6 +52,10 @@ type JobsService struct {
 	// workers when a mailbox's risk band changes. Nil disables the job.
 	AssignmentService workerapp.WorkerAssignmentService
 
+	// Notifier tells affected orgs (members with manage_emails) when the
+	// dead-worker job moves or strands their mailboxes. Nil disables it.
+	Notifier OrgNotifier
+
 	eventHandlers map[models.JobEventType]func(ctx context.Context, body any) error
 }
 

--- a/internal/app/notification/email.go
+++ b/internal/app/notification/email.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,13 +24,50 @@ import (
 // notification in-app cancels its pending email (repo.MarkRead), which is
 // what keeps active users from ever being emailed about things they saw.
 const (
-	emailFlushEvery   = 30 * time.Second
-	emailSmartHold    = 15 * time.Minute
-	emailRetryDelay   = 10 * time.Minute
-	emailMaxAttempts  = 3
-	emailSendTimeout  = 10 * time.Second
-	emailFlushTimeout = 2 * time.Minute
+	emailFlushEvery    = 30 * time.Second
+	emailSmartHold     = 15 * time.Minute
+	emailRetryDelay    = 10 * time.Minute
+	emailMaxAttempts   = 3
+	emailSendTimeout   = 10 * time.Second
+	emailFlushTimeout  = 2 * time.Minute
+	emailDailyCapValue = 25
 )
+
+// Hosted-deployment cost guards. Every notification email is provider spend
+// on the cloud, so the per-event instant cadence is opt-in (self-host sets
+// NOTIFICATION_EMAIL_ALLOW_INSTANT) and each user gets a rolling 24h email
+// budget (NOTIFICATION_EMAIL_DAILY_CAP, 0 disables). Security sign-in alerts
+// bypass both — they are rare and must always arrive.
+
+// InstantEmailAllowed reports whether the instant cadence is enabled on this
+// deployment. Off by default: the fastest hosted cadence is the smart hold.
+func InstantEmailAllowed() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NOTIFICATION_EMAIL_ALLOW_INSTANT"))) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// EmailDailyCap is the max non-security notification emails one user receives
+// per rolling 24h. 0 means unlimited.
+func EmailDailyCap() int {
+	if raw := os.Getenv("NOTIFICATION_EMAIL_DAILY_CAP"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
+			return n
+		}
+	}
+	return emailDailyCapValue
+}
+
+func smartHold() time.Duration {
+	if raw := os.Getenv("NOTIFICATION_EMAIL_SMART_HOLD"); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return emailSmartHold
+}
 
 // emailHold maps the user's cadence to the pending window. Security sign-in
 // alerts always go out on the next tick regardless of cadence.
@@ -39,19 +77,29 @@ func emailHold(cadence string, category models.NotificationCategory) time.Durati
 	}
 	switch cadence {
 	case models.EmailDigestInstant:
+		if !InstantEmailAllowed() {
+			return smartHold() // stored instant on a hosted deploy degrades to smart
+		}
 		return 0
 	case models.EmailDigestHourly:
 		return time.Hour
 	case models.EmailDigestDaily:
 		return 24 * time.Hour
 	default:
-		if raw := os.Getenv("NOTIFICATION_EMAIL_SMART_HOLD"); raw != "" {
-			if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-				return d
-			}
-		}
-		return emailSmartHold
+		return smartHold()
 	}
+}
+
+// overEmailBudget reports whether a user has spent their rolling 24h email
+// budget. Errors count as in-budget — the cap is a cost guard, not a gate
+// worth losing alerts over.
+func (s *service) overEmailBudget(ctx context.Context, userID uuid.UUID) bool {
+	limit := EmailDailyCap()
+	if limit <= 0 {
+		return false
+	}
+	sent, err := s.repo.CountEmailedSince(ctx, userID, time.Now().Add(-24*time.Hour))
+	return err == nil && sent >= limit
 }
 
 func (s *service) emailFlushLoop() {
@@ -111,22 +159,55 @@ func (s *service) flushDueEmails() {
 }
 
 // sendGroupEmail delivers one shared event to all its recipients in a single
-// message, addresses together in To — teammates see who else was told.
+// message, addresses together in To — teammates see who else was told. Before
+// sending it re-verifies each recipient: still an accepted member of the org
+// (permissions were checked at event time, but membership can end during the
+// hold) and still inside their email budget. Dropped recipients' rows go to
+// skipped; the in-app feed remains their record.
 func (s *service) sendGroupEmail(ctx context.Context, rows []models.Notification) {
+	var stillMember map[uuid.UUID]bool
+	if s.members != nil && rows[0].OrganizationID != nil {
+		if members, err := s.members.GetMembers(ctx, *rows[0].OrganizationID); err == nil {
+			stillMember = map[uuid.UUID]bool{}
+			for _, m := range members {
+				if m.AcceptedAt != nil {
+					stillMember[m.UserID] = true
+				}
+			}
+		}
+	}
+
 	to := make([]string, 0, len(rows))
 	seen := map[string]bool{}
+	kept := make([]models.Notification, 0, len(rows))
+	dropped := make([]uuid.UUID, 0)
+	budgetOK := map[uuid.UUID]bool{}
 	for _, n := range rows {
+		if stillMember != nil && !stillMember[n.UserID] {
+			dropped = append(dropped, n.ID)
+			continue
+		}
+		if _, checked := budgetOK[n.UserID]; !checked {
+			budgetOK[n.UserID] = !s.overEmailBudget(ctx, n.UserID)
+		}
+		if !budgetOK[n.UserID] {
+			dropped = append(dropped, n.ID)
+			continue
+		}
+		kept = append(kept, n)
 		if user, err := s.users.GetUser(ctx, n.UserID); err == nil && user != nil && user.Email != "" && !seen[user.Email] {
 			seen[user.Email] = true
 			to = append(to, user.Email)
 		}
 	}
-	ids := notifIDs(rows)
+	_ = s.repo.SkipEmails(ctx, dropped)
+
+	ids := notifIDs(kept)
 	if len(to) == 0 {
 		_ = s.repo.MarkEmailed(ctx, ids) // nobody resolvable — don't retry forever
 		return
 	}
-	first := rows[0]
+	first := kept[0]
 	html, gerr := templates.GenerateNotificationHTML(first.Title, first.Body, absoluteLink(first.Link), "")
 	if gerr != nil {
 		_ = s.repo.RequeueEmails(ctx, ids, emailRetryDelay, emailMaxAttempts)
@@ -136,8 +217,27 @@ func (s *service) sendGroupEmail(ctx context.Context, rows []models.Notification
 }
 
 // sendUserEmail bundles everything pending for one user: a lone row renders
-// as itself, several become a digest listing each item.
+// as itself, several become a digest listing each item. Over the email
+// budget, non-security rows skip (the feed keeps them) and only security
+// sign-in alerts still send.
 func (s *service) sendUserEmail(ctx context.Context, userID uuid.UUID, rows []models.Notification) {
+	if s.overEmailBudget(ctx, userID) {
+		var capped []uuid.UUID
+		kept := rows[:0:0]
+		for _, n := range rows {
+			if n.Category == models.NotifSecuritySignIn {
+				kept = append(kept, n)
+			} else {
+				capped = append(capped, n.ID)
+			}
+		}
+		_ = s.repo.SkipEmails(ctx, capped)
+		if len(kept) == 0 {
+			return
+		}
+		rows = kept
+	}
+
 	ids := notifIDs(rows)
 	user, err := s.users.GetUser(ctx, userID)
 	if err != nil || user == nil || user.Email == "" {

--- a/internal/app/notification/email.go
+++ b/internal/app/notification/email.go
@@ -1,0 +1,198 @@
+package notification
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/notify/templates"
+)
+
+// Email digest engine. Email-channel notifications never send at creation:
+// notifyOne queues them as pending rows with a due time from the user's
+// cadence, and this loop flushes what is still unread when due. One flush
+// sends at most one email per user (their pending rows bundle into a digest)
+// plus one email per org group (the same event across several members
+// coalesces into a single message with every recipient in To). Reading a
+// notification in-app cancels its pending email (repo.MarkRead), which is
+// what keeps active users from ever being emailed about things they saw.
+const (
+	emailFlushEvery   = 30 * time.Second
+	emailSmartHold    = 15 * time.Minute
+	emailRetryDelay   = 10 * time.Minute
+	emailMaxAttempts  = 3
+	emailSendTimeout  = 10 * time.Second
+	emailFlushTimeout = 2 * time.Minute
+)
+
+// emailHold maps the user's cadence to the pending window. Security sign-in
+// alerts always go out on the next tick regardless of cadence.
+func emailHold(cadence string, category models.NotificationCategory) time.Duration {
+	if category == models.NotifSecuritySignIn {
+		return 0
+	}
+	switch cadence {
+	case models.EmailDigestInstant:
+		return 0
+	case models.EmailDigestHourly:
+		return time.Hour
+	case models.EmailDigestDaily:
+		return 24 * time.Hour
+	default:
+		if raw := os.Getenv("NOTIFICATION_EMAIL_SMART_HOLD"); raw != "" {
+			if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+				return d
+			}
+		}
+		return emailSmartHold
+	}
+}
+
+func (s *service) emailFlushLoop() {
+	ticker := time.NewTicker(emailFlushEvery)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.flushDueEmails()
+	}
+}
+
+func (s *service) flushDueEmails() {
+	ctx, cancel := context.WithTimeout(context.Background(), emailFlushTimeout)
+	defer cancel()
+
+	claimed, err := s.repo.ClaimDueEmails(ctx)
+	if err != nil || len(claimed) == 0 {
+		return
+	}
+
+	// Partition: org groups spanning several users become one coalesced
+	// email; everything else bundles per user.
+	byGroup := map[string][]models.Notification{}
+	for _, n := range claimed {
+		if n.GroupKey != "" && n.OrganizationID != nil {
+			key := n.OrganizationID.String() + "|" + n.GroupKey
+			byGroup[key] = append(byGroup[key], n)
+		}
+	}
+	grouped := map[uuid.UUID]bool{}
+	for key, rows := range byGroup {
+		users := map[uuid.UUID]bool{}
+		for _, n := range rows {
+			users[n.UserID] = true
+		}
+		if len(users) < 2 {
+			delete(byGroup, key) // single recipient — bundle with their digest
+			continue
+		}
+		for _, n := range rows {
+			grouped[n.ID] = true
+		}
+	}
+
+	for _, rows := range byGroup {
+		s.sendGroupEmail(ctx, rows)
+	}
+
+	byUser := map[uuid.UUID][]models.Notification{}
+	for _, n := range claimed {
+		if !grouped[n.ID] {
+			byUser[n.UserID] = append(byUser[n.UserID], n)
+		}
+	}
+	for userID, rows := range byUser {
+		s.sendUserEmail(ctx, userID, rows)
+	}
+}
+
+// sendGroupEmail delivers one shared event to all its recipients in a single
+// message, addresses together in To — teammates see who else was told.
+func (s *service) sendGroupEmail(ctx context.Context, rows []models.Notification) {
+	to := make([]string, 0, len(rows))
+	seen := map[string]bool{}
+	for _, n := range rows {
+		if user, err := s.users.GetUser(ctx, n.UserID); err == nil && user != nil && user.Email != "" && !seen[user.Email] {
+			seen[user.Email] = true
+			to = append(to, user.Email)
+		}
+	}
+	ids := notifIDs(rows)
+	if len(to) == 0 {
+		_ = s.repo.MarkEmailed(ctx, ids) // nobody resolvable — don't retry forever
+		return
+	}
+	first := rows[0]
+	html, gerr := templates.GenerateNotificationHTML(first.Title, first.Body, absoluteLink(first.Link), "")
+	if gerr != nil {
+		_ = s.repo.RequeueEmails(ctx, ids, emailRetryDelay, emailMaxAttempts)
+		return
+	}
+	s.settleSend(ctx, ids, to, first.Title, html)
+}
+
+// sendUserEmail bundles everything pending for one user: a lone row renders
+// as itself, several become a digest listing each item.
+func (s *service) sendUserEmail(ctx context.Context, userID uuid.UUID, rows []models.Notification) {
+	ids := notifIDs(rows)
+	user, err := s.users.GetUser(ctx, userID)
+	if err != nil || user == nil || user.Email == "" {
+		_ = s.repo.MarkEmailed(ctx, ids)
+		return
+	}
+
+	var subject, html string
+	var gerr error
+	if len(rows) == 1 {
+		n := rows[0]
+		subject = n.Title
+		html, gerr = templates.GenerateNotificationHTML(n.Title, n.Body, absoluteLink(n.Link), "")
+	} else {
+		sort.Slice(rows, func(i, j int) bool { return rows[i].CreatedAt.Before(rows[j].CreatedAt) })
+		items := make([]templates.DigestItem, 0, len(rows))
+		for _, n := range rows {
+			items = append(items, templates.DigestItem{Title: n.Title, Body: n.Body, URL: absoluteLink(n.Link)})
+		}
+		subject = fmt.Sprintf("%d updates in your Warmbly workspace", len(rows))
+		html, gerr = templates.GenerateDigestHTML(len(rows), items)
+	}
+	if gerr != nil {
+		_ = s.repo.RequeueEmails(ctx, ids, emailRetryDelay, emailMaxAttempts)
+		return
+	}
+	s.settleSend(ctx, ids, []string{user.Email}, subject, html)
+}
+
+func (s *service) settleSend(ctx context.Context, ids []uuid.UUID, to []string, subject, html string) {
+	sctx, cancel := context.WithTimeout(ctx, emailSendTimeout)
+	defer cancel()
+	if err := s.email.Send(sctx, to, nil, nil, subject, html); err != nil {
+		_ = s.repo.RequeueEmails(ctx, ids, emailRetryDelay, emailMaxAttempts)
+		return
+	}
+	_ = s.repo.MarkEmailed(ctx, ids)
+}
+
+func notifIDs(rows []models.Notification) []uuid.UUID {
+	ids := make([]uuid.UUID, 0, len(rows))
+	for _, n := range rows {
+		ids = append(ids, n.ID)
+	}
+	return ids
+}
+
+// absoluteLink turns a dashboard-relative link into a clickable URL.
+func absoluteLink(link string) string {
+	if link == "" || link[0] != '/' {
+		return link
+	}
+	base := strings.TrimRight(os.Getenv("APP_URL"), "/")
+	if base == "" {
+		base = "https://app.warmbly.com"
+	}
+	return base + link
+}

--- a/internal/app/notification/email.go
+++ b/internal/app/notification/email.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/notify/templates"
 )
@@ -25,7 +26,6 @@ import (
 // what keeps active users from ever being emailed about things they saw.
 const (
 	emailFlushEvery    = 30 * time.Second
-	emailSmartHold     = 15 * time.Minute
 	emailRetryDelay    = 10 * time.Minute
 	emailMaxAttempts   = 3
 	emailSendTimeout   = 10 * time.Second
@@ -33,24 +33,10 @@ const (
 	emailDailyCapValue = 25
 )
 
-// Hosted-deployment cost guards. Every notification email is provider spend
-// on the cloud, so the per-event instant cadence is opt-in (self-host sets
-// NOTIFICATION_EMAIL_ALLOW_INSTANT) and each user gets a rolling 24h email
-// budget (NOTIFICATION_EMAIL_DAILY_CAP, 0 disables). Security sign-in alerts
-// bypass both — they are rare and must always arrive.
-
-// InstantEmailAllowed reports whether the instant cadence is enabled on this
-// deployment. Off by default: the fastest hosted cadence is the smart hold.
-func InstantEmailAllowed() bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("NOTIFICATION_EMAIL_ALLOW_INSTANT"))) {
-	case "1", "true", "yes":
-		return true
-	}
-	return false
-}
-
 // EmailDailyCap is the max non-security notification emails one user receives
-// per rolling 24h. 0 means unlimited.
+// per rolling 24h — a backstop on top of the bundling window (which already
+// bounds the channel: there is no per-event mode, the floor is 30 minutes).
+// NOTIFICATION_EMAIL_DAILY_CAP overrides; 0 means unlimited.
 func EmailDailyCap() int {
 	if raw := os.Getenv("NOTIFICATION_EMAIL_DAILY_CAP"); raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
@@ -60,34 +46,14 @@ func EmailDailyCap() int {
 	return emailDailyCapValue
 }
 
-func smartHold() time.Duration {
-	if raw := os.Getenv("NOTIFICATION_EMAIL_SMART_HOLD"); raw != "" {
-		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-			return d
-		}
-	}
-	return emailSmartHold
-}
-
-// emailHold maps the user's cadence to the pending window. Security sign-in
-// alerts always go out on the next tick regardless of cadence.
-func emailHold(cadence string, category models.NotificationCategory) time.Duration {
+// emailHold maps the user's bundling window to the pending hold. Security
+// sign-in alerts always go out on the next tick regardless of the window.
+func emailHold(minutes int, category models.NotificationCategory) time.Duration {
 	if category == models.NotifSecuritySignIn {
 		return 0
 	}
-	switch cadence {
-	case models.EmailDigestInstant:
-		if !InstantEmailAllowed() {
-			return smartHold() // stored instant on a hosted deploy degrades to smart
-		}
-		return 0
-	case models.EmailDigestHourly:
-		return time.Hour
-	case models.EmailDigestDaily:
-		return 24 * time.Hour
-	default:
-		return smartHold()
-	}
+	m := min(max(minutes, config.NotificationEmailWindowMinMinutes), config.NotificationEmailWindowMaxMinutes)
+	return time.Duration(m) * time.Minute
 }
 
 // overEmailBudget reports whether a user has spent their rolling 24h email

--- a/internal/app/notification/push.go
+++ b/internal/app/notification/push.go
@@ -219,6 +219,10 @@ func digestTitle(category models.NotificationCategory, n int) string {
 		return fmt.Sprintf("%d worker alerts", n)
 	case models.NotifSecuritySignIn:
 		return fmt.Sprintf("%d new sign-ins", n)
+	case models.NotifBillingAlert:
+		return fmt.Sprintf("%d billing alerts", n)
+	case models.NotifTeamActivity:
+		return fmt.Sprintf("%d team updates", n)
 	default:
 		return fmt.Sprintf("%d new notifications", n)
 	}

--- a/internal/app/notification/service.go
+++ b/internal/app/notification/service.go
@@ -7,8 +7,6 @@ package notification
 
 import (
 	"context"
-	"os"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -17,7 +15,6 @@ import (
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
-	"github.com/warmbly/warmbly/internal/notify/templates"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -39,6 +36,12 @@ type UserLookup interface {
 	GetUser(ctx context.Context, id uuid.UUID) (*models.User, error)
 }
 
+// MemberLookup enumerates an org's members so NotifyOrg can resolve a
+// permission-targeted audience. Satisfied by the organization repository.
+type MemberLookup interface {
+	GetMembers(ctx context.Context, orgID uuid.UUID) ([]models.OrganizationMember, error)
+}
+
 type Service interface {
 	GetPreferences(ctx context.Context, userID uuid.UUID) (*models.NotificationPreferences, *errx.Error)
 	UpdatePreferences(ctx context.Context, userID uuid.UUID, prefs *models.NotificationPreferences) *errx.Error
@@ -50,10 +53,18 @@ type Service interface {
 	// Notify is the gated ingress — best-effort, never errors out the caller.
 	Notify(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any)
 
-	// WireDelivery attaches the email + Slack + user-lookup dependencies for
-	// the email/Slack channels (wired post-construction in both mains). Any
-	// may be nil — the matching channel is then skipped.
-	WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup)
+	// NotifyOrg raises the same notification for every accepted org member
+	// holding perm (never the whole org blindly), excluding exclude when set.
+	// Rows share groupKey, so the email flush coalesces the event into one
+	// message with every recipient in To; Slack fires at most once. Each
+	// member's own preferences still gate their channels. Best-effort.
+	NotifyOrg(ctx context.Context, orgID uuid.UUID, perm models.OrganizationPermission, exclude uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any, groupKey string)
+
+	// WireDelivery attaches the email + Slack + user/member-lookup
+	// dependencies (wired post-construction in both mains) and starts the
+	// email digest flush loop when the email channel is deliverable. Any
+	// dependency may be nil — the matching channel is then skipped.
+	WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup, members MemberLookup)
 
 	// WirePush attaches APNs + device-token storage + the Redis digest window
 	// and starts the digest loop. Any nil dependency leaves push disabled.
@@ -70,16 +81,21 @@ type service struct {
 	email     EmailSender
 	slack     SlackNotifier
 	users     UserLookup
+	members   MemberLookup
 
 	push         PushSender
 	deviceTokens repository.DeviceTokenRepository
 	pushRedis    *redis.Client
 }
 
-func (s *service) WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup) {
+func (s *service) WireDelivery(email EmailSender, slack SlackNotifier, users UserLookup, members MemberLookup) {
 	s.email = email
 	s.slack = slack
 	s.users = users
+	s.members = members
+	if s.email != nil && s.users != nil {
+		go s.emailFlushLoop()
+	}
 }
 
 func NewService(repo repository.NotificationRepository, publisher *pubsub.StreamingPublisher) Service {
@@ -131,24 +147,61 @@ func (s *service) MarkAllRead(ctx context.Context, userID uuid.UUID) *errx.Error
 	return nil
 }
 
-// Notify checks the user's preference for category and, when in-app is enabled,
-// persists a feed row + pushes a realtime event. Silent on any miss/error.
+// Notify checks the user's preference for category and fans the enabled
+// channels. Silent on any miss/error.
 func (s *service) Notify(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any) {
-	if s == nil || userID == uuid.Nil {
+	if s == nil {
 		return
+	}
+	s.notifyOne(ctx, userID, orgID, category, title, body, link, meta, "", false)
+}
+
+// NotifyOrg resolves the permission-targeted audience and raises the
+// notification for each member. Slack posts to one org workspace, so it fires
+// for the first member whose prefs allow it and stays suppressed for the rest.
+func (s *service) NotifyOrg(ctx context.Context, orgID uuid.UUID, perm models.OrganizationPermission, exclude uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any, groupKey string) {
+	if s == nil || s.members == nil || orgID == uuid.Nil {
+		return
+	}
+	members, err := s.members.GetMembers(ctx, orgID)
+	if err != nil {
+		return
+	}
+	org := orgID
+	slackFired := false
+	for _, m := range members {
+		if m.AcceptedAt == nil || m.UserID == uuid.Nil || m.UserID == exclude {
+			continue
+		}
+		if perm != 0 && !m.Permissions.HasPermission(perm) {
+			continue
+		}
+		fired := s.notifyOne(ctx, m.UserID, &org, category, title, body, link, meta, groupKey, slackFired)
+		slackFired = slackFired || fired
+	}
+}
+
+// notifyOne is the per-user ingress behind Notify/NotifyOrg. The feed row is
+// the delivery record for both the in-app and email channels: email-channel
+// rows queue as pending with a due time from the user's digest cadence, and
+// the flush loop bundles them later (see email.go). Returns whether the Slack
+// channel fired, so org fan-outs post to the shared workspace only once.
+func (s *service) notifyOne(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any, groupKey string, suppressSlack bool) bool {
+	if userID == uuid.Nil {
+		return false
 	}
 	prefs, err := s.repo.GetPreferences(ctx, userID)
 	if err != nil || prefs == nil {
-		return
+		return false
 	}
 	cat := prefs.CategoryPref(category)
 	if !cat.Enabled {
-		return // category off — no channel fires
+		return false // category off — no channel fires
 	}
 
-	// In-app: persist the feed row + push the realtime event.
-	if cat.Channels.InApp {
-		created, cerr := s.repo.Create(ctx, &models.Notification{
+	emailOn := cat.Channels.Email && s.email != nil && s.users != nil
+	if cat.Channels.InApp || emailOn {
+		n := &models.Notification{
 			UserID:         userID,
 			OrganizationID: orgID,
 			Category:       category,
@@ -156,19 +209,26 @@ func (s *service) Notify(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID
 			Body:           body,
 			Link:           link,
 			Metadata:       meta,
-		})
-		if cerr == nil && created != nil && s.publisher != nil {
+			GroupKey:       groupKey,
+			// In-app off but email on: keep the row as the email record
+			// without ringing the bell.
+			PreRead: !cat.Channels.InApp,
+		}
+		if emailOn {
+			due := time.Now().Add(emailHold(prefs.EmailDigest, category))
+			n.EmailState = "pending"
+			n.EmailDueAt = &due
+		}
+		created, cerr := s.repo.Create(ctx, n)
+		if cerr == nil && created != nil && cat.Channels.InApp && s.publisher != nil {
 			s.publisher.PublishNotificationCreated(ctx, userID.String(), created.ID.String(), string(category), title, link)
 		}
 	}
 
-	// Email: deliver to the user's account email (detached, best-effort).
-	if cat.Channels.Email && s.email != nil && s.users != nil {
-		go s.deliverEmail(userID, title, body, link)
-	}
-
 	// Slack: post to the org's connected workspace (detached, best-effort).
-	if cat.Channels.Slack && s.slack != nil && orgID != nil {
+	slackFired := false
+	if cat.Channels.Slack && !suppressSlack && s.slack != nil && orgID != nil {
+		slackFired = true
 		org := *orgID
 		go func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
@@ -181,30 +241,5 @@ func (s *service) Notify(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID
 	if cat.Channels.Push && s.push != nil && s.deviceTokens != nil && s.pushRedis != nil {
 		go s.deliverPush(userID, category, title, body, link)
 	}
-}
-
-// deliverEmail renders the notification on the shared transactional
-// shell and emails it to the user. Title/body are auto-escaped by the
-// template; a relative link is absolutized into the CTA button.
-func (s *service) deliverEmail(userID uuid.UUID, title, body, link string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	user, err := s.users.GetUser(ctx, userID)
-	if err != nil || user == nil || user.Email == "" {
-		return
-	}
-	href := link
-	if href != "" && href[0] == '/' {
-		base := strings.TrimRight(os.Getenv("APP_URL"), "/")
-		if base == "" {
-			base = "https://app.warmbly.com"
-		}
-		href = base + href
-	}
-	html, gerr := templates.GenerateNotificationHTML(title, body, href, "")
-	if gerr != nil {
-		return
-	}
-	_ = s.email.Send(ctx, []string{user.Email}, nil, nil, title, html)
+	return slackFired
 }

--- a/internal/app/notification/service.go
+++ b/internal/app/notification/service.go
@@ -107,6 +107,11 @@ func (s *service) GetPreferences(ctx context.Context, userID uuid.UUID) (*models
 	if err != nil {
 		return nil, errx.InternalError()
 	}
+	// Hosted deploys don't offer per-event email; a stored instant (set
+	// while self-hosted, or before the gate) reads back as smart.
+	if p != nil && p.EmailDigest == models.EmailDigestInstant && !InstantEmailAllowed() {
+		p.EmailDigest = models.EmailDigestSmart
+	}
 	return p, nil
 }
 

--- a/internal/app/notification/service.go
+++ b/internal/app/notification/service.go
@@ -107,11 +107,6 @@ func (s *service) GetPreferences(ctx context.Context, userID uuid.UUID) (*models
 	if err != nil {
 		return nil, errx.InternalError()
 	}
-	// Hosted deploys don't offer per-event email; a stored instant (set
-	// while self-hosted, or before the gate) reads back as smart.
-	if p != nil && p.EmailDigest == models.EmailDigestInstant && !InstantEmailAllowed() {
-		p.EmailDigest = models.EmailDigestSmart
-	}
 	return p, nil
 }
 
@@ -220,7 +215,7 @@ func (s *service) notifyOne(ctx context.Context, userID uuid.UUID, orgID *uuid.U
 			PreRead: !cat.Channels.InApp,
 		}
 		if emailOn {
-			due := time.Now().Add(emailHold(prefs.EmailDigest, category))
+			due := time.Now().Add(emailHold(prefs.EmailDigestMinutes, category))
 			n.EmailState = "pending"
 			n.EmailDueAt = &due
 		}

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -139,6 +139,15 @@ const (
 	UndoSendSecondsMin     = 5
 	UndoSendSecondsDefault = 30
 	UndoSendSecondsMax     = 120
+
+	// Notification email window: how long email-channel notifications hold
+	// before flushing as one bundled email. Per-user setting; the 30 minute
+	// floor is deliberate — there is no per-event email mode, so the channel
+	// can never become a per-notification firehose. Security sign-in alerts
+	// bypass the window entirely.
+	NotificationEmailWindowMinMinutes     = 30
+	NotificationEmailWindowDefaultMinutes = 30
+	NotificationEmailWindowMaxMinutes     = 1440
 )
 
 // InboundClassificationHeaders are the internet headers the API-based inbound

--- a/internal/infrastructure/db/migrations/000076_notification_email_digest.down.sql
+++ b/internal/infrastructure/db/migrations/000076_notification_email_digest.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_notifications_email_pending;
+ALTER TABLE notifications
+    DROP COLUMN IF EXISTS group_key,
+    DROP COLUMN IF EXISTS email_state,
+    DROP COLUMN IF EXISTS email_due_at,
+    DROP COLUMN IF EXISTS email_attempts;

--- a/internal/infrastructure/db/migrations/000076_notification_email_digest.up.sql
+++ b/internal/infrastructure/db/migrations/000076_notification_email_digest.up.sql
@@ -1,0 +1,14 @@
+-- Email digest state for the notification email channel. Rows queue as
+-- pending with a due time derived from the user's digest cadence; a flush
+-- loop bundles due rows into one email per user (or one shared email per
+-- org group), and reading a notification in-app cancels its pending email.
+ALTER TABLE notifications
+    ADD COLUMN group_key TEXT,
+    ADD COLUMN email_state TEXT NOT NULL DEFAULT 'none'
+        CONSTRAINT notifications_email_state_check
+        CHECK (email_state IN ('none', 'pending', 'sending', 'sent', 'skipped')),
+    ADD COLUMN email_due_at TIMESTAMPTZ,
+    ADD COLUMN email_attempts INT NOT NULL DEFAULT 0;
+
+CREATE INDEX idx_notifications_email_pending ON notifications (email_due_at)
+    WHERE email_state IN ('pending', 'sending');

--- a/internal/jobs/trial_expiration.go
+++ b/internal/jobs/trial_expiration.go
@@ -6,17 +6,34 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/notify"
 	"github.com/warmbly/warmbly/internal/notify/templates"
 	"github.com/warmbly/warmbly/internal/repository"
 )
+
+// OrgNotifier raises a permission-targeted org notification (in-app feed +
+// each member's enabled channels, email digest-coalesced). Satisfied by
+// *notification.Service; local interface to avoid an import cycle.
+type OrgNotifier interface {
+	NotifyOrg(ctx context.Context, orgID uuid.UUID, perm models.OrganizationPermission, exclude uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any, groupKey string)
+}
 
 // TrialExpirationJob handles expired free trials
 type TrialExpirationJob struct {
 	subRepo                  repository.SubscriptionRepository
 	db                       *pgxpool.Pool
 	emailNotificationService notify.EmailNotificationService
+	notifier                 OrgNotifier
+}
+
+// WireNotifier routes trial-expired alerts through the notification system
+// (billing members, preference-gated, one coalesced email) instead of the
+// legacy direct email to the subscription owner.
+func (j *TrialExpirationJob) WireNotifier(n OrgNotifier) {
+	j.notifier = n
 }
 
 // NewTrialExpirationJob creates a new trial expiration job
@@ -78,7 +95,19 @@ func (j *TrialExpirationJob) Run(ctx context.Context) error {
 			// Continue processing other users
 		}
 
-		// Send notification email to user
+		// Tell whoever can fix it: members with manage_billing, through the
+		// notification system (their prefs gate channels; the shared group
+		// key coalesces several admins into one email). Falls back to the
+		// legacy direct owner email when the notifier isn't wired.
+		if j.notifier != nil && sub.OrganizationID != uuid.Nil {
+			j.notifier.NotifyOrg(ctx, sub.OrganizationID, models.PermManageBilling, uuid.Nil,
+				models.NotifBillingAlert,
+				"Your Warmbly trial has expired",
+				"Campaigns are paused and warmup is disabled until you upgrade.",
+				"/app/settings/billing", nil,
+				"trial_expired:"+sub.OrganizationID.String())
+			continue
+		}
 		userEmail := ""
 		if sub.UserEmail != nil {
 			userEmail = *sub.UserEmail

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -18,7 +18,29 @@ const (
 	NotifHealthComplaint NotificationCategory = "health_complaint"
 	NotifWorkerDowntime  NotificationCategory = "health_worker_downtime"
 	NotifSecuritySignIn  NotificationCategory = "security_new_signin"
+	NotifBillingAlert    NotificationCategory = "billing_alert"
+	NotifTeamActivity    NotificationCategory = "team_activity"
 )
+
+// EmailDigestCadence controls how the email channel batches: instant sends as
+// soon as the flush loop ticks; the others hold pending emails for the window
+// so several notifications bundle into one message (and anything read in-app
+// before the hold expires is never emailed at all).
+const (
+	EmailDigestInstant = "instant"
+	EmailDigestSmart   = "smart"
+	EmailDigestHourly  = "hourly"
+	EmailDigestDaily   = "daily"
+)
+
+// ValidEmailDigest reports whether v is a known cadence value.
+func ValidEmailDigest(v string) bool {
+	switch v {
+	case EmailDigestInstant, EmailDigestSmart, EmailDigestHourly, EmailDigestDaily:
+		return true
+	}
+	return false
+}
 
 // ChannelPrefs is the per-category delivery toggles: in-app feed, account
 // email, a connected Slack workspace, and mobile push (APNs).
@@ -44,6 +66,12 @@ type NotificationPreferences struct {
 	HealthComplaint CategoryPref `json:"health_complaint"`
 	WorkerDowntime  CategoryPref `json:"health_worker_downtime"`
 	SecuritySignIn  CategoryPref `json:"security_new_signin"`
+	BillingAlert    CategoryPref `json:"billing_alert"`
+	TeamActivity    CategoryPref `json:"team_activity"`
+
+	// EmailDigest is the email-channel batching cadence (EmailDigest*
+	// constants). Security sign-in alerts always go out immediately.
+	EmailDigest string `json:"email_digest"`
 }
 
 // DefaultNotificationPreferences is the merge base. Health categories default ON
@@ -55,6 +83,9 @@ type NotificationPreferences struct {
 func DefaultNotificationPreferences() NotificationPreferences {
 	on := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true}}
 	off := CategoryPref{Enabled: false, Channels: ChannelPrefs{InApp: true, Push: true}}
+	// Billing defaults to email on: rare, and a paused workspace must reach
+	// whoever can fix it even when nobody is watching the dashboard.
+	billing := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true, Email: true}}
 	return NotificationPreferences{
 		InboundReply:    off,
 		InboundOOO:      off,
@@ -62,6 +93,9 @@ func DefaultNotificationPreferences() NotificationPreferences {
 		HealthComplaint: on,
 		WorkerDowntime:  on,
 		SecuritySignIn:  on,
+		BillingAlert:    billing,
+		TeamActivity:    on,
+		EmailDigest:     EmailDigestSmart,
 	}
 }
 
@@ -80,6 +114,10 @@ func (p NotificationPreferences) CategoryPref(c NotificationCategory) CategoryPr
 		return p.WorkerDowntime
 	case NotifSecuritySignIn:
 		return p.SecuritySignIn
+	case NotifBillingAlert:
+		return p.BillingAlert
+	case NotifTeamActivity:
+		return p.TeamActivity
 	default:
 		return CategoryPref{}
 	}
@@ -97,6 +135,18 @@ type Notification struct {
 	Metadata       map[string]any       `json:"metadata,omitempty"`
 	ReadAt         *time.Time           `json:"read_at,omitempty"`
 	CreatedAt      time.Time            `json:"created_at"`
+
+	// Email-channel digest bookkeeping — internal, never serialized to
+	// clients. GroupKey ties the same org event across users so the flush
+	// loop can coalesce it into one email with every recipient in To.
+	GroupKey      string     `json:"-"`
+	EmailState    string     `json:"-"`
+	EmailDueAt    *time.Time `json:"-"`
+	EmailAttempts int        `json:"-"`
+	// PreRead inserts the row already read: used when the user has the
+	// in-app channel off but email on, so the feed stays the delivery
+	// record without ringing the bell.
+	PreRead bool `json:"-"`
 }
 
 // UpdateNotificationPreferencesRequest is the PUT payload.

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -22,26 +22,6 @@ const (
 	NotifTeamActivity    NotificationCategory = "team_activity"
 )
 
-// EmailDigestCadence controls how the email channel batches: instant sends as
-// soon as the flush loop ticks; the others hold pending emails for the window
-// so several notifications bundle into one message (and anything read in-app
-// before the hold expires is never emailed at all).
-const (
-	EmailDigestInstant = "instant"
-	EmailDigestSmart   = "smart"
-	EmailDigestHourly  = "hourly"
-	EmailDigestDaily   = "daily"
-)
-
-// ValidEmailDigest reports whether v is a known cadence value.
-func ValidEmailDigest(v string) bool {
-	switch v {
-	case EmailDigestInstant, EmailDigestSmart, EmailDigestHourly, EmailDigestDaily:
-		return true
-	}
-	return false
-}
-
 // ChannelPrefs is the per-category delivery toggles: in-app feed, account
 // email, a connected Slack workspace, and mobile push (APNs).
 type ChannelPrefs struct {
@@ -69,9 +49,11 @@ type NotificationPreferences struct {
 	BillingAlert    CategoryPref `json:"billing_alert"`
 	TeamActivity    CategoryPref `json:"team_activity"`
 
-	// EmailDigest is the email-channel batching cadence (EmailDigest*
-	// constants). Security sign-in alerts always go out immediately.
-	EmailDigest string `json:"email_digest"`
+	// EmailDigestMinutes is the email-channel bundling window: pending
+	// notification emails hold this long, then flush as one email. Bounded
+	// by config.NotificationEmailWindow* (30 min floor, 24h ceiling).
+	// Security sign-in alerts always go out immediately.
+	EmailDigestMinutes int `json:"email_digest_minutes"`
 }
 
 // DefaultNotificationPreferences is the merge base. Health categories default ON
@@ -87,15 +69,15 @@ func DefaultNotificationPreferences() NotificationPreferences {
 	// whoever can fix it even when nobody is watching the dashboard.
 	billing := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true, Email: true}}
 	return NotificationPreferences{
-		InboundReply:    off,
-		InboundOOO:      off,
-		HealthBounce:    on,
-		HealthComplaint: on,
-		WorkerDowntime:  on,
-		SecuritySignIn:  on,
-		BillingAlert:    billing,
-		TeamActivity:    on,
-		EmailDigest:     EmailDigestSmart,
+		InboundReply:       off,
+		InboundOOO:         off,
+		HealthBounce:       on,
+		HealthComplaint:    on,
+		WorkerDowntime:     on,
+		SecuritySignIn:     on,
+		BillingAlert:       billing,
+		TeamActivity:       on,
+		EmailDigestMinutes: 30,
 	}
 }
 

--- a/internal/notify/templates/digest.go
+++ b/internal/notify/templates/digest.go
@@ -1,0 +1,74 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// Notification digest: several pending notifications bundled into one email
+// by the flush loop, so a busy stretch produces a single message instead of
+// a stream. Items render newest-last with their own links; titles and bodies
+// are plain text, auto-escaped by html/template.
+
+// DigestItem is one bundled notification.
+type DigestItem struct {
+	Title string
+	Body  string
+	URL   string
+}
+
+const digestContent = `
+<p style="margin:0 0 4px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:11px;color:#94a3b8;letter-spacing:0.14em;text-transform:uppercase;font-weight:500;">
+Digest
+</p>
+<h2 style="margin:0 0 12px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-weight:600;font-size:19px;color:#0f172a;letter-spacing:-0.01em;line-height:1.3;">
+While you were away
+</h2>
+<p style="margin:0 0 20px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;color:#475569;line-height:20px;">
+{{.Count}} updates in your Warmbly workspace, bundled into one email.
+</p>
+{{range .Items}}
+<div style="margin:0 0 14px;padding:12px 14px;border:1px solid #e2e8f0;border-radius:8px;">
+<p style="margin:0 0 2px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#0f172a;line-height:19px;">
+{{if .URL}}<a href="{{.URL}}" target="_blank" style="color:#0f172a;text-decoration:none;">{{.Title}}</a>{{else}}{{.Title}}{{end}}
+</p>
+{{if .Body}}
+<p style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12.5px;color:#475569;line-height:19px;">
+{{.Body}}
+</p>
+{{end}}
+</div>
+{{end}}
+<table cellpadding="0" cellspacing="0" border="0" align="center" role="presentation" style="margin:8px 0 24px;">
+<tr>
+<td align="center" style="border-radius:6px;background:#0f172a;">
+<a href="{{.AppURL}}" target="_blank" style="display:inline-block;padding:10px 22px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:0.01em;">Open Warmbly</a>
+</td>
+</tr>
+</table>
+<div style="margin:0 0 16px;height:1px;background:#e2e8f0;"></div>
+
+<p style="margin:0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:12px;color:#94a3b8;line-height:18px;">
+Updates you read in the app are never emailed, and the rest bundle on the cadence you chose. Manage both in your notification settings.
+</p>
+`
+
+var digestTmpl = template.Must(template.New("digest_content").Parse(digestContent))
+
+// GenerateDigestHTML renders the bundled-notifications email.
+func GenerateDigestHTML(count int, items []DigestItem) (string, error) {
+	data := struct {
+		Count  int
+		Items  []DigestItem
+		AppURL string
+	}{Count: count, Items: items, AppURL: AppURL}
+	var buf bytes.Buffer
+	if err := digestTmpl.Execute(&buf, data); err != nil {
+		sentry.CaptureException(err)
+		return "", err
+	}
+	return renderEmail(fmt.Sprintf("%d updates in your Warmbly workspace", count), buf.String())
+}

--- a/internal/repository/pg_notification.go
+++ b/internal/repository/pg_notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -20,6 +21,21 @@ type NotificationRepository interface {
 	CountUnread(ctx context.Context, userID uuid.UUID) (int, error)
 	MarkRead(ctx context.Context, userID, notifID uuid.UUID) error
 	MarkAllRead(ctx context.Context, userID uuid.UUID) error
+
+	// ClaimDueEmails atomically claims every pending email row belonging to a
+	// user with at least one due row (so all their pending mail bundles into
+	// one digest) or sharing an org group with a due row (so a shared event
+	// coalesces into one email even when its recipients digest on different
+	// cadences). Safe across replicas: the claim is an UPDATE guarded by
+	// FOR UPDATE SKIP LOCKED, and stale claims from crashed flushes recover
+	// back to pending first.
+	ClaimDueEmails(ctx context.Context) ([]models.Notification, error)
+	// MarkEmailed settles claimed rows as sent.
+	MarkEmailed(ctx context.Context, ids []uuid.UUID) error
+	// RequeueEmails returns claimed rows to pending after a send failure,
+	// with a retry delay; rows that already burned their attempts are
+	// dropped to skipped instead of retrying forever.
+	RequeueEmails(ctx context.Context, ids []uuid.UUID, delay time.Duration, maxAttempts int) error
 }
 
 type notificationRepository struct {
@@ -45,6 +61,9 @@ func (r *notificationRepository) GetPreferences(ctx context.Context, userID uuid
 	if len(raw) > 0 {
 		_ = json.Unmarshal(raw, &prefs)
 	}
+	if !models.ValidEmailDigest(prefs.EmailDigest) {
+		prefs.EmailDigest = models.EmailDigestSmart
+	}
 	return &prefs, nil
 }
 
@@ -65,11 +84,20 @@ func (r *notificationRepository) Create(ctx context.Context, n *models.Notificat
 	if len(meta) == 0 {
 		meta = []byte("{}")
 	}
+	if n.EmailState == "" {
+		n.EmailState = "none"
+	}
+	var groupKey *string
+	if n.GroupKey != "" {
+		groupKey = &n.GroupKey
+	}
 	err := r.db.QueryRow(ctx, `
-		INSERT INTO notifications (id, user_id, organization_id, category, title, body, link, metadata)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO notifications (id, user_id, organization_id, category, title, body, link, metadata,
+			group_key, email_state, email_due_at, read_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, CASE WHEN $12 THEN now() END)
 		RETURNING created_at`,
-		n.ID, n.UserID, n.OrganizationID, n.Category, n.Title, n.Body, n.Link, meta).Scan(&n.CreatedAt)
+		n.ID, n.UserID, n.OrganizationID, n.Category, n.Title, n.Body, n.Link, meta,
+		groupKey, n.EmailState, n.EmailDueAt, n.PreRead).Scan(&n.CreatedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +140,86 @@ func (r *notificationRepository) CountUnread(ctx context.Context, userID uuid.UU
 	return c, err
 }
 
+// MarkRead also cancels the row's pending email: a notification the user has
+// already seen in-app must never email them later.
 func (r *notificationRepository) MarkRead(ctx context.Context, userID, notifID uuid.UUID) error {
-	_, err := r.db.Exec(ctx, `UPDATE notifications SET read_at = now() WHERE id = $1 AND user_id = $2 AND read_at IS NULL`, notifID, userID)
+	_, err := r.db.Exec(ctx, `
+		UPDATE notifications
+		SET read_at = now(),
+			email_state = CASE WHEN email_state = 'pending' THEN 'skipped' ELSE email_state END
+		WHERE id = $1 AND user_id = $2 AND read_at IS NULL`, notifID, userID)
 	return err
 }
 
 func (r *notificationRepository) MarkAllRead(ctx context.Context, userID uuid.UUID) error {
-	_, err := r.db.Exec(ctx, `UPDATE notifications SET read_at = now() WHERE user_id = $1 AND read_at IS NULL`, userID)
+	_, err := r.db.Exec(ctx, `
+		UPDATE notifications
+		SET read_at = now(),
+			email_state = CASE WHEN email_state = 'pending' THEN 'skipped' ELSE email_state END
+		WHERE user_id = $1 AND read_at IS NULL`, userID)
+	return err
+}
+
+// ClaimDueEmails flips claimable rows to 'sending' and returns them. While a
+// row is 'sending', email_due_at doubles as the claim timestamp so crashed
+// claims can be recovered back to pending.
+func (r *notificationRepository) ClaimDueEmails(ctx context.Context) ([]models.Notification, error) {
+	_, _ = r.db.Exec(ctx, `
+		UPDATE notifications SET email_state = 'pending', email_due_at = now()
+		WHERE email_state = 'sending' AND email_due_at < now() - interval '10 minutes'`)
+
+	rows, err := r.db.Query(ctx, `
+		UPDATE notifications SET email_state = 'sending', email_due_at = now()
+		WHERE id IN (
+			SELECT n.id FROM notifications n
+			WHERE n.email_state = 'pending' AND (
+				n.user_id IN (
+					SELECT user_id FROM notifications
+					WHERE email_state = 'pending' AND email_due_at <= now())
+				OR (n.group_key IS NOT NULL AND n.organization_id IS NOT NULL AND (n.organization_id, n.group_key) IN (
+					SELECT organization_id, group_key FROM notifications
+					WHERE email_state = 'pending' AND email_due_at <= now()
+						AND group_key IS NOT NULL AND organization_id IS NOT NULL))
+			)
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING id, user_id, organization_id, category, title, body, link,
+			COALESCE(group_key, ''), email_attempts, created_at`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []models.Notification{}
+	for rows.Next() {
+		var n models.Notification
+		if err := rows.Scan(&n.ID, &n.UserID, &n.OrganizationID, &n.Category, &n.Title, &n.Body,
+			&n.Link, &n.GroupKey, &n.EmailAttempts, &n.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+func (r *notificationRepository) MarkEmailed(ctx context.Context, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err := r.db.Exec(ctx, `
+		UPDATE notifications SET email_state = 'sent', email_due_at = NULL
+		WHERE id = ANY($1) AND email_state = 'sending'`, ids)
+	return err
+}
+
+func (r *notificationRepository) RequeueEmails(ctx context.Context, ids []uuid.UUID, delay time.Duration, maxAttempts int) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err := r.db.Exec(ctx, `
+		UPDATE notifications SET
+			email_attempts = email_attempts + 1,
+			email_state = CASE WHEN email_attempts + 1 >= $3 THEN 'skipped' ELSE 'pending' END,
+			email_due_at = CASE WHEN email_attempts + 1 >= $3 THEN NULL ELSE now() + make_interval(secs => $2) END
+		WHERE id = ANY($1) AND email_state = 'sending'`, ids, delay.Seconds(), maxAttempts)
 	return err
 }

--- a/internal/repository/pg_notification.go
+++ b/internal/repository/pg_notification.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -68,9 +69,13 @@ func (r *notificationRepository) GetPreferences(ctx context.Context, userID uuid
 	if len(raw) > 0 {
 		_ = json.Unmarshal(raw, &prefs)
 	}
-	if !models.ValidEmailDigest(prefs.EmailDigest) {
-		prefs.EmailDigest = models.EmailDigestSmart
+	// Absent/zero (older blobs) takes the default; out-of-range clamps.
+	if prefs.EmailDigestMinutes == 0 {
+		prefs.EmailDigestMinutes = config.NotificationEmailWindowDefaultMinutes
 	}
+	prefs.EmailDigestMinutes = min(
+		max(prefs.EmailDigestMinutes, config.NotificationEmailWindowMinMinutes),
+		config.NotificationEmailWindowMaxMinutes)
 	return &prefs, nil
 }
 

--- a/internal/repository/pg_notification.go
+++ b/internal/repository/pg_notification.go
@@ -30,8 +30,15 @@ type NotificationRepository interface {
 	// FOR UPDATE SKIP LOCKED, and stale claims from crashed flushes recover
 	// back to pending first.
 	ClaimDueEmails(ctx context.Context) ([]models.Notification, error)
-	// MarkEmailed settles claimed rows as sent.
+	// MarkEmailed settles claimed rows as sent. On sent rows email_due_at
+	// becomes the send time, which is what the daily budget counts.
 	MarkEmailed(ctx context.Context, ids []uuid.UUID) error
+	// SkipEmails settles claimed rows as skipped (dropped recipient, spent
+	// budget); the in-app feed remains the record.
+	SkipEmails(ctx context.Context, ids []uuid.UUID) error
+	// CountEmailedSince counts notification emails delivered to a user after
+	// since — the rolling daily budget check.
+	CountEmailedSince(ctx context.Context, userID uuid.UUID, since time.Time) (int, error)
 	// RequeueEmails returns claimed rows to pending after a send failure,
 	// with a retry delay; rows that already burned their attempts are
 	// dropped to skipped instead of retrying forever.
@@ -206,9 +213,27 @@ func (r *notificationRepository) MarkEmailed(ctx context.Context, ids []uuid.UUI
 		return nil
 	}
 	_, err := r.db.Exec(ctx, `
-		UPDATE notifications SET email_state = 'sent', email_due_at = NULL
+		UPDATE notifications SET email_state = 'sent', email_due_at = now()
 		WHERE id = ANY($1) AND email_state = 'sending'`, ids)
 	return err
+}
+
+func (r *notificationRepository) SkipEmails(ctx context.Context, ids []uuid.UUID) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	_, err := r.db.Exec(ctx, `
+		UPDATE notifications SET email_state = 'skipped', email_due_at = NULL
+		WHERE id = ANY($1) AND email_state = 'sending'`, ids)
+	return err
+}
+
+func (r *notificationRepository) CountEmailedSince(ctx context.Context, userID uuid.UUID, since time.Time) (int, error) {
+	var c int
+	err := r.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM notifications
+		WHERE user_id = $1 AND email_state = 'sent' AND email_due_at >= $2`, userID, since).Scan(&c)
+	return c, err
 }
 
 func (r *notificationRepository) RequeueEmails(ctx context.Context, ids []uuid.UUID, delay time.Duration, maxAttempts int) error {

--- a/ios/Warmbly/Features/More/MoreModels.swift
+++ b/ios/Warmbly/Features/More/MoreModels.swift
@@ -302,6 +302,25 @@ struct NotificationPreferences: Codable, Sendable {
 
 struct MoreNotificationPreferencesEnvelope: Codable, Sendable {
     var preferences: NotificationPreferences?
+    var emailDelivery: MoreEmailDeliveryInfo?
+
+    enum CodingKeys: String, CodingKey {
+        case preferences
+        case emailDelivery = "email_delivery"
+    }
+}
+
+/// What the deployment's email channel offers: hosted deploys hide the
+/// per-event instant cadence (a cost sink there); self-hosted can enable it.
+/// dailyCap is the rolling 24h notification-email budget per user.
+struct MoreEmailDeliveryInfo: Codable, Sendable {
+    var instantAllowed: Bool?
+    var dailyCap: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case instantAllowed = "instant_allowed"
+        case dailyCap = "daily_cap"
+    }
 }
 
 struct MorePreferencesBody: Encodable {

--- a/ios/Warmbly/Features/More/MoreModels.swift
+++ b/ios/Warmbly/Features/More/MoreModels.swift
@@ -243,22 +243,60 @@ struct MoreCategoryPref: Codable, Sendable {
 }
 
 /// The preferences object keyed by category string; decoded dynamically so new
-/// backend categories render without an app update.
+/// backend categories render without an app update. `email_digest` is a sibling
+/// scalar in the same object, so it is split out of the category map.
 struct NotificationPreferences: Codable, Sendable {
     var categories: [String: MoreCategoryPref]
+    var emailDigest: String
 
-    init(categories: [String: MoreCategoryPref] = [:]) {
+    static let emailDigestKey = "email_digest"
+
+    init(categories: [String: MoreCategoryPref] = [:], emailDigest: String = "smart") {
         self.categories = categories
+        self.emailDigest = emailDigest
+    }
+
+    private struct DynamicKey: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { nil }
     }
 
     init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        categories = try container.decode([String: MoreCategoryPref].self)
+        let container = try decoder.container(keyedBy: DynamicKey.self)
+        var decoded: [String: MoreCategoryPref] = [:]
+        var digest = "smart"
+        for key in container.allKeys {
+            if key.stringValue == Self.emailDigestKey {
+                digest = (try? container.decode(String.self, forKey: key)) ?? "smart"
+            } else if let pref = try? container.decode(MoreCategoryPref.self, forKey: key) {
+                decoded[key.stringValue] = pref
+            }
+        }
+        // Older servers omit these categories; seed the backend defaults.
+        if decoded["billing_alert"] == nil {
+            decoded["billing_alert"] = MoreCategoryPref(
+                enabled: true,
+                channels: MoreChannelPrefs(inApp: true, email: true, slack: false, push: true)
+            )
+        }
+        if decoded["team_activity"] == nil {
+            decoded["team_activity"] = MoreCategoryPref(
+                enabled: true,
+                channels: MoreChannelPrefs(inApp: true, email: false, slack: false, push: true)
+            )
+        }
+        categories = decoded
+        emailDigest = digest
     }
 
     func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(categories)
+        var container = encoder.container(keyedBy: DynamicKey.self)
+        for (key, pref) in categories {
+            try container.encode(pref, forKey: DynamicKey(stringValue: key))
+        }
+        try container.encode(emailDigest, forKey: DynamicKey(stringValue: Self.emailDigestKey))
     }
 }
 

--- a/ios/Warmbly/Features/More/MoreModels.swift
+++ b/ios/Warmbly/Features/More/MoreModels.swift
@@ -243,17 +243,20 @@ struct MoreCategoryPref: Codable, Sendable {
 }
 
 /// The preferences object keyed by category string; decoded dynamically so new
-/// backend categories render without an app update. `email_digest` is a sibling
-/// scalar in the same object, so it is split out of the category map.
+/// backend categories render without an app update. `email_digest_minutes` is
+/// a sibling scalar in the same object, so it is split out of the category
+/// map (30 minute floor, 24h ceiling, mirroring the backend bounds).
 struct NotificationPreferences: Codable, Sendable {
     var categories: [String: MoreCategoryPref]
-    var emailDigest: String
+    var emailDigestMinutes: Int
 
-    static let emailDigestKey = "email_digest"
+    static let emailWindowKey = "email_digest_minutes"
+    static let emailWindowMin = 30
+    static let emailWindowMax = 1440
 
-    init(categories: [String: MoreCategoryPref] = [:], emailDigest: String = "smart") {
+    init(categories: [String: MoreCategoryPref] = [:], emailDigestMinutes: Int = 30) {
         self.categories = categories
-        self.emailDigest = emailDigest
+        self.emailDigestMinutes = emailDigestMinutes
     }
 
     private struct DynamicKey: CodingKey {
@@ -266,10 +269,11 @@ struct NotificationPreferences: Codable, Sendable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: DynamicKey.self)
         var decoded: [String: MoreCategoryPref] = [:]
-        var digest = "smart"
+        var window = Self.emailWindowMin
         for key in container.allKeys {
-            if key.stringValue == Self.emailDigestKey {
-                digest = (try? container.decode(String.self, forKey: key)) ?? "smart"
+            if key.stringValue == Self.emailWindowKey {
+                let raw = (try? container.decode(Int.self, forKey: key)) ?? Self.emailWindowMin
+                window = min(max(raw, Self.emailWindowMin), Self.emailWindowMax)
             } else if let pref = try? container.decode(MoreCategoryPref.self, forKey: key) {
                 decoded[key.stringValue] = pref
             }
@@ -288,7 +292,7 @@ struct NotificationPreferences: Codable, Sendable {
             )
         }
         categories = decoded
-        emailDigest = digest
+        emailDigestMinutes = window
     }
 
     func encode(to encoder: Encoder) throws {
@@ -296,7 +300,7 @@ struct NotificationPreferences: Codable, Sendable {
         for (key, pref) in categories {
             try container.encode(pref, forKey: DynamicKey(stringValue: key))
         }
-        try container.encode(emailDigest, forKey: DynamicKey(stringValue: Self.emailDigestKey))
+        try container.encode(emailDigestMinutes, forKey: DynamicKey(stringValue: Self.emailWindowKey))
     }
 }
 
@@ -310,15 +314,16 @@ struct MoreNotificationPreferencesEnvelope: Codable, Sendable {
     }
 }
 
-/// What the deployment's email channel offers: hosted deploys hide the
-/// per-event instant cadence (a cost sink there); self-hosted can enable it.
-/// dailyCap is the rolling 24h notification-email budget per user.
+/// Email-channel bounds from the deployment: the window range clients should
+/// offer, and the rolling 24h per-user email budget (0 = unlimited).
 struct MoreEmailDeliveryInfo: Codable, Sendable {
-    var instantAllowed: Bool?
+    var minMinutes: Int?
+    var maxMinutes: Int?
     var dailyCap: Int?
 
     enum CodingKeys: String, CodingKey {
-        case instantAllowed = "instant_allowed"
+        case minMinutes = "min_minutes"
+        case maxMinutes = "max_minutes"
         case dailyCap = "daily_cap"
     }
 }

--- a/ios/Warmbly/Features/More/NotificationsView.swift
+++ b/ios/Warmbly/Features/More/NotificationsView.swift
@@ -7,6 +7,7 @@ final class MoreNotificationsStore {
     var items: [UserNotification] = []
     var unread = 0
     var preferences: [String: MoreCategoryPref] = [:]
+    var emailDigest = "smart"
     var loadedOnce = false
     var isLoading = false
     var errorMessage: String?
@@ -26,6 +27,7 @@ final class MoreNotificationsStore {
             PushManager.shared.setBadge(unread)
             let envelope: MoreNotificationPreferencesEnvelope = try await api.get("auth/me/notification-preferences")
             preferences = envelope.preferences?.categories ?? [:]
+            emailDigest = envelope.preferences?.emailDigest ?? "smart"
             loadedOnce = true
         } catch {
             errorMessage = error.localizedDescription
@@ -64,6 +66,15 @@ final class MoreNotificationsStore {
         await persist(previous: previous, api)
     }
 
+    /// Email cadence, saved through the same PUT as the toggles.
+    func setEmailDigest(_ cadence: String, _ api: APIClient) async {
+        guard cadence != emailDigest else { return }
+        let previous = preferences
+        let previousDigest = emailDigest
+        emailDigest = cadence
+        await persist(previous: previous, previousDigest: previousDigest, api)
+    }
+
     /// Global channel state, like the web settings page: a channel reads "on"
     /// only when every category delivers to it.
     func channelOn(_ channel: WritableKeyPath<MoreChannelPrefs, Bool?>) -> Bool {
@@ -84,18 +95,22 @@ final class MoreNotificationsStore {
         await persist(previous: previous, api)
     }
 
-    private func persist(previous: [String: MoreCategoryPref], _ api: APIClient) async {
+    private func persist(previous: [String: MoreCategoryPref], previousDigest: String? = nil, _ api: APIClient) async {
         do {
-            let body = MorePreferencesBody(preferences: NotificationPreferences(categories: preferences))
+            let body = MorePreferencesBody(
+                preferences: NotificationPreferences(categories: preferences, emailDigest: emailDigest)
+            )
             let echoed: MoreNotificationPreferencesEnvelope = try await api.put(
                 "auth/me/notification-preferences",
                 body: body
             )
-            if let categories = echoed.preferences?.categories {
-                preferences = categories
+            if let echoedPrefs = echoed.preferences {
+                preferences = echoedPrefs.categories
+                emailDigest = echoedPrefs.emailDigest
             }
         } catch {
             preferences = previous
+            if let previousDigest { emailDigest = previousDigest }
             actionError = error.localizedDescription
         }
     }
@@ -110,6 +125,8 @@ private enum MoreNotificationMeta {
         case "health_complaint": return "flag.fill"
         case "health_worker_downtime": return "bolt.slash.fill"
         case "security_new_signin": return "lock.shield.fill"
+        case "billing_alert": return "creditcard.fill"
+        case "team_activity": return "person.2.fill"
         default: return "bell.fill"
         }
     }
@@ -122,6 +139,8 @@ private enum MoreNotificationMeta {
         case "health_complaint": return .rose
         case "health_worker_downtime": return .amber
         case "security_new_signin": return .indigo
+        case "billing_alert": return .orange
+        case "team_activity": return .sky
         default: return .sky
         }
     }
@@ -134,6 +153,8 @@ private enum MoreNotificationMeta {
         case "health_complaint": return "Spam complaints"
         case "health_worker_downtime": return "Worker downtime"
         case "security_new_signin": return "New sign-ins"
+        case "billing_alert": return "Billing"
+        case "team_activity": return "Team"
         default:
             let pretty = key.replacingOccurrences(of: "_", with: " ")
             return pretty.prefix(1).uppercased() + pretty.dropFirst()
@@ -148,6 +169,8 @@ private enum MoreNotificationMeta {
         case "health_complaint": return "A recipient marks your mail as spam"
         case "health_worker_downtime": return "A sending worker goes offline"
         case "security_new_signin": return "Your account signs in from a new device"
+        case "billing_alert": return "Your trial is ending or a payment needs attention"
+        case "team_activity": return "A teammate joined your workspace"
         default: return nil
         }
     }
@@ -156,7 +179,23 @@ private enum MoreNotificationMeta {
         ("Inbound", ["inbound_reply", "inbound_out_of_office"]),
         ("Mailbox health", ["health_bounce", "health_complaint", "health_worker_downtime"]),
         ("Security", ["security_new_signin"]),
+        ("Account", ["billing_alert", "team_activity"]),
     ]
+
+    static let digestOptions: [(value: String, label: String, caption: String)] = [
+        ("instant", "Instant", "Every alert emails right away."),
+        ("smart", "Smart", "Waits 15 minutes and skips anything you already read."),
+        ("hourly", "Hourly", "At most one bundled email per hour."),
+        ("daily", "Daily", "At most one bundled email per day."),
+    ]
+
+    static func digestLabel(_ value: String) -> String {
+        digestOptions.first(where: { $0.value == value })?.label ?? value.capitalized
+    }
+
+    static func digestCaption(_ value: String) -> String {
+        digestOptions.first(where: { $0.value == value })?.caption ?? "Choose how email alerts are bundled."
+    }
 }
 
 /// In-app notification feed plus per-category preferences, rendered as one
@@ -387,6 +426,36 @@ struct NotificationsView: View {
                 .font(.footnote)
                 .foregroundStyle(.secondary)
                 .padding(.top, 16)
+                .padding(.bottom, 4)
+                .moreFlatRow(separator: .hidden)
+            MoreFlatSectionHeader("Email delivery")
+            channelRow(
+                symbol: "tray.full.fill",
+                tone: .indigo,
+                label: "Cadence",
+                caption: MoreNotificationMeta.digestCaption(store.emailDigest)
+            ) {
+                Menu {
+                    Picker("Cadence", selection: digestBinding) {
+                        ForEach(MoreNotificationMeta.digestOptions, id: \.value) { option in
+                            Text(option.label).tag(option.value)
+                        }
+                    }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(MoreNotificationMeta.digestLabel(store.emailDigest))
+                            .font(.subheadline.weight(.medium))
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .foregroundStyle(WTheme.accent)
+                    .contentShape(Rectangle())
+                }
+            }
+            Text("Alerts you read in the app are never emailed. Security sign-in alerts always send immediately.")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.top, 16)
                 .padding(.bottom, 28)
                 .moreFlatRow(separator: .hidden)
         }
@@ -425,6 +494,15 @@ struct NotificationsView: View {
             get: { store.preferences[key]?.enabled ?? false },
             set: { newValue in
                 Task { await store.setEnabled(key, newValue, env.api) }
+            }
+        )
+    }
+
+    private var digestBinding: Binding<String> {
+        Binding(
+            get: { store.emailDigest },
+            set: { newValue in
+                Task { await store.setEmailDigest(newValue, env.api) }
             }
         )
     }

--- a/ios/Warmbly/Features/More/NotificationsView.swift
+++ b/ios/Warmbly/Features/More/NotificationsView.swift
@@ -8,6 +8,9 @@ final class MoreNotificationsStore {
     var unread = 0
     var preferences: [String: MoreCategoryPref] = [:]
     var emailDigest = "smart"
+    // Hosted deploys don't offer the per-event instant cadence (email there
+    // is metered spend); shown only when the server says it is available.
+    var instantAllowed = false
     var loadedOnce = false
     var isLoading = false
     var errorMessage: String?
@@ -28,6 +31,7 @@ final class MoreNotificationsStore {
             let envelope: MoreNotificationPreferencesEnvelope = try await api.get("auth/me/notification-preferences")
             preferences = envelope.preferences?.categories ?? [:]
             emailDigest = envelope.preferences?.emailDigest ?? "smart"
+            instantAllowed = envelope.emailDelivery?.instantAllowed ?? false
             loadedOnce = true
         } catch {
             errorMessage = error.localizedDescription
@@ -437,7 +441,10 @@ struct NotificationsView: View {
             ) {
                 Menu {
                     Picker("Cadence", selection: digestBinding) {
-                        ForEach(MoreNotificationMeta.digestOptions, id: \.value) { option in
+                        ForEach(
+                            MoreNotificationMeta.digestOptions.filter { store.instantAllowed || $0.value != "instant" },
+                            id: \.value
+                        ) { option in
                             Text(option.label).tag(option.value)
                         }
                     }

--- a/ios/Warmbly/Features/More/NotificationsView.swift
+++ b/ios/Warmbly/Features/More/NotificationsView.swift
@@ -7,10 +7,7 @@ final class MoreNotificationsStore {
     var items: [UserNotification] = []
     var unread = 0
     var preferences: [String: MoreCategoryPref] = [:]
-    var emailDigest = "smart"
-    // Hosted deploys don't offer the per-event instant cadence (email there
-    // is metered spend); shown only when the server says it is available.
-    var instantAllowed = false
+    var emailDigestMinutes = 30
     var loadedOnce = false
     var isLoading = false
     var errorMessage: String?
@@ -30,8 +27,7 @@ final class MoreNotificationsStore {
             PushManager.shared.setBadge(unread)
             let envelope: MoreNotificationPreferencesEnvelope = try await api.get("auth/me/notification-preferences")
             preferences = envelope.preferences?.categories ?? [:]
-            emailDigest = envelope.preferences?.emailDigest ?? "smart"
-            instantAllowed = envelope.emailDelivery?.instantAllowed ?? false
+            emailDigestMinutes = envelope.preferences?.emailDigestMinutes ?? 30
             loadedOnce = true
         } catch {
             errorMessage = error.localizedDescription
@@ -70,13 +66,13 @@ final class MoreNotificationsStore {
         await persist(previous: previous, api)
     }
 
-    /// Email cadence, saved through the same PUT as the toggles.
-    func setEmailDigest(_ cadence: String, _ api: APIClient) async {
-        guard cadence != emailDigest else { return }
+    /// Email bundling window, saved through the same PUT as the toggles.
+    func setEmailWindow(_ minutes: Int, _ api: APIClient) async {
+        guard minutes != emailDigestMinutes else { return }
         let previous = preferences
-        let previousDigest = emailDigest
-        emailDigest = cadence
-        await persist(previous: previous, previousDigest: previousDigest, api)
+        let previousWindow = emailDigestMinutes
+        emailDigestMinutes = minutes
+        await persist(previous: previous, previousWindow: previousWindow, api)
     }
 
     /// Global channel state, like the web settings page: a channel reads "on"
@@ -99,10 +95,10 @@ final class MoreNotificationsStore {
         await persist(previous: previous, api)
     }
 
-    private func persist(previous: [String: MoreCategoryPref], previousDigest: String? = nil, _ api: APIClient) async {
+    private func persist(previous: [String: MoreCategoryPref], previousWindow: Int? = nil, _ api: APIClient) async {
         do {
             let body = MorePreferencesBody(
-                preferences: NotificationPreferences(categories: preferences, emailDigest: emailDigest)
+                preferences: NotificationPreferences(categories: preferences, emailDigestMinutes: emailDigestMinutes)
             )
             let echoed: MoreNotificationPreferencesEnvelope = try await api.put(
                 "auth/me/notification-preferences",
@@ -110,11 +106,11 @@ final class MoreNotificationsStore {
             )
             if let echoedPrefs = echoed.preferences {
                 preferences = echoedPrefs.categories
-                emailDigest = echoedPrefs.emailDigest
+                emailDigestMinutes = echoedPrefs.emailDigestMinutes
             }
         } catch {
             preferences = previous
-            if let previousDigest { emailDigest = previousDigest }
+            if let previousWindow { emailDigestMinutes = previousWindow }
             actionError = error.localizedDescription
         }
     }
@@ -186,19 +182,30 @@ private enum MoreNotificationMeta {
         ("Account", ["billing_alert", "team_activity"]),
     ]
 
-    static let digestOptions: [(value: String, label: String, caption: String)] = [
-        ("instant", "Instant", "Every alert emails right away."),
-        ("smart", "Smart", "Waits 15 minutes and skips anything you already read."),
-        ("hourly", "Hourly", "At most one bundled email per hour."),
-        ("daily", "Daily", "At most one bundled email per day."),
+    // Bundling-window presets in minutes. The 30 minute floor mirrors the
+    // backend: there is no per-event email mode.
+    static let windowOptions: [(minutes: Int, label: String, caption: String)] = [
+        (30, "Every 30 minutes", "The fastest option. Skips anything you already read."),
+        (60, "Every hour", "At most one bundled email per hour."),
+        (180, "Every 3 hours", "A few bundles across a working day."),
+        (360, "Every 6 hours", "Morning, afternoon, evening."),
+        (720, "Every 12 hours", "Twice a day at most."),
+        (1440, "Once a day", "One daily summary of everything unread."),
     ]
 
-    static func digestLabel(_ value: String) -> String {
-        digestOptions.first(where: { $0.value == value })?.label ?? value.capitalized
+    static func windowLabel(_ minutes: Int) -> String {
+        if let match = windowOptions.first(where: { $0.minutes == minutes }) {
+            return match.label
+        }
+        if minutes % 60 == 0 {
+            return "Every \(minutes / 60) hours"
+        }
+        return "Every \(minutes) minutes"
     }
 
-    static func digestCaption(_ value: String) -> String {
-        digestOptions.first(where: { $0.value == value })?.caption ?? "Choose how email alerts are bundled."
+    static func windowCaption(_ minutes: Int) -> String {
+        windowOptions.first(where: { $0.minutes == minutes })?.caption
+            ?? "Bundles everything unread into one email per window."
     }
 }
 
@@ -436,21 +443,18 @@ struct NotificationsView: View {
             channelRow(
                 symbol: "tray.full.fill",
                 tone: .indigo,
-                label: "Cadence",
-                caption: MoreNotificationMeta.digestCaption(store.emailDigest)
+                label: "Bundling window",
+                caption: MoreNotificationMeta.windowCaption(store.emailDigestMinutes)
             ) {
                 Menu {
-                    Picker("Cadence", selection: digestBinding) {
-                        ForEach(
-                            MoreNotificationMeta.digestOptions.filter { store.instantAllowed || $0.value != "instant" },
-                            id: \.value
-                        ) { option in
-                            Text(option.label).tag(option.value)
+                    Picker("Bundling window", selection: windowBinding) {
+                        ForEach(windowChoices, id: \.self) { minutes in
+                            Text(MoreNotificationMeta.windowLabel(minutes)).tag(minutes)
                         }
                     }
                 } label: {
                     HStack(spacing: 4) {
-                        Text(MoreNotificationMeta.digestLabel(store.emailDigest))
+                        Text(MoreNotificationMeta.windowLabel(store.emailDigestMinutes))
                             .font(.subheadline.weight(.medium))
                         Image(systemName: "chevron.up.chevron.down")
                             .font(.caption2.weight(.semibold))
@@ -505,11 +509,22 @@ struct NotificationsView: View {
         )
     }
 
-    private var digestBinding: Binding<String> {
+    // Preset windows, plus the server value when it matches none (set to a
+    // custom window on the web) so the picker never lies about the state.
+    private var windowChoices: [Int] {
+        var choices = MoreNotificationMeta.windowOptions.map(\.minutes)
+        if !choices.contains(store.emailDigestMinutes) {
+            choices.append(store.emailDigestMinutes)
+            choices.sort()
+        }
+        return choices
+    }
+
+    private var windowBinding: Binding<Int> {
         Binding(
-            get: { store.emailDigest },
+            get: { store.emailDigestMinutes },
             set: { newValue in
-                Task { await store.setEmailDigest(newValue, env.api) }
+                Task { await store.setEmailWindow(newValue, env.api) }
             }
         )
     }

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -77,12 +77,17 @@ export default function NotificationsSettingsPage() {
         if (data) {
             // An older backend (or cached response) may miss newer categories;
             // the rows index them directly, so fill gaps with the defaults.
-            const full = normalizeNotificationPreferences(data);
+            const full = normalizeNotificationPreferences(data.preferences);
             setDraft(full);
             autosave.markSaved(full);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);
+
+    // Per-event email is a hosted cost sink; the backend only offers instant
+    // on deployments that opted in, and hides it otherwise.
+    const instantAllowed = data?.email_delivery?.instant_allowed === true;
+    const digestOptions = instantAllowed ? DIGEST_OPTIONS : DIGEST_OPTIONS.filter((o) => o.value !== "instant");
 
     const setEnabled = (key: NotificationCategoryKey, on: boolean) =>
         setDraft((d) => (d ? { ...d, [key]: { ...d[key], enabled: on } } : d));
@@ -168,7 +173,7 @@ export default function NotificationsSettingsPage() {
                             cols={2}
                             value={draft.email_digest}
                             onChange={(v) => setDraft((d) => (d ? { ...d, email_digest: v } : d))}
-                            options={DIGEST_OPTIONS}
+                            options={digestOptions}
                         />
                         <p className="text-[11px] text-slate-400 leading-relaxed">
                             Alerts you read in the app are never emailed. Security sign-in alerts always send immediately, and alerts that concern several teammates arrive as one shared email.

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -67,14 +67,17 @@ export default function NotificationsSettingsPage() {
     });
     useRegisterUnsaved(autosave, () => setDraft(autosave.savedValue));
 
+    // One-shot hydration: server data seeds the draft once (normalized, since
+    // an older backend or cached response may miss newer categories the rows
+    // index directly). After that the save path owns the baseline — re-adopting
+    // every refetch would stomp edits made while a save was in flight.
+    const hydratedRef = React.useRef(false);
     React.useEffect(() => {
-        if (data) {
-            // An older backend (or cached response) may miss newer categories;
-            // the rows index them directly, so fill gaps with the defaults.
-            const full = normalizeNotificationPreferences(data.preferences);
-            setDraft(full);
-            autosave.markSaved(full);
-        }
+        if (!data || hydratedRef.current) return;
+        hydratedRef.current = true;
+        const full = normalizeNotificationPreferences(data.preferences);
+        setDraft(full);
+        autosave.markSaved(full);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);
 

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -3,8 +3,13 @@ import {
     useNotificationPreferences,
     useUpdateNotificationPreferences,
 } from "@/lib/api/hooks/app/notifications/useNotifications";
-import type { NotificationCategoryKey, NotificationPreferences } from "@/lib/api/models/app/notifications/Notification";
+import type {
+    EmailDigestCadence,
+    NotificationCategoryKey,
+    NotificationPreferences,
+} from "@/lib/api/models/app/notifications/Notification";
 import { Row, Section, SectionShell, Toggle } from "../_components/SectionShell";
+import { OptionSelect } from "@/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox";
 import SaveStatus from "../_components/SaveStatus";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useRegisterUnsaved } from "@/hooks/context/unsaved";
@@ -22,6 +27,32 @@ const HEALTH: { key: NotificationCategoryKey; label: string; hint: string }[] = 
 
 const SECURITY: { key: NotificationCategoryKey; label: string; hint: string }[] = [
     { key: "security_new_signin", label: "New sign-in", hint: "Your account was accessed from a device you haven't used before." },
+];
+
+const BILLING: { key: NotificationCategoryKey; label: string; hint: string }[] = [
+    { key: "billing_alert", label: "Trial and billing alerts", hint: "Your trial is about to expire or your workspace was paused. Goes to members who manage billing." },
+];
+
+const TEAM: { key: NotificationCategoryKey; label: string; hint: string }[] = [
+    { key: "team_activity", label: "Teammate joined your workspace", hint: "A new member accepted an invite. Goes to members who manage the team." },
+];
+
+const DIGEST_OPTIONS: { value: EmailDigestCadence; label: React.ReactNode; hint: string }[] = [
+    { value: "instant", label: "Instant", hint: "Every alert is its own email, sent right away." },
+    {
+        value: "smart",
+        label: (
+            <span className="inline-flex items-center gap-1.5">
+                Smart
+                <span className="text-[9.5px] uppercase tracking-[0.08em] font-semibold rounded-sm px-1 py-px bg-sky-100 text-sky-700">
+                    Recommended
+                </span>
+            </span>
+        ),
+        hint: "Waits 15 minutes, then bundles what you have not already read into one email.",
+    },
+    { value: "hourly", label: "Hourly", hint: "At most one bundled email per hour." },
+    { value: "daily", label: "Daily", hint: "At most one bundled email per day." },
 ];
 
 export default function NotificationsSettingsPage() {
@@ -59,6 +90,8 @@ export default function NotificationsSettingsPage() {
         "health_complaint",
         "health_worker_downtime",
         "security_new_signin",
+        "billing_alert",
+        "team_activity",
     ];
     // Channels present globally: "on" when every category carries the channel.
     const channelOn = (ch: "email" | "slack" | "push") =>
@@ -102,6 +135,12 @@ export default function NotificationsSettingsPage() {
                     <Section eyebrow="Security" description="Account access alerts.">
                         {rows(SECURITY)}
                     </Section>
+                    <Section eyebrow="Billing" description="Trial and billing alerts.">
+                        {rows(BILLING)}
+                    </Section>
+                    <Section eyebrow="Team" description="Activity from your teammates.">
+                        {rows(TEAM)}
+                    </Section>
                     <Section eyebrow="Channels" description="Where enabled notifications are delivered. Applies across every category above.">
                         <Row label="In-app" description="The bell in the dashboard chrome (controlled per category above).">
                             <span className="text-[11px] font-medium text-emerald-600">On</span>
@@ -118,6 +157,18 @@ export default function NotificationsSettingsPage() {
                         <Row label="Slack" description="Posts to your connected Slack, on the channel set up for Slack in the Integrations tab. Connect Slack and configure a channel there first.">
                             <Toggle on={channelOn("slack")} onChange={(v) => setChannel("slack", v)} />
                         </Row>
+                    </Section>
+                    <Section eyebrow="Email delivery" description="How often the email channel sends. Bundling keeps a busy day to a few emails instead of one per alert.">
+                        <OptionSelect
+                            aria-label="Email digest cadence"
+                            cols={2}
+                            value={draft.email_digest}
+                            onChange={(v) => setDraft((d) => (d ? { ...d, email_digest: v } : d))}
+                            options={DIGEST_OPTIONS}
+                        />
+                        <p className="text-[11px] text-slate-400 leading-relaxed">
+                            Alerts you read in the app are never emailed. Security sign-in alerts always send immediately, and alerts that concern several teammates arrive as one shared email.
+                        </p>
                     </Section>
                 </>
             )}

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -4,13 +4,15 @@ import {
     useUpdateNotificationPreferences,
 } from "@/lib/api/hooks/app/notifications/useNotifications";
 import {
+    EMAIL_WINDOW_MAX_MINUTES,
+    EMAIL_WINDOW_MIN_MINUTES,
     normalizeNotificationPreferences,
-    type EmailDigestCadence,
     type NotificationCategoryKey,
     type NotificationPreferences,
 } from "@/lib/api/models/app/notifications/Notification";
 import { Row, Section, SectionShell, Toggle } from "../_components/SectionShell";
 import { OptionSelect } from "@/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox";
+import { NumberInput } from "@/components/ui/field";
 import SaveStatus from "../_components/SaveStatus";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useRegisterUnsaved } from "@/hooks/context/unsaved";
@@ -38,22 +40,14 @@ const TEAM: { key: NotificationCategoryKey; label: string; hint: string }[] = [
     { key: "team_activity", label: "Teammate joined your workspace", hint: "A new member accepted an invite. Goes to members who manage the team." },
 ];
 
-const DIGEST_OPTIONS: { value: EmailDigestCadence; label: React.ReactNode; hint: string }[] = [
-    { value: "instant", label: "Instant", hint: "Every alert is its own email, sent right away." },
-    {
-        value: "smart",
-        label: (
-            <span className="inline-flex items-center gap-1.5">
-                Smart
-                <span className="text-[9.5px] uppercase tracking-[0.08em] font-semibold rounded-sm px-1 py-px bg-sky-100 text-sky-700">
-                    Recommended
-                </span>
-            </span>
-        ),
-        hint: "Waits 15 minutes, then bundles what you have not already read into one email.",
-    },
-    { value: "hourly", label: "Hourly", hint: "At most one bundled email per hour." },
-    { value: "daily", label: "Daily", hint: "At most one bundled email per day." },
+// Window presets in minutes; "custom" reveals a minutes input. There is no
+// per-event option on purpose — 30 minutes is the floor.
+const WINDOW_PRESETS: { value: string; label: React.ReactNode; hint: string }[] = [
+    { value: "30", label: "Every 30 minutes", hint: "The fastest option. Bundles anything you have not already read." },
+    { value: "60", label: "Every hour", hint: "At most one bundled email per hour." },
+    { value: "180", label: "Every 3 hours", hint: "A few bundles across a working day." },
+    { value: "1440", label: "Once a day", hint: "One daily summary of everything unread." },
+    { value: "custom", label: "Custom", hint: "Pick your own window, from 30 minutes up to a day." },
 ];
 
 export default function NotificationsSettingsPage() {
@@ -84,10 +78,22 @@ export default function NotificationsSettingsPage() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);
 
-    // Per-event email is a hosted cost sink; the backend only offers instant
-    // on deployments that opted in, and hides it otherwise.
-    const instantAllowed = data?.email_delivery?.instant_allowed === true;
-    const digestOptions = instantAllowed ? DIGEST_OPTIONS : DIGEST_OPTIONS.filter((o) => o.value !== "instant");
+    // Window selection: preset when the minutes match one, custom otherwise.
+    // customMode keeps Custom selected while its input holds a preset value.
+    const [customMode, setCustomMode] = React.useState(false);
+    const minutes = draft?.email_digest_minutes ?? EMAIL_WINDOW_MIN_MINUTES;
+    const matchingPreset = WINDOW_PRESETS.find((p) => p.value === String(minutes) && p.value !== "custom");
+    const windowSelection = customMode || !matchingPreset ? "custom" : matchingPreset.value;
+    const setMinutes = (m: number) =>
+        setDraft((d) => (d ? { ...d, email_digest_minutes: m } : d));
+    const pickWindow = (v: string) => {
+        if (v === "custom") {
+            setCustomMode(true);
+            return;
+        }
+        setCustomMode(false);
+        setMinutes(Number(v));
+    };
 
     const setEnabled = (key: NotificationCategoryKey, on: boolean) =>
         setDraft((d) => (d ? { ...d, [key]: { ...d[key], enabled: on } } : d));
@@ -167,14 +173,28 @@ export default function NotificationsSettingsPage() {
                             <Toggle on={channelOn("slack")} onChange={(v) => setChannel("slack", v)} />
                         </Row>
                     </Section>
-                    <Section eyebrow="Email delivery" description="How often the email channel sends. Bundling keeps a busy day to a few emails instead of one per alert.">
+                    <Section eyebrow="Email delivery" description="How often the email channel sends. Everything unread bundles into one email per window, so a busy day costs a few emails instead of one per alert.">
                         <OptionSelect
-                            aria-label="Email digest cadence"
+                            aria-label="Email bundling window"
                             cols={2}
-                            value={draft.email_digest}
-                            onChange={(v) => setDraft((d) => (d ? { ...d, email_digest: v } : d))}
-                            options={digestOptions}
+                            value={windowSelection}
+                            onChange={pickWindow}
+                            options={WINDOW_PRESETS}
                         />
+                        {windowSelection === "custom" && (
+                            <div className="flex items-center gap-2">
+                                <span className="text-[12px] text-slate-500">Bundle every</span>
+                                <NumberInput
+                                    value={minutes}
+                                    onChange={setMinutes}
+                                    min={EMAIL_WINDOW_MIN_MINUTES}
+                                    max={EMAIL_WINDOW_MAX_MINUTES}
+                                    step={15}
+                                    suffix="minutes"
+                                    className="w-36"
+                                />
+                            </div>
+                        )}
                         <p className="text-[11px] text-slate-400 leading-relaxed">
                             Alerts you read in the app are never emailed. Security sign-in alerts always send immediately, and alerts that concern several teammates arrive as one shared email.
                         </p>

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -3,10 +3,11 @@ import {
     useNotificationPreferences,
     useUpdateNotificationPreferences,
 } from "@/lib/api/hooks/app/notifications/useNotifications";
-import type {
-    EmailDigestCadence,
-    NotificationCategoryKey,
-    NotificationPreferences,
+import {
+    normalizeNotificationPreferences,
+    type EmailDigestCadence,
+    type NotificationCategoryKey,
+    type NotificationPreferences,
 } from "@/lib/api/models/app/notifications/Notification";
 import { Row, Section, SectionShell, Toggle } from "../_components/SectionShell";
 import { OptionSelect } from "@/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox";
@@ -74,8 +75,11 @@ export default function NotificationsSettingsPage() {
 
     React.useEffect(() => {
         if (data) {
-            setDraft(data);
-            autosave.markSaved(data);
+            // An older backend (or cached response) may miss newer categories;
+            // the rows index them directly, so fill gaps with the defaults.
+            const full = normalizeNotificationPreferences(data);
+            setDraft(full);
+            autosave.markSaved(full);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [data]);

--- a/web/src/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox.tsx
+++ b/web/src/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox.tsx
@@ -167,7 +167,7 @@ export function OptionSelect<T extends string>({
 }: {
     value: T;
     onChange: (v: T) => void;
-    options: { value: T; label: string; hint?: string }[];
+    options: { value: T; label: React.ReactNode; hint?: string }[];
     /** Columns from the sm breakpoint up. Mobile is always a single column. */
     cols?: 1 | 2 | 3;
     className?: string;

--- a/web/src/components/layout/NotificationBell.tsx
+++ b/web/src/components/layout/NotificationBell.tsx
@@ -5,7 +5,19 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { AnimatePresence, motion } from "framer-motion";
-import { BellIcon } from "lucide-react";
+import {
+    BellIcon,
+    ClockIcon,
+    CreditCardIcon,
+    KeyRoundIcon,
+    ReplyIcon,
+    ServerCrashIcon,
+    Settings2Icon,
+    ShieldAlertIcon,
+    TriangleAlertIcon,
+    UsersIcon,
+    type LucideIcon,
+} from "lucide-react";
 import useClickOutside from "@/hooks/useClickOutside";
 import {
     useNotifications,
@@ -14,26 +26,137 @@ import {
 } from "@/lib/api/hooks/app/notifications/useNotifications";
 import type { AppNotification } from "@/lib/api/models/app/notifications/Notification";
 
+// Per-category icon + tone so the list scans by kind before reading titles.
+const CATEGORY_META: Record<string, { icon: LucideIcon; tone: string }> = {
+    inbound_reply: { icon: ReplyIcon, tone: "bg-sky-50 text-sky-600" },
+    inbound_out_of_office: { icon: ClockIcon, tone: "bg-slate-100 text-slate-500" },
+    health_bounce: { icon: TriangleAlertIcon, tone: "bg-amber-50 text-amber-600" },
+    health_complaint: { icon: ShieldAlertIcon, tone: "bg-rose-50 text-rose-600" },
+    health_worker_downtime: { icon: ServerCrashIcon, tone: "bg-rose-50 text-rose-600" },
+    security_new_signin: { icon: KeyRoundIcon, tone: "bg-violet-50 text-violet-600" },
+    billing_alert: { icon: CreditCardIcon, tone: "bg-amber-50 text-amber-600" },
+    team_activity: { icon: UsersIcon, tone: "bg-emerald-50 text-emerald-600" },
+};
+
+const FALLBACK_META = { icon: BellIcon, tone: "bg-slate-100 text-slate-500" };
+
+type Bucket = "today" | "yesterday" | "earlier";
+
+const BUCKET_LABELS: Record<Bucket, string> = {
+    today: "Today",
+    yesterday: "Yesterday",
+    earlier: "Earlier",
+};
+
+function startOfToday(): number {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+}
+
+function bucketFor(d: Date): Bucket {
+    const today = startOfToday();
+    const yesterday = today - 24 * 60 * 60 * 1000;
+    const t = d.getTime();
+    if (t >= today) return "today";
+    if (t >= yesterday) return "yesterday";
+    return "earlier";
+}
+
+// Compact relative timestamp: "now", "2m", "3h", "Yesterday", then a short date.
+function relTime(iso: string): string {
+    const d = new Date(iso);
+    const s = Math.max(0, Math.floor((Date.now() - d.getTime()) / 1000));
+    if (s < 60) return "now";
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m`;
+    const h = Math.floor(m / 60);
+    if (h < 24) return `${h}h`;
+    if (bucketFor(d) === "yesterday") return "Yesterday";
+    return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
 export function NotificationBell() {
-    const { data } = useNotifications();
+    const { data, isLoading } = useNotifications();
     const markAll = useMarkAllNotificationsRead();
     const markOne = useMarkNotificationRead();
     const [open, setOpen] = React.useState(false);
+    const [filter, setFilter] = React.useState<"all" | "unread">("all");
     const ref = React.useRef<HTMLDivElement>(null);
     const close = React.useCallback(() => setOpen(false), []);
     useClickOutside(ref, close);
 
     const unread = data?.unread ?? 0;
     const items = data?.notifications ?? [];
+    const visible = filter === "unread" ? items.filter((n) => !n.read_at) : items;
 
-    const itemBody = (n: AppNotification) => (
-        <div className="flex items-start gap-2">
-            {!n.read_at && <span className="mt-1.5 size-1.5 rounded-full bg-sky-500 shrink-0" />}
-            <div className={`min-w-0 ${n.read_at ? "opacity-60" : ""}`}>
-                <div className="text-[12px] font-medium text-slate-800 truncate">{n.title}</div>
-                {n.body && <div className="text-[11px] text-slate-500 truncate">{n.body}</div>}
-                <div className="text-[10px] text-slate-400 mt-0.5">{new Date(n.created_at).toLocaleString()}</div>
+    // Group by day bucket; the feed is newest → oldest, so one pass keeps
+    // both global order and group adjacency (same shape as the unibox list).
+    const grouped = React.useMemo(() => {
+        const groups: { bucket: Bucket; rows: AppNotification[] }[] = [];
+        for (const n of visible) {
+            const b = bucketFor(new Date(n.created_at));
+            const tail = groups[groups.length - 1];
+            if (tail && tail.bucket === b) tail.rows.push(n);
+            else groups.push({ bucket: b, rows: [n] });
+        }
+        return groups;
+    }, [visible]);
+
+    const itemBody = (n: AppNotification) => {
+        const meta = CATEGORY_META[n.category] ?? FALLBACK_META;
+        const Icon = meta.icon;
+        return (
+            <div className="flex items-start gap-2.5">
+                <span className={`mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md ${meta.tone}`}>
+                    <Icon className="size-3.5" />
+                </span>
+                <div className="min-w-0 flex-1">
+                    <div
+                        className={`text-[12px] truncate ${
+                            n.read_at ? "font-normal text-slate-600" : "font-semibold text-slate-900"
+                        }`}
+                    >
+                        {n.title}
+                    </div>
+                    {n.body && (
+                        <div className={`text-[11px] truncate ${n.read_at ? "text-slate-400" : "text-slate-500"}`}>
+                            {n.body}
+                        </div>
+                    )}
+                </div>
+                <div className="flex shrink-0 items-center gap-1.5 pt-0.5">
+                    <span className="text-[10px] text-slate-400">{relTime(n.created_at)}</span>
+                    {!n.read_at && <span className="size-1.5 rounded-full bg-sky-500" />}
+                </div>
             </div>
+        );
+    };
+
+    const rowClass = (n: AppNotification) =>
+        `block w-full text-left px-3 py-2 border-l-2 transition-colors hover:bg-slate-50 ${
+            n.read_at ? "border-l-transparent" : "border-l-sky-500 bg-sky-50/40"
+        }`;
+
+    const emptyState = (
+        <div className="px-3 py-8 flex flex-col items-center gap-2 text-center">
+            <span className="flex size-8 items-center justify-center rounded-full bg-slate-100 text-slate-400">
+                <BellIcon className="size-4" />
+            </span>
+            <span className="text-[12px] text-slate-400">You&apos;re all caught up.</span>
+        </div>
+    );
+
+    const skeleton = (
+        <div className="px-3 py-2.5 space-y-3 animate-pulse" aria-hidden="true">
+            {[0, 1, 2, 3].map((i) => (
+                <div key={i} className="flex items-start gap-2.5">
+                    <div className="size-6 rounded-md bg-slate-100" />
+                    <div className="flex-1 space-y-1.5 pt-0.5">
+                        <div className="h-2.5 w-2/3 rounded bg-slate-100" />
+                        <div className="h-2 w-1/2 rounded bg-slate-100" />
+                    </div>
+                </div>
+            ))}
         </div>
     );
 
@@ -60,51 +183,76 @@ export function NotificationBell() {
                         animate={{ opacity: 1, y: 0 }}
                         exit={{ opacity: 0, y: -4 }}
                         transition={{ duration: 0.12 }}
-                        className="absolute right-0 top-full mt-1.5 w-80 max-w-[90vw] rounded-md border border-slate-200 bg-white shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)] z-50 overflow-hidden"
+                        className="absolute right-0 top-full mt-1.5 w-[340px] max-w-[90vw] rounded-md border border-slate-200 bg-white shadow-[0_12px_32px_-8px_rgba(15,23,42,0.18)] z-50 overflow-hidden"
                     >
-                    <div className="h-9 px-3 flex items-center border-b border-slate-200">
-                        <span className="text-[12px] font-medium text-slate-900">Notifications</span>
-                        {unread > 0 && (
-                            <button
-                                type="button"
-                                onClick={() => markAll.mutate()}
-                                className="ml-auto text-[11px] text-sky-600 hover:text-sky-700"
-                            >
-                                Mark all read
-                            </button>
-                        )}
-                    </div>
-                    <div className="max-h-96 overflow-y-auto">
-                        {items.length === 0 ? (
-                            <div className="px-3 py-6 text-center text-[12px] text-slate-400">You&apos;re all caught up.</div>
-                        ) : (
-                            items.map((n) => {
-                                const click = () => {
-                                    if (!n.read_at) markOne.mutate(n.id);
-                                    setOpen(false);
-                                };
-                                return n.link ? (
-                                    <Link
-                                        key={n.id}
-                                        to={n.link}
-                                        onClick={click}
-                                        className="block px-3 py-2 hover:bg-slate-50 border-b border-slate-100 last:border-0"
-                                    >
-                                        {itemBody(n)}
-                                    </Link>
-                                ) : (
+                        <div className="h-9 px-3 flex items-center gap-2 border-b border-slate-200">
+                            <span className="text-[12px] font-medium text-slate-900">Notifications</span>
+                            <div className="ml-auto flex items-center gap-0.5 rounded-md bg-slate-100 p-0.5">
+                                {(["all", "unread"] as const).map((f) => (
                                     <button
-                                        key={n.id}
+                                        key={f}
                                         type="button"
-                                        onClick={click}
-                                        className="block w-full text-left px-3 py-2 hover:bg-slate-50 border-b border-slate-100 last:border-0"
+                                        onClick={() => setFilter(f)}
+                                        className={`h-5 px-1.5 rounded text-[10.5px] font-medium transition-colors ${
+                                            filter === f
+                                                ? "bg-white text-slate-900 shadow-sm"
+                                                : "text-slate-500 hover:text-slate-900"
+                                        }`}
                                     >
-                                        {itemBody(n)}
+                                        {f === "all" ? "All" : "Unread"}
                                     </button>
-                                );
-                            })
-                        )}
-                    </div>
+                                ))}
+                            </div>
+                            {unread > 0 && (
+                                <button
+                                    type="button"
+                                    onClick={() => markAll.mutate()}
+                                    className="text-[11px] text-sky-600 hover:text-sky-700 shrink-0"
+                                >
+                                    Mark all read
+                                </button>
+                            )}
+                        </div>
+                        <div className="max-h-96 overflow-y-auto">
+                            {isLoading ? (
+                                skeleton
+                            ) : visible.length === 0 ? (
+                                emptyState
+                            ) : (
+                                grouped.map((g) => (
+                                    <div key={g.bucket}>
+                                        <div className="sticky top-0 z-10 px-3 pt-2 pb-1 bg-white text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">
+                                            {BUCKET_LABELS[g.bucket]}
+                                        </div>
+                                        {g.rows.map((n) => {
+                                            const click = () => {
+                                                if (!n.read_at) markOne.mutate(n.id);
+                                                setOpen(false);
+                                            };
+                                            return n.link ? (
+                                                <Link key={n.id} to={n.link} onClick={click} className={rowClass(n)}>
+                                                    {itemBody(n)}
+                                                </Link>
+                                            ) : (
+                                                <button key={n.id} type="button" onClick={click} className={rowClass(n)}>
+                                                    {itemBody(n)}
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                ))
+                            )}
+                        </div>
+                        <div className="border-t border-slate-200 bg-slate-50/60">
+                            <Link
+                                to="/app/settings/notifications"
+                                onClick={close}
+                                className="flex h-8 items-center justify-center gap-1.5 text-[11.5px] text-slate-500 hover:text-slate-900 transition-colors"
+                            >
+                                <Settings2Icon className="size-3.5" />
+                                Notification settings
+                            </Link>
+                        </div>
                     </motion.div>
                 )}
             </AnimatePresence>

--- a/web/src/hooks/useAutosave.ts
+++ b/web/src/hooks/useAutosave.ts
@@ -41,6 +41,7 @@ export function useAutosave<T>({
     const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const initializedRef = useRef(false);
+    const inflightRef = useRef<Promise<void> | null>(null);
     valueRef.current = value;
 
     const commitSaved = useCallback((v: T) => {
@@ -48,26 +49,39 @@ export function useAutosave<T>({
         setSavedValue(v);
     }, []);
 
-    const run = useCallback(async () => {
-        const toSave = valueRef.current;
-        if (isEqual(toSave, savedRef.current)) return;
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-            timerRef.current = null;
-        }
-        setStatus("saving");
-        try {
-            await save(toSave);
-            commitSaved(toSave);
-            if (isEqual(valueRef.current, toSave)) {
+    // Single-flight: the change effect re-arms on every render (save is
+    // typically an inline closure, so its identity changes each render), and
+    // the baseline only moves once the request resolves — without this guard
+    // every render during an in-flight save fired another request, snowballing
+    // into a request storm. Concurrent callers share the in-flight promise;
+    // the loop picks up edits made while a save was running.
+    const run = useCallback((): Promise<void> => {
+        if (inflightRef.current) return inflightRef.current;
+        if (isEqual(valueRef.current, savedRef.current)) return Promise.resolve();
+        const p = (async () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+                timerRef.current = null;
+            }
+            setStatus("saving");
+            try {
+                while (!isEqual(valueRef.current, savedRef.current)) {
+                    const toSave = valueRef.current;
+                    await save(toSave);
+                    commitSaved(toSave);
+                }
                 setStatus("saved");
                 if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
                 savedTimerRef.current = setTimeout(() => setStatus("idle"), 2000);
+            } catch {
+                setStatus("error");
+                throw new Error("autosave failed");
+            } finally {
+                inflightRef.current = null;
             }
-        } catch {
-            setStatus("error");
-            throw new Error("autosave failed");
-        }
+        })();
+        inflightRef.current = p;
+        return p;
     }, [save, isEqual, commitSaved]);
 
     useEffect(() => {
@@ -102,9 +116,10 @@ export function useAutosave<T>({
     }, []);
 
     const flush = useCallback(async () => {
-        if (isEqual(valueRef.current, savedRef.current)) return;
+        // run() resolves immediately when clean and returns the shared
+        // promise when a save is already in flight.
         await run();
-    }, [run, isEqual]);
+    }, [run]);
 
     const retry = useCallback(() => void run().catch(() => {}), [run]);
 

--- a/web/src/lib/api/client/app/notifications/notifications.ts
+++ b/web/src/lib/api/client/app/notifications/notifications.ts
@@ -1,13 +1,16 @@
-import type { AppNotification, NotificationPreferences } from "@/lib/api/models/app/notifications/Notification";
+import type {
+    AppNotification,
+    NotificationPreferences,
+    NotificationPreferencesEnvelope,
+} from "@/lib/api/models/app/notifications/Notification";
 import Request from "../../Request";
 
-export async function getNotificationPreferences(): Promise<NotificationPreferences> {
-    const res = await Request<{ preferences: NotificationPreferences }>({
+export async function getNotificationPreferences(): Promise<NotificationPreferencesEnvelope> {
+    return await Request<NotificationPreferencesEnvelope>({
         method: "GET",
         url: "/auth/me/notification-preferences",
         authorization: true,
     });
-    return res.preferences;
 }
 
 export async function updateNotificationPreferences(preferences: NotificationPreferences): Promise<NotificationPreferences> {

--- a/web/src/lib/api/client/app/notifications/notifications.ts
+++ b/web/src/lib/api/client/app/notifications/notifications.ts
@@ -13,14 +13,13 @@ export async function getNotificationPreferences(): Promise<NotificationPreferen
     });
 }
 
-export async function updateNotificationPreferences(preferences: NotificationPreferences): Promise<NotificationPreferences> {
-    const res = await Request<{ preferences: NotificationPreferences }>({
+export async function updateNotificationPreferences(preferences: NotificationPreferences): Promise<NotificationPreferencesEnvelope> {
+    return await Request<NotificationPreferencesEnvelope>({
         method: "PUT",
         url: "/auth/me/notification-preferences",
         data: { preferences },
         authorization: true,
     });
-    return res.preferences;
 }
 
 export async function listNotifications(unreadOnly = false, limit = 50): Promise<{ notifications: AppNotification[]; unread: number }> {

--- a/web/src/lib/api/hooks/app/notifications/useNotifications.ts
+++ b/web/src/lib/api/hooks/app/notifications/useNotifications.ts
@@ -19,11 +19,14 @@ export function useNotificationPreferences() {
     });
 }
 
+// The PUT echoes the saved envelope; write it into the cache instead of
+// invalidating — a refetch per save is wasted traffic and re-rendered the
+// settings page mid-save.
 export function useUpdateNotificationPreferences() {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: (prefs: NotificationPreferences) => updateNotificationPreferences(prefs),
-        onSuccess: () => qc.invalidateQueries({ queryKey: PREFS_KEY }),
+        onSuccess: (envelope) => qc.setQueryData(PREFS_KEY, envelope),
     });
 }
 

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -30,6 +30,19 @@ export interface NotificationPreferences {
 
 export type NotificationCategoryKey = Exclude<keyof NotificationPreferences, "email_digest">;
 
+// What the deployment's email channel offers. instant_allowed is false on the
+// hosted cloud (per-event email is a cost sink there); self-hosted deploys
+// can enable it. daily_cap is the rolling 24h budget per user (0 = unlimited).
+export interface EmailDeliveryInfo {
+    instant_allowed: boolean;
+    daily_cap: number;
+}
+
+export interface NotificationPreferencesEnvelope {
+    preferences: NotificationPreferences;
+    email_delivery?: EmailDeliveryInfo;
+}
+
 // Client-side mirror of the backend defaults merge: a response from an older
 // backend (or a cached one) may miss newer categories or email_digest, and
 // consumers index categories directly, so fill any gap before use.

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -30,6 +30,29 @@ export interface NotificationPreferences {
 
 export type NotificationCategoryKey = Exclude<keyof NotificationPreferences, "email_digest">;
 
+// Client-side mirror of the backend defaults merge: a response from an older
+// backend (or a cached one) may miss newer categories or email_digest, and
+// consumers index categories directly, so fill any gap before use.
+export function normalizeNotificationPreferences(
+    p: Partial<NotificationPreferences> | null | undefined,
+): NotificationPreferences {
+    const on: CategoryPref = { enabled: true, channels: { in_app: true, email: false, slack: false, push: true } };
+    const off: CategoryPref = { enabled: false, channels: { in_app: true, email: false, slack: false, push: true } };
+    const billing: CategoryPref = { enabled: true, channels: { in_app: true, email: true, slack: false, push: true } };
+    const cadence: EmailDigestCadence[] = ["instant", "smart", "hourly", "daily"];
+    return {
+        inbound_reply: p?.inbound_reply ?? off,
+        inbound_out_of_office: p?.inbound_out_of_office ?? off,
+        health_bounce: p?.health_bounce ?? on,
+        health_complaint: p?.health_complaint ?? on,
+        health_worker_downtime: p?.health_worker_downtime ?? on,
+        security_new_signin: p?.security_new_signin ?? on,
+        billing_alert: p?.billing_alert ?? billing,
+        team_activity: p?.team_activity ?? on,
+        email_digest: p?.email_digest && cadence.includes(p.email_digest) ? p.email_digest : "smart",
+    };
+}
+
 export interface AppNotification {
     id: string;
     user_id: string;

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -12,6 +12,10 @@ export interface CategoryPref {
     channels: ChannelPrefs;
 }
 
+// How the email channel batches alerts. Security sign-in alerts always email
+// immediately regardless of cadence.
+export type EmailDigestCadence = "instant" | "smart" | "hourly" | "daily";
+
 export interface NotificationPreferences {
     inbound_reply: CategoryPref;
     inbound_out_of_office: CategoryPref;
@@ -19,9 +23,12 @@ export interface NotificationPreferences {
     health_complaint: CategoryPref;
     health_worker_downtime: CategoryPref;
     security_new_signin: CategoryPref;
+    billing_alert: CategoryPref;
+    team_activity: CategoryPref;
+    email_digest: EmailDigestCadence;
 }
 
-export type NotificationCategoryKey = keyof NotificationPreferences;
+export type NotificationCategoryKey = Exclude<keyof NotificationPreferences, "email_digest">;
 
 export interface AppNotification {
     id: string;

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -12,9 +12,13 @@ export interface CategoryPref {
     channels: ChannelPrefs;
 }
 
-// How the email channel batches alerts. Security sign-in alerts always email
-// immediately regardless of cadence.
-export type EmailDigestCadence = "instant" | "smart" | "hourly" | "daily";
+// The email-channel bundling window bounds (also returned by the API so the
+// control never hardcodes them): pending notification emails hold for the
+// user's window, then flush as one bundled email. The 30 minute floor is
+// deliberate — there is no per-event email mode. Security sign-in alerts
+// always email immediately.
+export const EMAIL_WINDOW_MIN_MINUTES = 30;
+export const EMAIL_WINDOW_MAX_MINUTES = 1440;
 
 export interface NotificationPreferences {
     inbound_reply: CategoryPref;
@@ -25,16 +29,16 @@ export interface NotificationPreferences {
     security_new_signin: CategoryPref;
     billing_alert: CategoryPref;
     team_activity: CategoryPref;
-    email_digest: EmailDigestCadence;
+    email_digest_minutes: number;
 }
 
-export type NotificationCategoryKey = Exclude<keyof NotificationPreferences, "email_digest">;
+export type NotificationCategoryKey = Exclude<keyof NotificationPreferences, "email_digest_minutes">;
 
-// What the deployment's email channel offers. instant_allowed is false on the
-// hosted cloud (per-event email is a cost sink there); self-hosted deploys
-// can enable it. daily_cap is the rolling 24h budget per user (0 = unlimited).
+// Email-channel bounds from the deployment: the window range clients should
+// offer, and the rolling 24h per-user email budget (0 = unlimited).
 export interface EmailDeliveryInfo {
-    instant_allowed: boolean;
+    min_minutes: number;
+    max_minutes: number;
     daily_cap: number;
 }
 
@@ -52,7 +56,7 @@ export function normalizeNotificationPreferences(
     const on: CategoryPref = { enabled: true, channels: { in_app: true, email: false, slack: false, push: true } };
     const off: CategoryPref = { enabled: false, channels: { in_app: true, email: false, slack: false, push: true } };
     const billing: CategoryPref = { enabled: true, channels: { in_app: true, email: true, slack: false, push: true } };
-    const cadence: EmailDigestCadence[] = ["instant", "smart", "hourly", "daily"];
+    const minutes = p?.email_digest_minutes ?? EMAIL_WINDOW_MIN_MINUTES;
     return {
         inbound_reply: p?.inbound_reply ?? off,
         inbound_out_of_office: p?.inbound_out_of_office ?? off,
@@ -62,7 +66,7 @@ export function normalizeNotificationPreferences(
         security_new_signin: p?.security_new_signin ?? on,
         billing_alert: p?.billing_alert ?? billing,
         team_activity: p?.team_activity ?? on,
-        email_digest: p?.email_digest && cadence.includes(p.email_digest) ? p.email_digest : "smart",
+        email_digest_minutes: Math.min(Math.max(minutes, EMAIL_WINDOW_MIN_MINUTES), EMAIL_WINDOW_MAX_MINUTES),
     };
 }
 


### PR DESCRIPTION
## What this does

Makes notifications cheap and quiet without losing anything. The email channel follows three rules:

1. **Read means no email.** Email notifications queue instead of sending. Reading one in the app (web or iOS) cancels its pending email.
2. **One email, not a stream.** A flush loop bundles everything still unread into a single email per user, on a configurable window: presets from every 30 minutes up to once a day, or a custom value. Default is 30 minutes and 30 minutes is a hard floor, so there is no per-event mode anywhere. Security sign-in alerts always send immediately.
3. **Shared events share one email.** Org events carry a group key, and the same event across several members goes out as one email with everyone together in To instead of a copy per person. Membership is re-verified at send time.

Routing is permission-targeted, never org-wide: NotifyOrg resolves only accepted members holding the required permission.

## Backend

- Migration 000076: notifications gains group_key, email_state, email_due_at, email_attempts plus a partial index.
- Flush claims via FOR UPDATE SKIP LOCKED, safe across backend and consumer replicas, with crash recovery and bounded retries.
- New categories billing_alert (default on incl. email) and team_activity, plus email_digest_minutes (30 to 1440, validated, clamped on read; bounds returned as email_delivery on the preferences GET).
- Rolling 24h per-user email budget (NOTIFICATION_EMAIL_DAILY_CAP, default 25, 0 unlimited). Over budget, alerts stay in the feed. Security sign-ins exempt.
- New producers: dead-worker downtime to manage_emails members (deduped per incident), trial expiry to manage_billing members through the notification system, invitation accepts to manage_team members.

## Web

- The bell becomes a notification center: category icon chips, day groups, relative times, unread filter, skeleton, empty state, settings link.
- Settings gains Billing and Team sections plus the bundling window control (presets and a custom minutes input), hardened against version skew.
- useAutosave is now single-flight, fixing a PUT storm where every render during an in-flight save fired another request.

## iOS

- Preferences decode via a dynamic keyed container (fixes a latent decode break), Billing and Team rows, a native window picker, feed icons for the new categories.

## Docs

- guides/notifications covers the three rules, the window, and the budget. The deployment guide documents the env.

## Verification

Go fmt and lint clean, web tsc and eslint clean, docs typecheck clean, iOS build succeeded.