### PR TITLE
fix: stop the unibox thread pane flashing on load

### DIFF
--- a/web/src/app/app/unibox/page.tsx
+++ b/web/src/app/app/unibox/page.tsx
@@ -79,21 +79,27 @@ export default function UniboxPage() {
     [navigate, urlScope, urlThread, urlScopeRef],
   );
 
-  // Mirror URL → store (so a deep link / refresh restores the open thread) and
-  // store → URL (so a ConversationItem click, which sets the store, updates the
-  // path). The two stay in lock-step because each only writes on a real change.
+  // Keep the open thread in sync between the URL (deep-linkable) and the store
+  // (set by row clicks + keyboard nav) through a single reconciler. Tracking
+  // which side actually moved lets the two writers converge; two mutually
+  // writing effects would instead swap the values every commit, remounting the
+  // thread pane in a tight loop whenever the store and URL start out disagreeing
+  // (a stale singleton thread id carried into a fresh /app/unibox/all session).
   const setSelectedThreadId = useAppStore((s) => s.setSelectedThreadId);
-  React.useEffect(() => {
-    setSelectedThreadId(urlThread);
-  }, [urlThread, setSelectedThreadId]);
-
   const storeThread = useAppStore((s) => s.selectedThreadId);
+  const lastUrlThread = React.useRef(urlThread);
+  const lastStoreThread = React.useRef(storeThread);
   React.useEffect(() => {
-    if (storeThread !== urlThread) {
-      goTo({ threadId: storeThread });
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storeThread]);
+    const urlMoved = urlThread !== lastUrlThread.current;
+    const storeMoved = storeThread !== lastStoreThread.current;
+    lastUrlThread.current = urlThread;
+    lastStoreThread.current = storeThread;
+    if (urlThread === storeThread) return;
+    // The store wins only when it alone moved (a click / keypress); otherwise
+    // the URL is the source of truth (deep link, back/forward, mount mismatch).
+    if (storeMoved && !urlMoved) goTo({ threadId: storeThread });
+    else setSelectedThreadId(urlThread);
+  }, [urlThread, storeThread, setSelectedThreadId, goTo]);
 
   // ── Scope (derived from URL + ref) ─────────────────────────────
   const scope: UniboxScope = React.useMemo(() => {


### PR DESCRIPTION
## What

The unibox right pane (the open thread) flashes and reloads continuously the first time you open the inbox after logging in.

## Cause

`web/src/app/app/unibox/page.tsx` synced the open thread between the URL and the zustand store with two effects that write to each other (`url → store` and `store → url`). Each lags a commit, so when they start out disagreeing they swap the two values every render instead of converging. That flips the URL thread id between the thread and null on every commit, remounting `ThreadView` in a tight loop while `navigate({replace:true})` spams `history.replaceState` until the browser throttles it.

`selectedThreadId` is not persisted, so a pristine login is fine. It bites when the module-singleton store still holds a thread id from before while a fresh session lands on bare `/app/unibox/all` (a client-side re-login, or the command palette's "Unibox" jump to bare `/app/unibox` with a thread still selected).

## Fix

Replace the two fighting effects with one reconciler that tracks which side actually moved:

- URL and store agree: nothing to do
- store alone moved (row click / keyboard nav): update the URL
- otherwise (real URL change, back/forward, mount mismatch): the URL wins and the store follows

Every path converges in one step: fresh login, stale-store mismatch, row click, deep link, browser back, command-palette jump. No callers change; the page stays the single place that reconciles URL and store.

## Verified

- `tsc -b` clean
- `eslint` clean