### PR TITLE
Fix the inbound mail pipeline

### DIFF
--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -16,6 +16,13 @@ import (
 )
 
 func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewEmail) error {
+	// Drop malformed events rather than dereferencing nil: this handler runs on
+	// the shared consumer, so one bad payload would otherwise panic the process
+	// and stop every org's event processing.
+	if e == nil || e.Message == nil {
+		log.Warn().Msg("NEW_EMAIL event without a message body, dropping")
+		return nil
+	}
 	// Check for warmup token header in message headers.
 	// Try the current header name first, then the legacy "X-Warmbly-Token"
 	// so messages in flight during the rollout continue to verify.

--- a/internal/app/consumer/events.go
+++ b/internal/app/consumer/events.go
@@ -3,9 +3,9 @@ package jobs
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -14,7 +14,12 @@ type EventHandler[T any] func(ctx context.Context, event T) error
 func (s *JobsService) HandleEvent(ctx context.Context, event *models.JobEvent) error {
 	resp, ok := s.eventHandlers[event.Type]
 	if !ok {
-		return errors.New("invalid event type")
+		// Ack rather than nak: an unregistered type is not a transient failure,
+		// so redelivering it just burns the retry budget and fills the log on
+		// every occurrence. Warn so a genuinely missing handler still surfaces.
+		log.Warn().Str("event_type", string(event.Type)).
+			Msg("no handler registered for job event type, dropping")
+		return nil
 	}
 	return resp(ctx, event.Body)
 }

--- a/internal/app/email/validate_credentials.go
+++ b/internal/app/email/validate_credentials.go
@@ -11,8 +11,16 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// ValidateCredentials seals a copy of the credentials with the org DEK and asks
+// a worker to try them against the live servers. The caller's credentials are
+// never mutated: they go on to be stored under the credentials key, and sealing
+// them in place here would double-encrypt the stored password.
 func (s *emailService) ValidateCredentials(ctx context.Context, orgID uuid.UUID, workerID string, credentials *models.SmtpImap) *errx.Error {
 	processID := uuid.New()
+
+	if credentials == nil || credentials.SMTP == nil || credentials.IMAP == nil {
+		return errx.ErrEmailCredentialsRequired
+	}
 
 	cipher, err := s.cipherService.Cipher(ctx, orgID)
 	if err != nil {
@@ -20,13 +28,15 @@ func (s *emailService) ValidateCredentials(ctx context.Context, orgID uuid.UUID,
 		return errx.InternalError()
 	}
 
-	credentials.IMAP.Password, err = cipher.Encrypt(ctx, credentials.IMAP.Password)
+	sealedIMAP := *credentials.IMAP
+	sealedIMAP.Password, err = cipher.Encrypt(ctx, credentials.IMAP.Password)
 	if err != nil {
 		sentry.CaptureException(err)
 		return errx.InternalError()
 	}
 
-	credentials.SMTP.Password, err = cipher.Encrypt(ctx, credentials.SMTP.Password)
+	sealedSMTP := *credentials.SMTP
+	sealedSMTP.Password, err = cipher.Encrypt(ctx, credentials.SMTP.Password)
 	if err != nil {
 		sentry.CaptureException(err)
 		return errx.InternalError()
@@ -35,7 +45,7 @@ func (s *emailService) ValidateCredentials(ctx context.Context, orgID uuid.UUID,
 	if err := s.publisher.PublishEmailValidation(ctx, workerID, models.EventWorkerEmailValidation{
 		OrgID:       orgID,
 		ProcessID:   processID,
-		Credentials: credentials,
+		Credentials: &models.SmtpImap{SMTP: &sealedSMTP, IMAP: &sealedIMAP},
 	}); err != nil {
 		sentry.CaptureException(err)
 		return errx.InternalError()

--- a/internal/app/worker/event_email_validation.go
+++ b/internal/app/worker/event_email_validation.go
@@ -2,7 +2,6 @@ package worker
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -32,15 +31,28 @@ func (w *WorkerService) HandleEmailValidation(ctx context.Context, data models.E
 		return nil
 	}
 
-	var group sync.WaitGroup
 	results := make(chan bool, 2)
-	group.Add(2)
-	go func() {
-		results <- email.VerifyImap(ctx, data.Credentials.IMAP.Host, data.Credentials.IMAP.Port, data.Credentials.IMAP.Username, data.Credentials.IMAP.Password)
-	}()
-	go func() {
-		results <- email.VerifySMTP(ctx, data.Credentials.SMTP.Host, data.Credentials.SMTP.Port, data.Credentials.SMTP.Username, data.Credentials.SMTP.Password)
-	}()
+	// Credentials are untrusted user input. A panic in a bare goroutine cannot
+	// be recovered by the caller and would take down the whole worker along
+	// with every mailbox assigned to it, so each probe recovers its own.
+	probe := func(fn func() bool) {
+		go func() {
+			ok := false
+			defer func() {
+				if r := recover(); r != nil {
+					sentry.CurrentHub().Recover(r)
+				}
+				results <- ok
+			}()
+			ok = fn()
+		}()
+	}
+	probe(func() bool {
+		return email.VerifyImap(ctx, data.Credentials.IMAP.Host, data.Credentials.IMAP.Port, data.Credentials.IMAP.Username, data.Credentials.IMAP.Password)
+	})
+	probe(func() bool {
+		return email.VerifySMTP(ctx, data.Credentials.SMTP.Host, data.Credentials.SMTP.Port, data.Credentials.SMTP.Username, data.Credentials.SMTP.Password)
+	})
 
 	result1 := <-results
 	result2 := <-results

--- a/internal/app/worker/mailmanager/add_email.go
+++ b/internal/app/worker/mailmanager/add_email.go
@@ -30,7 +30,10 @@ func (m *MailManager) AddWMail(
 		m.cipherService,
 	)
 	if err != nil {
-		return nil
+		// Surface it: swallowing this leaves the mailbox absent from the map
+		// while the caller logs a successful load, so a mailbox that cannot
+		// authenticate looks connected and silently never sends or syncs.
+		return err
 	}
 
 	m.Emails[data.ID] = newMail

--- a/internal/app/worker/wmail/event_google.go
+++ b/internal/app/worker/wmail/event_google.go
@@ -78,7 +78,10 @@ func (w *WMail) onGoogleMessageAdd(ctx context.Context, msg *models.EmailMessage
 
 	w.maybeEmitBounce(msg)
 
-	if err := w.onEvent(models.JobEventTypeNewEmail, data); err != nil {
+	if err := w.onEvent(models.JobEventTypeNewEmail, &models.JobEventNewEmail{
+		UserID:  w.UserID,
+		Message: data,
+	}); err != nil {
 		return err
 	}
 

--- a/internal/app/worker/wmail/event_graph.go
+++ b/internal/app/worker/wmail/event_graph.go
@@ -78,7 +78,10 @@ func (w *WMail) onGraphMessageAdd(ctx context.Context, msg *models.EmailMessageD
 	}
 
 	w.maybeEmitBounce(msg)
-	return w.onEvent(models.JobEventTypeNewEmail, data)
+	return w.onEvent(models.JobEventTypeNewEmail, &models.JobEventNewEmail{
+		UserID:  w.UserID,
+		Message: data,
+	})
 }
 
 // onGraphMessageRemove emits REMOVE_EMAIL for a message deleted or moved out of a

--- a/internal/app/worker/wmail/event_imap.go
+++ b/internal/app/worker/wmail/event_imap.go
@@ -99,7 +99,13 @@ func (w *WMail) onImapEmailUpdate(ctx context.Context, msg *models.EmailMessageD
 
 		w.maybeEmitBounce(msg)
 
-		if err := w.onEvent(models.JobEventTypeNewEmail, data); err != nil {
+		// The consumer decodes NEW_EMAIL as JobEventNewEmail{user_id, message}.
+		// Sending the bare message left Message nil on the far side and the
+		// consumer panicked on the first inbound mail.
+		if err := w.onEvent(models.JobEventTypeNewEmail, &models.JobEventNewEmail{
+			UserID:  w.UserID,
+			Message: data,
+		}); err != nil {
 			return err
 		}
 	} else {

--- a/internal/app/worker/wmail/new_email_event_test.go
+++ b/internal/app/worker/wmail/new_email_event_test.go
@@ -1,0 +1,133 @@
+package wmail
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// fakeMessageMap reports every message as unseen so the "new email" branch is
+// the one under test, and records nothing else.
+type fakeMessageMap struct{}
+
+func (fakeMessageMap) Add(context.Context, repository.EmailMessageData) error { return nil }
+func (fakeMessageMap) Get(context.Context, uuid.UUID, uuid.UUID, string) (*repository.EmailMessageData, error) {
+	return nil, nil
+}
+func (fakeMessageMap) Del(context.Context, uuid.UUID, uuid.UUID, string, uuid.UUID) error {
+	return nil
+}
+
+type fakeStore struct{}
+
+func (fakeStore) Get(context.Context, string) (io.ReadCloser, error) { return nil, nil }
+func (fakeStore) Put(context.Context, string, io.Reader, string) error {
+	return nil
+}
+func (fakeStore) PutPublic(context.Context, string, io.Reader, string) (string, error) {
+	return "", nil
+}
+func (fakeStore) Delete(context.Context, string) error      { return nil }
+func (fakeStore) Has(context.Context, string) (bool, error) { return false, nil }
+func (fakeStore) Name() string                              { return "fake" }
+func (fakeStore) PresignedGetURL(context.Context, string, time.Duration) (string, error) {
+	return "", nil
+}
+
+type captured struct {
+	eventType models.JobEventType
+	body      any
+}
+
+// newTestWMail builds a WMail with no Redis (which disables sync rate limiting)
+// and fakes for the two dependencies the new-email paths touch.
+func newTestWMail(t *testing.T, provider models.InboxProvider, got *[]captured) *WMail {
+	t.Helper()
+	w := &WMail{
+		ID:                        uuid.New(),
+		UserID:                    uuid.New(),
+		Email:                     "box@example.test",
+		EmailType:                 provider,
+		Storage:                   fakeStore{},
+		EmailMessageMapRepository: fakeMessageMap{},
+		SmtpImapData:              &SmtpImapData{},
+	}
+	w.onEvent = func(jobType models.JobEventType, body any) error {
+		*got = append(*got, captured{eventType: jobType, body: body})
+		return nil
+	}
+	return w
+}
+
+// TestNewEmailEventShape pins the worker -> consumer contract for NEW_EMAIL
+// across all three providers. The consumer decodes it as JobEventNewEmail; each
+// provider previously emitted the bare message, which left Message nil on the
+// far side and panicked the consumer on the first inbound mail.
+func TestNewEmailEventShape(t *testing.T) {
+	msg := func() *models.EmailMessageData {
+		return &models.EmailMessageData{
+			MessageID: "<abc@example.test>",
+			GmailID:   "provider-id-1",
+			Subject:   "hello",
+			From:      []string{"someone@example.test"},
+		}
+	}
+
+	cases := []struct {
+		name     string
+		provider models.InboxProvider
+		invoke   func(w *WMail) error
+	}{
+		{"imap", models.InboxProviderSMTPIMAP, func(w *WMail) error {
+			return w.onImapEmailUpdate(context.Background(), msg())
+		}},
+		{"google", models.InboxProviderGoogle, func(w *WMail) error {
+			return w.onGoogleMessageAdd(context.Background(), msg())
+		}},
+		{"graph", models.InboxProviderOutlook, func(w *WMail) error {
+			return w.onGraphMessageAdd(context.Background(), msg())
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var got []captured
+			w := newTestWMail(t, tc.provider, &got)
+
+			if err := tc.invoke(w); err != nil {
+				t.Fatalf("handler returned error: %v", err)
+			}
+
+			var found *captured
+			for i := range got {
+				if got[i].eventType == models.JobEventTypeNewEmail {
+					found = &got[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("no NEW_EMAIL event emitted (got %d events)", len(got))
+			}
+
+			ev, ok := found.body.(*models.JobEventNewEmail)
+			if !ok {
+				t.Fatalf("NEW_EMAIL body is %T, want *models.JobEventNewEmail — "+
+					"the consumer decodes this type and would see a nil Message", found.body)
+			}
+			if ev.Message == nil {
+				t.Fatal("NEW_EMAIL carried a nil Message")
+			}
+			if ev.UserID != w.UserID {
+				t.Errorf("UserID = %s, want %s", ev.UserID, w.UserID)
+			}
+			if ev.Message.EmailID != w.ID {
+				t.Errorf("Message.EmailID = %s, want %s", ev.Message.EmailID, w.ID)
+			}
+		})
+	}
+}

--- a/internal/app/worker/wmail/sync_imap.go
+++ b/internal/app/worker/wmail/sync_imap.go
@@ -33,7 +33,7 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 				return err
 			}
 			if count > 0 {
-				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, 0); err != nil {
+				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, 0, count); err != nil {
 					return err
 				}
 			}
@@ -49,7 +49,7 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 				return err
 			}
 			if count > 0 {
-				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, befBox.HighestModSeq); err != nil {
+				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, befBox.HighestModSeq, count); err != nil {
 					return err
 				}
 			}

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -191,12 +191,40 @@ func (c *Client) SelectForSync(mailbox string) (uint32, *errx.MailError) {
 	return data.NumMessages, nil
 }
 
-func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.MailError {
-	// 1:* — an empty SeqSet has no encodable ranges and panics inside
-	// go-imap; ChangedSince narrows the result server-side.
-	var allMessages imap.SeqSet
-	allMessages.AddRange(1, 0)
-	cmd := c.client.Fetch(allMessages, &imap.FetchOptions{
+// FetchChanges walks the selected mailbox in bounded sequence windows, emitting
+// each changed message through OnUpdate. count is the mailbox's message count
+// from SelectForSync; it bounds the walk so a first sync of a large mailbox
+// (ChangedSince 0 matches everything) can't buffer the whole folder at once.
+func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64, count uint32) *errx.MailError {
+	if count == 0 {
+		return nil
+	}
+	const batch = uint32(config.ImapFetchBatchSize)
+	for lo := uint32(1); lo <= count; lo += batch {
+		hi := lo + batch - 1
+		if hi > count {
+			hi = count
+		}
+		if err := c.fetchRange(ctx, lastModSeq, lo, hi); err != nil {
+			return err
+		}
+		// The caller's context is the mailbox's sync context; abandon a long
+		// walk promptly when the mailbox is removed or the worker shuts down.
+		if ctx.Err() != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+// fetchRange fetches one sequence window and emits it. Bodies are fetched only
+// after the window's command is closed — a nested FETCH on the same connection
+// blocks until the outer one finishes, and the outer one cannot finish while we
+// wait, which deadlocks the sync on the first message.
+func (c *Client) fetchRange(ctx context.Context, lastModSeq uint64, lo, hi uint32) *errx.MailError {
+	var seqs imap.SeqSet
+	seqs.AddRange(lo, hi)
+	cmd := c.client.Fetch(seqs, &imap.FetchOptions{
 		UID:      true,
 		Envelope: true,
 		BodyStructure: &imap.FetchItemBodyStructure{
@@ -212,6 +240,13 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.Mail
 			Peek:         true,
 		}},
 	})
+	type pending struct {
+		email models.EmailMessageData
+		uid   imap.UID
+		body  imap.BodyStructure
+	}
+	var collected []pending
+
 	for em := cmd.Next(); em != nil; em = cmd.Next() {
 		var email models.EmailMessageData
 		var euid imap.UID
@@ -256,16 +291,21 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64) *errx.Mail
 		}
 
 		email.Flags = append(email.Flags, headerFlags...)
-		email.BodyPlain, email.BodyHTML = fetchTextParts(c.client, euid, bodyStructure)
-
-		if err := c.OnUpdate(ctx, &email); err != nil {
-			log.Warn().Err(err).Msg("Failed to Send Message Update")
-			return nil
-		}
+		collected = append(collected, pending{email: email, uid: euid, body: bodyStructure})
 	}
 
 	if err := cmd.Close(); err != nil {
 		return c.handleError(err)
+	}
+
+	for i := range collected {
+		p := &collected[i]
+		p.email.BodyPlain, p.email.BodyHTML = fetchTextParts(c.client, p.uid, p.body)
+
+		if err := c.OnUpdate(ctx, &p.email); err != nil {
+			log.Warn().Err(err).Msg("Failed to Send Message Update")
+			return nil
+		}
 	}
 
 	return nil

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -26,6 +26,11 @@ const (
 	MaxEmailBodySize = 200 * 1024 // 200 KB
 	MaxEmailFolders  = 30
 
+	// ImapFetchBatchSize bounds how many messages one IMAP sync window holds in
+	// memory. A first sync matches the whole folder, so without this a large
+	// mailbox would buffer every envelope before fetching any body.
+	ImapFetchBatchSize = 200
+
 	// Sequences. Empty by default so the editor shows a smart, position-based
 	// label (e.g. "Email 1") until the user names the step themselves.
 	SequenceDefaultName  = ""

--- a/internal/email/imap.go
+++ b/internal/email/imap.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/warmbly/warmbly/internal/client/netbind"
 )
 
 func VerifyImap(ctx context.Context, host string, port int, user, pass string) bool {
@@ -20,7 +21,13 @@ func VerifyImap(ctx context.Context, host string, port int, user, pass string) b
 	}
 	defer conn.Close()
 
-	tlsConn := tls.Client(conn, &tls.Config{ServerName: host})
+	// Matches the sync client's TLS policy: MAIL_TLS_INSECURE is a dev-only
+	// knob for the local self-signed sandbox, never set in production. Without
+	// it, validation rejects mailboxes the worker would go on to sync fine.
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: netbind.InsecureTLS(),
+	})
 	if err := tlsConn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return false
 	}

--- a/internal/email/smtp.go
+++ b/internal/email/smtp.go
@@ -7,6 +7,8 @@ import (
 	"net"
 	"net/smtp"
 	"time"
+
+	"github.com/warmbly/warmbly/internal/client/netbind"
 )
 
 func VerifySMTP(ctx context.Context, host string, port int, user, pass string) bool {
@@ -15,11 +17,18 @@ func VerifySMTP(ctx context.Context, host string, port int, user, pass string) b
 	var conn net.Conn
 	var err error
 
+	// Matches the send client's TLS policy: MAIL_TLS_INSECURE is a dev-only
+	// knob for the local self-signed sandbox, never set in production.
+	tlsConf := &tls.Config{
+		ServerName:         host,
+		InsecureSkipVerify: netbind.InsecureTLS(),
+	}
+
 	switch port {
 	case 465:
 		dialer := &tls.Dialer{
 			NetDialer: &net.Dialer{Timeout: 5 * time.Second},
-			Config:    &tls.Config{ServerName: host},
+			Config:    tlsConf,
 		}
 		conn, err = dialer.DialContext(ctx, "tcp", addr)
 
@@ -30,24 +39,25 @@ func VerifySMTP(ctx context.Context, host string, port int, user, pass string) b
 	default:
 		return false
 	}
+	// A bad host is ordinary user input, not an exceptional case: dial failed
+	// means conn is nil, and closing it would panic this goroutine and take
+	// the whole worker down with it.
+	if err != nil || conn == nil {
+		return false
+	}
 	defer conn.Close()
 
-	var c *smtp.Client
-	switch port {
-	case 465:
-		c, err = smtp.NewClient(conn, host)
-	case 587:
-		c, err = smtp.NewClient(conn, host)
-		if err == nil {
-			if err = c.StartTLS(&tls.Config{ServerName: host}); err != nil {
-				return false
-			}
-		}
-	}
+	c, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return false
 	}
 	defer c.Close()
+
+	if port == 587 {
+		if err := c.StartTLS(tlsConf); err != nil {
+			return false
+		}
+	}
 
 	auth := smtp.PlainAuth("", user, pass, host)
 

--- a/internal/email/verify_test.go
+++ b/internal/email/verify_test.go
@@ -1,0 +1,55 @@
+package email
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestVerifySMTP_UnreachableHost guards against a nil-conn deref. A wrong SMTP
+// host is ordinary onboarding input, and these probes run in bare goroutines
+// inside the worker, so a panic here takes the worker down along with every
+// mailbox assigned to it.
+func TestVerifySMTP_UnreachableHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	for _, tc := range []struct {
+		name string
+		host string
+		port int
+	}{
+		// 465/587 are the only ports onboarding accepts, and each takes a
+		// different dial path (implicit TLS vs STARTTLS).
+		{"closed port, 587", "127.0.0.1", 587},
+		{"closed port, 465", "127.0.0.1", 465},
+		{"unresolvable host", "no-such-mail-host.invalid", 587},
+		{"unresolvable host, implicit tls", "no-such-mail-host.invalid", 465},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("VerifySMTP panicked: %v", r)
+				}
+			}()
+			if VerifySMTP(ctx, tc.host, tc.port, "user", "pass") {
+				t.Fatal("VerifySMTP returned true for an unreachable server")
+			}
+		})
+	}
+}
+
+// TestVerifyImap_UnreachableHost is the same guard for the IMAP probe.
+func TestVerifyImap_UnreachableHost(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("VerifyImap panicked: %v", r)
+		}
+	}()
+	if VerifyImap(ctx, "no-such-mail-host.invalid", 993, "user", "pass") {
+		t.Fatal("VerifyImap returned true for an unreachable server")
+	}
+}

--- a/internal/infrastructure/eventbus/bus.go
+++ b/internal/infrastructure/eventbus/bus.go
@@ -25,9 +25,13 @@ package eventbus
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 // EventBus is the transport-level interface. Implementations must be safe for
@@ -83,6 +87,24 @@ type Message struct {
 // the substitution rule.
 func Subject(topic string) string {
 	return strings.ReplaceAll(topic, ":", ".")
+}
+
+// invokeHandler runs a Handler and converts a panic into an error. Handlers
+// process payloads produced by other services, so one malformed or unexpected
+// message must not take the whole subscriber process down and stop every
+// organization's event processing. The message is nak'd like any other failure.
+func invokeHandler(ctx context.Context, handler Handler, msg Message) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("eventbus: handler panic on topic %s: %v", msg.Topic, r)
+			log.Error().
+				Str("topic", msg.Topic).
+				Str("key", msg.Key).
+				Bytes("stack", debug.Stack()).
+				Msg("eventbus handler panic recovered")
+		}
+	}()
+	return handler(ctx, msg)
 }
 
 // handlerTimeout is the per-message processing budget shared by both bus

--- a/internal/infrastructure/eventbus/kafka.go
+++ b/internal/infrastructure/eventbus/kafka.go
@@ -136,7 +136,7 @@ func (b *KafkaBus) Subscribe(ctx context.Context, topics []string, group string,
 		}
 		hctx, cancel := context.WithTimeout(ctx, handlerTimeout())
 		defer cancel()
-		if err := handler(hctx, Message{
+		if err := invokeHandler(hctx, handler, Message{
 			Topic:   topic,
 			Key:     string(msg.Key),
 			Payload: msg.Value,

--- a/internal/infrastructure/eventbus/nats.go
+++ b/internal/infrastructure/eventbus/nats.go
@@ -185,9 +185,10 @@ func (b *NATSBus) Publish(ctx context.Context, topic, key string, payload []byte
 		Header:  nats.Header{},
 	}
 	if key != "" {
-		// Nats-Msg-Id enables JetStream's built-in dedup window so retries of
-		// the same logical event don't get persisted twice.
-		msg.Header.Set(nats.MsgIdHdr, key)
+		// Carried as a plain header, never as Nats-Msg-Id: the key is a
+		// partition/affinity hint (one mailbox, one org), not a unique event
+		// id, so feeding it to JetStream's dedup window would silently drop
+		// every event after the first for that key within the window.
 		msg.Header.Set("Warmbly-Key", key)
 	}
 
@@ -248,7 +249,7 @@ func (b *NATSBus) Subscribe(ctx context.Context, topics []string, group string, 
 		// on the exact separator and should use Subject() if it needs to
 		// compare against a Kafka-style topic name.
 		topic := strings.TrimPrefix(m.Subject(), b.prefix+".")
-		if err := handler(hctx, Message{
+		if err := invokeHandler(hctx, handler, Message{
 			Topic:   topic,
 			Key:     key,
 			Payload: m.Data(),

--- a/internal/infrastructure/eventbus/nats_key_test.go
+++ b/internal/infrastructure/eventbus/nats_key_test.go
@@ -1,0 +1,159 @@
+package eventbus
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+// TestNATSBus_KeyIsNotADedupID guards the rule that Publish's key is a
+// partition/affinity hint, not a unique event id. The worker keys every event
+// from one mailbox by that mailbox's ID; if the key reaches JetStream as
+// Nats-Msg-Id, the dedup window swallows every event after the first.
+func TestNATSBus_KeyIsNotADedupID(t *testing.T) {
+	bus := newTestNATSBus(t)
+	topic := "jobs:worker-events"
+	const n = 20
+	const key = "11111111-1111-1111-1111-111111111111"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	go func() {
+		_ = bus.Subscribe(ctx, []string{topic}, "key-dedup", func(_ context.Context, m Message) error {
+			mu.Lock()
+			seen = append(seen, string(m.Payload))
+			mu.Unlock()
+			return nil
+		})
+	}()
+	time.Sleep(300 * time.Millisecond)
+
+	for i := 0; i < n; i++ {
+		if err := bus.Publish(ctx, topic, key, []byte(fmt.Sprintf("new-email-%d", i))); err != nil {
+			t.Fatalf("publish %d: %v", i, err)
+		}
+	}
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := len(seen)
+		mu.Unlock()
+		if got == n {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(seen) != n {
+		t.Fatalf("published %d events with the same key, handler saw %d (dedup dropped %d)", n, len(seen), n-len(seen))
+	}
+}
+
+// TestNATSBus_PublishSetsNoMsgID is the direct guard: dedup in JetStream is
+// stream-wide, so a stray Nats-Msg-Id also collides across topics (a mailbox's
+// AddEmail command against that same mailbox's first result event).
+func TestNATSBus_PublishSetsNoMsgID(t *testing.T) {
+	bus := newTestNATSBus(t)
+	topic := "jobs:msgid-header"
+	const key = "mailbox-1"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	got := make(chan nats.Header, 1)
+	go func() {
+		_ = bus.Subscribe(ctx, []string{topic}, "msgid-header", func(_ context.Context, m Message) error {
+			return nil
+		})
+	}()
+	time.Sleep(300 * time.Millisecond)
+
+	// Read the raw stream message so we assert on what was persisted, not on
+	// what Subscribe chose to expose.
+	sub, err := bus.nc.SubscribeSync(bus.subject(topic))
+	if err != nil {
+		t.Fatalf("raw subscribe: %v", err)
+	}
+	defer sub.Unsubscribe()
+
+	if err := bus.Publish(ctx, topic, key, []byte("payload")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	msg, err := sub.NextMsg(5 * time.Second)
+	if err != nil {
+		t.Fatalf("next msg: %v", err)
+	}
+	close(got)
+
+	if id := msg.Header.Get(nats.MsgIdHdr); id != "" {
+		t.Fatalf("Publish set %s=%q; the key is a partition hint and must not drive JetStream dedup", nats.MsgIdHdr, id)
+	}
+	if k := msg.Header.Get("Warmbly-Key"); k != key {
+		t.Fatalf("Warmbly-Key = %q, want %q", k, key)
+	}
+}
+
+// TestNATSBus_HandlerPanicDoesNotKillSubscriber pins the resilience rule: a
+// handler panic (a malformed payload from another service) must be contained
+// and nak'd, not crash the whole subscriber process and stop every org's
+// event processing.
+func TestNATSBus_HandlerPanicDoesNotKillSubscriber(t *testing.T) {
+	bus := newTestNATSBus(t)
+	topic := "jobs:panic-guard"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		mu       sync.Mutex
+		attempts int
+	)
+	survived := make(chan struct{})
+	go func() {
+		_ = bus.Subscribe(ctx, []string{topic}, "panic-guard", func(_ context.Context, m Message) error {
+			mu.Lock()
+			attempts++
+			n := attempts
+			mu.Unlock()
+			if n == 1 {
+				var p *Message
+				_ = p.Topic // deliberate nil deref
+			}
+			select {
+			case <-survived:
+			default:
+				close(survived)
+			}
+			return nil
+		})
+	}()
+	time.Sleep(300 * time.Millisecond)
+
+	if err := bus.Publish(ctx, topic, "k", []byte("payload")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	select {
+	case <-survived:
+	case <-time.After(15 * time.Second):
+		t.Fatal("subscriber did not survive the handler panic and redeliver")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts < 2 {
+		t.Fatalf("expected the panicking message to be redelivered, got %d attempts", attempts)
+	}
+}

--- a/internal/repository/pg_mailbox.go
+++ b/internal/repository/pg_mailbox.go
@@ -38,8 +38,9 @@ func (r *mailboxRepository) CreateEntry(ctx context.Context, userId, emailId uui
 			updated_at = EXCLUDED.updated_at
 	`
 
+	// attributes is NOT NULL; a nil slice binds as SQL NULL. See textArray.
 	_, err := r.db.Exec(ctx, query,
-		emailId, mb.UIDValidity, mb.Name, mb.Attrs, mb.HighestModSeq, mb.UpdatedAt,
+		emailId, mb.UIDValidity, mb.Name, textArray(mb.Attrs), mb.HighestModSeq, mb.UpdatedAt,
 	)
 	return err
 }

--- a/internal/repository/pg_unibox.go
+++ b/internal/repository/pg_unibox.go
@@ -105,14 +105,26 @@ func (r *uniboxRepository) CreateEntry(ctx context.Context, userID uuid.UUID, e 
 		ON CONFLICT (id) DO NOTHING
 	`
 
+	// The array columns are NOT NULL. A nil Go slice binds as SQL NULL, so a
+	// message with no In-Reply-To (any thread root) would fail the insert.
 	_, err := r.db.Exec(ctx, query,
 		e.ID, userID, e.EmailID, e.Mailbox, e.ThreadID, e.MessageID,
 		e.GmailID, e.ParentID, e.UID, e.ModSeq,
-		e.Flags, e.BCC, e.CC, e.FromAddr, e.InReplyTo, e.ReplyTo,
-		e.ToAddr, e.Subject, e.Size, e.InternalDate, e.SentDate,
+		textArray(e.Flags), textArray(e.BCC), textArray(e.CC), textArray(e.FromAddr),
+		textArray(e.InReplyTo), textArray(e.ReplyTo), textArray(e.ToAddr),
+		e.Subject, e.Size, e.InternalDate, e.SentDate,
 		e.Snippet, e.Seen, e.CreatedAt, e.UpdatedAt,
 	)
 	return err
+}
+
+// textArray coalesces a nil slice to an empty one so it binds as '{}' rather
+// than NULL.
+func textArray(v []string) []string {
+	if v == nil {
+		return []string{}
+	}
+	return v
 }
 
 func (r *uniboxRepository) UpdateEntry(ctx context.Context, userID, emailID, id uuid.UUID, e *UpdateUniboxEntry) error {

--- a/internal/tasks/dispatch.go
+++ b/internal/tasks/dispatch.go
@@ -38,7 +38,10 @@ func (s *tasksService) HandleTask(task *proto.ProcessTask) *errx.Error {
 		return s.HandleCampaignTask(task)
 	case "warmup":
 		return s.HandleEmailTask(task)
-	case "user_email":
+	// "email" is the task_type enum value emailsend writes for a one-off send
+	// (compose, reply, agent-draft approval). It is not spelled "user_email"
+	// anywhere in the database.
+	case "email":
 		return s.HandleUserEmailTask(task)
 	default:
 		log.Warn().Str("task_id", taskID.String()).Str("task_type", rec.TaskType).Msg("task dispatch: unknown task type")


### PR DESCRIPTION
Inbound mail never worked. Six bugs were stacked on each other, each one hiding the next, so nothing downstream ever ran.

- NATS published the partition key as `Nats-Msg-Id`, so JetStream's 2 minute dedup window dropped every event after the first for a mailbox. Measured 19 of 20 dropped. Dedup is stream wide, so it also collided across topics.
- `FetchChanges` issued a nested FETCH for message bodies while the outer FETCH was still open. go-imap serialises commands per connection, so sync deadlocked on the first message and never recovered.
- The worker sent a bare message for `NEW_EMAIL` but the consumer decodes `{user_id, message}`, so `Message` was nil and the consumer panicked on the first inbound email. All three providers had it.
- `unibox_emails` rejected every thread root, because a nil `in_reply_to` binds as SQL NULL against a NOT NULL column.
- `VerifySMTP` closed a nil conn when the host was unreachable. It runs in a bare goroutine, so one mistyped SMTP host killed the whole worker.
- Onboarding sealed the credentials in place before storing them, so SMTP/IMAP passwords went into the database encrypted twice and never decrypted back to anything usable.
- Direct sends were written with `task_type` "email" but the dispatcher only routed "user_email", which is not in the DB enum, so every compose and reply retried forever.

Also hardened along the way: handler panics are contained at the bus layer instead of killing the subscriber, IMAP fetches are batched at 200 so a first sync of a large mailbox does not buffer the whole folder, and a mailbox that fails to load no longer logs success.

## Verification

Run against dovecot and mailpit, not mocks. Onboarded a mailbox through the real API, confirmed the stored password round trips back to plaintext, sent a real email that arrived, and watched 10 inbound messages land in `unibox_emails`. Separately fetched 250 messages across the batch boundary with no gaps or duplicates.

New tests cover the dedup rule, the panic containment, the `NEW_EMAIL` shape for all three providers, and the unreachable host crash.

## Not covered

No real Gmail or Outlook mailbox was tested. Those two paths have a contract test but no live traffic behind them.

## Deploy note

Ship consumers before workers. An old worker still sends the bare payload, and a new consumer drops it rather than crashing.

Overlaps #87 on the `NEW_EMAIL` fix. That PR's `normalizeNewEmailEvent` also recovers in flight legacy payloads, which is worth taking on top of this.
