### PR TITLE
Match automation AI steps to campaign steps

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1084,10 +1084,13 @@ func main() {
 			Orgs:     organizationRepository,
 		})
 		integrationServiceForHandler.SetPublisher(streamingPublisher)
-		// AI automation nodes (ai_classify / ai_extract / ai_generate) run over the
-		// same provider + credit ledger as the rest of the AI layer. Nil provider
-		// (no AI_PROVIDER) leaves the nodes returning a clean "not available".
+		// AI automation nodes (ai_step / ai_switch) run over the same provider +
+		// credit ledger as the rest of the AI layer. Nil provider (no AI_PROVIDER)
+		// leaves the nodes returning a clean "not available".
 		integrationServiceForHandler.SetAI(aiProvider, creditService)
+		// The AI switch's optional web search shares the same pluggable backend as
+		// the campaign switch and dashboard agent.
+		integrationServiceForHandler.SetAISearch(aiSearch)
 		// Port reply-classifier Layer 3 onto the platform provider (OpenAI-first,
 		// self-hostable). Platform-paid, never charged to org credits. Nil provider
 		// leaves Layer 3 disabled (the ambiguous middle resolves to "unknown").

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -224,8 +224,8 @@ func main() {
 	webhookService.WireDispatchSink(integrationServiceC.DispatchAny)
 	// AI automation nodes + reply-classifier Layer 3 run in THIS process (reply /
 	// warmup / bounce events dispatch here). Build the credit ledger + provider so
-	// ai_classify / ai_extract / ai_generate nodes can charge + call, and so the
-	// classifier's optional model layer rides the same OpenAI-first provider.
+	// the ai_step / ai_switch nodes can charge + call, and so the classifier's
+	// optional model layer rides the same OpenAI-first provider.
 	creditRepoC := repository.NewCreditRepository(primaryDB)
 	aiSettingsRepoC := repository.NewAISettingsRepository(primaryDB)
 	creditServiceC := credits.NewService(creditRepoC, aiSettingsRepoC, redisCache)
@@ -233,6 +233,13 @@ func main() {
 	// alert. Auto top-up stays backend-only (no Stripe service here).
 	creditServiceC.SetMonitor(creditwatch.New(aiSettingsRepoC, creditRepoC, redisCache, streamingPublisher, nil).OnBalanceChanged)
 	var aiProviderC generation.Provider
+	// Pluggable web search (Serper/SearXNG) backs the AI switch's optional
+	// company lookup on reply-triggered automations that run in the consumer.
+	aiSearchC := generation.NewSearchClient(
+		cfg.GetStringOptional(ctx, "SEARCH_PROVIDER", "search/provider", ""),
+		cfg.GetStringOptional(ctx, "SEARCH_API_URL", "search/api_url", ""),
+		cfg.GetSecretOptional(ctx, "SEARCH_API_KEY", "search/api_key", ""),
+	)
 	// Provider selection mirrors the backend: AI_PROVIDER preset + AI_* vars.
 	if cfgAI, rerr := generation.Resolve(generation.ProviderSettings{
 		Provider:   cfg.GetStringOptional(ctx, "AI_PROVIDER", "ai_provider", ""),
@@ -242,12 +249,14 @@ func main() {
 		ModelTrial: cfg.GetStringOptional(ctx, "AI_MODEL_TRIAL", "ai_model_trial", ""),
 		ModelPaid:  cfg.GetStringOptional(ctx, "AI_MODEL_PAID", "ai_model_paid", ""),
 		Free:       cfg.GetBoolPtr(ctx, "AI_FREE", "ai_free"),
+		Search:     aiSearchC,
 	}); rerr != nil {
 		log.Printf("AI provider misconfigured, AI features disabled: %v", rerr)
 	} else if p, perr := generation.NewProvider(cfgAI); perr == nil {
 		aiProviderC = p
 	}
 	integrationServiceC.SetAI(aiProviderC, creditServiceC)
+	integrationServiceC.SetAISearch(aiSearchC)
 	if aiProviderC != nil {
 		replyclassify.SetModelClassifier(func(ctx context.Context, system, user string) (string, error) {
 			res, err := aiProviderC.Complete(ctx, generation.CompletionRequest{System: system, Prompt: user, MaxTokens: 16, Temperature: generation.Deterministic()})

--- a/docs/content/docs/guides/ai-credits.mdx
+++ b/docs/content/docs/guides/ai-credits.mdx
@@ -30,7 +30,9 @@ Credits are charged from what each call actually uses. Every action has a flat *
 | Reply draft in the unibox | 2 |
 | Compose draft (grounded new-email draft; a clarifying question costs the same minimum) | 2 |
 | Contact research run | 2 |
-| AI step in an automation | 1 |
+| Single-shot AI step in an automation (classify, extract, generate) | 1 |
+| AI agent step in an automation (per step it takes) | 1 per step |
+| AI switch in an automation with the AI decider (the value decider is free) | 1 |
 | Ask AI branch in an automation (per evaluation) | 1 |
 | Switch step with the AI decider in a campaign sequence (per contact; the value decider is free) | 1 |
 | Inbox agent handled thread | 5 |

--- a/docs/content/docs/guides/ai-steps-in-automations.mdx
+++ b/docs/content/docs/guides/ai-steps-in-automations.mdx
@@ -1,81 +1,101 @@
 ---
 title: AI steps in automations
-description: Add a classify, extract, or generate step to an automation so a flow can read the event with a model, then branch on what it found.
+description: Add an AI step or an AI switch to an automation so a flow can read the event with a model, take reversible actions, or route down one of your cases.
 ---
 
-An AI step runs one model call in the middle of an automation. It reads the trigger event, does one job (label it, pull fields out of it, or write a line of text), and stores the result back into the flow as a variable. Later conditions and action text can then use that result, so a flow can branch on what the model decided.
+Automations have two AI nodes, and they mirror the AI steps in campaign sequences: an **AI step** that reads the event and either transforms it or acts on it, and an **AI switch** that routes the event down one of your cases. Both are built-in actions, so they need no integration or connection. See [AI credits](/guides/ai-credits/) for how credits work.
 
-AI steps are built-in actions, so they need no integration or connection. They cost one credit each. See [AI credits](/guides/ai-credits/) for how credits work.
+Add one from an action node: pick **Warmbly (built-in)** under **Run**, then choose **AI step** or **AI switch**.
 
-## The three steps
+## The AI step
 
-Add one from an action node: pick **Warmbly (built-in)** under **Run**, then choose the AI step.
+An AI step has a **mode** that decides what it does. Every mode takes an **instruction**, plain-language guidance for the model. The instruction is templated, so you can drop event fields into it with `{{.field}}` (for example `{{.subject}}` or `{{.snippet}}`). The step also sees the rest of the event data, so you do not have to list every field.
 
-| Step | What it does | Where the result lands |
+| Mode | What it does | Where the result lands |
 | --- | --- | --- |
-| AI classify | Picks exactly one of the labels you list | `ai_class` |
-| AI extract | Pulls the fields you name out of the event text | one variable per field |
-| AI generate | Writes a short piece of text from your instruction | `ai_text` |
+| Agent | Follows your instruction and takes the reversible actions you allow | acts on the contact / event |
+| Generate text | Writes a short piece of text from your instruction | `ai_text` |
+| Classify | Picks exactly one of the labels you list | `ai_class` |
+| Extract fields | Pulls the fields you name out of the event text | one variable per field |
 
-Every step takes an **instruction**: plain-language guidance for the model. The instruction is templated, so you can drop event fields into it with `{{.field}}` (for example `{{.subject}}` or `{{.snippet}}`). The step also sees the rest of the event data, so you do not have to list every field in the instruction.
+### Agent
 
-### AI classify
+The agent is the default. You write an instruction and check the reversible actions it may take: **add a tag**, **remove a tag**, **label the email**, **create a task**, **create a deal**, **move the deal stage**, **set variables**, and **unsubscribe**. The agent reads each event, decides which of those actions fit, and can chain several. It writes the details itself: the task title, the deal name and pipeline, the variable value. It only ever takes the actions you enable, and it never sends email or replies.
 
-Give it an instruction and a list of **labels**. The model reads the event and returns exactly one label from your list, stored in the variable `ai_class`. Use it to sort replies, tickets, or inbound leads into buckets your flow already branches on.
+For the tag and label actions you can set an optional **pool**: the tags or labels the agent is allowed to choose from. Leave a pool empty and the agent may use any of your tags for that action. When a pool is empty you can also let the agent create a brand-new tag or label when none of yours fits.
 
-Example: on a **Reply received** trigger, an instruction of "Classify this reply" with labels `interested`, `not_now`, `wrong_person`, `unsubscribe` lets the next condition test `ai_class equals interested` and route only hot replies to a deal.
+Example: on a **Reply received** trigger, an instruction of "If they ask about pricing, tag them and open a follow-up task; if they ask to stop, unsubscribe them" with **add a tag** and **create a task** and **unsubscribe** enabled lets one step handle all three outcomes without a separate node for each.
 
-You need at least two labels. If the model's answer does not match any label exactly, the closest match is used, and if none is close the raw answer is stored so you can see what happened in the run history.
+The agent is billed one credit per step it takes (per model turn), the same way the dashboard agent and the campaign AI step are billed.
 
-A classify step can also branch **multi-way directly on the canvas**: open the node and use **Route connections by label** to mark each outgoing connection as "always" or "when `<label>`". A labeled connection runs only when the model picked that label, so one classify node fans out into one path per label with no IF nodes in between. (Conditions on `ai_class` keep working too; use them when the routing needs to combine the label with other fields.)
-
-### AI extract
-
-Give it an instruction and a list of **output keys**. The model returns one value per key, each stored in a variable of that name. Use it to turn a free-text event into structured fields.
-
-Example: from an inbound webhook body or a reply, extract `company_size`, `budget`, and `timeline` and then branch on them or write them into a CRM deal with a Create deal step. A key the model cannot fill is stored as an empty string, so a later condition can test whether it was found.
-
-### AI generate
+### Generate text
 
 Give it an instruction. The model writes a short piece of text, stored in `ai_text`. Use it to compose a one-line summary, a task title, or a Slack message body that a later step sends.
 
 <Callout type="warn" title="Generated text is never sent on its own">
-An AI generate step only writes text into a variable. Nothing is emailed or sent because a model wrote it. To use the text you connect a later step (a Slack message, a task, a webhook) that you control, and Warmbly never sends outreach email from an AI step. See the sending-safety note below.
+A generate step only writes text into a variable. Nothing is emailed or sent because a model wrote it. To use the text you connect a later step (a Slack message, a task, a webhook) that you control, and Warmbly never sends outreach email from an AI step. See the sending-safety note below.
 </Callout>
+
+### Classify
+
+Give it an instruction and a list of **labels**. The model reads the event and returns exactly one label from your list, stored in `ai_class`. Use it to sort replies, tickets, or inbound leads into buckets your flow already branches on. You need at least two labels. If the model's answer does not match a label exactly, the closest match is used, and if none is close the raw answer is stored so you can see what happened in the run history.
+
+To branch on the result, add an IF node and test `ai_class` (for example `ai_class equals interested`). To route multi-way on the canvas instead, use an **AI switch** below.
+
+### Extract fields
+
+Give it an instruction and a list of **output keys**. The model returns one value per key, each stored in a variable of that name. Use it to turn a free-text event into structured fields, for example pulling `company_size`, `budget`, and `timeline` out of a reply and then branching on them or writing them into a CRM deal. A key the model cannot fill is stored as an empty string, so a later condition can test whether it was found.
+
+## The AI switch
+
+An AI switch routes the event down exactly one of your **cases**. Each case becomes its own dot on the node, and you drag each dot to the step that path leads to. The bottom dot is the "otherwise" fallback for events no case matched. Put ordinary action steps on a path to make things happen for the events routed down it. Add at least two cases.
+
+The switch has two deciders, chosen under **Decided by**:
+
+- **AI prompt.** You write an instruction and the model reads the event and picks one case. One credit per event.
+- **Value.** You write a template under **Value to match** (for example `{{.intent}}`), it is rendered against the event, and the result is matched to the case names. Matching ignores casing and extra spaces, and you can wrap a case in slashes for a regex, for example `/^(vip|enterprise)/`. The first matching case wins. This runs no model and costs nothing.
+
+An unmatched value (or a model that picks no case) follows the fallback path.
+
+## Capabilities
+
+Both AI nodes can turn on **extended thinking**, which routes the call to the stronger model with a larger reasoning budget. It costs more through usage metering rather than a flat credit.
+
+The AI switch (in AI-prompt mode) can also turn on **web search**: before deciding, it looks up the event's company on the web and feeds the results into the prompt as context. The lookup query is built only from event fields such as the company name or a corporate email domain, never from the reply text, and it costs one extra credit only when it actually returns results.
 
 ## The Ask AI branch
 
-Besides the three action steps, a **condition** node can ask the model directly. Pick **Ask AI (yes/no)** as the condition's field and write a plain-language question about the event, for example "Is this reply asking about pricing?". At run time the model reads the event data and answers: yes takes the right (true) path, no takes the bottom (false) path.
+A **condition** node can ask the model directly. Pick **Ask AI (yes/no)** as the condition's field and write a plain-language question about the event, for example "Is this reply asking about pricing?". At run time the model reads the event and answers: yes takes the right (true) path, no takes the bottom (false) path.
 
 - The question is templated like an instruction, so `{{.subject}}` or `{{.snippet}}` work inside it.
 - Each evaluation costs one credit, refunded if the provider call fails.
 - The branch fails safe: if the model can't answer, you are out of credits, or the answer is ambiguous, the **no** path runs and the reason is recorded on the run.
-- Prefer **AI classify** plus a normal condition when you need more than two outcomes; use Ask AI when one yes/no question is all the routing needs.
+- Prefer an **AI switch** when you need more than two outcomes; use Ask AI when one yes/no question is all the routing needs.
 
 ## Using the result downstream
 
-An AI step writes its result into the flow the same way a **Set variables** step does. Every step after it can read the result:
+A classify, extract, or generate step writes its result into the flow the same way a **Set variables** step does. Every step after it can read the result:
 
-- **Conditions.** Add an IF node and test the variable. For classify, `ai_class equals interested`. For extract, `budget exists` or `company_size contains enterprise`. Because a condition tests a named field, any AI output variable is reachable by typing its name.
+- **Conditions.** Add an IF node and test the variable. For classify, `ai_class equals interested`. For extract, `budget exists` or `company_size contains enterprise`.
 - **Action text.** Reference it with `{{.ai_class}}`, `{{.ai_text}}`, or `{{.your_key}}` in any templated field, like a Slack message or a task title.
 
 If two AI steps in one flow would both write `ai_class` or `ai_text`, set an **output variable name** on one of them so they do not overwrite each other.
 
 ## Cost, failures, and safety
 
-- **One credit per step.** Charged to your workspace when the step runs. If the model call fails for a provider reason, the credit is refunded automatically.
+- **Credits.** A single-shot step (classify, extract, generate) costs one credit; the agent is billed one credit per step it takes; an AI switch costs one credit in AI mode and nothing in value mode. If the model call fails for a provider reason, the reserved credit is refunded automatically.
 - **Out of credits.** A step with no credits left fails with a clear message and the run continues down the normal path, so the rest of the flow still runs. Nothing is half-charged. Connect the step's **on error** branch if you want a specific fallback path.
 - **Auto-pause.** If a flow's AI steps keep failing for lack of credits, run after run, Warmbly turns the automation off so it stops trying against an empty balance. Top up your credits and switch it back on.
 - **Timing.** Each AI step is bounded to a few seconds so a slow model never stalls the flow.
-- **Sending safety.** An AI step never sends email and never contacts anyone. It only writes a variable. Any outbound message is a step you added and controls, and Warmbly never sends cold outreach from a model decision.
+- **Sending safety.** An AI step never sends email and never contacts anyone. The agent only takes the reversible actions you enable, and the other modes only write a variable. Any outbound message is a step you added and control, and Warmbly never sends cold outreach from a model decision.
 
 ## AI in campaign sequences
 
-Campaign sequences have a Switch step that runs per contact instead of per event: you define named cases as draggable dots on the node, and an AI prompt (or a plain value match) routes each contact down exactly one of them. See [Sequences](/guides/sequences/#switch-steps).
+Campaign sequences have the same two AI steps, run per contact instead of per event: an AI step (agent) that takes reversible actions, and a Switch step with the AI or value decider. See [Sequences](/guides/sequences/#switch-steps).
 
 ## Testing an AI step
 
-Press **Test** in the builder to dry-run the flow. Unlike other actions, AI steps (and Ask AI branches) run **for real** in a Test so you can see the actual model output and the branch it drives. That means a Test spends one credit per AI step. The trace panel shows each step's output next to the node, and the path the flow took. See [Testing and run history](/guides/automations/#testing-and-run-history).
+Press **Test** in the builder to dry-run the flow. Unlike other actions, AI steps (and Ask AI branches) run **for real** in a Test so you can see the actual model output and the branch it drives. The agent reports what it would do without applying the change on a Test. A Test spends credits for the AI steps it runs. The trace panel shows each step's output next to the node, and the path the flow took. See [Testing and run history](/guides/automations/#testing-and-run-history).
 
 ## See also
 

--- a/docs/content/docs/guides/automations.mdx
+++ b/docs/content/docs/guides/automations.mdx
@@ -17,10 +17,10 @@ The canvas works like the campaign sequence editor:
 
 - The **Trigger** node sits at the top. You can't delete it.
 - Drag from a node's dot to draw a connection to another node.
-- Drag from a dot onto empty canvas to drop a **new action** already connected to that node.
+- Drag from a dot onto empty canvas to open a menu and drop what comes next already connected to that node: an **AI step**, an **AI switch**, a **condition**, a built-in or integration action, or a **Stop** to end that path.
 - Click any node to open its editor panel on the right.
 - Click a connection line, then press `Delete` or `Backspace`, to remove it.
-- Use **Add action** and **Add condition** (top-left) to place new nodes, and **Tidy up** to auto-arrange the layout.
+- Use the **Add** button (its dropdown places an AI step, AI switch, condition, or any action) and **Tidy up** to auto-arrange the layout.
 
 Where you drag the cards sticks. The arrangement saves on its own, so a flow opens exactly how you left it, and moving a card is not a change you have to save. The builder is also a shared canvas: when a teammate is in the same flow you see their cursor, watch cards move as they drag them, and see the cards they have selected outlined in their color. Press `/` to chat from your cursor. See [Collaboration](/guides/collaboration/).
 
@@ -65,7 +65,7 @@ An **IF** node splits the flow into a **yes** path and a **no** path. Add one wi
 - the node's **right** dot to the steps that should run when the condition is **true** (the "yes" path)
 - the node's **bottom** dot to the steps that should run when the condition is **false** (the "no" path)
 
-At run time the flow follows only the branch that matches the outcome. A branch you leave unconnected simply ends there.
+At run time the flow follows only the branch that matches the outcome. A branch you leave unconnected simply ends there, or you can drag it to a **Stop** node to end it explicitly.
 
 ### Building a condition
 
@@ -136,7 +136,8 @@ These act directly on the event's contact and need no external connection. Pick 
 | Unsubscribe the contact | Unsubscribes the contact (works when the event carries a campaign) |
 | Set variables | Computes named values from templates and stores them for later steps to reuse |
 | Fire event | Publishes a custom event to the realtime gateway; your app receives it over the API websocket, with no public URL |
-| AI classify, extract, generate | Runs one AI step over the event and stores its output for later steps to branch on. See [AI steps in automations](/guides/ai-steps-in-automations/) |
+| AI step | One AI node: an agent that takes reversible actions, or a single-shot classify, extract, or generate over the event. See [AI steps in automations](/guides/ai-steps-in-automations/) |
+| AI switch | Routes the event down one of your cases, decided by an AI prompt or a value match. See [AI steps in automations](/guides/ai-steps-in-automations/) |
 
 **Move the deal stage** acts on the contact's most recent open deal in the chosen pipeline. If they have no open deal there, nothing happens. **Unsubscribe the contact** only applies when the triggering event carries a campaign, such as a reply, bounce, or unsubscribe. **Label the email** only works on a **Reply received** automation: it labels the conversation that reply belongs to (the same labels you set by hand in the unibox), so it needs an inbox thread to act on.
 

--- a/internal/app/aiagentargs/resolve.go
+++ b/internal/app/aiagentargs/resolve.go
@@ -6,6 +6,7 @@ package aiagentargs
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
@@ -107,4 +108,52 @@ func ResolvePipelineStage(pipelines []models.Pipeline, pipelineName, stageName s
 		}
 	}
 	return pl.ID, st.ID, nil
+}
+
+// MatchValueToCases maps a rendered "value" (a template output or event field)
+// onto a switch's case set for the deterministic, no-model "value" decider:
+// normalized equality on plain cases first (case- and whitespace-insensitive),
+// then "/pattern/" regex cases in configured order. First match wins; "" on a
+// miss routes down the fallback path. Deliberately NO prefix/substring fuzziness
+// ("not interested" must never land on an "interested" case). Shared verbatim by
+// the campaign switch step and the automation AI switch so both route identically.
+func MatchValueToCases(value string, cases []string) string {
+	norm := normalizeSwitchText(value)
+	if norm == "" {
+		return ""
+	}
+	for _, c := range cases {
+		if caseRegex(c) == nil && normalizeSwitchText(c) == norm {
+			return c
+		}
+	}
+	trimmed := strings.TrimSpace(value)
+	for _, c := range cases {
+		if re := caseRegex(c); re != nil && re.MatchString(trimmed) {
+			return c
+		}
+	}
+	return ""
+}
+
+// normalizeSwitchText lowercases, trims, and collapses inner whitespace so
+// "VIP  Customer " matches the case "vip customer". Value matching must not fail
+// on casing or stray spaces in the rendered value.
+func normalizeSwitchText(s string) string {
+	return strings.ToLower(strings.Join(strings.Fields(s), " "))
+}
+
+// caseRegex compiles a "/pattern/" case name into a case-insensitive regex, or
+// returns nil for a plain-text case (or an invalid pattern — the write-time
+// validator rejects those, so nil here only means "not a regex").
+func caseRegex(name string) *regexp.Regexp {
+	name = strings.TrimSpace(name)
+	if len(name) < 3 || !strings.HasPrefix(name, "/") || !strings.HasSuffix(name, "/") {
+		return nil
+	}
+	re, err := regexp.Compile("(?i)" + name[1:len(name)-1])
+	if err != nil {
+		return nil
+	}
+	return re
 }

--- a/internal/app/credits/costs.go
+++ b/internal/app/credits/costs.go
@@ -18,8 +18,8 @@ const (
 	// CostResearchRun is one contact research run (nothing_found included).
 	CostResearchRun = 2
 
-	// CostAutomationAINode is one ai_classify/ai_extract/ai_generate node
-	// execution, and one Ask-AI branch evaluation.
+	// CostAutomationAINode is one single-shot AI step (classify/extract/generate
+	// mode) or AI switch execution, and one Ask-AI branch evaluation.
 	CostAutomationAINode = 1
 
 	// CostCampaignAIStep is one campaign-sequence AI-decided "switch" step execution (one

--- a/internal/app/integration/ai_actions.go
+++ b/internal/app/integration/ai_actions.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/warmbly/warmbly/internal/app/aiagentargs"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
@@ -16,23 +17,31 @@ import (
 	"github.com/google/uuid"
 )
 
-// AI action nodes (M9). One LLM step runs over the event data and merges its
-// output back into the data map (exactly like set_variables), so downstream
-// condition nodes can branch on it. Kinds:
+// AI action nodes mirror the campaign step types: one unified ai_step plus an
+// ai_switch router. A single-shot step runs one LLM call over the event data and
+// merges its output back into the data map (exactly like set_variables), so
+// downstream condition nodes can branch on it. Step modes:
 //
-//   - ai_classify: pick one of the configured labels -> variable "ai_class"
+//   - classify: pick one of the configured labels -> variable "ai_class"
 //     (or the node's output_key).
-//   - ai_extract:  pull the configured output_keys as string values.
-//   - ai_generate: write text from the instruction -> variable "ai_text"
+//   - extract:  pull the configured output_keys as string values.
+//   - generate: write text from the instruction -> variable "ai_text"
 //     (or the node's output_key).
+//   - agent:    a bounded tool-use loop (see execAIAgentStep).
 //
-// Each node costs one credit, charged to the org, refunded if the provider call
-// fails. Out-of-credits fails only that node (the run continues down the normal
-// edge); a flow whose org is persistently out of credits auto-pauses after
-// aiCreditFailurePauseAt consecutive misses so it stops hammering a hard wall.
+// The ai_switch router decides one of config.cases[] via an LLM call (ai) or a
+// rendered template match (value, free). config.thinking routes to the stronger
+// model tier; config.web_search grounds an ai-mode switch in a bounded lookup.
+//
+// Each single-shot step costs one credit, charged to the org, refunded if the
+// provider call fails. Out-of-credits fails only that node (the run continues
+// down the normal edge); a flow whose org is persistently out of credits
+// auto-pauses after aiCreditFailurePauseAt consecutive misses so it stops
+// hammering a hard wall.
 const (
 	aiNodeCredits          = 1
 	aiNodeMaxTokens        = 512
+	aiThinkingMaxTokens    = 2048 // stronger tier gets a larger output budget
 	aiNodeTimeout          = 20 * time.Second
 	aiCreditFailurePauseAt = 20
 
@@ -44,7 +53,7 @@ const (
 
 	aiClassVar         = "ai_class"
 	aiTextVar          = "ai_text"
-	aiCaseVar          = "ai_case"        // ai_step mode=decide default output
+	aiCaseVar          = "ai_case"        // decide default output (fallback key)
 	aiSwitchCaseVar    = "ai_switch_case" // ai_switch default output (distinct key)
 	aiAgentVar         = "ai_agent"       // ai_step mode=agent final text
 	automationRunIDKey = "_run_id"
@@ -52,16 +61,16 @@ const (
 	// maxAIConditionPrompt bounds an Ask-AI branch question at write time.
 	maxAIConditionPrompt = 2000
 
-	// aiLabelEdgePrefix marks a per-label edge out of an ai_classify node
-	// ("label:<x>"): the walk follows it only when the model picked <x>, so
-	// one classify node routes multi-way on the canvas. Reused verbatim by the
-	// decide mode and the AI switch (their "cases" are labels).
+	// aiLabelEdgePrefix marks a per-label edge out of a routing AI node
+	// ("label:<x>"): the walk follows it only when the model picked <x>, so an
+	// AI switch routes multi-way on the canvas (its "cases" are the labels).
 	aiLabelEdgePrefix = "label:"
 )
 
-// aiStepMode enumerates what a warmbly.ai_step node does. The three legacy ids
-// (ai_classify/ai_extract/ai_generate) and ai_switch map onto these modes too,
-// so one shared code path serves every AI node.
+// aiStepMode enumerates what a warmbly.ai_step node does; ai_switch maps onto
+// the decide mode, so one shared code path serves every AI node. decide is not a
+// step mode (routing is the AI switch's job) but stays defined because ai_switch
+// resolves to it.
 const (
 	aiModeClassify = "classify"
 	aiModeExtract  = "extract"
@@ -70,23 +79,17 @@ const (
 	aiModeAgent    = "agent"
 )
 
-// resolveMode maps an AI node to its behavior. Legacy ids pin their historical
-// mode so saved graphs run byte-identically; the unified ai_step reads
-// config.mode (defaulting to generate for a malformed/empty blob); ai_switch is
-// always decide.
+// resolveMode maps an AI node to its behavior. The unified ai_step reads
+// config.mode (classify | extract | generate | agent, defaulting to generate for
+// a malformed/empty blob); ai_switch is always decide (its switch_on picks the
+// ai-vs-value decider inside the decide path, not here).
 func resolveMode(action models.IntegrationAction, cfg aiActionConfig) string {
 	switch action {
-	case models.IntegrationActionAIClassify:
-		return aiModeClassify
-	case models.IntegrationActionAIExtract:
-		return aiModeExtract
-	case models.IntegrationActionAIGenerate:
-		return aiModeGenerate
 	case models.IntegrationActionAISwitch:
 		return aiModeDecide
 	case models.IntegrationActionAIStep:
 		switch strings.TrimSpace(cfg.Mode) {
-		case aiModeClassify, aiModeExtract, aiModeGenerate, aiModeDecide, aiModeAgent:
+		case aiModeClassify, aiModeExtract, aiModeAgent:
 			return strings.TrimSpace(cfg.Mode)
 		default:
 			return aiModeGenerate
@@ -97,15 +100,10 @@ func resolveMode(action models.IntegrationAction, cfg aiActionConfig) string {
 }
 
 // aiNodeRoutesByLabel reports whether an AI node fans out on "label:<x>" edges:
-// classify (Labels) and decide / ai_switch (Cases). Used to authorize per-label
+// only the ai_switch (decide) routes on its cases. Used to authorize per-case
 // edges at write time.
 func aiNodeRoutesByLabel(n models.AutomationNode) bool {
-	switch resolveMode(n.Action, parseAIConfig(n.Config)) {
-	case aiModeClassify, aiModeDecide:
-		return true
-	default:
-		return false
-	}
+	return resolveMode(n.Action, parseAIConfig(n.Config)) == aiModeDecide
 }
 
 // aiNodeHasBranch reports whether label is one of the node's routing choices
@@ -162,21 +160,23 @@ func actionSuccessEdges(n models.AutomationNode, data map[string]any, edges []mo
 }
 
 // aiActionConfig is the per-node config for an AI action node. The unified
-// ai_step reuses this same blob (Instruction + the mode-specific fields); the
-// legacy nodes only ever set the subset they need.
+// ai_step and the ai_switch share this same blob (Instruction + the mode/router
+// fields); each mode only reads the subset it needs. New fields are additive:
+// absent in an older blob means the zero value, which is the prior behavior.
 type aiActionConfig struct {
-	// Mode drives the unified ai_step (classify|extract|generate|decide|agent).
-	// Empty for legacy nodes (their id fixes the mode via resolveMode).
+	// Mode drives the unified ai_step (classify|extract|generate|agent). Empty
+	// for ai_switch (its id fixes decide via resolveMode).
 	Mode string `json:"mode"`
 	// Instruction is the user's prompt, Go-templated against the event data so
 	// it can reference {{.subject}}, {{.snippet}}, etc. In agent mode it is the
-	// system instruction the model follows while choosing tools.
+	// system instruction the model follows while choosing tools. Unused by a
+	// value-mode switch.
 	Instruction string `json:"instruction"`
-	// Labels is the closed set ai_classify must choose from.
+	// Labels is the closed set classify mode must choose from.
 	Labels []string `json:"labels"`
-	// OutputKeys are the variable names ai_extract fills from the text.
+	// OutputKeys are the variable names extract mode fills from the text.
 	OutputKeys []string `json:"output_keys"`
-	// Cases is the closed set decide / ai_switch route on ("label:<case>" edges).
+	// Cases is the closed set the ai_switch routes on ("label:<case>" edges).
 	Cases []string `json:"cases"`
 	// Allowlist is the guarded set of reversible native actions an agent-mode
 	// step may call as tools (add_tag, remove_tag, create_task, create_deal,
@@ -187,6 +187,31 @@ type aiActionConfig struct {
 	// nodes in one flow don't collide (classify->ai_class, generate->ai_text,
 	// decide->ai_case, agent->ai_agent).
 	OutputKey string `json:"output_key"`
+
+	// SwitchOn selects the ai_switch decider: "ai" (default — one LLM call) or
+	// "value" (SwitchValue rendered against the event and matched to the cases;
+	// free, no model call). Mirrors the campaign switch.
+	SwitchOn string `json:"switch_on"`
+	// SwitchValue is the template a value-mode switch renders and matches to the
+	// case names (e.g. "{{.intent}}"). Ignored in ai mode.
+	SwitchValue string `json:"switch_value"`
+	// Thinking routes any AI node to the stronger model tier with a larger output
+	// budget; the extra token cost flows through usage metering.
+	Thinking bool `json:"thinking"`
+	// WebSearch runs one bounded web search about the event's company before an
+	// ai-mode switch decides, fed in as fenced untrusted context (+1 credit when
+	// results are found). Ignored outside the ai switch.
+	WebSearch bool `json:"web_search"`
+
+	// AddTags / RemoveTags / Labels are OPTIONAL pools an agent-mode step's
+	// tag/label tools pick from by name. An empty pool means unrestricted: the
+	// executor lists the org owner's tags/labels live at run time and the agent
+	// may use any (tags and unibox labels are the same category registry).
+	// AllowCreateTags additionally lets an empty-pool pick mint a new tag/label.
+	AddTags         []models.AITagRef `json:"ai_add_tags"`
+	RemoveTags      []models.AITagRef `json:"ai_remove_tags"`
+	LabelPool       []models.AITagRef `json:"ai_labels"`
+	AllowCreateTags bool              `json:"ai_allow_create_tags"`
 }
 
 func parseAIConfig(raw json.RawMessage) aiActionConfig {
@@ -200,12 +225,6 @@ func parseAIConfig(raw json.RawMessage) aiActionConfig {
 // aiActionLabel is a short run-history label for an AI node.
 func aiActionLabel(a models.IntegrationAction) string {
 	switch a {
-	case models.IntegrationActionAIClassify:
-		return "AI classify"
-	case models.IntegrationActionAIExtract:
-		return "AI extract"
-	case models.IntegrationActionAIGenerate:
-		return "AI generate"
 	case models.IntegrationActionAIStep:
 		return "AI step"
 	case models.IntegrationActionAISwitch:
@@ -241,12 +260,22 @@ func (s *service) execAIAction(ctx context.Context, a models.Automation, n model
 		return errors.New("AI steps are not available on this deployment")
 	}
 	cfg := parseAIConfig(n.Config)
+	mode := resolveMode(n.Action, cfg)
+
+	// A value-mode AI switch is deterministic: render the value template against
+	// the event and match it to the cases, no model call and no credit. Handled
+	// before the instruction check because value mode has no instruction.
+	if mode == aiModeDecide && strings.TrimSpace(cfg.SwitchOn) == "value" {
+		data[decideOutputKey(n.Action, cfg)] = aiagentargs.MatchValueToCases(
+			strings.TrimSpace(renderTemplate(cfg.SwitchValue, data)), nonEmptyStrings(cfg.Cases))
+		return nil
+	}
+
 	instruction := strings.TrimSpace(renderTemplate(cfg.Instruction, data))
 	if instruction == "" {
 		return errors.New("this AI step has no instruction")
 	}
 
-	mode := resolveMode(n.Action, cfg)
 	// Agent mode runs a bounded tool-use loop (its own credit lifecycle); the
 	// other modes share the single-shot Complete path below.
 	if mode == aiModeAgent {
@@ -255,8 +284,9 @@ func (s *service) execAIAction(ctx context.Context, a models.Automation, n model
 
 	// gate -> consume(Idempotency-Key) -> call -> refund-on-failure. The key is
 	// scoped to this run + node so a retried walk never double-charges. A
-	// free/local model (AI_FREE) runs un-metered, so skip the charge.
-	model := s.aiProvider.ModelForTier(false)
+	// free/local model (AI_FREE) runs un-metered, so skip the charge. Thinking
+	// routes to the stronger tier; its higher pricing flows through the settle.
+	model := s.aiProvider.ModelForTier(cfg.Thinking)
 	idemKey := "auto_ai:" + stringFromMap(data, automationRunIDKey) + ":" + n.ID
 	// Attribute the charge (and its settle/refund) to this automation node run.
 	ctx = models.WithCreditMeta(ctx, models.CreditMeta{Context: models.CreditContext{
@@ -282,16 +312,39 @@ func (s *service) execAIAction(ctx context.Context, a models.Automation, n model
 		}
 	}
 
+	// Web search capability (ai-mode switch only): one bounded lookup about the
+	// event's company, fed in as fenced untrusted context. The query is derived
+	// from event fields (never from reply content), and it is charged only when
+	// it actually returned results.
+	web := ""
+	if mode == aiModeDecide && cfg.WebSearch && s.aiSearch != nil {
+		if q := automationSearchQuery(data); q != "" {
+			sctx, scancel := context.WithTimeout(ctx, 15*time.Second)
+			results, serr := s.aiSearch.Search(sctx, q, 3)
+			scancel()
+			if serr == nil && len(results) > 0 {
+				web = renderAISearchResults(q, results)
+				if !s.aiProvider.IsLocal() {
+					_, _ = s.credits.Consume(ctx, a.OrganizationID, credits.CostWebSearch, "automation_ai_search", "", 0, idemKey+":search")
+				}
+			}
+		}
+	}
+
 	// Per-node ceiling well under the 30s graph budget.
 	cctx, cancel := context.WithTimeout(ctx, aiNodeTimeout)
 	defer cancel()
 
-	system, prompt := buildAIPrompt(mode, cfg, instruction, data)
+	maxTokens := aiNodeMaxTokens
+	if cfg.Thinking {
+		maxTokens = aiThinkingMaxTokens
+	}
+	system, prompt := buildAIPrompt(mode, cfg, instruction, data, web)
 	res, gerr := s.aiProvider.Complete(cctx, generation.CompletionRequest{
 		System:      system,
 		Prompt:      prompt,
 		Model:       model,
-		MaxTokens:   aiNodeMaxTokens,
+		MaxTokens:   maxTokens,
 		Temperature: aiTemperature(mode),
 	})
 	if gerr != nil || res == nil {
@@ -334,9 +387,12 @@ func (s *service) execAIAgentStep(ctx context.Context, a models.Automation, n mo
 	if s.aiProvider == nil || s.credits == nil {
 		return errors.New("AI steps are not available on this deployment")
 	}
-	tools := s.guardedAITools(a, n, cfg, data, feedPause)
+	tools := s.guardedAITools(ctx, a, n, cfg, data, feedPause)
+	if len(tools) == 0 {
+		return nil // nothing enabled: harmless no-op
+	}
 
-	model := s.aiProvider.ModelForTier(false)
+	model := s.aiProvider.ModelForTier(cfg.Thinking)
 	runID := stringFromMap(data, automationRunIDKey)
 	ctx = models.WithCreditMeta(ctx, models.CreditMeta{Context: models.CreditContext{
 		AutomationID:   a.ID.String(),
@@ -377,14 +433,18 @@ func (s *service) execAIAgentStep(ctx context.Context, a models.Automation, n mo
 	cctx, cancel := context.WithTimeout(ctx, aiAgentTimeout)
 	defer cancel()
 
-	system := "You are an automation agent. Follow the instruction and act on the event by calling the available tools. Only take actions the instruction asks for; if none apply, take none. Each tool applies a reversible change to the contact or event. When done, briefly state what you did." + aiEventGuard
+	maxTokens := aiNodeMaxTokens
+	if cfg.Thinking {
+		maxTokens = aiThinkingMaxTokens
+	}
+	system := "You are an automation agent. Follow the instruction and act on the event by calling the available tools. Only take actions the instruction asks for; if none apply, take none. Each tool applies a reversible change to the contact or event. You write any tag, task, or deal details yourself. When done, briefly state what you did." + aiEventGuard
 	res, gerr := s.aiProvider.RunAgent(cctx, generation.AgentRequest{
 		System:        system + "\n\nInstruction: " + instruction,
 		Messages:      []generation.AgentMessage{{Role: "user", Content: "Event data:\n" + fencedEventContext(data)}},
 		Tools:         tools,
 		Model:         model,
 		MaxIterations: aiAgentMaxIterations,
-		MaxTokens:     aiNodeMaxTokens,
+		MaxTokens:     maxTokens,
 		PreIteration:  preIteration,
 	})
 	// The loop stopped because the org ran out of credits: surface that, not a
@@ -413,38 +473,34 @@ func aiToolName(action models.IntegrationAction) string {
 	return strings.TrimPrefix(string(action), "warmbly.")
 }
 
-// aiToolDescription tells the model what firing a guarded tool does. The
-// side-effect parameters are fixed by the node config, so the model only
-// decides whether to call it.
-func aiToolDescription(action models.IntegrationAction) string {
-	switch action {
-	case models.IntegrationActionAddTag:
-		return "Add the configured tag to the contact."
-	case models.IntegrationActionRemoveTag:
-		return "Remove the configured tag from the contact."
-	case models.IntegrationActionCreateTask:
-		return "Create the configured CRM task for the contact."
-	case models.IntegrationActionCreateDeal:
-		return "Create the configured CRM deal for the contact."
-	case models.IntegrationActionMoveDealStage:
-		return "Move the contact's deal to the configured pipeline stage."
-	case models.IntegrationActionLabelEmail:
-		return "Apply the configured labels to the event's email conversation."
-	case models.IntegrationActionSetVariables:
-		return "Set the configured variables on the event for later steps."
-	case models.IntegrationActionUnsubscribe:
-		return "Unsubscribe the contact from the campaign in the event."
-	default:
-		return "Run the " + aiToolName(action) + " action."
+// guardedAITools builds one argument-taking tool per allowlisted native action
+// the agent may call, mirroring the campaign AI step. The model supplies the
+// specifics (which tag, task title, deal name/pipeline) and the executor
+// resolves them live: an optional pool restricts a tag/label choice, an empty
+// pool means any of the owner's tags (with optional create). Guarded two ways:
+// only isAllowlistedAIAction ids become tools (never a send/reply or connection
+// action), and every tool dispatches through the existing native executor. On a
+// dry run each tool reports what it would do without applying anything.
+func (s *service) guardedAITools(ctx context.Context, a models.Automation, n models.AutomationNode, cfg aiActionConfig, data map[string]any, feedPause bool) []generation.ToolDef {
+	// The org owner scopes tag/label reads + writes (categories are per user).
+	// The live category list (tags == unibox labels) is fetched once, only when a
+	// tag/label capability is enabled, so an unrestricted pool can offer any.
+	needCats := false
+	for _, raw := range cfg.Allowlist {
+		switch models.IntegrationAction(strings.TrimSpace(raw)) {
+		case models.IntegrationActionAddTag, models.IntegrationActionRemoveTag, models.IntegrationActionLabelEmail:
+			needCats = true
+		}
 	}
-}
+	var owner uuid.UUID
+	if o, err := s.native.OrgOwner(ctx, a.OrganizationID); err == nil {
+		owner = o
+	}
+	var liveCats []models.MiniCategory
+	if needCats && owner != uuid.Nil {
+		liveCats, _ = s.native.ListCategories(ctx, owner)
+	}
 
-// guardedAITools builds one tool per allowlisted native action the agent may
-// call. Guarded two ways: only isAllowlistedAIAction ids become tools (never a
-// send/reply or connection action), and the side-effect parameters come from
-// the node config (the model decides WHETHER to fire an effect, not arbitrary
-// CRM targets). On a dry run the tool reports the effect without applying it.
-func (s *service) guardedAITools(a models.Automation, n models.AutomationNode, cfg aiActionConfig, data map[string]any, feedPause bool) []generation.ToolDef {
 	seen := map[models.IntegrationAction]bool{}
 	tools := make([]generation.ToolDef, 0, len(cfg.Allowlist))
 	for _, raw := range cfg.Allowlist {
@@ -453,30 +509,269 @@ func (s *service) guardedAITools(a models.Automation, n models.AutomationNode, c
 			continue
 		}
 		seen[action] = true
-		act := action // capture per iteration for the handler closure
-		tools = append(tools, generation.ToolDef{
-			Name:        aiToolName(act),
-			Description: aiToolDescription(act),
-			InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
-			Risk:        generation.RiskWrite,
-			Handler: func(ctx context.Context, _ json.RawMessage) (string, error) {
-				if !feedPause {
-					return "(test run: would " + aiToolName(act) + ")", nil
-				}
-				// Re-check the guard at run time, then dispatch through the
-				// existing native executor with the node's pinned config.
-				if !isAllowlistedAIAction(act) {
-					return "", fmt.Errorf("%s is not an allowed action", aiToolName(act))
-				}
-				syn := models.AutomationNode{ID: n.ID, Type: models.AutomationNodeAction, Action: act, Config: n.Config}
-				if err := s.execNativeAction(ctx, a, syn, data); err != nil {
-					return "", err
-				}
-				return "done: " + aiToolName(act), nil
-			},
-		})
+		switch action {
+		case models.IntegrationActionAddTag:
+			tools = append(tools, s.aiTagTool(a, n, data, feedPause, owner, action, cfg.AddTags, liveCats, cfg.AllowCreateTags))
+		case models.IntegrationActionRemoveTag:
+			tools = append(tools, s.aiTagTool(a, n, data, feedPause, owner, action, cfg.RemoveTags, liveCats, false))
+		case models.IntegrationActionLabelEmail:
+			tools = append(tools, s.aiTagTool(a, n, data, feedPause, owner, action, cfg.LabelPool, liveCats, cfg.AllowCreateTags))
+		case models.IntegrationActionCreateTask:
+			tools = append(tools, s.aiTaskTool(a, n, data, feedPause))
+		case models.IntegrationActionCreateDeal:
+			tools = append(tools, s.aiDealTool(a, n, data, feedPause, action))
+		case models.IntegrationActionMoveDealStage:
+			tools = append(tools, s.aiDealTool(a, n, data, feedPause, action))
+		case models.IntegrationActionSetVariables:
+			tools = append(tools, s.aiSetVarsTool(a, n, data, feedPause))
+		case models.IntegrationActionUnsubscribe:
+			tools = append(tools, s.aiUnsubscribeTool(a, n, data, feedPause))
+		}
 	}
 	return tools
+}
+
+// dispatchSynthetic runs a native action with a freshly-built config (the args
+// the agent supplied) through the existing executor, so the agent tools reuse
+// the same side-effect code path as a standalone action node.
+func (s *service) dispatchSynthetic(ctx context.Context, a models.Automation, n models.AutomationNode, action models.IntegrationAction, cfg map[string]any, data map[string]any) error {
+	raw, _ := json.Marshal(cfg)
+	syn := models.AutomationNode{ID: n.ID, Type: models.AutomationNodeAction, Action: action, Config: raw}
+	return s.execNativeAction(ctx, a, syn, data)
+}
+
+// aiTagTool builds an argument-taking add_tag / remove_tag / label_email tool.
+// The model picks a name; a configured pool restricts the choice (offered as an
+// enum), while an empty pool is unrestricted and resolved against the live
+// category list (with optional create for add/label). It can be called
+// repeatedly.
+func (s *service) aiTagTool(a models.Automation, n models.AutomationNode, data map[string]any, feedPause bool, owner uuid.UUID, action models.IntegrationAction, pool []models.AITagRef, live []models.MiniCategory, allowCreate bool) generation.ToolDef {
+	kind := aiToolName(action)
+	allowCreate = allowCreate && action != models.IntegrationActionRemoveTag
+	enum := aiagentargs.TagEnum(pool, live)
+	verb := map[string]string{"add_tag": "Add the tag", "remove_tag": "Remove the tag", "label_email": "Apply the label"}[kind]
+	desc := verb + " named by `tag` on the contact. Call again for another."
+	if len(pool) > 0 {
+		desc = verb + " (one of: " + strings.Join(enum, ", ") + ") on the contact. Call again for another."
+	} else if allowCreate {
+		desc += " Any name; a new tag is created if it does not exist."
+	}
+	tagProp := map[string]any{"type": "string", "description": "The tag/label name"}
+	// Only pin an enum when a pool restricts the choice; a live list may be large,
+	// so keep it free-text (validated at resolve time) to bound the schema.
+	if len(pool) > 0 && len(enum) > 0 {
+		tagProp["enum"] = enum
+	}
+	return generation.ToolDef{
+		Name:        kind,
+		Description: desc,
+		InputSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"tag": tagProp},
+			"required":   []string{"tag"},
+		},
+		Risk: generation.RiskWrite,
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var in struct {
+				Tag string `json:"tag"`
+			}
+			_ = json.Unmarshal(args, &in)
+			if !feedPause {
+				return "(test run: would " + kind + " " + strings.TrimSpace(in.Tag) + ")", nil
+			}
+			id, err := aiagentargs.ResolveTag(pool, live, allowCreate, in.Tag, func(title string) (uuid.UUID, error) {
+				c, cerr := s.native.CreateCategory(ctx, owner, title, "")
+				if cerr != nil {
+					return uuid.Nil, cerr
+				}
+				return c.ID, nil
+			})
+			if err != nil {
+				return "", err
+			}
+			cfg := map[string]any{}
+			if action == models.IntegrationActionLabelEmail {
+				cfg["label_ids"] = []string{id.String()}
+			} else {
+				cfg["category_id"] = id.String()
+			}
+			if err := s.dispatchSynthetic(ctx, a, n, action, cfg, data); err != nil {
+				return "", err
+			}
+			return "done: " + kind + " " + in.Tag, nil
+		},
+	}
+}
+
+// aiTaskTool lets the agent create a CRM task, writing the title (and optional
+// type/priority/due) itself from the instruction and event.
+func (s *service) aiTaskTool(a models.Automation, n models.AutomationNode, data map[string]any, feedPause bool) generation.ToolDef {
+	return generation.ToolDef{
+		Name:        "create_task",
+		Description: "Create a CRM task for the contact. You write the title; type/priority/due are optional.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"title":           map[string]any{"type": "string", "description": "The task title"},
+				"type":            map[string]any{"type": "string", "description": "Optional task type (e.g. call, email)"},
+				"priority":        map[string]any{"type": "string", "enum": []string{"low", "medium", "high", "urgent"}},
+				"due_offset_days": map[string]any{"type": "integer", "description": "Optional days from now until due"},
+			},
+			"required": []string{"title"},
+		},
+		Risk: generation.RiskWrite,
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var in struct {
+				Title         string `json:"title"`
+				Type          string `json:"type"`
+				Priority      string `json:"priority"`
+				DueOffsetDays *int   `json:"due_offset_days"`
+			}
+			_ = json.Unmarshal(args, &in)
+			if strings.TrimSpace(in.Title) == "" {
+				return "", fmt.Errorf("a task needs a title")
+			}
+			if !feedPause {
+				return "(test run: would create_task " + in.Title + ")", nil
+			}
+			cfg := map[string]any{"task_title": in.Title}
+			if in.Type != "" {
+				cfg["task_type"] = in.Type
+			}
+			if in.Priority != "" {
+				cfg["task_priority"] = in.Priority
+			}
+			if in.DueOffsetDays != nil {
+				cfg["task_due_offset_days"] = *in.DueOffsetDays
+			}
+			if err := s.dispatchSynthetic(ctx, a, n, models.IntegrationActionCreateTask, cfg, data); err != nil {
+				return "", err
+			}
+			return "done: create_task " + in.Title, nil
+		},
+	}
+}
+
+// aiDealTool backs create_deal / move_deal_stage: the agent writes the deal name
+// and may name a pipeline/stage, resolved against the org's live pipelines
+// (defaulting to the first pipeline and stage).
+func (s *service) aiDealTool(a models.Automation, n models.AutomationNode, data map[string]any, feedPause bool, action models.IntegrationAction) generation.ToolDef {
+	kind := aiToolName(action)
+	props := map[string]any{
+		"pipeline": map[string]any{"type": "string", "description": "Optional pipeline name; defaults to your first"},
+		"stage":    map[string]any{"type": "string", "description": "Optional stage name; defaults to the first stage"},
+	}
+	required := []string{}
+	if action == models.IntegrationActionCreateDeal {
+		props["name"] = map[string]any{"type": "string", "description": "The deal name"}
+		props["value"] = map[string]any{"type": "number", "description": "Optional deal value"}
+		props["currency"] = map[string]any{"type": "string", "description": "Optional ISO currency, defaults USD"}
+		required = []string{"name"}
+	}
+	desc := "Create a CRM deal for the contact; you write the name and may name a pipeline/stage."
+	if action == models.IntegrationActionMoveDealStage {
+		desc = "Move the contact's open deal to a pipeline stage."
+	}
+	return generation.ToolDef{
+		Name:        kind,
+		Description: desc,
+		InputSchema: map[string]any{"type": "object", "properties": props, "required": required},
+		Risk:        generation.RiskWrite,
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var in struct {
+				Name     string   `json:"name"`
+				Value    *float64 `json:"value"`
+				Currency string   `json:"currency"`
+				Pipeline string   `json:"pipeline"`
+				Stage    string   `json:"stage"`
+			}
+			_ = json.Unmarshal(args, &in)
+			if !feedPause {
+				return "(test run: would " + kind + ")", nil
+			}
+			pipelines, perr := s.native.ListPipelines(ctx, a.OrganizationID)
+			if perr != nil {
+				return "", perr
+			}
+			plID, stID, rerr := aiagentargs.ResolvePipelineStage(pipelines, in.Pipeline, in.Stage)
+			if rerr != nil {
+				return "", rerr
+			}
+			cfg := map[string]any{"deal_pipeline_id": plID.String(), "deal_stage_id": stID.String()}
+			if action == models.IntegrationActionCreateDeal {
+				if strings.TrimSpace(in.Name) != "" {
+					cfg["deal_name"] = in.Name
+				}
+				if in.Value != nil {
+					cfg["deal_value"] = *in.Value
+				}
+				if in.Currency != "" {
+					cfg["deal_currency"] = in.Currency
+				}
+			}
+			if err := s.dispatchSynthetic(ctx, a, n, action, cfg, data); err != nil {
+				return "", err
+			}
+			return "done: " + kind, nil
+		},
+	}
+}
+
+// aiSetVarsTool lets the agent write one named variable back into the event data
+// for later steps to read. The agent supplies key + value (automation-specific;
+// campaigns have no per-event scratchpad).
+func (s *service) aiSetVarsTool(a models.Automation, n models.AutomationNode, data map[string]any, feedPause bool) generation.ToolDef {
+	return generation.ToolDef{
+		Name:        "set_variables",
+		Description: "Set a named variable on the event for later steps to read. Call again for another.",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"key":   map[string]any{"type": "string", "description": "The variable name"},
+				"value": map[string]any{"type": "string", "description": "The value to store"},
+			},
+			"required": []string{"key", "value"},
+		},
+		Risk: generation.RiskWrite,
+		Handler: func(ctx context.Context, args json.RawMessage) (string, error) {
+			var in struct {
+				Key   string `json:"key"`
+				Value string `json:"value"`
+			}
+			_ = json.Unmarshal(args, &in)
+			if strings.TrimSpace(in.Key) == "" {
+				return "", fmt.Errorf("a variable needs a name")
+			}
+			if !feedPause {
+				return "(test run: would set " + in.Key + ")", nil
+			}
+			cfg := map[string]any{"set_vars": []map[string]any{{"key": in.Key, "value": in.Value}}}
+			if err := s.dispatchSynthetic(ctx, a, n, models.IntegrationActionSetVariables, cfg, data); err != nil {
+				return "", err
+			}
+			return "done: set " + in.Key, nil
+		},
+	}
+}
+
+// aiUnsubscribeTool unsubscribes the event's contact from the campaign in the
+// event data. No arguments — the model only decides whether to fire it.
+func (s *service) aiUnsubscribeTool(a models.Automation, n models.AutomationNode, data map[string]any, feedPause bool) generation.ToolDef {
+	return generation.ToolDef{
+		Name:        "unsubscribe",
+		Description: "Unsubscribe the contact from the campaign in the event.",
+		InputSchema: map[string]any{"type": "object", "properties": map[string]any{}},
+		Risk:        generation.RiskWrite,
+		Handler: func(ctx context.Context, _ json.RawMessage) (string, error) {
+			if !feedPause {
+				return "(test run: would unsubscribe)", nil
+			}
+			if err := s.dispatchSynthetic(ctx, a, n, models.IntegrationActionUnsubscribe, map[string]any{}, data); err != nil {
+				return "", err
+			}
+			return "done: unsubscribe", nil
+		},
+	}
 }
 
 // evalAICondition answers an Ask-AI branch node's yes/no question about the
@@ -582,8 +877,9 @@ func (s *service) noteAICreditFailure(ctx context.Context, a models.Automation) 
 
 // buildAIPrompt builds the system + user prompt for one AI node. The event data
 // (minus internal keys) is included so the model can read the fields the
-// instruction references.
-func buildAIPrompt(mode string, cfg aiActionConfig, instruction string, data map[string]any) (system, prompt string) {
+// instruction references. web, when set (an ai-mode switch with results), is
+// appended as fenced untrusted context.
+func buildAIPrompt(mode string, cfg aiActionConfig, instruction string, data map[string]any, web string) (system, prompt string) {
 	eventCtx := fencedEventContext(data)
 	switch mode {
 	case aiModeClassify:
@@ -599,7 +895,62 @@ func buildAIPrompt(mode string, cfg aiActionConfig, instruction string, data map
 		system = "You write short, useful text for an automation step based on the instruction and event data. Reply with only the text, no preamble, no quotes." + aiEventGuard
 	}
 	prompt = "Instruction: " + instruction + "\n\nEvent data:\n" + eventCtx
+	if strings.TrimSpace(web) != "" {
+		prompt += "\n\nWeb search results about the company:\n" + fenceUntrusted(web)
+	}
 	return system, prompt
+}
+
+// automationSearchQuery derives a web-search query from the event's own fields:
+// a company name, else a corporate email domain. Never built from reply content,
+// so a hostile message cannot steer the search.
+func automationSearchQuery(data map[string]any) string {
+	if company := strings.TrimSpace(stringFromMap(data, "company")); company != "" {
+		return company
+	}
+	email := strings.TrimSpace(stringFromMap(data, "contact_email", "email", "invitee_email"))
+	if at := strings.LastIndex(email, "@"); at >= 0 {
+		domain := strings.ToLower(strings.TrimSpace(email[at+1:]))
+		if domain != "" && !freeMailDomain(domain) {
+			return domain
+		}
+	}
+	return ""
+}
+
+// freeMailDomain reports a consumer mailbox domain that never identifies a
+// company, so it is useless as a search fallback.
+func freeMailDomain(domain string) bool {
+	switch domain {
+	case "gmail.com", "googlemail.com", "outlook.com", "hotmail.com", "live.com",
+		"yahoo.com", "icloud.com", "me.com", "aol.com", "proton.me", "protonmail.com",
+		"gmx.com", "mail.com":
+		return true
+	default:
+		return false
+	}
+}
+
+// renderAISearchResults renders bounded title/snippet lines for the prompt.
+// Plain text; buildAIPrompt fences it as untrusted before it reaches the model.
+func renderAISearchResults(query string, results []generation.SearchResult) string {
+	var b strings.Builder
+	b.WriteString("Query: ")
+	b.WriteString(truncate(query, 120))
+	b.WriteString("\n")
+	for i, r := range results {
+		if i >= 3 {
+			break
+		}
+		b.WriteString("- ")
+		b.WriteString(truncate(strings.TrimSpace(r.Title), 120))
+		if snip := strings.TrimSpace(r.Snippet); snip != "" {
+			b.WriteString(": ")
+			b.WriteString(truncate(snip, 300))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 // Untrusted-content fence for the event data section: automation events carry
@@ -614,7 +965,13 @@ const (
 )
 
 func fencedEventContext(data map[string]any) string {
-	s := aiEventContext(data)
+	return fenceUntrusted(aiEventContext(data))
+}
+
+// fenceUntrusted strips any embedded fence markers from s (so the content can't
+// spoof the fence and terminate it early) and wraps it in the untrusted-content
+// markers the AI-node system prompts pin their task against.
+func fenceUntrusted(s string) string {
 	s = strings.ReplaceAll(s, aiEventFenceBegin, "")
 	s = strings.ReplaceAll(s, aiEventFenceEnd, "")
 	return aiEventFenceBegin + "\n" + strings.TrimSpace(s) + "\n" + aiEventFenceEnd

--- a/internal/app/integration/graph_executor.go
+++ b/internal/app/integration/graph_executor.go
@@ -356,7 +356,7 @@ func (s *service) dryRunGraph(ctx context.Context, a models.Automation, data map
 			}
 			// A dry run never fails an action, so it follows the normal path and
 			// not the "on error" branch (a skipped action still continues the
-			// walk; a skipped ai_classify has no verdict, so its label branches
+			// walk; a skipped AI switch has no verdict, so its label branches
 			// stay unfollowed).
 			for _, e := range actionSuccessEdges(n, data, outEdges[id]) {
 				queue = append(queue, e.Target)

--- a/internal/app/integration/native_actions.go
+++ b/internal/app/integration/native_actions.go
@@ -48,37 +48,31 @@ func validateNativeActionConfig(action models.IntegrationAction, raw json.RawMes
 		if strings.TrimSpace(cfg.EventName) == "" {
 			return fmt.Errorf("a fire-event action needs an event name")
 		}
-	case models.IntegrationActionAIClassify:
-		ai := parseAIConfig(raw)
-		if strings.TrimSpace(ai.Instruction) == "" {
-			return fmt.Errorf("an AI classify step needs an instruction")
-		}
-		if len(nonEmptyStrings(ai.Labels)) < 2 {
-			return fmt.Errorf("an AI classify step needs at least two labels")
-		}
-	case models.IntegrationActionAIExtract:
-		ai := parseAIConfig(raw)
-		if strings.TrimSpace(ai.Instruction) == "" {
-			return fmt.Errorf("an AI extract step needs an instruction")
-		}
-		if len(nonEmptyStrings(ai.OutputKeys)) == 0 {
-			return fmt.Errorf("an AI extract step needs at least one output key")
-		}
-	case models.IntegrationActionAIGenerate:
-		ai := parseAIConfig(raw)
-		if strings.TrimSpace(ai.Instruction) == "" {
-			return fmt.Errorf("an AI generate step needs an instruction")
-		}
 	case models.IntegrationActionAIStep:
 		return validateAIStepConfig(raw)
 	case models.IntegrationActionAISwitch:
-		ai := parseAIConfig(raw)
-		if strings.TrimSpace(ai.Instruction) == "" {
-			return fmt.Errorf("an AI switch needs an instruction")
+		return validateAISwitchConfig(raw)
+	}
+	return nil
+}
+
+// validateAISwitchConfig validates the AI switch router by decider mode
+// (mirrors the campaign switch): "value" mode needs a value template and at
+// least two cases (no model call, so no instruction); "ai" mode needs an
+// instruction and at least two cases.
+func validateAISwitchConfig(raw json.RawMessage) error {
+	ai := parseAIConfig(raw)
+	if len(nonEmptyStrings(ai.Cases)) < 2 {
+		return fmt.Errorf("an AI switch needs at least two cases")
+	}
+	if strings.TrimSpace(ai.SwitchOn) == "value" {
+		if strings.TrimSpace(ai.SwitchValue) == "" {
+			return fmt.Errorf("a value switch needs a value to match")
 		}
-		if len(nonEmptyStrings(ai.Cases)) < 2 {
-			return fmt.Errorf("an AI switch needs at least two cases")
-		}
+		return nil
+	}
+	if strings.TrimSpace(ai.Instruction) == "" {
+		return fmt.Errorf("an AI switch needs an instruction")
 	}
 	return nil
 }
@@ -103,9 +97,11 @@ func isAllowlistedAIAction(a models.IntegrationAction) bool {
 	}
 }
 
-// validateAIStepConfig validates the unified AI step by mode, plus the guarded
-// action allowlist for agent mode (every entry must pass isAllowlistedAIAction
-// and carry the config its executor needs, checked against the same node blob).
+// validateAIStepConfig validates the unified AI step by mode. Routing lives in
+// the AI switch node, so decide is not a step mode. Agent mode only checks the
+// guarded allowlist: every entry must pass isAllowlistedAIAction, and the agent
+// supplies each action's target (which tag/task/deal) as a tool argument at run
+// time, so no pinned per-action config is required here.
 func validateAIStepConfig(raw json.RawMessage) error {
 	ai := parseAIConfig(raw)
 	if strings.TrimSpace(ai.Instruction) == "" {
@@ -120,10 +116,6 @@ func validateAIStepConfig(raw json.RawMessage) error {
 		if len(nonEmptyStrings(ai.OutputKeys)) == 0 {
 			return fmt.Errorf("extract mode needs at least one output key")
 		}
-	case "decide":
-		if len(nonEmptyStrings(ai.Cases)) < 2 {
-			return fmt.Errorf("decide mode needs at least two cases")
-		}
 	case "agent":
 		enabled := nonEmptyStrings(ai.Allowlist)
 		if len(enabled) == 0 {
@@ -133,11 +125,6 @@ func validateAIStepConfig(raw json.RawMessage) error {
 			id := models.IntegrationAction(strings.TrimSpace(raw2))
 			if !isAllowlistedAIAction(id) {
 				return fmt.Errorf("%q is not an allowed agent action", raw2)
-			}
-			// Each enabled action's pinned config lives in the same node blob,
-			// so validate it the way that action normally would.
-			if err := validateNativeActionConfig(id, raw); err != nil {
-				return fmt.Errorf("allowed action %q: %w", aiToolName(id), err)
 			}
 		}
 	case "generate", "":
@@ -181,6 +168,15 @@ type NativeActions interface {
 	// behalf of the mailbox-owner userID (categories are per user). Backs the
 	// "label_email" action; userID + threadID come from the reply event data.
 	LabelThread(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) error
+
+	// ListCategories / CreateCategory / ListPipelines back the AI agent step's
+	// argument-based tools: the model picks a tag/label/pipeline by name and the
+	// executor resolves it live (empty pool = any of the owner's tags). Keyed by
+	// the org OWNER (categories are per user); pipelines are org-scoped with
+	// stages hydrated in position order. Mirrors the campaign agent tools.
+	ListCategories(ctx context.Context, ownerID uuid.UUID) ([]models.MiniCategory, error)
+	CreateCategory(ctx context.Context, ownerID uuid.UUID, title, color string) (models.MiniCategory, error)
+	ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, error)
 }
 
 // nativeActionConfig is the per-node config for native action nodes (mirrors the

--- a/internal/app/integration/service.go
+++ b/internal/app/integration/service.go
@@ -94,10 +94,14 @@ type Service interface {
 	SetNativeActions(n NativeActions)
 	SetPublisher(p *pubsub.StreamingPublisher)
 	// SetAI wires the LLM provider + credit ledger the AI automation nodes
-	// (ai_classify / ai_extract / ai_generate) use. Both may be nil (AI steps
-	// then fail with a clear "not available" error); the provider is nil when no
-	// AI_PROVIDER is configured.
+	// (ai_step / ai_switch) use. Both may be nil (AI steps then fail with a clear
+	// "not available" error); the provider is nil when no AI_PROVIDER is
+	// configured.
 	SetAI(p generation.Provider, c credits.CreditService)
+	// SetAISearch wires the optional web-search backend an ai-mode AI switch may
+	// use to look up the event's company. Nil leaves web search unavailable (the
+	// node runs without it). Mirrors tasks.Service.SetAISearch.
+	SetAISearch(sc generation.SearchClient)
 
 	// ListSyncRuns returns recent observability records for a connection.
 	ListSyncRuns(ctx context.Context, orgID, connID uuid.UUID, limit int) ([]models.IntegrationSyncRun, error)
@@ -169,6 +173,7 @@ type service struct {
 	publisher  *pubsub.StreamingPublisher
 	aiProvider generation.Provider
 	credits    credits.CreditService
+	aiSearch   generation.SearchClient
 }
 
 // NewService builds the integration service. cipherSvc seals provider secrets
@@ -188,6 +193,7 @@ func (s *service) SetAI(p generation.Provider, c credits.CreditService) {
 	s.aiProvider = p
 	s.credits = c
 }
+func (s *service) SetAISearch(sc generation.SearchClient) { s.aiSearch = sc }
 
 func (s *service) Repo() repository.IntegrationRepository { return s.repo }
 
@@ -677,6 +683,9 @@ func (s *service) validateAutomationGraph(ctx context.Context, orgID uuid.UUID, 
 		switch n.Type {
 		case models.AutomationNodeTrigger:
 			triggers++
+		case models.AutomationNodeStop:
+			// A terminal marker: no action, no config, no outgoing edges. Accepted
+			// so a path can explicitly end at a visible Stop node.
 		case models.AutomationNodeAction:
 			if strings.TrimSpace(string(n.Action)) == "" {
 				return errors.New("an action node is missing its action")
@@ -769,10 +778,10 @@ func (s *service) validateAutomationGraph(ctx context.Context, orgID uuid.UUID, 
 		case src.Type == models.AutomationNodeAction:
 			if lbl, ok := strings.CutPrefix(e.When, aiLabelEdgePrefix); ok {
 				if !aiNodeRoutesByLabel(src) {
-					return errors.New("only an AI classify, AI step (decide), or AI switch can have per-label branches")
+					return errors.New("only an AI switch can have per-case branches")
 				}
 				if !aiNodeHasBranch(src, lbl) {
-					return fmt.Errorf("branch label %q is not one of the AI step's choices", lbl)
+					return fmt.Errorf("branch case %q is not one of the AI switch's cases", lbl)
 				}
 			} else if e.When != "" && e.When != "error" {
 				return errors.New("an action edge must be a plain path or an on-error branch")

--- a/internal/app/nativeactions/adapter.go
+++ b/internal/app/nativeactions/adapter.go
@@ -104,3 +104,19 @@ func (a Adapter) Unsubscribe(ctx context.Context, campaignID, contactID uuid.UUI
 func (a Adapter) LabelThread(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) error {
 	return a.Adv.LabelThread(ctx, userID, threadID, categoryIDs)
 }
+
+// ListCategories / CreateCategory / ListPipelines back the AI agent step's
+// argument-based tag/label/deal tools (the model picks a name, resolved live).
+// Categories are owner-scoped (tags == unibox labels); pipelines are org-scoped
+// with stages hydrated. All three delegate straight to the advanced service.
+func (a Adapter) ListCategories(ctx context.Context, ownerID uuid.UUID) ([]models.MiniCategory, error) {
+	return a.Adv.ListCategories(ctx, ownerID)
+}
+
+func (a Adapter) CreateCategory(ctx context.Context, ownerID uuid.UUID, title, color string) (models.MiniCategory, error) {
+	return a.Adv.CreateCategory(ctx, ownerID, title, color)
+}
+
+func (a Adapter) ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, error) {
+	return a.Adv.ListPipelines(ctx, orgID)
+}

--- a/internal/models/automation_graph.go
+++ b/internal/models/automation_graph.go
@@ -10,6 +10,10 @@ const (
 	AutomationNodeTrigger   = "trigger"
 	AutomationNodeCondition = "condition"
 	AutomationNodeAction    = "action"
+	// AutomationNodeStop is a terminal marker: a path routed into it ends (the
+	// executor's default case follows its outgoing edges, of which a stop has
+	// none). It carries no action or condition. Mirrors the campaign Stop node.
+	AutomationNodeStop = "stop"
 
 	// The conventional id of the single entry node.
 	AutomationTriggerNodeID = "trigger"

--- a/internal/models/integration.go
+++ b/internal/models/integration.go
@@ -285,34 +285,30 @@ const (
 	// so it replaces an outbound webhook for "tell my system this happened".
 	IntegrationActionFireEvent IntegrationAction = "warmbly.fire_event"
 
-	// AI nodes: run one LLM step over the event data and merge the output back
-	// via set_variables so downstream conditions can branch on it. Config is
-	// {instruction (templated), output_keys[] | labels[]}. 1 credit per run.
-	//   ai_classify: pick one of labels[] -> variable "ai_class".
-	//   ai_extract:  pull output_keys[] structured values from the text.
-	//   ai_generate: write text from the instruction -> variable "ai_text".
-	IntegrationActionAIClassify IntegrationAction = "warmbly.ai_classify"
-	IntegrationActionAIExtract  IntegrationAction = "warmbly.ai_extract"
-	IntegrationActionAIGenerate IntegrationAction = "warmbly.ai_generate"
-
+	// AI nodes mirror the campaign step types: one unified AI step plus an AI
+	// switch router.
+	//
 	// IntegrationActionAIStep is the unified AI node. config.mode selects the
-	// behavior: classify | extract | generate | decide (single LLM call, merged
-	// into data like the legacy nodes) or agent (a bounded tool-use loop where
-	// the model, following config.instruction, calls a guarded allowlist of
-	// reversible native actions in config.allowed_actions[]). The three legacy
-	// ids above stay valid so saved graphs keep running unchanged.
+	// behavior: classify | extract | generate (single LLM call over the event,
+	// merged into data so downstream conditions can branch) or agent (a bounded
+	// tool-use loop where the model, following config.instruction, calls a
+	// guarded allowlist of reversible native actions in config.allowed_actions[],
+	// choosing tags/tasks/deals itself). config.thinking routes any mode to the
+	// stronger model tier.
 	IntegrationActionAIStep IntegrationAction = "warmbly.ai_step"
-	// IntegrationActionAISwitch is a campaign-style multi-way router: one LLM
-	// call picks exactly one of config.cases[], stored so the "label:<case>"
-	// edges route the walk. Decide-only; it takes no actions.
+	// IntegrationActionAISwitch is a campaign-style multi-way router: it picks
+	// exactly one of config.cases[], stored so the "label:<case>" edges route the
+	// walk. config.switch_on selects the decider — "ai" (one LLM call, optional
+	// web search + thinking) or "value" (config.switch_value rendered against the
+	// event and matched to the case names; free, no model call). Decide-only; it
+	// takes no actions.
 	IntegrationActionAISwitch IntegrationAction = "warmbly.ai_switch"
 )
 
 // IsAIAction reports whether an action is an AI node (LLM-backed, credit-charged).
 func IsAIAction(a IntegrationAction) bool {
 	switch a {
-	case IntegrationActionAIClassify, IntegrationActionAIExtract, IntegrationActionAIGenerate,
-		IntegrationActionAIStep, IntegrationActionAISwitch:
+	case IntegrationActionAIStep, IntegrationActionAISwitch:
 		return true
 	default:
 		return false
@@ -327,7 +323,6 @@ func IsNativeAction(a IntegrationAction) bool {
 		IntegrationActionCreateDeal, IntegrationActionMoveDealStage, IntegrationActionUnsubscribe,
 		IntegrationActionRunAutomation, IntegrationActionLabelEmail,
 		IntegrationActionSetVariables, IntegrationActionFireEvent,
-		IntegrationActionAIClassify, IntegrationActionAIExtract, IntegrationActionAIGenerate,
 		IntegrationActionAIStep, IntegrationActionAISwitch:
 		return true
 	default:

--- a/internal/pkg/generation/provider.go
+++ b/internal/pkg/generation/provider.go
@@ -154,7 +154,7 @@ var (
 )
 
 // CompletionRequest is a single, tool-less generation with an explicit system
-// prompt. Used by reply drafts (M4) and automation ai_generate (M9).
+// prompt. Used by reply drafts (M4) and the automation ai_step (generate mode).
 type CompletionRequest struct {
 	System    string
 	Prompt    string

--- a/internal/pkg/generation/voice.go
+++ b/internal/pkg/generation/voice.go
@@ -11,8 +11,8 @@ import (
 // low-friction ask, <=80 words, and preserves {{.Merge}} variables.
 //
 // This is the shared "voice rules" foundation: the writing assistant, reply
-// drafts, research openers, and automation ai_generate all compose their prompt
-// on top of it via BuildVoiceRules, so a single humanizer definition governs
+// drafts, research openers, and the automation ai_step (generate mode) all
+// compose their prompt on top of it via BuildVoiceRules, so a single humanizer definition governs
 // every AI writing surface.
 const humanWritingSystemPrompt = `You are Warmbly's cold-outreach email writer. You write very short, first-touch cold emails that sound like a real, busy person typed them in 30 seconds. Your only goal is replies. Sounding human and getting replies are the same goal; do not try to "beat detectors."
 
@@ -78,8 +78,8 @@ type VoiceContext struct {
 
 // BuildVoiceRules composes the humanizer foundation with the optional org
 // grounding into a single system prompt. It is the one place every AI writing
-// surface (writing assistant, reply drafts, research openers, automation
-// ai_generate) builds its instruction, so the humanizer and the org's voice are
+// surface (writing assistant, reply drafts, research openers, the automation
+// ai_step in generate mode) builds its instruction, so the humanizer and the org's voice are
 // applied uniformly. A zero VoiceContext yields the base humanizer rules
 // unchanged (preserving the pre-M4 writing-assistant behavior byte-for-byte).
 func BuildVoiceRules(vc VoiceContext) string {

--- a/internal/tasks/switch_step.go
+++ b/internal/tasks/switch_step.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 	"time"
 
@@ -111,7 +110,7 @@ func (s *tasksService) execSequenceSwitchStep(ctx context.Context, campaign *mod
 		if value == "" {
 			return nil // unconfigured or empty value: fall through to the fallback path
 		}
-		matched := matchSwitchValue(value, cases)
+		matched := aiagentargs.MatchValueToCases(value, cases)
 		if matched == "" {
 			// A value matching no case is the normal "otherwise" outcome, not an
 			// error: store nothing so routing takes the fallback branch.
@@ -384,52 +383,6 @@ func contactAIContext(contact *models.Contact) string {
 		return "(no fields)"
 	}
 	return b.String()
-}
-
-// normalizeSwitchText lowercases, trims, and collapses inner whitespace so
-// "VIP  Customer " matches the case "vip customer". Value matching must not
-// fail on casing or stray spaces in contact data.
-func normalizeSwitchText(s string) string {
-	return strings.ToLower(strings.Join(strings.Fields(s), " "))
-}
-
-// switchCaseRegex compiles a "/pattern/" case name into a case-insensitive
-// regex, or returns nil for a plain-text case (or an invalid pattern — the
-// write-time validator rejects those, so nil here only means "not a regex").
-func switchCaseRegex(name string) *regexp.Regexp {
-	name = strings.TrimSpace(name)
-	if len(name) < 3 || !strings.HasPrefix(name, "/") || !strings.HasSuffix(name, "/") {
-		return nil
-	}
-	re, err := regexp.Compile("(?i)" + name[1:len(name)-1])
-	if err != nil {
-		return nil
-	}
-	return re
-}
-
-// matchSwitchValue maps a rendered value onto the case set: normalized
-// equality on plain cases first (case- and whitespace-insensitive), then
-// "/pattern/" regex cases in configured order. First match wins; "" on a miss
-// routes the contact down the fallback path. Deliberately NO prefix/substring
-// fuzziness here — "not interested" must never land on an "interested" case.
-func matchSwitchValue(value string, cases []string) string {
-	norm := normalizeSwitchText(value)
-	if norm == "" {
-		return ""
-	}
-	for _, c := range cases {
-		if switchCaseRegex(c) == nil && normalizeSwitchText(c) == norm {
-			return c
-		}
-	}
-	trimmed := strings.TrimSpace(value)
-	for _, c := range cases {
-		if re := switchCaseRegex(c); re != nil && re.MatchString(trimmed) {
-			return c
-		}
-	}
-	return ""
 }
 
 // matchSwitchCase maps the model's AI-mode answer onto the case set:

--- a/web/src/components/app/automations/AutomationFlow.tsx
+++ b/web/src/components/app/automations/AutomationFlow.tsx
@@ -22,6 +22,7 @@ import {
     useNodesState,
     useEdgesState,
     useReactFlow,
+    useUpdateNodeInternals,
     type Node,
     type Edge,
     type Connection,
@@ -34,11 +35,14 @@ import { AnimatePresence, motion } from "framer-motion";
 import dagre from "@dagrejs/dagre";
 import {
     ArrowLeftIcon,
+    BracesIcon,
     BriefcaseIcon,
     CheckCircle2Icon,
     CheckIcon,
+    ChevronDownIcon,
     CheckSquareIcon,
     CopyIcon,
+    FlagIcon,
     GitBranchIcon,
     HistoryIcon,
     Link2Icon,
@@ -74,6 +78,7 @@ import type {
     AutomationEdge as GEdge,
     AutomationNodeResult,
     AutomationRun,
+    AITagRef,
     DryRunResponse,
 } from "@/lib/api/models/app/automations/Automation";
 import {
@@ -277,8 +282,137 @@ function ConditionNode({ data, selected }: NodeProps) {
     );
 }
 
-function ActionNode({ data, selected }: NodeProps) {
-    const d = data as { title: string; sub: string; provider: string; native?: boolean; onDelete: () => void };
+// switchCaseHandle is the react-flow handle id for an AI switch case dot. It IS
+// the case's "label:<case>" route, so dragging from the dot creates that edge and
+// an existing case edge re-attaches to its dot on load, with no separate mapping.
+const switchCaseHandle = (name: string) => "label:" + name.trim();
+
+// Fresh config for a newly-created action node: agent mode for the AI step, two
+// starter cases for the AI switch (so its case dots show at once), else empty.
+function defaultConfigForAction(action: string): Record<string, unknown> {
+    if (action === "warmbly.ai_step") return { mode: "agent" };
+    if (action === "warmbly.ai_switch") return { switch_on: "ai", cases: ["interested", "not interested"] };
+    return {};
+}
+
+function ActionNode({ id, data, selected }: NodeProps) {
+    const d = data as {
+        title: string;
+        sub: string;
+        provider: string;
+        native?: boolean;
+        action?: string;
+        config?: Record<string, unknown>;
+        connectedCases?: string[];
+        onDelete: () => void;
+    };
+    const isSwitch = d.action === "warmbly.ai_switch";
+    const cases = isSwitch && Array.isArray(d.config?.cases)
+        ? (d.config!.cases as unknown[]).map((c) => String(c).trim()).filter(Boolean)
+        : [];
+    // Re-measure when the case dots (and so the handles) change.
+    const updateInternals = useUpdateNodeInternals();
+    const casesSig = cases.join("|");
+    React.useEffect(() => {
+        if (isSwitch) updateInternals(id);
+    }, [id, casesSig, isSwitch, updateInternals]);
+
+    const header = (
+        <div
+            className={cn(
+                "flex items-center gap-2 rounded-t-xl border-b px-2.5 py-1.5",
+                isSwitch ? "border-purple-200/60 bg-gradient-to-r from-purple-50/60 to-white" : "border-slate-200/70 bg-gradient-to-r from-slate-50 to-white",
+            )}
+        >
+            {isSwitch ? (
+                <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-purple-100 text-purple-600 ring-1 ring-purple-200/70">
+                    <GitBranchIcon className="w-3 h-3" />
+                </span>
+            ) : d.provider ? (
+                <ProviderGlyph provider={d.provider} name={d.provider} size={7} />
+            ) : d.native ? (
+                <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-indigo-100 text-indigo-600 ring-1 ring-indigo-200/70">
+                    <ZapIcon className="w-3 h-3" />
+                </span>
+            ) : (
+                <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-400 ring-1 ring-slate-200/70 text-[10px]">?</span>
+            )}
+            <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">{d.title}</span>
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    d.onDelete();
+                }}
+                title="Delete action"
+                className="nodrag inline-flex size-5 shrink-0 items-center justify-center rounded text-slate-300 transition-colors hover:bg-rose-50 hover:text-rose-600"
+            >
+                <Trash2Icon className="w-3 h-3" />
+            </button>
+        </div>
+    );
+
+    // AI switch: a row per case with its own draggable dot (drag it to the step
+    // that case leads to), plus an "otherwise" fallback row. Mirrors the campaign
+    // switch node so both builders route the same way.
+    if (isSwitch) {
+        const connected = new Set(d.connectedCases ?? []);
+        const aiMode = String(d.config?.switch_on ?? "ai") !== "value";
+        return (
+            <div
+                className={cn(
+                    "w-[248px] rounded-xl border bg-white shadow-sm transition-shadow duration-200 hover:shadow-md",
+                    selected ? "border-purple-400 ring-2 ring-purple-100" : "border-purple-200",
+                )}
+            >
+                <Handle type="target" position={Position.Top} className="!h-3 !w-3 md:!h-2 md:!w-2 !border-2 !border-white !bg-slate-300" />
+                {header}
+                <div className="px-2.5 pt-1.5 pb-1">
+                    <div className="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">
+                        {aiMode ? "AI decides" : "Value match"}
+                    </div>
+                    {d.sub && <div className="mt-0.5 truncate text-[11.5px] text-slate-500">{d.sub}</div>}
+                </div>
+                {cases.length === 0 ? (
+                    <div className="px-2.5 pb-2 text-[10.5px] text-slate-400">Open the step to add cases</div>
+                ) : (
+                    <div className="pb-1.5">
+                        {cases.map((c) => {
+                            const on = connected.has(c.toLowerCase());
+                            return (
+                                <div key={c} className="relative flex h-6 items-center pl-2.5 pr-4">
+                                    <span className={cn("min-w-0 flex-1 truncate text-[11.5px]", on ? "text-slate-700" : "text-slate-400")}>{c}</span>
+                                    <Handle
+                                        type="source"
+                                        id={switchCaseHandle(c)}
+                                        position={Position.Right}
+                                        className={cn(
+                                            "!absolute !-right-1.5 !top-1/2 !h-3 !w-3 !-translate-y-1/2 pointer-coarse:!h-5 pointer-coarse:!w-5 !border-2 !border-white",
+                                            on ? "!bg-purple-500" : "!bg-slate-300",
+                                        )}
+                                    />
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+                {/* The "otherwise" fallback: events no case matched follow this dot. */}
+                <div
+                    className="relative flex h-6 items-center rounded-b-xl border-t border-slate-200/70 bg-slate-50/60 pl-2.5 pr-4"
+                    title="Where events go when no case matched. Drag the dot to the next step."
+                >
+                    <span className="min-w-0 flex-1 truncate text-[10.5px] font-medium uppercase tracking-[0.1em] text-slate-400">Otherwise</span>
+                    <Handle
+                        type="source"
+                        id="s"
+                        position={Position.Right}
+                        className="!absolute !-right-1.5 !top-1/2 !h-3 !w-3 !-translate-y-1/2 pointer-coarse:!h-5 pointer-coarse:!w-5 !border-2 !border-white !bg-slate-400"
+                    />
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div
             className={cn(
@@ -287,31 +421,7 @@ function ActionNode({ data, selected }: NodeProps) {
             )}
         >
             <Handle type="target" position={Position.Top} className="!h-3 !w-3 md:!h-2 md:!w-2 !border-2 !border-white !bg-slate-300" />
-            <div className="flex items-center gap-2 rounded-t-xl border-b border-slate-200/70 bg-gradient-to-r from-slate-50 to-white px-2.5 py-1.5">
-                {d.provider ? (
-                    <ProviderGlyph provider={d.provider} name={d.provider} size={7} />
-                ) : d.native ? (
-                    <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-indigo-100 text-indigo-600 ring-1 ring-indigo-200/70">
-                        <ZapIcon className="w-3 h-3" />
-                    </span>
-                ) : (
-                    <span className="inline-flex size-5 shrink-0 items-center justify-center rounded-md bg-slate-100 text-slate-400 ring-1 ring-slate-200/70 text-[10px]">
-                        ?
-                    </span>
-                )}
-                <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-slate-800">{d.title}</span>
-                <button
-                    type="button"
-                    onClick={(e) => {
-                        e.stopPropagation();
-                        d.onDelete();
-                    }}
-                    title="Delete action"
-                    className="nodrag inline-flex size-5 shrink-0 items-center justify-center rounded text-slate-300 transition-colors hover:bg-rose-50 hover:text-rose-600"
-                >
-                    <Trash2Icon className="w-3 h-3" />
-                </button>
-            </div>
+            {header}
             <div className="px-2.5 py-2">
                 <div className="text-[9.5px] font-semibold uppercase tracking-[0.12em] text-slate-300">Then</div>
                 <div className="mt-0.5 truncate text-[11.5px] text-slate-500">{d.sub || "Pick an integration…"}</div>
@@ -323,7 +433,36 @@ function ActionNode({ data, selected }: NodeProps) {
     );
 }
 
-const nodeTypes = { trigger: TriggerNode, condition: ConditionNode, action: ActionNode };
+// StopNode — a terminal marker a path routes into to end explicitly. Just a
+// target dot and a red "Stop" pill, mirroring the campaign Stop node.
+function StopNode({ data, selected }: NodeProps) {
+    const d = data as { onDelete: () => void };
+    return (
+        <div
+            className={cn(
+                "inline-flex items-center gap-1.5 rounded-full border bg-white px-3 py-1 shadow-sm transition-shadow duration-200 hover:shadow-md",
+                selected ? "border-rose-400 ring-2 ring-rose-100" : "border-rose-200",
+            )}
+        >
+            <Handle type="target" position={Position.Top} className="!h-3 !w-3 md:!h-2 md:!w-2 !border-2 !border-white !bg-slate-300" />
+            <FlagIcon className="w-3.5 h-3.5 text-rose-500" />
+            <span className="text-[12px] font-semibold text-rose-600">Stop</span>
+            <button
+                type="button"
+                onClick={(e) => {
+                    e.stopPropagation();
+                    d.onDelete();
+                }}
+                title="Delete stop"
+                className="nodrag inline-flex size-4 shrink-0 items-center justify-center rounded text-rose-300 transition-colors hover:bg-rose-50 hover:text-rose-600"
+            >
+                <XIcon className="w-3 h-3" />
+            </button>
+        </div>
+    );
+}
+
+const nodeTypes = { trigger: TriggerNode, condition: ConditionNode, action: ActionNode, stop: StopNode };
 
 // ── Convergent edge (geometry-aware curve, mirrored from CampaignFlow) ────────
 // Unit outward direction for a handle side.
@@ -442,13 +581,18 @@ function ConvergeEdge({
 const edgeTypes = { converge: ConvergeEdge };
 
 // "" plain | "true"/"false" condition paths | "error" | "label:<x>" (an AI
-// classify action's per-label route — followed only when the model picks x).
+// switch's per-case route — followed only when the decider picks case x).
 type When = string;
 
+// An AI switch's per-case dots use the case's "label:<case>" route as the handle
+// id, so dragging from a case dot (or loading an existing case edge) round-trips
+// through the same string with no separate encoding.
 function handleToWhen(h?: string | null): When {
+    if (h && h.startsWith("label:")) return h;
     return h === "out" ? "true" : h === "else" ? "false" : h === "err" ? "error" : "";
 }
 function whenToHandle(w?: string): string {
+    if (w && w.startsWith("label:")) return w;
     return w === "true" ? "out" : w === "false" ? "else" : w === "error" ? "err" : "s";
 }
 
@@ -674,6 +818,9 @@ export default function AutomationFlow({
                     data: { condition: n.condition ?? { field: "intent", operator: "equals" }, label: conditionLabel(n.condition), onDelete: () => deleteNode(n.id) },
                 };
             }
+            if (n.type === "stop") {
+                return { id: n.id, type: "stop", position, data: { onDelete: () => deleteNode(n.id) } };
+            }
             return {
                 id: n.id,
                 type: "action",
@@ -683,11 +830,14 @@ export default function AutomationFlow({
                     connection_id: n.connection_id,
                     config: n.config ?? {},
                     title: n.action ? actionLabel(n.action) : "Choose an action",
-                    sub: isAIAction(String(n.action ?? ""))
-                        ? "Built-in AI step · 1 credit"
-                        : isNativeAction(String(n.action ?? ""))
-                          ? "Built-in action"
-                          : connLabel(n.connection_id),
+                    sub:
+                        n.action === "warmbly.ai_switch"
+                            ? "Routes to one case"
+                            : isAIAction(String(n.action ?? ""))
+                              ? "Built-in AI step · 1 credit"
+                              : isNativeAction(String(n.action ?? ""))
+                                ? "Built-in action"
+                                : connLabel(n.connection_id),
                     provider: providerOf(n.connection_id),
                     native: isNativeAction(String(n.action ?? "")),
                     onDelete: () => deleteNode(n.id),
@@ -790,6 +940,27 @@ export default function AutomationFlow({
         [setNodes],
     );
 
+    // Keep each AI switch node's per-case dot coloring in sync with its edges: a
+    // case whose dot is wired to a step shows solid. Only patches when the set
+    // actually changes, so it can't loop with the node state it writes.
+    React.useEffect(() => {
+        setNodes((ns) => {
+            let changed = false;
+            const next = ns.map((n) => {
+                if (n.type !== "action" || (n.data as { action?: string }).action !== "warmbly.ai_switch") return n;
+                const connected = edges
+                    .filter((e) => e.source === n.id && String((e.data as { when?: string })?.when ?? "").startsWith("label:"))
+                    .map((e) => String((e.data as { when?: string }).when).slice("label:".length).trim().toLowerCase());
+                const sig = [...connected].sort().join("|");
+                const prev = [...((n.data as { connectedCases?: string[] }).connectedCases ?? [])].sort().join("|");
+                if (sig === prev) return n;
+                changed = true;
+                return { ...n, data: { ...n.data, connectedCases: connected } };
+            });
+            return changed ? next : ns;
+        });
+    }, [edges, setNodes]);
+
     // Connect / drag handlers -------------------------------------------------
     const onConnect = React.useCallback(
         (c: Connection) => {
@@ -808,14 +979,16 @@ export default function AutomationFlow({
     );
 
     const addNode = React.useCallback(
-        (type: "action" | "condition", at?: { x: number; y: number }, presetAction?: string) => {
+        (type: "action" | "condition" | "stop", at?: { x: number; y: number }, presetAction?: string) => {
             const id = uid();
             const maxY = nodes.reduce((m, n) => Math.max(m, n.position.y), 0);
             const position = at ?? { x: 0, y: maxY + 140 };
             const defCond = defaultConditionForTrigger(trigger);
             const native = !!presetAction && isNativeAction(presetAction);
             const node: Node =
-                type === "condition"
+                type === "stop"
+                    ? { id, type: "stop", position, data: { onDelete: () => deleteNode(id) } }
+                    : type === "condition"
                     ? {
                           id,
                           type: "condition",
@@ -830,10 +1003,11 @@ export default function AutomationFlow({
                               ? {
                                     action: presetAction,
                                     connection_id: undefined,
-                                    // A fresh AI step defaults to the agent mode (its headline use).
-                                    config: presetAction === "warmbly.ai_step" ? { mode: "agent" } : {},
+                                    // A fresh AI step defaults to agent mode; a fresh AI switch
+                                    // seeds two cases so its case dots show immediately.
+                                    config: defaultConfigForAction(presetAction),
                                     title: actionLabel(presetAction),
-                                    sub: native ? "Built-in action" : "Pick an integration…",
+                                    sub: presetAction === "warmbly.ai_switch" ? "Routes to one case" : native ? "Built-in action" : "Pick an integration…",
                                     provider: "",
                                     native,
                                     onDelete: () => deleteNode(id),
@@ -857,7 +1031,11 @@ export default function AutomationFlow({
             const base = src?.position ?? { x: 0, y: 0 };
             const at = { x: base.x, y: base.y + 140 };
             const newId =
-                choice === "condition" ? addNode("condition", at) : addNode("action", at, choice === "action" ? undefined : choice);
+                choice === "condition"
+                    ? addNode("condition", at)
+                    : choice === "stop"
+                      ? addNode("stop", at)
+                      : addNode("action", at, choice === "action" ? undefined : choice);
             setEdges((es) => {
                 const filtered =
                     when === "" ? es : es.filter((e) => !(e.source === sourceId && (e.data as { when?: string })?.when === when));
@@ -926,19 +1104,16 @@ export default function AutomationFlow({
                     return false;
                 }
                 const aiInstruction = String(d.config?.instruction ?? "").trim();
-                if (
-                    (need === "ai_classify" ||
-                        need === "ai_extract" ||
-                        need === "ai_generate" ||
-                        need === "ai_step" ||
-                        need === "ai_switch") &&
-                    !aiInstruction
-                ) {
+                const aiStepMode = String(d.config?.mode ?? "agent");
+                const switchValueMode = need === "ai_switch" && String(d.config?.switch_on ?? "ai") === "value";
+                // Every AI node needs an instruction, except a value-mode switch
+                // (it matches a template with no model call).
+                if ((need === "ai_step" || need === "ai_switch") && !switchValueMode && !aiInstruction) {
                     toast.error("An AI step needs an instruction");
                     setSelectedId(n.id);
                     return false;
                 }
-                if (need === "ai_step" && String(d.config?.mode ?? "agent") === "agent") {
+                if (need === "ai_step" && aiStepMode === "agent") {
                     const acts = Array.isArray(d.config?.allowed_actions)
                         ? (d.config.allowed_actions as unknown[]).filter((a) => String(a).trim())
                         : [];
@@ -949,28 +1124,34 @@ export default function AutomationFlow({
                     }
                 }
                 if (
-                    need === "ai_switch" &&
-                    !(Array.isArray(d.config?.cases) && (d.config.cases as unknown[]).filter((c) => String(c).trim()).length >= 2)
-                ) {
-                    toast.error("An AI switch needs at least two cases");
-                    setSelectedId(n.id);
-                    return false;
-                }
-                if (
-                    need === "ai_classify" &&
+                    need === "ai_step" &&
+                    aiStepMode === "classify" &&
                     !(Array.isArray(d.config?.labels) && (d.config.labels as unknown[]).filter((l) => String(l).trim()).length >= 2)
                 ) {
-                    toast.error("An AI classify step needs at least two labels");
+                    toast.error("Classify mode needs at least two labels");
                     setSelectedId(n.id);
                     return false;
                 }
                 if (
-                    need === "ai_extract" &&
+                    need === "ai_step" &&
+                    aiStepMode === "extract" &&
                     !(Array.isArray(d.config?.output_keys) && (d.config.output_keys as unknown[]).some((k) => String(k).trim()))
                 ) {
-                    toast.error("An AI extract step needs at least one output key");
+                    toast.error("Extract mode needs at least one output key");
                     setSelectedId(n.id);
                     return false;
+                }
+                if (need === "ai_switch") {
+                    if (!(Array.isArray(d.config?.cases) && (d.config.cases as unknown[]).filter((c) => String(c).trim()).length >= 2)) {
+                        toast.error("An AI switch needs at least two cases");
+                        setSelectedId(n.id);
+                        return false;
+                    }
+                    if (switchValueMode && !String(d.config?.switch_value ?? "").trim()) {
+                        toast.error("A value switch needs a value to match");
+                        setSelectedId(n.id);
+                        return false;
+                    }
                 }
                 continue; // native actions need no connection
             }
@@ -1017,19 +1198,13 @@ export default function AutomationFlow({
             edges: edges.map((e) => {
                 let when = (e.data as { when?: string })?.when ?? "";
                 // Heal stale per-label routes: if the source is no longer a
-                // routing AI node (classify labels, or switch / decide cases), or
-                // the choice was removed from its set, fall back to a plain
-                // "always" edge instead of failing the save.
+                // routing AI node (an AI switch's cases), or the choice was removed
+                // from its set, fall back to a plain "always" edge instead of
+                // failing the save.
                 if (when.startsWith("label:")) {
                     const src = nodes.find((n) => n.id === e.source);
                     const d = src?.data as { action?: string; config?: Record<string, unknown> } | undefined;
-                    const choices =
-                        d?.action === "warmbly.ai_classify"
-                            ? d?.config?.labels
-                            : d?.action === "warmbly.ai_switch" ||
-                                (d?.action === "warmbly.ai_step" && String(d?.config?.mode ?? "") === "decide")
-                              ? d?.config?.cases
-                              : undefined;
+                    const choices = d?.action === "warmbly.ai_switch" ? d?.config?.cases : undefined;
                     const norm = (Array.isArray(choices) ? (choices as unknown[]) : []).map((l) =>
                         String(l).trim().toLowerCase(),
                     );
@@ -1333,14 +1508,10 @@ export default function AutomationFlow({
                     )}
                     <Panel position="top-left">
                         <div className="flex items-center gap-1.5">
-                            <button
-                                type="button"
-                                onClick={() => addNode("action")}
-                                className="inline-flex h-8 items-center gap-1.5 rounded-md bg-sky-600 px-2.5 text-[12px] font-medium text-white shadow-sm hover:bg-sky-700"
-                            >
-                                <PlusIcon className="w-3.5 h-3.5" />
-                                Add action
-                            </button>
+                            <AddStepMenu
+                                onAdd={(choice) => (choice === "action" ? addNode("action") : addNode("action", undefined, choice))}
+                                onAddCondition={() => addNode("condition")}
+                            />
                             <button
                                 type="button"
                                 onClick={() => addNode("condition")}
@@ -1370,7 +1541,7 @@ export default function AutomationFlow({
                 )}
 
                 <AnimatePresence>
-                {selectedNode && !panel && (
+                {selectedNode && selectedNode.type !== "stop" && !panel && (
                     <SidePanel key="editor">
                     <NodeEditor
                         key={selectedNode.id}
@@ -1392,7 +1563,7 @@ export default function AutomationFlow({
                         actionsForProvider={actionsForProvider}
                         providerOf={providerOf}
                         onAction={(patch) => updateNodeData(selectedNode.id, patch)}
-                        // AI classify per-label routing: this node's outgoing
+                        // AI switch per-case routing: this node's outgoing
                         // plain/label edges, editable from the node editor.
                         labelRoutes={edges
                             .filter((e) => e.source === selectedNode.id && (e.data as { when?: string })?.when !== "error")
@@ -1806,16 +1977,12 @@ function NodeEditor({
     const isCondition = node.type === "condition";
     const nodeAction = (node.data as { action?: string }).action;
     const nodeConfig = (node.data as { config?: Record<string, unknown> }).config ?? {};
-    // The routing choices a node fans out on ("label:<x>" edges): an AI classify
-    // routes by its labels; an AI switch and a decide-mode AI step route by
-    // their cases. Everything else has none.
+    // The routing choices a node fans out on ("label:<x>" edges): only an AI
+    // switch routes, by its cases. Everything else has none.
     const routeLabels = ((): string[] => {
         const asList = (v: unknown) =>
             Array.isArray(v) ? v.map((l) => String(l).trim()).filter(Boolean) : [];
-        if (nodeAction === "warmbly.ai_classify") return asList(nodeConfig.labels);
         if (nodeAction === "warmbly.ai_switch") return asList(nodeConfig.cases);
-        if (nodeAction === "warmbly.ai_step" && String(nodeConfig.mode ?? "") === "decide")
-            return asList(nodeConfig.cases);
         return [];
     })();
 
@@ -1885,9 +2052,9 @@ function NodeEditor({
     );
 }
 
-// AILabelRoutes — per-label routing for an AI classify node: each outgoing
-// connection can run always, or only when the model picked a specific label,
-// so one classify step branches multi-way on the canvas.
+// AILabelRoutes — per-case routing for an AI switch node from the editor drawer:
+// each outgoing connection can run always, or only when the decider picked a
+// specific case (an alternative to dragging the node's per-case dots).
 function AILabelRoutes({
     labels,
     routes,
@@ -2106,11 +2273,8 @@ const ACTION_VISUAL: Record<string, { Icon: typeof TagIcon; tint: string; bg: st
     "warmbly.label_email": { Icon: TagsIcon, tint: "text-fuchsia-600", bg: "bg-fuchsia-50", desc: "Label the conversation the contact replied on." },
     "warmbly.set_variables": { Icon: WandSparklesIcon, tint: "text-amber-600", bg: "bg-amber-50", desc: "Compute named values from templates for later steps to reuse." },
     "warmbly.fire_event": { Icon: SendIcon, tint: "text-sky-600", bg: "bg-sky-50", desc: "Publish a custom event to the realtime gateway — your app receives it over the API websocket, no public URL." },
-    "warmbly.ai_classify": { Icon: SparklesIcon, tint: "text-purple-600", bg: "bg-purple-50", desc: "Read the event with AI and pick one label (stored as ai_class). Costs 1 credit." },
-    "warmbly.ai_extract": { Icon: SparklesIcon, tint: "text-indigo-600", bg: "bg-indigo-50", desc: "Pull named fields out of the event with AI. Costs 1 credit." },
-    "warmbly.ai_generate": { Icon: SparklesIcon, tint: "text-cyan-600", bg: "bg-cyan-50", desc: "Write a short piece of text from an instruction (stored as ai_text). Costs 1 credit." },
-    "warmbly.ai_step": { Icon: SparklesIcon, tint: "text-purple-600", bg: "bg-purple-50", desc: "An AI agent that follows your instruction and takes reversible actions (tag, task, deal, label…). Billed 1 credit per step it takes." },
-    "warmbly.ai_switch": { Icon: GitBranchIcon, tint: "text-purple-600", bg: "bg-purple-50", desc: "Route the event: AI picks one of your cases and follows that connection. Costs 1 credit." },
+    "warmbly.ai_step": { Icon: SparklesIcon, tint: "text-purple-600", bg: "bg-purple-50", desc: "One AI step: an agent that takes reversible actions (tag, task, deal, label…), or a single-shot classify, extract, or generate over the event. Billed in credits." },
+    "warmbly.ai_switch": { Icon: GitBranchIcon, tint: "text-purple-600", bg: "bg-purple-50", desc: "Route the event: AI picks one of your cases, or match a value template. AI mode costs 1 credit; value mode is free." },
     "slack.notify": { Icon: MessageSquareIcon, tint: "text-violet-600", bg: "bg-violet-50" },
     "discord.notify": { Icon: MessageSquareIcon, tint: "text-indigo-600", bg: "bg-indigo-50" },
     "webhook.ping": { Icon: SendIcon, tint: "text-sky-600", bg: "bg-sky-50" },
@@ -2180,13 +2344,17 @@ function DragCreateMenu({
                         }}
                     >
                         <div className="px-2 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">Add</div>
-                        <CreateRow icon={<ZapIcon className="w-3.5 h-3.5 text-sky-600" />} label="Action" onClick={() => pick("action")} />
+                        <CreateRow icon={actionGlyph("warmbly.ai_step")} label={actionLabel("warmbly.ai_step")} onClick={() => pick("warmbly.ai_step")} />
+                        <CreateRow icon={actionGlyph("warmbly.ai_switch")} label={actionLabel("warmbly.ai_switch")} onClick={() => pick("warmbly.ai_switch")} />
                         <CreateRow icon={<GitBranchIcon className="w-3.5 h-3.5 text-amber-600" />} label="Condition (branch)" onClick={() => pick("condition")} />
                         <div className="my-1 h-px bg-slate-100" />
-                        <div className="px-2 pt-0.5 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">Built-in actions</div>
-                        {NATIVE_ACTIONS.map((a) => (
+                        <div className="px-2 pt-0.5 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">Actions</div>
+                        <CreateRow icon={<ZapIcon className="w-3.5 h-3.5 text-sky-600" />} label="Integration action" onClick={() => pick("action")} />
+                        {NATIVE_ACTIONS.filter((a) => !isAIAction(a)).map((a) => (
                             <CreateRow key={a} icon={actionGlyph(a)} label={actionLabel(a)} onClick={() => pick(a)} />
                         ))}
+                        <div className="my-1 h-px bg-slate-100" />
+                        <CreateRow icon={<FlagIcon className="w-3.5 h-3.5 text-rose-500" />} label="Stop here" onClick={() => pick("stop")} />
                     </motion.div>
                 )}
             </AnimatePresence>
@@ -2205,6 +2373,65 @@ function CreateRow({ icon, label, onClick }: { icon: React.ReactNode; label: str
             {icon}
             {label}
         </button>
+    );
+}
+
+// AddStepMenu — the toolbar "Add" split button. The primary click drops a blank
+// action; the chevron opens a dropdown to add an AI step, AI switch, a condition,
+// or any built-in action directly, mirroring the campaign steps "Add step" menu.
+function AddStepMenu({ onAdd, onAddCondition }: { onAdd: (choice: string) => void; onAddCondition: () => void }) {
+    const [open, setOpen] = React.useState(false);
+    const pick = (fn: () => void) => {
+        fn();
+        setOpen(false);
+    };
+    return (
+        <div className="relative inline-flex">
+            <button
+                type="button"
+                onClick={() => onAdd("action")}
+                className="inline-flex h-8 items-center gap-1.5 rounded-l-md bg-sky-600 px-2.5 text-[12px] font-medium text-white shadow-sm transition-colors hover:bg-sky-700"
+            >
+                <PlusIcon className="w-3.5 h-3.5" />
+                Add action
+            </button>
+            <button
+                type="button"
+                aria-label="More step types"
+                onClick={() => setOpen((o) => !o)}
+                className="inline-flex h-8 items-center rounded-r-md border-l border-sky-500/60 bg-sky-600 px-1.5 text-white shadow-sm transition-colors hover:bg-sky-700"
+            >
+                <ChevronDownIcon className="w-3.5 h-3.5" />
+            </button>
+            <AnimatePresence>
+                {open && (
+                    <>
+                        <div className="fixed inset-0 z-40" onMouseDown={() => setOpen(false)} />
+                        <motion.div
+                            key="add-step-menu"
+                            className="absolute left-0 top-full z-50 mt-1 max-h-[360px] w-56 overflow-y-auto rounded-lg border border-slate-200 bg-white p-1 shadow-xl"
+                            style={{ transformOrigin: "top left", willChange: "transform, opacity" }}
+                            role="menu"
+                            initial={{ opacity: 0, scale: 0.95, y: -4 }}
+                            animate={{ opacity: 1, scale: 1, y: 0 }}
+                            exit={{ opacity: 0, scale: 0.97, y: -2 }}
+                            transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+                        >
+                            <div className="px-2 pt-1 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">AI</div>
+                            <CreateRow icon={actionGlyph("warmbly.ai_step")} label={actionLabel("warmbly.ai_step")} onClick={() => pick(() => onAdd("warmbly.ai_step"))} />
+                            <CreateRow icon={actionGlyph("warmbly.ai_switch")} label={actionLabel("warmbly.ai_switch")} onClick={() => pick(() => onAdd("warmbly.ai_switch"))} />
+                            <div className="my-1 h-px bg-slate-100" />
+                            <CreateRow icon={<GitBranchIcon className="w-3.5 h-3.5 text-amber-600" />} label="Condition (branch)" onClick={() => pick(onAddCondition)} />
+                            <div className="my-1 h-px bg-slate-100" />
+                            <div className="px-2 pt-0.5 pb-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">Built-in actions</div>
+                            {NATIVE_ACTIONS.filter((a) => !isAIAction(a)).map((a) => (
+                                <CreateRow key={a} icon={actionGlyph(a)} label={actionLabel(a)} onClick={() => pick(() => onAdd(a))} />
+                            ))}
+                        </motion.div>
+                    </>
+                )}
+            </AnimatePresence>
+        </div>
     );
 }
 
@@ -2267,7 +2494,7 @@ function ActionEditor({
     const pickAction = (action: string) =>
         onAction({
             action,
-            config: {},
+            config: defaultConfigForAction(action),
             title: actionLabel(action),
             native: isNativeAction(action),
             ...(isNativeAction(action) ? { connection_id: undefined } : {}),
@@ -2526,15 +2753,7 @@ function NativeActionConfig({
 
             {need === "vars" && <SetVariablesFields config={config} patchConfig={patchConfig} />}
 
-            {need === "ai_classify" && <AIClassifyFields config={config} patchConfig={patchConfig} />}
-
-            {need === "ai_extract" && <AIExtractFields config={config} patchConfig={patchConfig} />}
-
-            {need === "ai_generate" && <AIGenerateFields config={config} patchConfig={patchConfig} />}
-
-            {need === "ai_step" && (
-                <AIStepFields config={config} patchConfig={patchConfig} trigger={trigger} selfId={selfId} />
-            )}
+            {need === "ai_step" && <AIStepFields config={config} patchConfig={patchConfig} />}
 
             {need === "ai_switch" && <AISwitchFields config={config} patchConfig={patchConfig} />}
 
@@ -2887,9 +3106,8 @@ function AIGenerateFields({
     );
 }
 
-// The AI step is the agent (and the single-shot transforms). Routing is the AI
-// switch's job, so "decide" is deliberately not offered here — the two nodes
-// stay distinct.
+// The AI step mirrors the campaign agent plus single-shot transforms. Routing is
+// the AI switch's job, so "decide" is deliberately not a step mode.
 const AI_STEP_MODE_OPTIONS: SelectOption[] = [
     { value: "agent", label: "Agent (decide + act)" },
     { value: "generate", label: "Generate text" },
@@ -2897,19 +3115,80 @@ const AI_STEP_MODE_OPTIONS: SelectOption[] = [
     { value: "extract", label: "Extract fields" },
 ];
 
-// AIStepFields is the unified AI step editor: a mode selector that swaps between
-// the single-shot sub-forms (classify/extract/generate/decide) and the agent
-// (decide + act) form. Every mode writes into the one shared node config blob.
-function AIStepFields({
+// AIToggle — one capability row (extended thinking, web search) matching the
+// campaign switch's toggle. Purple accent when on.
+function AIToggle({
+    label,
+    detail,
+    on,
+    onToggle,
+}: {
+    label: string;
+    detail: string;
+    on: boolean;
+    onToggle: () => void;
+}) {
+    return (
+        <div
+            className={cn(
+                "flex items-center gap-2 rounded-md px-2 py-1.5 ring-1 transition-colors",
+                on ? "bg-purple-50 ring-purple-200" : "bg-slate-50 ring-slate-200",
+            )}
+        >
+            <div className="min-w-0 flex-1">
+                <div className={cn("text-[11.5px] font-medium", on ? "text-purple-700" : "text-slate-500")}>{label}</div>
+                <div className="text-[10.5px] text-slate-400">{detail}</div>
+            </div>
+            <button
+                type="button"
+                role="switch"
+                aria-checked={on}
+                aria-label={label}
+                onClick={onToggle}
+                className={cn(
+                    "relative inline-flex h-[18px] w-8 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-300",
+                    on ? "bg-purple-600" : "bg-slate-300",
+                )}
+            >
+                <span
+                    className={cn(
+                        "inline-block h-3.5 w-3.5 transform rounded-full bg-white shadow-sm transition-transform duration-200",
+                        on ? "translate-x-[15px]" : "translate-x-[2px]",
+                    )}
+                />
+            </button>
+        </div>
+    );
+}
+
+// AIThinkingToggle — the "extended thinking" capability shown on every AI node
+// (step + switch): route to the stronger model tier.
+function AIThinkingToggle({
     config,
     patchConfig,
-    trigger,
-    selfId,
 }: {
     config: Record<string, unknown>;
     patchConfig: (p: Record<string, unknown>) => void;
-    trigger: string;
-    selfId: string;
+}) {
+    return (
+        <AIToggle
+            label="Extended thinking"
+            detail="Uses the stronger model with a bigger reasoning budget. Costs more through usage metering"
+            on={!!config.thinking}
+            onToggle={() => patchConfig({ thinking: !config.thinking })}
+        />
+    );
+}
+
+// AIStepFields is the unified AI step editor: a mode selector swaps between the
+// single-shot transforms (classify/extract/generate) and the agent, and every
+// mode can route to the stronger model tier. All write one shared config blob.
+function AIStepFields({
+    config,
+    patchConfig,
+}: {
+    config: Record<string, unknown>;
+    patchConfig: (p: Record<string, unknown>) => void;
 }) {
     const mode = String(config.mode ?? "agent");
     return (
@@ -2927,80 +3206,80 @@ function AIStepFields({
             {mode === "classify" && <AIClassifyFields config={config} patchConfig={patchConfig} />}
             {mode === "extract" && <AIExtractFields config={config} patchConfig={patchConfig} />}
             {mode === "generate" && <AIGenerateFields config={config} patchConfig={patchConfig} />}
-            {mode === "agent" && (
-                <AIAgentFields config={config} patchConfig={patchConfig} trigger={trigger} selfId={selfId} />
-            )}
+            {mode === "agent" && <AIAgentFields config={config} patchConfig={patchConfig} />}
+            <div>
+                <Label>Capabilities</Label>
+                <AIThinkingToggle config={config} patchConfig={patchConfig} />
+            </div>
         </div>
     );
 }
 
-// AIDecideFields: instruction + the cases the model picks from. Route each
-// outgoing connection to a case with the "Route connections by label" control.
-// Also backs the standalone AI switch node.
-function AIDecideFields({
-    config,
-    patchConfig,
+// The allowlist ids whose agent tool draws from an optional tag/label pool.
+const AI_POOL_KEY: Record<string, "ai_add_tags" | "ai_remove_tags" | "ai_labels"> = {
+    "warmbly.add_tag": "ai_add_tags",
+    "warmbly.remove_tag": "ai_remove_tags",
+    "warmbly.label_email": "ai_labels",
+};
+
+// AITagPoolField — a multi-select pool of tags/labels the agent may use. The
+// display name is stored alongside the id so the backend can offer the tag to
+// the model and resolve its pick without a category lookup. Empty = any.
+function AITagPoolField({
+    label,
+    value,
+    onChange,
 }: {
-    config: Record<string, unknown>;
-    patchConfig: (p: Record<string, unknown>) => void;
+    label: string;
+    value: AITagRef[];
+    onChange: (refs: AITagRef[]) => void;
 }) {
-    const cases = Array.isArray(config.cases) ? (config.cases as unknown[]).map(String) : [];
+    const { user } = useUserProfile();
+    const titleById = React.useMemo(() => {
+        const m = new Map<string, string>();
+        for (const c of user.categories ?? []) m.set(c.id, c.title);
+        return m;
+    }, [user.categories]);
+    const knownName = React.useMemo(() => new Map(value.map((r) => [r.id, r.name])), [value]);
     return (
-        <div className="space-y-3">
-            <AIInstruction
-                value={String(config.instruction ?? "")}
-                onChange={(v) => patchConfig({ instruction: v })}
-                placeholder="Decide which path fits this reply."
+        <div>
+            <Label>{label}</Label>
+            <CategoryPicker
+                value={value.map((r) => r.id)}
+                onChange={(ids) => onChange(ids.map((id) => ({ id, name: titleById.get(id) ?? knownName.get(id) ?? id })))}
+                placeholder="Any — leave empty to let the agent choose"
             />
-            <AIStringList
-                label="Cases"
-                values={cases}
-                onChange={(next) => patchConfig({ cases: next })}
-                placeholder="interested"
-                addLabel="Add case"
-            />
-            <p className="text-[11px] text-slate-400 leading-relaxed">
-                The model picks exactly one case. Add at least two, then route each connection to a case with
-                “Route connections by label” below. Costs 1 credit.
+            <p className="mt-1.5 text-[11px] text-slate-400">
+                {value.length
+                    ? "The agent chooses among these for each event."
+                    : "Empty, so the agent may use any of your tags for each event."}
             </p>
         </div>
     );
 }
 
-// AISwitchFields — the standalone AI switch router. Same shape as decide.
-function AISwitchFields({
-    config,
-    patchConfig,
-}: {
-    config: Record<string, unknown>;
-    patchConfig: (p: Record<string, unknown>) => void;
-}) {
-    return <AIDecideFields config={config} patchConfig={patchConfig} />;
-}
-
-// AIAgentFields — the agentic AI step: an instruction plus the guarded set of
-// reversible actions the model may call. The agent decides which to use per
-// event; each enabled action that needs config shows its pinned inputs (shared
-// in this one node blob). It can never send or reply.
+// AIAgentFields — the agentic AI step: an instruction plus the guarded reversible
+// actions the model may call, choosing which per event and writing task/deal
+// details itself. Tag/label actions carry an optional pool (empty = any of your
+// tags). It never sends or replies.
 function AIAgentFields({
     config,
     patchConfig,
-    trigger,
-    selfId,
 }: {
     config: Record<string, unknown>;
     patchConfig: (p: Record<string, unknown>) => void;
-    trigger: string;
-    selfId: string;
 }) {
-    const enabled = Array.isArray(config.allowed_actions)
-        ? (config.allowed_actions as unknown[]).map(String)
-        : [];
+    const enabled = Array.isArray(config.allowed_actions) ? (config.allowed_actions as unknown[]).map(String) : [];
     const toggle = (id: string) =>
         patchConfig({
             allowed_actions: enabled.includes(id) ? enabled.filter((a) => a !== id) : [...enabled, id],
         });
-    const needsConfig = enabled.filter((id) => nativeActionNeeds(id) !== "none");
+    const poolFor = (id: string): AITagRef[] => {
+        const key = AI_POOL_KEY[id];
+        const v = key ? config[key] : undefined;
+        return Array.isArray(v) ? (v as AITagRef[]) : [];
+    };
+    const anyOpenPool = Object.keys(AI_POOL_KEY).some((id) => enabled.includes(id) && poolFor(id).length === 0);
     return (
         <div className="space-y-3">
             <AIInstruction
@@ -3010,48 +3289,167 @@ function AIAgentFields({
             />
             <div>
                 <Label>Actions the agent may take</Label>
-                <div className="space-y-0.5 rounded-md border border-slate-200 p-1">
+                <div className="divide-y divide-slate-100 rounded-md border border-slate-200 p-1">
                     {AI_ALLOWLIST_ACTIONS.map((id) => {
                         const on = enabled.includes(id);
+                        const poolKey = AI_POOL_KEY[id];
+                        return (
+                            <div key={id} className="py-0.5">
+                                <button
+                                    type="button"
+                                    onClick={() => toggle(id)}
+                                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12.5px] text-slate-700 transition-colors hover:bg-slate-100"
+                                >
+                                    <span
+                                        className={cn(
+                                            "inline-flex size-4 shrink-0 items-center justify-center rounded border",
+                                            on ? "border-sky-500 bg-sky-500 text-white" : "border-slate-300 bg-white",
+                                        )}
+                                    >
+                                        {on && <CheckIcon className="w-3 h-3" />}
+                                    </span>
+                                    {actionLabel(id)}
+                                </button>
+                                {on && poolKey && (
+                                    <div className="ml-[1.35rem] mt-1 space-y-3 border-l border-slate-200 pl-3 pb-1.5">
+                                        <AITagPoolField
+                                            label={
+                                                id === "warmbly.add_tag"
+                                                    ? "Tags the agent can add"
+                                                    : id === "warmbly.remove_tag"
+                                                      ? "Tags the agent can remove"
+                                                      : "Labels the agent can apply"
+                                            }
+                                            value={poolFor(id)}
+                                            onChange={(refs) => patchConfig({ [poolKey]: refs })}
+                                        />
+                                    </div>
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+                {anyOpenPool && (
+                    <button
+                        type="button"
+                        onClick={() => patchConfig({ ai_allow_create_tags: !config.ai_allow_create_tags })}
+                        className="mt-2 flex w-full items-center gap-2 rounded px-1.5 py-1.5 text-left text-[12px] text-slate-600 transition-colors hover:bg-slate-50"
+                    >
+                        <span
+                            className={cn(
+                                "inline-flex size-4 shrink-0 items-center justify-center rounded border",
+                                config.ai_allow_create_tags ? "border-sky-500 bg-sky-500 text-white" : "border-slate-300 bg-white",
+                            )}
+                        >
+                            {!!config.ai_allow_create_tags && <CheckIcon className="w-3 h-3" />}
+                        </span>
+                        Let the agent create a new tag/label when none fits
+                    </button>
+                )}
+                <p className="mt-1.5 text-[11px] text-slate-400 leading-relaxed">
+                    The agent decides which of these to use for each event, writes any task or deal details itself, and
+                    can chain several. It only takes these reversible actions — it never sends or replies. Billed 1
+                    credit per step it takes.
+                </p>
+            </div>
+        </div>
+    );
+}
+
+// AISwitchFields — the AI switch router, mirroring the campaign switch: pick the
+// decider (an AI prompt over the event, or a value template matched to the case
+// names), then route each connection to a case with "Route connections by label".
+function AISwitchFields({
+    config,
+    patchConfig,
+}: {
+    config: Record<string, unknown>;
+    patchConfig: (p: Record<string, unknown>) => void;
+}) {
+    const cases = Array.isArray(config.cases) ? (config.cases as unknown[]).map(String) : [];
+    const aiMode = String(config.switch_on ?? "ai") !== "value";
+    return (
+        <div className="space-y-3">
+            <div>
+                <Label>Decided by</Label>
+                <div className="grid grid-cols-2 gap-1.5">
+                    {(
+                        [
+                            { ai: true, Icon: SparklesIcon, title: "AI prompt", detail: "A model reads the event and picks a case. 1 credit." },
+                            { ai: false, Icon: BracesIcon, title: "Value", detail: "A field or template is matched to the cases. Free." },
+                        ] as const
+                    ).map(({ ai, Icon, title, detail }) => {
+                        const active = aiMode === ai;
                         return (
                             <button
-                                key={id}
+                                key={title}
                                 type="button"
-                                onClick={() => toggle(id)}
-                                className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12.5px] text-slate-700 transition-colors hover:bg-slate-100"
+                                onClick={() => patchConfig({ switch_on: ai ? "ai" : "value" })}
+                                className={cn(
+                                    "flex items-start gap-1.5 rounded-md border px-2 py-1.5 text-left transition-colors",
+                                    active ? "border-purple-300 bg-purple-50" : "border-slate-200 bg-white hover:border-slate-300",
+                                )}
                             >
-                                <span
-                                    className={cn(
-                                        "inline-flex size-4 shrink-0 items-center justify-center rounded border",
-                                        on ? "border-sky-500 bg-sky-500 text-white" : "border-slate-300 bg-white",
-                                    )}
-                                >
-                                    {on && <CheckIcon className="w-3 h-3" />}
+                                <Icon className={cn("mt-0.5 w-3.5 h-3.5 shrink-0", active ? "text-purple-600" : "text-slate-400")} />
+                                <span className="min-w-0">
+                                    <span className={cn("block text-[11.5px] font-medium", active ? "text-purple-700" : "text-slate-700")}>
+                                        {title}
+                                    </span>
+                                    <span className="block text-[10.5px] leading-snug text-slate-400">{detail}</span>
                                 </span>
-                                {actionLabel(id)}
                             </button>
                         );
                     })}
                 </div>
-                <p className="mt-1.5 text-[11px] text-slate-400 leading-relaxed">
-                    The agent decides which of these to use for each event, and can chain several. It only takes these
-                    reversible actions — it never sends or replies. Billed 1 credit per step it takes.
-                </p>
             </div>
-            {needsConfig.map((id) => (
-                <div key={id} className="rounded-md border border-slate-200 p-2.5">
-                    <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-slate-400">
-                        {actionLabel(id)}
-                    </div>
-                    <NativeActionConfig
-                        action={id}
-                        trigger={trigger}
-                        config={config}
-                        patchConfig={patchConfig}
-                        selfId={selfId}
+
+            {aiMode ? (
+                <>
+                    <AIInstruction
+                        value={String(config.instruction ?? "")}
+                        onChange={(v) => patchConfig({ instruction: v })}
+                        placeholder="Decide which path fits this event."
                     />
+                    <div>
+                        <Label>Capabilities</Label>
+                        <div className="space-y-1">
+                            <AIToggle
+                                label="Web search"
+                                detail="Looks up the event's company on the web before deciding. +1 credit when results are found"
+                                on={!!config.web_search}
+                                onToggle={() => patchConfig({ web_search: !config.web_search })}
+                            />
+                            <AIThinkingToggle config={config} patchConfig={patchConfig} />
+                        </div>
+                    </div>
+                </>
+            ) : (
+                <div>
+                    <Label>Value to match</Label>
+                    <TextInput
+                        value={String(config.switch_value ?? "")}
+                        onChange={(v) => patchConfig({ switch_value: v.slice(0, 500) })}
+                        placeholder="e.g. {{.intent}}"
+                        className="w-full font-mono"
+                    />
+                    <p className="mt-1 text-[11px] text-slate-400 leading-relaxed">
+                        Rendered against the event and matched to the case names. Matching ignores casing and extra
+                        spaces; wrap a case in slashes for a regex, e.g. <code className="font-mono">/^(vip|enterprise)/</code>.
+                        First match wins. No model call, no credits.
+                    </p>
                 </div>
-            ))}
+            )}
+
+            <AIStringList
+                label="Cases"
+                values={cases}
+                onChange={(next) => patchConfig({ cases: next })}
+                placeholder="interested"
+                addLabel="Add case"
+            />
+            <p className="text-[11px] text-slate-400 leading-relaxed">
+                Add at least two cases, then route each connection to a case with “Route connections by label” below.
+            </p>
         </div>
     );
 }

--- a/web/src/lib/api/models/app/automations/Automation.ts
+++ b/web/src/lib/api/models/app/automations/Automation.ts
@@ -20,7 +20,9 @@ export interface AutomationCondition {
 // action on a connection.
 export interface AutomationNode {
     id: string;
-    type: "trigger" | "condition" | "action";
+    // "stop" is a terminal marker: a path routed into it ends. It carries no
+    // action or condition (mirrors the campaign Stop node).
+    type: "trigger" | "condition" | "action" | "stop";
     action?: IntegrationAction;
     connection_id?: string;
     config?: Record<string, unknown>;
@@ -50,12 +52,20 @@ export interface AutomationGraph {
 
 // Read-time parse helpers for the untyped AutomationNode.config blob (jsonb).
 // They are tolerant views, never schemas that reject unknown keys, so the blob
-// stays forward/back-compatible. AIStepConfig is the unified AI step
-// (warmbly.ai_step); its mode selects behavior and, in agent mode, the model
-// may call the reversible actions in allowed_actions[]. AISwitchConfig is the
-// AI router (warmbly.ai_switch), decided over cases[] and routed by
-// "label:<case>" edges (the same edge vocabulary an AI classify node uses).
-export type AIStepMode = "classify" | "extract" | "generate" | "decide" | "agent";
+// stays forward/back-compatible. These mirror the campaign step types:
+// AIStepConfig is the unified AI step (warmbly.ai_step) — a single-shot
+// transform (classify/extract/generate) or an agent that calls the reversible
+// actions in allowed_actions[], choosing tags/tasks/deals itself. AISwitchConfig
+// is the AI router (warmbly.ai_switch), decided over cases[] by an AI prompt or
+// a value template and routed by "label:<case>" edges.
+export type AIStepMode = "classify" | "extract" | "generate" | "agent";
+
+// One tag/label the agent may use: id + display name, so the backend can offer
+// it to the model and resolve its pick without a category lookup.
+export interface AITagRef {
+    id: string;
+    name: string;
+}
 
 export interface AIStepConfig {
     mode: AIStepMode;
@@ -63,14 +73,27 @@ export interface AIStepConfig {
     output_key?: string;
     labels?: string[];
     output_keys?: string[];
-    cases?: string[];
     allowed_actions?: NativeActionAllow[];
+    // Agent tag/label pools (empty = any of the org's tags); optional create.
+    ai_add_tags?: AITagRef[];
+    ai_remove_tags?: AITagRef[];
+    ai_labels?: AITagRef[];
+    ai_allow_create_tags?: boolean;
+    // Route any mode to the stronger model tier.
+    thinking?: boolean;
 }
 
 export interface AISwitchConfig {
     instruction: string;
     cases: string[];
     output_key?: string;
+    // "ai" (default) picks a case with one model call; "value" matches
+    // switch_value against the case names deterministically (free, no model).
+    switch_on?: "ai" | "value";
+    switch_value?: string;
+    // ai-mode capabilities.
+    web_search?: boolean;
+    thinking?: boolean;
 }
 
 export interface Automation {

--- a/web/src/lib/api/models/app/automations/meta.ts
+++ b/web/src/lib/api/models/app/automations/meta.ts
@@ -52,9 +52,6 @@ export const ACTION_LABELS: Record<string, string> = {
     "warmbly.label_email": "Label the email",
     "warmbly.set_variables": "Set variables",
     "warmbly.fire_event": "Fire event",
-    "warmbly.ai_classify": "AI classify",
-    "warmbly.ai_extract": "AI extract",
-    "warmbly.ai_generate": "AI generate",
     "warmbly.ai_step": "AI step",
     "warmbly.ai_switch": "AI switch",
 };
@@ -79,9 +76,6 @@ export const NATIVE_ACTIONS: string[] = [
     "warmbly.label_email",
     "warmbly.set_variables",
     "warmbly.fire_event",
-    "warmbly.ai_classify",
-    "warmbly.ai_extract",
-    "warmbly.ai_generate",
     "warmbly.ai_step",
     "warmbly.ai_switch",
 ];
@@ -102,16 +96,10 @@ export const AI_ALLOWLIST_ACTIONS = [
 
 export type NativeActionAllow = (typeof AI_ALLOWLIST_ACTIONS)[number];
 
-// AI action nodes run one LLM step over the event and store the result as a
-// variable for later steps to branch on. They cost one credit each.
+// AI action nodes run over the event with the model: the unified AI step (a
+// single-shot transform or an agent) or the AI switch router. They cost credits.
 export function isAIAction(a: string): boolean {
-    return (
-        a === "warmbly.ai_classify" ||
-        a === "warmbly.ai_extract" ||
-        a === "warmbly.ai_generate" ||
-        a === "warmbly.ai_step" ||
-        a === "warmbly.ai_switch"
-    );
+    return a === "warmbly.ai_step" || a === "warmbly.ai_switch";
 }
 
 export function isNativeAction(a: string): boolean {
@@ -129,9 +117,6 @@ export function nativeActionNeeds(
     | "automation"
     | "vars"
     | "event"
-    | "ai_classify"
-    | "ai_extract"
-    | "ai_generate"
     | "ai_step"
     | "ai_switch"
     | "none" {
@@ -156,12 +141,6 @@ export function nativeActionNeeds(
             return "vars";
         case "warmbly.fire_event":
             return "event";
-        case "warmbly.ai_classify":
-            return "ai_classify";
-        case "warmbly.ai_extract":
-            return "ai_extract";
-        case "warmbly.ai_generate":
-            return "ai_generate";
         default:
             return "none";
     }

--- a/web/src/lib/api/models/app/integrations/Integration.ts
+++ b/web/src/lib/api/models/app/integrations/Integration.ts
@@ -171,10 +171,9 @@ export type IntegrationAction =
     | "warmbly.label_email"
     | "warmbly.set_variables"
     | "warmbly.fire_event"
-    // AI steps: one LLM call over the event, output merged back as a variable.
-    | "warmbly.ai_classify"
-    | "warmbly.ai_extract"
-    | "warmbly.ai_generate";
+    // AI nodes mirroring the campaign step types: one unified AI step + AI switch.
+    | "warmbly.ai_step"
+    | "warmbly.ai_switch";
 
 export interface IntegrationEventSubscription {
     id: string;


### PR DESCRIPTION
Automations had four separate AI nodes, and the switch did not behave like the one in campaign steps. This brings them in line.

What changed:
- One AI step (an agent, or a single-shot classify, extract, or generate) plus one AI switch, matching campaign steps. The three legacy AI nodes are removed.
- The AI switch gets the same options as the campaign one: an AI or value decider, web search, extended thinking, and tag/label pools with optional create on the agent.
- The AI switch node now shows a dot per case that you drag straight to the next step, plus an Otherwise fallback.
- New Add dropdown to drop an AI step, AI switch, condition, or action, and a Stop node to end a path explicitly.
- Guides updated (ai steps in automations, automations, ai credits).
