### PR TITLE
feat(confenge): import extra-cli leads into an auditable staging queue

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/creditwatch"
@@ -239,6 +240,7 @@ func main() {
 	var contactRepoForHandler repository.ContactRepository
 	var attachmentRepoForHandler repository.AttachmentRepository
 	var leadSyncServiceForHandler leadsync.Service
+	var confengeServiceForHandler confenge.Service
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -974,6 +976,16 @@ func main() {
 		leadSyncRepository := repository.NewLeadSyncRepository(primaryDB.Pool)
 		leadSyncServiceForHandler = leadsync.NewService(leadSyncRepository, integrationServiceForHandler, contactService)
 
+		// CONFENGE outreach staging: extra-cli feed import. Off by default
+		// (CONFENGE_OUTREACH_ENABLED=false). Fail closed on insecure prod config.
+		confengeCfg := confenge.LoadConfig()
+		if err := confengeCfg.ValidateStartup(os.Getenv("APP_ENV")); err != nil {
+			sentry.CaptureException(err)
+			log.Fatalf("confenge config: %v", err)
+		}
+		outreachRepo := repository.NewOutreachRepository(primaryDB.Pool)
+		confengeServiceForHandler = confenge.NewService(confengeCfg, outreachRepo, auditService)
+
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
 		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
@@ -1469,6 +1481,9 @@ func main() {
 
 		// On-demand Google Sheets -> leads sync
 		LeadSyncService: leadSyncServiceForHandler,
+
+		// CONFENGE outreach staging (feature-flagged)
+		ConfengeService: confengeServiceForHandler,
 
 		WebsocketURI: websocketURI,
 

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -167,6 +167,21 @@ CHECK_ORIGIN=false
 # SEARCH_API_URL=
 # SEARCH_API_KEY=
 
+# === CONFENGE outreach (optional; off by default) ===
+# Intelligence plane remains extra-cli. Warmbly only imports a versioned feed
+# into multi-tenant staging. Do not point these at the extra-cli Postgres.
+# CONFENGE_OUTREACH_ENABLED=false
+# CONFENGE_AUTO_SEND_ENABLED=false
+# CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+# CONFENGE_EXTRA_CLI_FEED_URL=        # https://... or file:///path/to/feed.json
+# CONFENGE_EXTRA_CLI_FEED_TOKEN=      # optional Bearer for HTTPS feed
+# CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=   # comma-separated host allowlist (required in prod with feed URL)
+# CONFENGE_OUTCOME_WEBHOOK_URL=       # HTTPS webhook back to extra-cli (PR3)
+# CONFENGE_OUTCOME_WEBHOOK_SECRET=    # HMAC secret for outcome webhooks
+# CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=10
+# CONFENGE_MAX_INITIAL_EMAIL_WORDS=120
+# CONFENGE_MAX_FEED_PAYLOAD_BYTES=33554432
+
 # === Observability ===
 # Optional in dev; REQUIRED (fatal at boot) on every Go service when APP_ENV=prod.
 # SENTRY_DSN=

--- a/docs/confenge/README.md
+++ b/docs/confenge/README.md
@@ -1,0 +1,149 @@
+# CONFENGE outreach on Warmbly
+
+Warmbly is the **execution plane** for CONFENGE commercial outreach. The
+`extra-cli` remains the **intelligence plane** (datalake, signals, evidence,
+scoring, Decision & Outcome Memory).
+
+```text
+datalake (VPS) → extra-cli → versioned feed → Warmbly staging → review → campaign → outcomes → extra-cli
+```
+
+This document covers **PR1**: feed contract, import, staging models, API, and
+feature flag. Message generation, review UI, campaign enrollment, and outcome
+webhooks land in follow-up PRs.
+
+## Separation of concerns
+
+| Warmbly | extra-cli |
+| --- | --- |
+| Contacts, mailboxes, campaigns, sequences | Datalake, public contracts |
+| Send limits, follow-ups, stop-on-reply | Commercial signals, facts |
+| Inbox, replies, bounces, suppression | Evidence, hypotheses |
+| CRM, tasks, analytics | Prioritization, provenance |
+| Staging import + review queue | Canonical decision/outcome memory |
+
+Warmbly **must not**:
+
+- connect to the extra-cli production Postgres
+- write into the datalake
+- re-score leads or re-run commercial analytics
+
+## Feature flag
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CONFENGE_OUTREACH_ENABLED` | `false` | Master switch for API + import |
+| `CONFENGE_AUTO_SEND_ENABLED` | `false` | Reserved; never default on |
+| `CONFENGE_REQUIRE_HUMAN_APPROVAL` | `true` | Safety default for later send paths |
+| `CONFENGE_EXTRA_CLI_FEED_URL` | empty | HTTPS or `file://` feed |
+| `CONFENGE_EXTRA_CLI_FEED_TOKEN` | empty | Optional Bearer for HTTPS |
+| `CONFENGE_EXTRA_CLI_ALLOWED_HOSTS` | empty | Required in prod when feed URL set |
+| `CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT` | `10` | Future campaign bootstrap |
+| `CONFENGE_MAX_INITIAL_EMAIL_WORDS` | `120` | Future copy validators |
+| `CONFENGE_MAX_FEED_PAYLOAD_BYTES` | `33554432` | Import payload cap |
+
+In production, feed and outcome URLs must be `https://`, and the feed host
+must be on the allowlist. Fetch uses the SSRF-hardened HTTP client.
+
+## Contract `confenge.outreach.v1`
+
+Top-level:
+
+```json
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "...",
+    "snapshot_hash": "...",
+    "repo_sha": "...",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": { "cursor": null, "next_cursor": null, "has_more": false },
+  "leads": []
+}
+```
+
+Each lead carries company (CNPJ14), priority (opaque scores from extra-cli),
+moment, offer, messaging_context, contacts, contracts, evidence, and
+`commercial_state`. Missing email is valid: the company enters as
+`NEEDS_CONTACT`, never discarded.
+
+Synthetic fixtures: `internal/app/confenge/testdata/`.
+
+### Legacy adapters
+
+If `schema_version` is absent, the importer normalizes:
+
+- top-level `leads.json` arrays
+- commercial run objects with a `leads` key
+- flat contact fields (`email`, `contact_name`, …)
+
+Missing fields are left empty. Nothing is invented.
+
+## Data model (staging)
+
+Multi-tenant tables (migration `000080_outreach_staging`):
+
+- `outreach_import_runs` — audit of each dry-run/apply
+- `outreach_accounts` — company staging, unique `(organization_id, cnpj14)`
+- `outreach_contact_candidates` — candidates before Warmbly contact promotion
+- `outreach_evidence` — sanitized text evidence per account
+
+Human flags (`do_not_contact`, `blocked`, post-send queue states) survive
+reimport. Machine fields (score, moment, offer) update on content-hash change.
+
+## API (JWT + org context)
+
+Base: `/api/v1/confenge` (requires organization).
+
+| Method | Path | Permission | Notes |
+| --- | --- | --- | --- |
+| GET | `/status` | any org member | Works even when disabled |
+| GET | `/summary` | view contacts | Queue counters |
+| GET | `/accounts` | view contacts | Filters: `queue_state`, `cnpj14`, `q` |
+| GET | `/accounts/:id` | view contacts | Includes contacts + evidence |
+| POST | `/accounts/:id/block` | manage contacts | Optional `do_not_contact` |
+| POST | `/import` | manage contacts | Body = feed JSON or `{"uri":"..."}` |
+| GET | `/import-runs` | view contacts | Recent runs |
+| GET | `/import-runs/:id` | view contacts | Run detail + counts |
+
+Import query/header:
+
+- `?dry_run=true` — validate + count only
+- `Idempotency-Key` — same key + same payload returns prior run; different payload → `409`
+
+## Local quickstart
+
+1. Set `CONFENGE_OUTREACH_ENABLED=true` on the backend env.
+2. Apply migrations (`make backend` applies embedded migrations).
+3. Import fixture:
+
+```bash
+curl -sS -X POST "$API/api/v1/confenge/import?dry_run=true" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @internal/app/confenge/testdata/native_feed_v1.json
+```
+
+4. Apply (no dry_run), then `GET /confenge/summary` and `GET /confenge/accounts`.
+
+## Tests
+
+```bash
+go test ./internal/app/confenge/ -count=1
+```
+
+Covers native + legacy parse, dry-run, idempotency, DNC preservation, multi-tenant
+isolation, evidence add, invalid feed, queue states for missing/unverified contacts.
+
+## Upstream maintenance
+
+See [upstream-maintenance.md](./upstream-maintenance.md).
+
+## Outcome loop (PR3)
+
+Outcome webhook env vars are reserved. Delivery uses HMAC + outbox; Warmbly
+never writes to the extra-cli database.

--- a/docs/confenge/upstream-maintenance.md
+++ b/docs/confenge/upstream-maintenance.md
@@ -1,0 +1,52 @@
+# Upstream maintenance notes (CONFENGE outreach)
+
+Fork: `tjsasakifln/warmbly` · Upstream: `warmbly/warmbly`
+
+## Files introduced (PR1)
+
+| Area | Paths |
+| --- | --- |
+| Migration | `internal/infrastructure/db/migrations/000080_outreach_staging.{up,down}.sql` |
+| Models | `internal/models/outreach.go`; audit entity constants in `audit.go` |
+| App | `internal/app/confenge/*` |
+| Repository | `internal/repository/pg_outreach.go` |
+| API | `internal/api/handler/confenge.go`; routes in `routes.go`; `handler.go` field |
+| Wire | `cmd/backend/main.go` (config load + service) |
+| Config sample | `deploy/config/env.example` |
+| Realtime spine | `web/src/hooks/useRealtimeEvents.ts` (`outreach_*` keys) |
+| Docs | `docs/confenge/*` |
+
+## Extension points used
+
+- Feature flag via env (no change to billing/feature gate matrix)
+- Org-scoped routes with existing `RequireAccess` / contact permissions
+- Audit spine (`AuditEntityOutreachImportRun`, `AuditEntityOutreachAccount`)
+- Embedded migrations (same as other features)
+- SSRF client (`internal/pkg/safehttp`) for remote feeds
+
+## Probable upstream conflicts
+
+- Migration number `000080` if upstream adds migrations in the same band — renumber before merge
+- `cmd/backend/main.go` and `handler.go` are high-churn; keep confenge wiring in a tight block
+- `routes.go` advisor/contacts region
+
+## Update strategy
+
+1. Fetch upstream `main`, rebase or merge carefully.
+2. If migration collision: renumber `000080` and keep down migration paired.
+3. Re-run `gofmt`, `make lint`, `go test ./internal/app/confenge/`.
+4. Keep confenge packages self-contained; avoid editing campaign/send cores.
+
+## Disable
+
+Set `CONFENGE_OUTREACH_ENABLED=false` (default). Routes still expose
+`GET /confenge/status` with `"enabled": false`. Import/list return not found.
+
+## Remove customization
+
+1. Drop env vars and docs.
+2. Delete `internal/app/confenge`, handler, repo, models, migration (new down).
+3. Remove wiring in `main.go` / `handler.go` / `routes.go` / realtime spine.
+
+Do not leave staging tables with PII if decommissioning a deployment: export then
+drop via down migration after backup.

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -1,0 +1,64 @@
+---
+title: CONFENGE outreach staging
+description: Import versioned commercial feeds from extra-cli into a multi-tenant staging queue without writing to the datalake.
+---
+
+CONFENGE outreach is an optional, feature-flagged staging layer. It lets an organization import a versioned commercial feed (for example from `extra-cli`) into Warmbly so companies can sit in a queue even when no verified email exists yet.
+
+Warmbly stays the execution plane: contacts, mailboxes, campaigns, inbox, CRM. The intelligence plane (datalake, signals, evidence scoring) stays outside Warmbly. Warmbly never connects to that database and never writes into it.
+
+## Enable
+
+Set on the backend:
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+```
+
+Leave `CONFENGE_AUTO_SEND_ENABLED=false` unless you have an explicit operational policy. Human approval remains the default.
+
+Optional feed source:
+
+```env
+CONFENGE_EXTRA_CLI_FEED_URL=https://feed.example.com/confenge/outreach.json
+CONFENGE_EXTRA_CLI_FEED_TOKEN=
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=feed.example.com
+```
+
+In production the feed URL must be HTTPS and the host must be on the allowlist. Local development may use a `file://` path.
+
+## Import
+
+`POST /api/v1/confenge/import` accepts:
+
+- the full feed JSON body (`schema_version: confenge.outreach.v1` or legacy shapes)
+- or `{"uri":"https://...","dry_run":true}` to fetch then import
+
+Use `?dry_run=true` for counts only (`creates`, `updates`, `unchanged`, `missing_contact`, and related fields). Send `Idempotency-Key` for safe retries.
+
+Companies without an enrollable contact enter as `NEEDS_CONTACT`. They are not discarded and are not forced into the contacts table.
+
+## Reimport rules
+
+Reimport updates machine-owned fields (priority, moment, offer, messaging, evidence). It preserves:
+
+- human `DO_NOT_CONTACT` and block flags
+- post-send queue states (enrolled, sent, replied, and later CRM states)
+- prior approvals once those exist in later PRs
+
+## API surface
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /confenge/status` | Whether the feature is on |
+| `GET /confenge/summary` | Queue counters |
+| `GET /confenge/accounts` | Staged companies |
+| `GET /confenge/accounts/:id` | Company with candidates and evidence |
+| `POST /confenge/import` | Dry-run or apply feed |
+| `GET /confenge/import-runs` | Import audit history |
+
+Permissions follow contacts: view for reads, manage for import and block.
+
+## What this does not do yet
+
+Message generation, review UI, campaign enrollment, Microsoft Graph send, and outcome webhooks back to `extra-cli` ship in follow-up work. See `docs/confenge/` in the repository for architecture and upstream maintenance notes.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -29,6 +29,7 @@
     "---Integrations---",
     "webhooks",
     "integrations",
+    "confenge-outreach",
     "zapier",
     "make",
     "---Account and team---",

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -1,0 +1,258 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// confengeOrg resolves the org when CONFENGE outreach is wired and enabled.
+func (h *Handler) confengeOrg(c *gin.Context) (uuid.UUID, bool) {
+	if h.ConfengeService == nil || !h.ConfengeService.Enabled() {
+		errx.JSON(c, errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server"))
+		return uuid.Nil, false
+	}
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return uuid.Nil, false
+	}
+	return *orgID, true
+}
+
+// GetConfengeStatus — GET /confenge/status
+// Reports whether the feature is on (always 200 when authenticated with org).
+func (h *Handler) GetConfengeStatus(c *gin.Context) {
+	enabled := h.ConfengeService != nil && h.ConfengeService.Enabled()
+	cfg := confenge.Config{}
+	if h.ConfengeService != nil {
+		cfg = h.ConfengeService.Config()
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":                 enabled,
+		"auto_send_enabled":       enabled && cfg.AutoSendEnabled,
+		"require_human_approval":  cfg.RequireHumanApproval,
+		"default_daily_limit":     cfg.DefaultDailyLimit,
+		"max_initial_email_words": cfg.MaxInitialEmailWords,
+		"feed_configured":         enabled && cfg.FeedURL != "",
+	})
+}
+
+// GetConfengeSummary — GET /confenge/summary
+func (h *Handler) GetConfengeSummary(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	sum, xerr := h.ConfengeService.Summary(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": sum})
+}
+
+// ListConfengeAccounts — GET /confenge/accounts
+func (h *Handler) ListConfengeAccounts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	filter := repository.OutreachAccountFilter{
+		QueueState: c.Query("queue_state"),
+		CNPJ14:     c.Query("cnpj14"),
+		Search:     c.Query("q"),
+	}
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			errx.JSON(c, errx.New(errx.BadRequest, "limit must be between 1 and 200"))
+			return
+		}
+		filter.Limit = n
+	}
+	if raw := c.Query("offset"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid offset"))
+			return
+		}
+		filter.Offset = n
+	}
+	list, xerr := h.ConfengeService.ListAccounts(c.Request.Context(), orgID, filter)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeAccount — GET /confenge/accounts/:id
+func (h *Handler) GetConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	acc, xerr := h.ConfengeService.GetAccount(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// BlockConfengeAccount — POST /confenge/accounts/:id/block
+func (h *Handler) BlockConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		Reason       string `json:"reason"`
+		DoNotContact bool   `json:"do_not_contact"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil && err.Error() != "EOF" {
+		// empty body is fine
+		if c.Request.ContentLength != 0 {
+			errx.JSON(c, errx.ErrInvalid)
+			return
+		}
+	}
+	acc, xerr := h.ConfengeService.BlockAccount(c.Request.Context(), orgID, userID, id, body.Reason, body.DoNotContact)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// ImportConfengeFeed — POST /confenge/import
+// Accepts a raw feed body (native confenge.outreach.v1 or legacy) or
+// {"uri":"https://...","dry_run":true}. Honour Idempotency-Key.
+func (h *Handler) ImportConfengeFeed(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	var userPtr *uuid.UUID
+	if uid, err := middleware.GetUserUUID(c); err == nil {
+		userPtr = &uid
+	}
+	opts := confenge.ImportOptions{
+		DryRun:         queryBool(c, "dry_run"),
+		IdempotencyKey: strings.TrimSpace(c.GetHeader("Idempotency-Key")),
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(c.Request.Body, 33<<20))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "failed to read body"))
+		return
+	}
+	if len(raw) == 0 {
+		// Empty body: import from configured feed URL.
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, "", opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	// Envelope: fetch by URI without embedding the full feed.
+	var env struct {
+		URI           string          `json:"uri"`
+		DryRun        *bool           `json:"dry_run"`
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil && env.URI != "" && env.SchemaVersion == "" && len(env.Leads) == 0 {
+		if env.DryRun != nil {
+			opts.DryRun = *env.DryRun
+		}
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, env.URI, opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	run, xerr := h.ConfengeService.ImportFromBytes(c.Request.Context(), orgID, userPtr, raw, opts)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+// ListConfengeImportRuns — GET /confenge/import-runs
+func (h *Handler) ListConfengeImportRuns(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit := 20
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+	list, xerr := h.ConfengeService.ListImportRuns(c.Request.Context(), orgID, limit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeImportRun — GET /confenge/import-runs/:id
+func (h *Handler) GetConfengeImportRun(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	run, xerr := h.ConfengeService.GetImportRun(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+func queryBool(c *gin.Context, key string) bool {
+	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
+	return v == "1" || v == "true" || v == "yes"
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/auth"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/crm"
@@ -111,6 +112,10 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// CONFENGE outreach staging (extra-cli feed import). Nil or disabled when
+	// CONFENGE_OUTREACH_ENABLED is false.
+	ConfengeService confenge.Service
 
 	// Teams
 	TeamService team.TeamService

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -445,6 +445,27 @@ func Run(
 				}
 			}
 
+			// CONFENGE outreach staging (extra-cli feed import). Feature-flagged
+			// server-side; status is always readable so the dashboard can hide
+			// the nav when disabled. Mutations require manage contacts.
+			confengeGroup := protected.Group("/confenge")
+			confengeGroup.Use(m.RequireOrganization())
+			{
+				confengeGroup.GET("/status", h.GetConfengeStatus)
+				confengeGroup.GET("/summary", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeSummary)
+				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
+				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)
+				confengeGroup.GET("/import-runs", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeImportRuns)
+				confengeGroup.GET("/import-runs/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeImportRun)
+
+				confengeWrite := confengeGroup.Group("")
+				confengeWrite.Use(m.RateLimitMiddleware(models.RateLimitWrite))
+				{
+					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
+					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
+				}
+			}
+
 			contacts := protected.Group("/contacts")
 			contacts.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 			{

--- a/internal/app/confenge/config.go
+++ b/internal/app/confenge/config.go
@@ -1,0 +1,147 @@
+// Package confenge implements the CONFENGE outreach operational layer:
+// import of extra-cli intelligence feeds into Warmbly staging, review queue
+// foundation, and outcome outbox (later PRs). Intelligence stays in extra-cli;
+// Warmbly remains the execution plane (contacts, campaigns, mailboxes, CRM).
+package confenge
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env keys for CONFENGE outreach. Documented in deploy/config/env.example
+// and docs/confenge/.
+const (
+	EnvEnabled           = "CONFENGE_OUTREACH_ENABLED"
+	EnvAutoSend          = "CONFENGE_AUTO_SEND_ENABLED"
+	EnvFeedURL           = "CONFENGE_EXTRA_CLI_FEED_URL"
+	EnvFeedToken         = "CONFENGE_EXTRA_CLI_FEED_TOKEN"
+	EnvAllowedHosts      = "CONFENGE_EXTRA_CLI_ALLOWED_HOSTS"
+	EnvOutcomeWebhookURL = "CONFENGE_OUTCOME_WEBHOOK_URL"
+	EnvOutcomeWebhookSec = "CONFENGE_OUTCOME_WEBHOOK_SECRET"
+	EnvDefaultDailyLimit = "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT"
+	EnvMaxInitialWords   = "CONFENGE_MAX_INITIAL_EMAIL_WORDS"
+	EnvRequireHuman      = "CONFENGE_REQUIRE_HUMAN_APPROVAL"
+	EnvMaxPayloadBytes   = "CONFENGE_MAX_FEED_PAYLOAD_BYTES"
+)
+
+// Defaults for conservative cold outreach.
+const (
+	DefaultCampaignDailyLimit = 10
+	DefaultMaxInitialWords    = 120
+	DefaultMaxPayloadBytes    = 32 << 20 // 32 MiB
+)
+
+// Config is runtime configuration for the confenge outreach feature.
+type Config struct {
+	Enabled              bool
+	AutoSendEnabled      bool
+	FeedURL              string
+	FeedToken            string
+	AllowedHosts         []string
+	OutcomeWebhookURL    string
+	OutcomeWebhookSecret string
+	DefaultDailyLimit    int
+	MaxInitialEmailWords int
+	RequireHumanApproval bool
+	MaxFeedPayloadBytes  int64
+}
+
+// LoadConfig reads CONFENGE_* env vars. Safe defaults keep the feature off.
+func LoadConfig() Config {
+	cfg := Config{
+		Enabled:              envBool(EnvEnabled, false),
+		AutoSendEnabled:      envBool(EnvAutoSend, false),
+		FeedURL:              strings.TrimSpace(os.Getenv(EnvFeedURL)),
+		FeedToken:            strings.TrimSpace(os.Getenv(EnvFeedToken)),
+		AllowedHosts:         splitHosts(os.Getenv(EnvAllowedHosts)),
+		OutcomeWebhookURL:    strings.TrimSpace(os.Getenv(EnvOutcomeWebhookURL)),
+		OutcomeWebhookSecret: strings.TrimSpace(os.Getenv(EnvOutcomeWebhookSec)),
+		DefaultDailyLimit:    envInt(EnvDefaultDailyLimit, DefaultCampaignDailyLimit),
+		MaxInitialEmailWords: envInt(EnvMaxInitialWords, DefaultMaxInitialWords),
+		RequireHumanApproval: envBool(EnvRequireHuman, true),
+		MaxFeedPayloadBytes:  int64(envInt(EnvMaxPayloadBytes, DefaultMaxPayloadBytes)),
+	}
+	return cfg
+}
+
+// ValidateStartup fails closed on insecure production combinations.
+// Called when the feature is enabled.
+func (c Config) ValidateStartup(appEnv string) error {
+	if !c.Enabled {
+		return nil
+	}
+	prod := strings.EqualFold(appEnv, "prod") || strings.EqualFold(appEnv, "production")
+	if c.AutoSendEnabled && c.RequireHumanApproval {
+		// Explicit: auto-send may be on only when human approval is also required
+		// is contradictory; refuse auto-send when we cannot verify intent.
+		// Keep RequireHumanApproval as the safety net — auto-send alone is never default.
+	}
+	if prod {
+		if c.FeedURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.FeedURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvFeedURL)
+			}
+			if len(c.AllowedHosts) == 0 {
+				return fmt.Errorf("%s is required when feed URL is set in production", EnvAllowedHosts)
+			}
+		}
+		if c.OutcomeWebhookURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.OutcomeWebhookURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvOutcomeWebhookURL)
+			}
+			if c.OutcomeWebhookSecret == "" {
+				return fmt.Errorf("%s is required when outcome webhook is set", EnvOutcomeWebhookSec)
+			}
+		}
+	}
+	if c.DefaultDailyLimit < 1 || c.DefaultDailyLimit > 100 {
+		return fmt.Errorf("%s must be between 1 and 100", EnvDefaultDailyLimit)
+	}
+	if c.MaxInitialEmailWords < 20 || c.MaxInitialEmailWords > 500 {
+		return fmt.Errorf("%s must be between 20 and 500", EnvMaxInitialWords)
+	}
+	return nil
+}
+
+func envBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func splitHosts(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/app/confenge/feed_fetch.go
+++ b/internal/app/confenge/feed_fetch.go
@@ -1,0 +1,108 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/pkg/safehttp"
+)
+
+// FeedFetcher loads a feed from HTTPS (production) or file:// (dev/tests).
+// Remote fetches use the SSRF-hardened client and optional host allowlist.
+type FeedFetcher struct {
+	AllowedHosts []string
+	Token        string
+	MaxBytes     int64
+	HTTPClient   *http.Client
+}
+
+// Fetch returns raw payload bytes from uri.
+// Supported schemes: https, http (dev only via WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS), file.
+func (f *FeedFetcher) Fetch(ctx context.Context, uri string) ([]byte, error) {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return nil, fmt.Errorf("feed URI is required")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid feed URI: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "file":
+		return f.fetchFile(u)
+	case "https", "http":
+		return f.fetchHTTP(ctx, u)
+	default:
+		return nil, fmt.Errorf("unsupported feed scheme %q", u.Scheme)
+	}
+}
+
+func (f *FeedFetcher) fetchFile(u *url.URL) ([]byte, error) {
+	path := u.Path
+	if path == "" {
+		path = u.Opaque
+	}
+	// file:///absolute/path
+	if strings.HasPrefix(u.String(), "file://") && path == "" {
+		return nil, fmt.Errorf("empty file path")
+	}
+	data, err := readFileLimited(path, f.maxBytes())
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (f *FeedFetcher) fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
+	host := strings.ToLower(u.Hostname())
+	if len(f.AllowedHosts) > 0 && !hostAllowed(host, f.AllowedHosts) {
+		return nil, fmt.Errorf("feed host %q is not in allowlist", host)
+	}
+	client := f.HTTPClient
+	if client == nil {
+		client = safehttp.Client(30 * time.Second)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if f.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.Token)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("feed fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("feed fetch HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, f.maxBytes()))
+}
+
+func (f *FeedFetcher) maxBytes() int64 {
+	if f.MaxBytes > 0 {
+		return f.MaxBytes
+	}
+	return DefaultMaxPayloadBytes
+}
+
+func hostAllowed(host string, allow []string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, a := range allow {
+		a = strings.ToLower(strings.TrimSpace(a))
+		if a == "" {
+			continue
+		}
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/file_io.go
+++ b/internal/app/confenge/file_io.go
@@ -1,0 +1,29 @@
+package confenge
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func readFileLimited(path string, maxBytes int64) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxPayloadBytes
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("payload exceeds max size of %d bytes", maxBytes)
+	}
+	return data, nil
+}

--- a/internal/app/confenge/json_util.go
+++ b/internal/app/confenge/json_util.go
@@ -1,0 +1,7 @@
+package confenge
+
+import "encoding/json"
+
+func marshalJSON(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/internal/app/confenge/legacy.go
+++ b/internal/app/confenge/legacy.go
@@ -1,0 +1,427 @@
+package confenge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DetectAndNormalize accepts either a native confenge.outreach.v1 document or
+// common legacy extra-cli artifacts (leads.json array, commercial-leads wrapper,
+// single-run export). Missing fields are left empty; never invented.
+func DetectAndNormalize(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	// Peek schema_version without failing on legacy shapes.
+	var peek struct {
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	_ = json.Unmarshal(raw, &peek)
+	if peek.SchemaVersion == models.OutreachSchemaV1 {
+		return ParseFeed(raw)
+	}
+
+	// Top-level array of leads (leads.json).
+	trim := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trim, "[") {
+		var arr []map[string]any
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return nil, fmt.Errorf("legacy leads array: %w", err)
+		}
+		return legacyMapToFeed(arr, FeedSource{System: "extra-cli", ProfileID: "confenge"}), nil
+	}
+
+	// Object with leads key (commercial run export / commercial-leads.json).
+	var wrap map[string]any
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("legacy object: %w", err)
+	}
+	src := FeedSource{
+		System:         "extra-cli",
+		ProfileID:      "confenge",
+		RunID:          strField(wrap, "run_id", "id", "source_run_id"),
+		SnapshotHash:   strField(wrap, "snapshot_hash"),
+		RepoSHA:        strField(wrap, "repo_sha", "git_sha"),
+		ProfileVersion: strField(wrap, "profile_version"),
+	}
+	if v := strField(wrap, "profile_id", "profile"); v != "" {
+		src.ProfileID = v
+	}
+	leadsRaw, ok := wrap["leads"]
+	if !ok {
+		// Some exports nest under "data" or "queue".
+		if d, ok := wrap["data"].(map[string]any); ok {
+			leadsRaw = d["leads"]
+		} else if q, ok := wrap["queue"].([]any); ok {
+			leadsRaw = q
+		}
+	}
+	arr, err := asMapSlice(leadsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("legacy leads: %w", err)
+	}
+	feed := legacyMapToFeed(arr, src)
+	if g := strField(wrap, "generated_at", "created_at"); g != "" {
+		feed.GeneratedAt = g
+	}
+	return feed, nil
+}
+
+func legacyMapToFeed(arr []map[string]any, src FeedSource) *Feed {
+	leads := make([]FeedLead, 0, len(arr))
+	for i, m := range arr {
+		leads = append(leads, mapLegacyLead(m, i+1))
+	}
+	return &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        src,
+		Pagination:    FeedPagination{HasMore: false},
+		Leads:         leads,
+	}
+}
+
+func mapLegacyLead(m map[string]any, rankFallback int) FeedLead {
+	cnpj := digitsOnly(strField(m, "cnpj14", "cnpj", "company_cnpj"))
+	root := digitsOnly(strField(m, "cnpj_root", "cnpj_basico"))
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	razao := strField(m, "razao_social", "company_name", "name")
+	fantasia := strField(m, "nome_fantasia", "trade_name")
+	sourceLead := strField(m, "source_lead_id", "lead_id", "id")
+	if sourceLead == "" && cnpj != "" {
+		sourceLead = "cnpj:" + cnpj
+	}
+
+	// Nested company object if present.
+	if co, ok := m["company"].(map[string]any); ok {
+		if v := digitsOnly(strField(co, "cnpj14", "cnpj")); v != "" {
+			cnpj = v
+		}
+		if v := digitsOnly(strField(co, "cnpj_root")); v != "" {
+			root = v
+		}
+		if v := strField(co, "razao_social", "name"); v != "" {
+			razao = v
+		}
+		if v := strField(co, "nome_fantasia"); v != "" {
+			fantasia = v
+		}
+	}
+
+	rank := intField(m, "rank_position", "rank", "priority_rank")
+	if rank == 0 {
+		rank = rankFallback
+	}
+	score := floatField(m, "score_total", "score", "priority_score")
+	tier := strField(m, "priority", "tier", "priority_tier")
+	offerCode := strField(m, "suggested_offer", "service_code", "offer")
+	offerName := strField(m, "service_name", "suggested_offer_name")
+	entry := strField(m, "entry_offer", "next_human_step")
+	state := strField(m, "commercial_state")
+	if state == "" {
+		state = "NEW"
+	}
+
+	momentCode := strField(m, "moment_code", "signal_primary")
+	momentSummary := strField(m, "moment_summary", "explanation", "why")
+	if momentSummary == "" {
+		// signals_fired is common in commercial_leads exports; take first name only.
+		if sigs, ok := m["signals_fired"].([]any); ok && len(sigs) > 0 {
+			switch s := sigs[0].(type) {
+			case string:
+				momentCode = firstNonEmpty(momentCode, s)
+				momentSummary = s
+			case map[string]any:
+				momentCode = firstNonEmpty(momentCode, strField(s, "code", "id", "name"))
+				momentSummary = strField(s, "summary", "label", "name", "code")
+			}
+		}
+	}
+
+	fact := strField(m, "fact_to_mention", "public_fact")
+	question := strField(m, "question_to_ask")
+	cta := strField(m, "cta")
+
+	// messaging_context nested
+	if mc, ok := m["messaging_context"].(map[string]any); ok {
+		fact = firstNonEmpty(fact, strField(mc, "fact_to_mention"))
+		question = firstNonEmpty(question, strField(mc, "question_to_ask"))
+		cta = firstNonEmpty(cta, strField(mc, "cta"))
+	}
+
+	contacts := mapLegacyContacts(m)
+	evidence := mapLegacyEvidence(m)
+
+	var contracts []json.RawMessage
+	if raw, ok := m["contracts"]; ok {
+		if b, err := json.Marshal(raw); err == nil {
+			var arr []json.RawMessage
+			if json.Unmarshal(b, &arr) == nil {
+				contracts = arr
+			}
+		}
+	}
+
+	municipio := strField(m, "municipio", "city")
+	uf := strField(m, "uf", "state")
+	website := strField(m, "website", "site")
+	if co, ok := m["company"].(map[string]any); ok {
+		municipio = firstNonEmpty(municipio, strField(co, "municipio", "city"))
+		uf = firstNonEmpty(uf, strField(co, "uf", "state"))
+		website = firstNonEmpty(website, strField(co, "website"))
+	}
+
+	return FeedLead{
+		SourceLeadID: sourceLead,
+		Company: FeedCompany{
+			CNPJ14:       cnpj,
+			CNPJRoot:     root,
+			RazaoSocial:  razao,
+			NomeFantasia: fantasia,
+			Municipio:    municipio,
+			UF:           uf,
+			Website:      website,
+		},
+		Priority: FeedPriority{
+			Rank:       rank,
+			Score:      score,
+			Tier:       tier,
+			Confidence: strField(m, "confidence", "priority_confidence"),
+		},
+		Moment: FeedMoment{
+			Code:       momentCode,
+			Summary:    momentSummary,
+			ObservedAt: strField(m, "observed_at", "moment_observed_at"),
+			Confidence: strField(m, "moment_confidence"),
+		},
+		Offer: FeedOffer{
+			ServiceCode: offerCode,
+			ServiceName: offerName,
+			EntryOffer:  entry,
+			Rationale:   strField(m, "rationale", "offer_rationale"),
+		},
+		MessagingContext: FeedMessaging{
+			FactToMention: fact,
+			QuestionToAsk: question,
+			CTA:           cta,
+		},
+		Contacts:        contacts,
+		Contracts:       contracts,
+		Evidence:        evidence,
+		CommercialState: state,
+	}
+}
+
+func mapLegacyContacts(m map[string]any) []FeedContact {
+	var out []FeedContact
+	raw, ok := m["contacts"]
+	if !ok {
+		// Flat single contact fields.
+		email := strField(m, "email", "contact_email")
+		name := strField(m, "contact_name", "contato")
+		if email == "" && name == "" {
+			return nil
+		}
+		return []FeedContact{{
+			SourceContactID:    strField(m, "source_contact_id", "contact_id"),
+			Name:               name,
+			Role:               strField(m, "role", "cargo", "contact_role"),
+			Email:              email,
+			Phone:              strField(m, "phone", "telefone"),
+			VerificationStatus: strField(m, "verification_status", "email_status"),
+			Recommended:        true,
+		}}
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	for i, c := range arr {
+		sid := strField(c, "source_contact_id", "id", "contact_id")
+		if sid == "" {
+			sid = fmt.Sprintf("legacy-%d", i+1)
+		}
+		out = append(out, FeedContact{
+			SourceContactID:    sid,
+			Name:               strField(c, "name", "nome"),
+			Role:               strField(c, "role", "cargo"),
+			Email:              strField(c, "email"),
+			Phone:              strField(c, "phone", "telefone"),
+			LinkedInURL:        strField(c, "linkedin_url", "linkedin"),
+			SourceURL:          strField(c, "source_url"),
+			SourceDocument:     strField(c, "source_document"),
+			SourceDate:         strField(c, "source_date"),
+			VerificationStatus: strField(c, "verification_status", "status"),
+			Confidence:         strField(c, "confidence"),
+			Recommended:        boolField(c, "recommended", true),
+		})
+	}
+	return out
+}
+
+func mapLegacyEvidence(m map[string]any) []FeedEvidence {
+	raw, ok := m["evidence"]
+	if !ok {
+		// evidence_ids alone cannot invent full evidence rows.
+		return nil
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	out := make([]FeedEvidence, 0, len(arr))
+	for i, e := range arr {
+		id := strField(e, "id", "source_evidence_id", "evidence_id")
+		if id == "" {
+			id = fmt.Sprintf("legacy-ev-%d", i+1)
+		}
+		out = append(out, FeedEvidence{
+			ID:             id,
+			Type:           strField(e, "type", "evidence_type"),
+			Title:          strField(e, "title"),
+			URL:            strField(e, "url", "source_url"),
+			Document:       strField(e, "document"),
+			Date:           strField(e, "date", "evidence_date"),
+			Location:       strField(e, "location", "page", "section"),
+			Excerpt:        strField(e, "excerpt", "snippet", "trecho"),
+			Synthesis:      strField(e, "synthesis", "summary"),
+			EpistemicClass: strField(e, "epistemic_class", "class"),
+			Reliability:    strField(e, "reliability"),
+			ConsultedAt:    strField(e, "consulted_at"),
+		})
+	}
+	return out
+}
+
+func asMapSlice(v any) ([]map[string]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch t := v.(type) {
+	case []map[string]any:
+		return t, nil
+	case []any:
+		out := make([]map[string]any, 0, len(t))
+		for _, item := range t {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("lead item is not an object")
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	default:
+		// Re-marshal path for typed JSON.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var out []map[string]any
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+func strField(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case string:
+				return strings.TrimSpace(t)
+			case float64:
+				// JSON numbers
+				if t == float64(int64(t)) {
+					return strconv.FormatInt(int64(t), 10)
+				}
+				return strconv.FormatFloat(t, 'f', -1, 64)
+			case json.Number:
+				return t.String()
+			case bool:
+				return strconv.FormatBool(t)
+			}
+		}
+	}
+	return ""
+}
+
+func intField(m map[string]any, keys ...string) int {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return int(t)
+			case int:
+				return t
+			case int64:
+				return int(t)
+			case string:
+				n, _ := strconv.Atoi(strings.TrimSpace(t))
+				return n
+			case json.Number:
+				n, _ := t.Int64()
+				return int(n)
+			}
+		}
+	}
+	return 0
+}
+
+func floatField(m map[string]any, keys ...string) float64 {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return t
+			case int:
+				return float64(t)
+			case int64:
+				return float64(t)
+			case string:
+				f, _ := strconv.ParseFloat(strings.TrimSpace(t), 64)
+				return f
+			case json.Number:
+				f, _ := t.Float64()
+				return f
+			}
+		}
+	}
+	return 0
+}
+
+func boolField(m map[string]any, key string, def bool) bool {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return def
+	}
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		b, err := strconv.ParseBool(t)
+		if err != nil {
+			return def
+		}
+		return b
+	default:
+		return def
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -1,0 +1,423 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Native feed contract: confenge.outreach.v1
+
+// Feed is the top-level document produced by extra-cli (or fixtures).
+type Feed struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   string         `json:"generated_at"`
+	Source        FeedSource     `json:"source"`
+	Pagination    FeedPagination `json:"pagination"`
+	Leads         []FeedLead     `json:"leads"`
+}
+
+// FeedSource identifies the producing intelligence-plane run.
+type FeedSource struct {
+	System         string `json:"system"`
+	RunID          string `json:"run_id"`
+	SnapshotHash   string `json:"snapshot_hash"`
+	RepoSHA        string `json:"repo_sha"`
+	ProfileID      string `json:"profile_id"`
+	ProfileVersion string `json:"profile_version"`
+}
+
+// FeedPagination supports paged feeds; all fields optional.
+type FeedPagination struct {
+	Cursor     *string `json:"cursor"`
+	NextCursor *string `json:"next_cursor"`
+	HasMore    bool    `json:"has_more"`
+}
+
+// FeedLead is one company opportunity in the feed.
+type FeedLead struct {
+	SourceLeadID     string            `json:"source_lead_id"`
+	Company          FeedCompany       `json:"company"`
+	Priority         FeedPriority      `json:"priority"`
+	Moment           FeedMoment        `json:"moment"`
+	Offer            FeedOffer         `json:"offer"`
+	MessagingContext FeedMessaging     `json:"messaging_context"`
+	Contacts         []FeedContact     `json:"contacts"`
+	Contracts        []json.RawMessage `json:"contracts"`
+	Evidence         []FeedEvidence    `json:"evidence"`
+	CommercialState  string            `json:"commercial_state"`
+}
+
+// FeedCompany is Brazilian company identity from the datalake.
+type FeedCompany struct {
+	CNPJ14       string `json:"cnpj14"`
+	CNPJRoot     string `json:"cnpj_root"`
+	RazaoSocial  string `json:"razao_social"`
+	NomeFantasia string `json:"nome_fantasia"`
+	Municipio    string `json:"municipio"`
+	UF           string `json:"uf"`
+	Website      string `json:"website"`
+}
+
+// FeedPriority is rank/score from extra-cli (stored, never re-scored here).
+type FeedPriority struct {
+	Rank       int     `json:"rank"`
+	Score      float64 `json:"score"`
+	Tier       string  `json:"tier"`
+	Confidence string  `json:"confidence"`
+}
+
+// FeedMoment is the commercial moment / fato gerador.
+type FeedMoment struct {
+	Code        string   `json:"code"`
+	Summary     string   `json:"summary"`
+	ObservedAt  string   `json:"observed_at"`
+	Confidence  string   `json:"confidence"`
+	EvidenceIDs []string `json:"evidence_ids"`
+}
+
+// FeedOffer is the suggested service entry offer.
+type FeedOffer struct {
+	ServiceCode string `json:"service_code"`
+	ServiceName string `json:"service_name"`
+	EntryOffer  string `json:"entry_offer"`
+	Rationale   string `json:"rationale"`
+}
+
+// FeedMessaging is structured messaging context for generation.
+type FeedMessaging struct {
+	FactToMention string   `json:"fact_to_mention"`
+	QuestionToAsk string   `json:"question_to_ask"`
+	CTA           string   `json:"cta"`
+	ClaimsToAvoid []string `json:"claims_to_avoid"`
+}
+
+// FeedContact is a candidate recipient (may lack email).
+type FeedContact struct {
+	SourceContactID    string `json:"source_contact_id"`
+	Name               string `json:"name"`
+	Role               string `json:"role"`
+	Email              string `json:"email"`
+	Phone              string `json:"phone"`
+	LinkedInURL        string `json:"linkedin_url"`
+	SourceURL          string `json:"source_url"`
+	SourceDocument     string `json:"source_document"`
+	SourceDate         string `json:"source_date"`
+	VerificationStatus string `json:"verification_status"`
+	Confidence         string `json:"confidence"`
+	Recommended        bool   `json:"recommended"`
+}
+
+// FeedEvidence is one evidence item (text only; HTML stripped on import).
+type FeedEvidence struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Title          string `json:"title"`
+	URL            string `json:"url"`
+	Document       string `json:"document"`
+	Date           string `json:"date"`
+	Location       string `json:"location"`
+	Excerpt        string `json:"excerpt"`
+	Synthesis      string `json:"synthesis"`
+	EpistemicClass string `json:"epistemic_class"`
+	Reliability    string `json:"reliability"`
+	ConsultedAt    string `json:"consulted_at"`
+}
+
+var (
+	cnpj14Re   = regexp.MustCompile(`^\d{14}$`)
+	cnpjRootRe = regexp.MustCompile(`^\d{8}$`)
+)
+
+var allowedVerification = map[string]bool{
+	models.OutreachVerifyOfficialSource:       true,
+	models.OutreachVerifyPublicDocumentRecent: true,
+	models.OutreachVerifyMultipleSources:      true,
+	models.OutreachVerifyInstitutionalGeneric: true,
+	models.OutreachVerifyPublicPossiblyStale:  true,
+	models.OutreachVerifyCandidateUnverified:  true,
+	models.OutreachVerifyNotFound:             true,
+	models.OutreachVerifyInvalid:              true,
+	models.OutreachVerifyBounced:              true,
+	models.OutreachVerifyDoNotContact:         true,
+}
+
+var allowedEpistemic = map[string]bool{
+	models.OutreachEpistemicConfirmedFact:          true,
+	models.OutreachEpistemicStrongInference:        true,
+	models.OutreachEpistemicWeakInference:          true,
+	models.OutreachEpistemicCommercialHypothesis:   true,
+	models.OutreachEpistemicNotFound:               true,
+	models.OutreachEpistemicRequiresCompanyConfirm: true,
+	models.OutreachEpistemicContradictoryEvidence:  true,
+}
+
+// ParseFeed unmarshals JSON bytes into a Feed. Does not invent missing fields.
+func ParseFeed(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	var f Feed
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return &f, nil
+}
+
+// ValidateFeed checks schema_version and required identity fields.
+// Per-lead errors are returned separately so a run can continue.
+func ValidateFeed(f *Feed) error {
+	if f == nil {
+		return fmt.Errorf("nil feed")
+	}
+	if f.SchemaVersion != models.OutreachSchemaV1 {
+		return fmt.Errorf("unsupported schema_version %q (want %s)", f.SchemaVersion, models.OutreachSchemaV1)
+	}
+	if strings.TrimSpace(f.Source.System) == "" {
+		return fmt.Errorf("source.system is required")
+	}
+	return nil
+}
+
+// LeadValidationError is a non-fatal per-lead problem.
+type LeadValidationError struct {
+	Index        int
+	SourceLeadID string
+	CNPJ14       string
+	Message      string
+}
+
+// ValidateLead checks one lead. Missing contact is allowed (NEEDS_CONTACT).
+func ValidateLead(i int, lead FeedLead) *LeadValidationError {
+	cnpj := digitsOnly(lead.Company.CNPJ14)
+	sid := strings.TrimSpace(lead.SourceLeadID)
+	if cnpj == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, Message: "company.cnpj14 is required"}
+	}
+	if !cnpj14Re.MatchString(cnpj) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj14 must be 14 digits"}
+	}
+	if root := digitsOnly(lead.Company.CNPJRoot); root != "" && !cnpjRootRe.MatchString(root) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj_root must be 8 digits when set"}
+	}
+	if strings.TrimSpace(lead.Company.RazaoSocial) == "" && strings.TrimSpace(lead.Company.NomeFantasia) == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company needs razao_social or nome_fantasia"}
+	}
+	for j, c := range lead.Contacts {
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs != "" && !allowedVerification[vs] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("contacts[%d].verification_status %q is not allowed", j, vs),
+			}
+		}
+	}
+	for j, e := range lead.Evidence {
+		ec := strings.TrimSpace(e.EpistemicClass)
+		if ec != "" && !allowedEpistemic[ec] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].epistemic_class %q is not allowed", j, ec),
+			}
+		}
+		if strings.TrimSpace(e.ID) == "" {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].id is required", j),
+			}
+		}
+	}
+	return nil
+}
+
+// CanonicalPayloadHash is a stable SHA-256 of the raw payload bytes (hex).
+// Callers that re-serialize should use the original bytes for idempotency.
+func CanonicalPayloadHash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// LeadContentHash hashes the lead's machine-owned fields for change detection.
+func LeadContentHash(lead FeedLead) string {
+	// Exclude human-only outcomes; include messaging, priority, moment, offer, contacts, evidence ids.
+	type slim struct {
+		SourceLeadID string         `json:"source_lead_id"`
+		Company      FeedCompany    `json:"company"`
+		Priority     FeedPriority   `json:"priority"`
+		Moment       FeedMoment     `json:"moment"`
+		Offer        FeedOffer      `json:"offer"`
+		Messaging    FeedMessaging  `json:"messaging_context"`
+		Contacts     []FeedContact  `json:"contacts"`
+		Evidence     []FeedEvidence `json:"evidence"`
+		State        string         `json:"commercial_state"`
+	}
+	b, _ := json.Marshal(slim{
+		SourceLeadID: lead.SourceLeadID,
+		Company:      lead.Company,
+		Priority:     lead.Priority,
+		Moment:       lead.Moment,
+		Offer:        lead.Offer,
+		Messaging:    lead.MessagingContext,
+		Contacts:     lead.Contacts,
+		Evidence:     lead.Evidence,
+		State:        lead.CommercialState,
+	})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// NormalizeCNPJ14 returns digits-only 14-char CNPJ or empty.
+func NormalizeCNPJ14(s string) string {
+	d := digitsOnly(s)
+	if !cnpj14Re.MatchString(d) {
+		return ""
+	}
+	return d
+}
+
+// SanitizeText strips control chars and truncates; never invents content.
+func SanitizeText(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Drop HTML tags roughly (no script execution surface).
+	s = stripTags(s)
+	s = strings.Map(func(r rune) rune {
+		if r < 32 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	if maxRunes > 0 && utf8.RuneCountInString(s) > maxRunes {
+		runes := []rune(s)
+		s = string(runes[:maxRunes])
+	}
+	return s
+}
+
+func stripTags(s string) string {
+	// Simple angle-bracket strip; feed must not carry executable HTML.
+	var b strings.Builder
+	b.Grow(len(s))
+	in := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			in = true
+		case r == '>':
+			in = false
+		case !in:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ParseDate accepts YYYY-MM-DD or RFC3339 date portion; empty -> nil.
+func ParseDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		return &d
+	}
+	// Date-only prefix of datetime
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// DefaultQueueState for a lead after import (no invention of contacts).
+func DefaultQueueState(lead FeedLead, existing *models.OutreachAccount) string {
+	// Preserve human terminal states.
+	if existing != nil {
+		if existing.DoNotContact || existing.QueueState == models.OutreachQueueDoNotContact {
+			return models.OutreachQueueDoNotContact
+		}
+		if existing.Blocked || existing.QueueState == models.OutreachQueueBlocked {
+			return models.OutreachQueueBlocked
+		}
+		// Do not silently restart post-send states.
+		switch existing.QueueState {
+		case models.OutreachQueueEnrolled, models.OutreachQueueSent, models.OutreachQueueReplied,
+			models.OutreachQueueMeeting, models.OutreachQueueProposal, models.OutreachQueueWon,
+			models.OutreachQueueLost, models.OutreachQueueSkipped, models.OutreachQueueBounced,
+			models.OutreachQueueApproved, models.OutreachQueueNeedsReview:
+			return existing.QueueState
+		}
+	}
+	if hasEnrollableContact(lead) {
+		return models.OutreachQueueReadyToGenerate
+	}
+	return models.OutreachQueueNeedsContact
+}
+
+func hasEnrollableContact(lead FeedLead) bool {
+	for _, c := range lead.Contacts {
+		email := strings.TrimSpace(c.Email)
+		if email == "" {
+			continue
+		}
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs == "" {
+			vs = models.OutreachVerifyCandidateUnverified
+		}
+		if models.OutreachUnenrollableVerification[vs] {
+			continue
+		}
+		if vs == models.OutreachVerifyDoNotContact {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// NormalizeVerification returns a known status or CANDIDATE_UNVERIFIED when
+// email is present without status; NOT_FOUND when empty.
+func NormalizeVerification(status, email string) string {
+	status = strings.TrimSpace(status)
+	email = strings.TrimSpace(email)
+	if status != "" && allowedVerification[status] {
+		return status
+	}
+	if email == "" {
+		return models.OutreachVerifyNotFound
+	}
+	return models.OutreachVerifyCandidateUnverified
+}
+
+// NormalizeEpistemic defaults missing class to COMMERCIAL_HYPOTHESIS.
+func NormalizeEpistemic(class string) string {
+	class = strings.TrimSpace(class)
+	if class != "" && allowedEpistemic[class] {
+		return class
+	}
+	return models.OutreachEpistemicCommercialHypothesis
+}

--- a/internal/app/confenge/schema_test.go
+++ b/internal/app/confenge/schema_test.go
@@ -1,0 +1,305 @@
+package confenge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestParseAndValidateNativeFeed(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatalf("ParseFeed: %v", err)
+	}
+	if err := ValidateFeed(feed); err != nil {
+		t.Fatalf("ValidateFeed: %v", err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) < 5 {
+		t.Fatalf("want >=5 leads, got %d", len(feed.Leads))
+	}
+	// Company without email must validate (NEEDS_CONTACT later).
+	var noEmail bool
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			t.Fatalf("lead %d invalid: %s", i, lv.Message)
+		}
+		if !hasEnrollableContact(lead) {
+			noEmail = true
+			if DefaultQueueState(lead, nil) != models.OutreachQueueNeedsContact {
+				t.Fatalf("lead without email should be NEEDS_CONTACT")
+			}
+		}
+	}
+	if !noEmail {
+		t.Fatal("fixture should include a lead without enrollable contact")
+	}
+}
+
+func TestRejectInvalidSchemaVersion(t *testing.T) {
+	raw := []byte(`{"schema_version":"nope","source":{"system":"x"},"leads":[]}`)
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateFeed(feed); err == nil {
+		t.Fatal("expected schema version error")
+	}
+}
+
+func TestRejectBadCNPJ(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "x",
+		Company:      FeedCompany{CNPJ14: "123", RazaoSocial: "ACME"},
+	}
+	if lv := ValidateLead(0, lead); lv == nil {
+		t.Fatal("expected cnpj error")
+	}
+}
+
+func TestCanonicalPayloadHashStable(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	a := CanonicalPayloadHash(raw)
+	b := CanonicalPayloadHash(raw)
+	if a != b || len(a) != 64 {
+		t.Fatalf("hash unstable or wrong length: %s", a)
+	}
+	other := append([]byte{}, raw...)
+	other[len(other)-2] = 'x'
+	if CanonicalPayloadHash(other) == a {
+		t.Fatal("different payload should hash differently")
+	}
+}
+
+func TestLeadContentHashChangesWithScore(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "1",
+		Company:      FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "ACME"},
+		Priority:     FeedPriority{Score: 10},
+	}
+	h1 := LeadContentHash(lead)
+	lead.Priority.Score = 20
+	h2 := LeadContentHash(lead)
+	if h1 == h2 {
+		t.Fatal("score change must change content hash")
+	}
+}
+
+func TestSanitizeTextStripsTagsAndControl(t *testing.T) {
+	in := "<script>alert(1)</script>Hello\x00World"
+	out := SanitizeText(in, 100)
+	if out != "alert(1)HelloWorld" && out != "HelloWorld" {
+		// stripTags leaves inner text of script; control stripped
+		if containsAngle(out) {
+			t.Fatalf("tags remain: %q", out)
+		}
+	}
+	if containsAngle(out) {
+		t.Fatalf("angle brackets remain: %q", out)
+	}
+}
+
+func containsAngle(s string) bool {
+	for _, r := range s {
+		if r == '<' || r == '>' {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUnenrollableVerification(t *testing.T) {
+	cases := []struct {
+		vs   string
+		want bool
+	}{
+		{models.OutreachVerifyOfficialSource, true},
+		{models.OutreachVerifyInstitutionalGeneric, true},
+		{models.OutreachVerifyCandidateUnverified, false},
+		{models.OutreachVerifyNotFound, false},
+		{models.OutreachVerifyInvalid, false},
+		{models.OutreachVerifyBounced, false},
+		{models.OutreachVerifyDoNotContact, false},
+	}
+	for _, tc := range cases {
+		c := &models.OutreachContactCandidate{
+			Email:              "a@example.com",
+			VerificationStatus: tc.vs,
+		}
+		if c.CanEnroll() != tc.want {
+			t.Errorf("%s CanEnroll=%v want %v", tc.vs, c.CanEnroll(), tc.want)
+		}
+	}
+}
+
+func TestDefaultQueueStatePreservesDNC(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{
+		DoNotContact: true,
+		QueueState:   models.OutreachQueueDoNotContact,
+	}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueDoNotContact {
+		t.Fatal("DNC must be preserved on reimport")
+	}
+}
+
+func TestDefaultQueueStatePreservesSent(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{QueueState: models.OutreachQueueSent}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueSent {
+		t.Fatal("SENT must not restart on reimport")
+	}
+}
+
+func TestLegacyLeadsArrayNormalizes(t *testing.T) {
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("normalized schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) != 3 {
+		t.Fatalf("want 3 leads, got %d", len(feed.Leads))
+	}
+	// No invented email on contactless company
+	var missing bool
+	for _, l := range feed.Leads {
+		if !hasEnrollableContact(l) {
+			missing = true
+		}
+		if NormalizeCNPJ14(l.Company.CNPJ14) == "" {
+			t.Fatalf("cnpj not normalized: %q", l.Company.CNPJ14)
+		}
+	}
+	if !missing {
+		t.Fatal("legacy fixture should include company without contact")
+	}
+}
+
+func TestLegacyDoesNotInventMissingFields(t *testing.T) {
+	raw := []byte(`[{"cnpj14":"11222333000181","razao_social":"Only Name"}]`)
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := feed.Leads[0]
+	if l.Offer.ServiceCode != "" || l.MessagingContext.FactToMention != "" {
+		t.Fatalf("must not invent offer/fact: %+v", l)
+	}
+	if len(l.Contacts) != 0 {
+		t.Fatalf("must not invent contacts: %+v", l.Contacts)
+	}
+}
+
+func TestHostAllowlist(t *testing.T) {
+	if !hostAllowed("feed.example.com", []string{"example.com"}) {
+		t.Fatal("subdomain should match parent allow")
+	}
+	if hostAllowed("evil.com", []string{"example.com"}) {
+		t.Fatal("unrelated host must not match")
+	}
+	if !hostAllowed("example.com", []string{"example.com"}) {
+		t.Fatal("exact host should match")
+	}
+}
+
+func TestConfigDefaultsOff(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvAutoSend, "")
+	cfg := LoadConfig()
+	if cfg.Enabled || cfg.AutoSendEnabled {
+		t.Fatal("feature must default off")
+	}
+	if !cfg.RequireHumanApproval {
+		t.Fatal("human approval must default true")
+	}
+}
+
+func TestConfigValidateProdHTTPS(t *testing.T) {
+	cfg := Config{
+		Enabled:      true,
+		FeedURL:      "http://insecure.example.com/feed",
+		AllowedHosts: []string{"insecure.example.com"},
+	}
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require https feed")
+	}
+	cfg.FeedURL = "https://feed.example.com/x"
+	cfg.AllowedHosts = nil
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require allowlist when feed set")
+	}
+}
+
+func TestForbiddenWordsNotInFixtureSubjects(t *testing.T) {
+	// Structural: native fixture messaging must not use prohibited outreach phrases.
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	var feed Feed
+	if err := json.Unmarshal(raw, &feed); err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{"dinheiro a receber", "crédito identificado", "lead quente"}
+	for _, l := range feed.Leads {
+		blob := l.MessagingContext.FactToMention + l.MessagingContext.QuestionToAsk + l.MessagingContext.CTA
+		for _, b := range banned {
+			if containsFold(blob, b) {
+				t.Fatalf("fixture contains banned phrase %q", b)
+			}
+		}
+	}
+}
+
+func containsFold(s, sub string) bool {
+	return len(sub) > 0 && (s == sub || len(s) >= len(sub) &&
+		(json.Valid([]byte(`"`+s+`"`)) && // keep compiler happy path
+			false || stringContainsFold(s, sub)))
+}
+
+func stringContainsFold(s, sub string) bool {
+	// simple ASCII fold
+	ls, lsub := []rune(s), []rune(sub)
+	for i := 0; i+len(lsub) <= len(ls); i++ {
+		match := true
+		for j := range lsub {
+			a, b := ls[i+j], lsub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	p := filepath.Join("testdata", name)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -1,0 +1,500 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// AuditLogger writes org-scoped audit entries (realtime spine).
+type AuditLogger interface {
+	LogAction(ctx context.Context, orgID, actorID uuid.UUID, action models.AuditAction, entityType models.AuditEntityType, entityID *uuid.UUID, ip, userAgent string, changes, metadata map[string]string)
+}
+
+// Service is the control-plane surface for CONFENGE outreach staging.
+type Service interface {
+	Enabled() bool
+	Config() Config
+
+	// ImportFromBytes validates and optionally applies a feed payload.
+	ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+	// ImportFromURI fetches a feed (file/https) then imports.
+	ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error)
+
+	Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error)
+	BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error)
+}
+
+// ImportOptions controls dry-run, idempotency, and source tracking.
+type ImportOptions struct {
+	DryRun         bool
+	IdempotencyKey string
+	SourceURI      string
+}
+
+type service struct {
+	cfg   Config
+	repo  repository.OutreachRepository
+	audit AuditLogger
+	fetch *FeedFetcher
+}
+
+// NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
+func NewService(cfg Config, repo repository.OutreachRepository, audit AuditLogger) Service {
+	return &service{
+		cfg:   cfg,
+		repo:  repo,
+		audit: audit,
+		fetch: &FeedFetcher{
+			AllowedHosts: cfg.AllowedHosts,
+			Token:        cfg.FeedToken,
+			MaxBytes:     cfg.MaxFeedPayloadBytes,
+		},
+	}
+}
+
+func (s *service) Enabled() bool  { return s.cfg.Enabled }
+func (s *service) Config() Config { return s.cfg }
+
+func (s *service) requireEnabled() *errx.Error {
+	if !s.cfg.Enabled {
+		return errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server")
+	}
+	return nil
+}
+
+func (s *service) ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	// Prefer configured feed URL when client sends empty.
+	if strings.TrimSpace(uri) == "" {
+		uri = s.cfg.FeedURL
+	}
+	if strings.TrimSpace(uri) == "" {
+		return nil, errx.New(errx.BadRequest, "feed URI is required (or set CONFENGE_EXTRA_CLI_FEED_URL)")
+	}
+	opts.SourceURI = uri
+	raw, err := s.fetch.Fetch(ctx, uri)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "failed to fetch feed: "+err.Error())
+	}
+	return s.ImportFromBytes(ctx, orgID, userID, raw, opts)
+}
+
+func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if len(raw) == 0 {
+		return nil, errx.New(errx.BadRequest, "empty feed payload")
+	}
+	if s.cfg.MaxFeedPayloadBytes > 0 && int64(len(raw)) > s.cfg.MaxFeedPayloadBytes {
+		return nil, errx.New(errx.BadRequest, "feed payload too large")
+	}
+
+	payloadHash := CanonicalPayloadHash(raw)
+	if opts.IdempotencyKey != "" {
+		existing, err := s.repo.GetImportRunByIdempotency(ctx, orgID, opts.IdempotencyKey)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to check idempotency key")
+		}
+		if existing != nil {
+			// Same key + same hash: return prior result (idempotent).
+			if existing.PayloadHash == payloadHash {
+				return existing, nil
+			}
+			// Same key, different body: conflict.
+			return nil, errx.New(errx.Conflict, "idempotency key already used with a different payload")
+		}
+	}
+
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "invalid feed: "+err.Error())
+	}
+	if err := ValidateFeed(feed); err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+
+	run := &models.OutreachImportRun{
+		OrganizationID:  orgID,
+		SourceSystem:    feed.Source.System,
+		SourceRunID:     feed.Source.RunID,
+		SchemaVersion:   feed.SchemaVersion,
+		SnapshotHash:    feed.Source.SnapshotHash,
+		RepoSHA:         feed.Source.RepoSHA,
+		PayloadHash:     payloadHash,
+		ProfileID:       feed.Source.ProfileID,
+		ProfileVersion:  feed.Source.ProfileVersion,
+		Status:          models.OutreachImportRunning,
+		DryRun:          opts.DryRun,
+		CreatedByUserID: userID,
+		IdempotencyKey:  opts.IdempotencyKey,
+		SourceURI:       opts.SourceURI,
+		Warnings:        nil,
+		Errors:          nil,
+	}
+	if feed.Pagination.Cursor != nil {
+		run.CursorIn = *feed.Pagination.Cursor
+	}
+	if feed.Pagination.NextCursor != nil {
+		run.CursorOut = *feed.Pagination.NextCursor
+	}
+
+	if err := s.repo.CreateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to create import run: "+err.Error())
+	}
+
+	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, opts.DryRun)
+	run.Counts = counts
+	run.Errors = leadErrs
+	run.Warnings = warns
+	now := time.Now().UTC()
+	run.FinishedAt = &now
+	if len(leadErrs) > 0 && counts.Creates+counts.Updates > 0 {
+		run.Status = models.OutreachImportPartial
+	} else if len(leadErrs) > 0 && counts.Creates+counts.Updates == 0 && counts.LeadsProcessed == 0 {
+		run.Status = models.OutreachImportFailed
+	} else {
+		run.Status = models.OutreachImportCompleted
+	}
+	if err := s.repo.UpdateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to finalize import run")
+	}
+
+	if s.audit != nil && userID != nil && !opts.DryRun {
+		s.audit.LogAction(ctx, orgID, *userID, models.AuditActionCreate, models.AuditEntityOutreachImportRun, &run.ID, "", "",
+			map[string]string{
+				"payload_hash": payloadHash,
+				"creates":      fmt.Sprintf("%d", counts.Creates),
+				"updates":      fmt.Sprintf("%d", counts.Updates),
+			},
+			map[string]string{"source_system": feed.Source.System, "source_run_id": feed.Source.RunID},
+		)
+	}
+	return run, nil
+}
+
+func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {
+	var counts models.OutreachImportCounts
+	var leadErrs []models.OutreachImportError
+	var warns []string
+
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			counts.Invalid++
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lv.SourceLeadID,
+				CNPJ14:       lv.CNPJ14,
+				Message:      lv.Message,
+			})
+			continue
+		}
+		cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+		existing, err := s.repo.GetAccountByCNPJ(ctx, orgID, cnpj)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "db error loading account",
+			})
+			continue
+		}
+
+		// Preserve DNC: never re-open.
+		if existing != nil && existing.DoNotContact {
+			counts.Blocked++
+			counts.Unchanged++
+			counts.LeadsProcessed++
+			continue
+		}
+
+		contentHash := LeadContentHash(lead)
+		queueState := DefaultQueueState(lead, existing)
+		if !hasEnrollableContact(lead) {
+			counts.MissingContact++
+		}
+
+		if dryRun {
+			if existing == nil {
+				counts.Creates++
+			} else if existing.LastPayloadHash == contentHash {
+				counts.Unchanged++
+			} else {
+				counts.Updates++
+			}
+			// Estimate evidence adds
+			if existing != nil {
+				existingEv, _ := s.repo.ListEvidence(ctx, orgID, existing.ID)
+				known := map[string]bool{}
+				for _, e := range existingEv {
+					known[e.SourceEvidenceID] = true
+				}
+				for _, e := range lead.Evidence {
+					if e.ID != "" && !known[e.ID] {
+						counts.EvidenceAdded++
+					}
+				}
+			} else {
+				counts.EvidenceAdded += len(lead.Evidence)
+			}
+			counts.LeadsProcessed++
+			continue
+		}
+
+		// APPLY
+		acc := leadToAccount(orgID, lead, feed, run.ID, contentHash, queueState, existing)
+		created, err := s.repo.UpsertAccount(ctx, acc)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "upsert account: " + err.Error(),
+			})
+			continue
+		}
+		if created {
+			counts.Creates++
+		} else if existing != nil && existing.LastPayloadHash == contentHash {
+			counts.Unchanged++
+		} else {
+			counts.Updates++
+		}
+
+		for _, fc := range lead.Contacts {
+			cand := leadToCandidate(orgID, acc.ID, run.ID, fc)
+			if _, err := s.repo.UpsertCandidate(ctx, cand); err != nil {
+				warns = append(warns, fmt.Sprintf("%s contact %s: %v", cnpj, fc.Email, err))
+				counts.Warnings++
+			}
+		}
+		for _, fe := range lead.Evidence {
+			ev := leadToEvidence(orgID, acc.ID, run.ID, fe)
+			createdEv, err := s.repo.UpsertEvidence(ctx, ev)
+			if err != nil {
+				warns = append(warns, fmt.Sprintf("%s evidence %s: %v", cnpj, fe.ID, err))
+				counts.Warnings++
+				continue
+			}
+			if createdEv {
+				counts.EvidenceAdded++
+			}
+		}
+		counts.LeadsProcessed++
+	}
+	return counts, leadErrs, warns
+}
+
+func leadToAccount(orgID uuid.UUID, lead FeedLead, feed *Feed, runID uuid.UUID, contentHash, queueState string, existing *models.OutreachAccount) *models.OutreachAccount {
+	cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+	root := digitsOnly(lead.Company.CNPJRoot)
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	contracts, _ := json.Marshal(lead.Contracts)
+	if contracts == nil {
+		contracts = []byte("[]")
+	}
+	acc := &models.OutreachAccount{
+		OrganizationID:     orgID,
+		SourceLeadID:       SanitizeText(lead.SourceLeadID, 200),
+		CNPJ14:             cnpj,
+		CNPJRoot:           root,
+		RazaoSocial:        SanitizeText(lead.Company.RazaoSocial, 500),
+		NomeFantasia:       SanitizeText(lead.Company.NomeFantasia, 500),
+		Municipio:          SanitizeText(lead.Company.Municipio, 200),
+		UF:                 strings.ToUpper(SanitizeText(lead.Company.UF, 2)),
+		Website:            SanitizeText(lead.Company.Website, 500),
+		PriorityRank:       lead.Priority.Rank,
+		PriorityScore:      lead.Priority.Score,
+		PriorityTier:       SanitizeText(lead.Priority.Tier, 100),
+		PriorityConfidence: SanitizeText(lead.Priority.Confidence, 50),
+		MomentCode:         SanitizeText(lead.Moment.Code, 100),
+		MomentSummary:      SanitizeText(lead.Moment.Summary, 2000),
+		MomentObservedAt:   ParseDate(lead.Moment.ObservedAt),
+		MomentConfidence:   SanitizeText(lead.Moment.Confidence, 50),
+		MomentEvidenceIDs:  lead.Moment.EvidenceIDs,
+		ServiceCode:        SanitizeText(lead.Offer.ServiceCode, 100),
+		ServiceName:        SanitizeText(lead.Offer.ServiceName, 200),
+		EntryOffer:         SanitizeText(lead.Offer.EntryOffer, 1000),
+		OfferRationale:     SanitizeText(lead.Offer.Rationale, 2000),
+		FactToMention:      SanitizeText(lead.MessagingContext.FactToMention, 2000),
+		QuestionToAsk:      SanitizeText(lead.MessagingContext.QuestionToAsk, 1000),
+		CTA:                SanitizeText(lead.MessagingContext.CTA, 500),
+		ClaimsToAvoid:      lead.MessagingContext.ClaimsToAvoid,
+		CommercialState:    firstNonEmpty(SanitizeText(lead.CommercialState, 50), "NEW"),
+		QueueState:         queueState,
+		SourceSystem:       feed.Source.System,
+		SourceRunID:        feed.Source.RunID,
+		LastImportRunID:    &runID,
+		LastPayloadHash:    contentHash,
+		ContractsJSON:      contracts,
+	}
+	if existing != nil {
+		acc.ID = existing.ID
+		acc.HumanOverride = existing.HumanOverride
+		acc.Blocked = existing.Blocked
+		acc.BlockReason = existing.BlockReason
+		acc.DoNotContact = existing.DoNotContact
+		acc.CreatedAt = existing.CreatedAt
+	}
+	return acc
+}
+
+func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.OutreachContactCandidate {
+	email := strings.TrimSpace(strings.ToLower(fc.Email))
+	vs := NormalizeVerification(fc.VerificationStatus, email)
+	dnc := vs == models.OutreachVerifyDoNotContact
+	bounced := vs == models.OutreachVerifyBounced
+	return &models.OutreachContactCandidate{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		SourceContactID:    SanitizeText(fc.SourceContactID, 200),
+		Name:               SanitizeText(fc.Name, 300),
+		Role:               SanitizeText(fc.Role, 200),
+		Email:              email,
+		Phone:              SanitizeText(fc.Phone, 50),
+		LinkedInURL:        SanitizeText(fc.LinkedInURL, 500),
+		SourceURL:          SanitizeText(fc.SourceURL, 1000),
+		SourceDocument:     SanitizeText(fc.SourceDocument, 500),
+		SourceDate:         ParseDate(fc.SourceDate),
+		VerificationStatus: vs,
+		Confidence:         SanitizeText(fc.Confidence, 50),
+		Recommended:        fc.Recommended,
+		DoNotContact:       dnc,
+		Bounced:            bounced,
+		LastImportRunID:    &runID,
+	}
+}
+
+func leadToEvidence(orgID, accountID, runID uuid.UUID, fe FeedEvidence) *models.OutreachEvidence {
+	return &models.OutreachEvidence{
+		OrganizationID:   orgID,
+		AccountID:        accountID,
+		SourceEvidenceID: SanitizeText(fe.ID, 200),
+		EvidenceType:     SanitizeText(fe.Type, 100),
+		Title:            SanitizeText(fe.Title, 500),
+		URL:              SanitizeText(fe.URL, 1000),
+		Document:         SanitizeText(fe.Document, 500),
+		EvidenceDate:     ParseDate(fe.Date),
+		Location:         SanitizeText(fe.Location, 200),
+		Excerpt:          SanitizeText(fe.Excerpt, 4000),
+		Synthesis:        SanitizeText(fe.Synthesis, 2000),
+		EpistemicClass:   NormalizeEpistemic(fe.EpistemicClass),
+		Reliability:      SanitizeText(fe.Reliability, 50),
+		ConsultedAt:      ParseDate(fe.ConsultedAt),
+		LastImportRunID:  &runID,
+	}
+}
+
+func (s *service) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	run, err := s.repo.GetImportRun(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load import run")
+	}
+	if run == nil {
+		return nil, errx.New(errx.NotFound, "import run not found")
+	}
+	return run, nil
+}
+
+func (s *service) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListImportRuns(ctx, orgID, limit)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list import runs")
+	}
+	if list == nil {
+		list = []models.OutreachImportRun{}
+	}
+	return list, nil
+}
+
+func (s *service) Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	sum, err := s.repo.CountByQueueState(ctx, orgID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load summary")
+	}
+	return sum, nil
+}
+
+func (s *service) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListAccounts(ctx, orgID, filter)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list accounts")
+	}
+	if list == nil {
+		list = []models.OutreachAccount{}
+	}
+	return list, nil
+}
+
+func (s *service) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load account")
+	}
+	if acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	contacts, err := s.repo.ListCandidates(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load contacts")
+	}
+	evidence, err := s.repo.ListEvidence(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load evidence")
+	}
+	acc.Contacts = contacts
+	acc.Evidence = evidence
+	acc.ContactN = len(contacts)
+	acc.EvidenceN = len(evidence)
+	return acc, nil
+}
+
+func (s *service) BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	queue := models.OutreachQueueBlocked
+	if dnc {
+		queue = models.OutreachQueueDoNotContact
+	}
+	if err := s.repo.SetAccountHumanFlags(ctx, orgID, id, true, dnc, SanitizeText(reason, 500), queue); err != nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &id, "", "",
+			map[string]string{"blocked": "true", "do_not_contact": fmt.Sprintf("%v", dnc)},
+			map[string]string{"reason": reason},
+		)
+	}
+	return s.GetAccount(ctx, orgID, id)
+}

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -1,0 +1,466 @@
+package confenge
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// memRepo is an in-memory OutreachRepository for unit tests of ImportFromBytes.
+type memRepo struct {
+	mu       sync.Mutex
+	runs     map[uuid.UUID]*models.OutreachImportRun
+	byIdem   map[string]*models.OutreachImportRun
+	accounts map[string]*models.OutreachAccount // org|cnpj
+	byID     map[uuid.UUID]*models.OutreachAccount
+	cands    map[uuid.UUID][]models.OutreachContactCandidate
+	evidence map[uuid.UUID][]models.OutreachEvidence
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{
+		runs:     map[uuid.UUID]*models.OutreachImportRun{},
+		byIdem:   map[string]*models.OutreachImportRun{},
+		accounts: map[string]*models.OutreachAccount{},
+		byID:     map[uuid.UUID]*models.OutreachAccount{},
+		cands:    map[uuid.UUID][]models.OutreachContactCandidate{},
+		evidence: map[uuid.UUID][]models.OutreachEvidence{},
+	}
+}
+
+func accKey(org uuid.UUID, cnpj string) string { return org.String() + "|" + cnpj }
+
+func (m *memRepo) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.runs[id]
+	if r == nil || r.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byIdem[orgID.String()+"|"+key]
+	if r == nil {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	return nil, nil
+}
+
+func (m *memRepo) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.accounts[accKey(orgID, cnpj14)]
+	if a == nil {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := accKey(acc.OrganizationID, acc.CNPJ14)
+	existing := m.accounts[k]
+	created := existing == nil
+	if existing != nil {
+		acc.ID = existing.ID
+		// preserve DNC
+		if existing.DoNotContact {
+			acc.DoNotContact = true
+		}
+	} else if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	cp := *acc
+	m.accounts[k] = &cp
+	m.byID[cp.ID] = &cp
+	return created, nil
+}
+
+func (m *memRepo) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	return nil, nil
+}
+
+func (m *memRepo) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	return &models.OutreachQueueSummary{}, nil
+}
+
+func (m *memRepo) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return context.Canceled
+	}
+	a.Blocked = blocked
+	a.DoNotContact = dnc
+	a.BlockReason = reason
+	a.QueueState = queueState
+	a.HumanOverride = true
+	return nil
+}
+
+func (m *memRepo) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachContactCandidate{}, m.cands[accountID]...), nil
+}
+
+func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	list := m.cands[c.AccountID]
+	for i, existing := range list {
+		if existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID {
+			if existing.DoNotContact {
+				c.DoNotContact = true
+			}
+			c.ID = existing.ID
+			list[i] = *c
+			m.cands[c.AccountID] = list
+			return false, nil
+		}
+	}
+	m.cands[c.AccountID] = append(list, *c)
+	return true, nil
+}
+
+func (m *memRepo) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	return nil, nil
+}
+
+func (m *memRepo) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachEvidence{}, m.evidence[accountID]...), nil
+}
+
+func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	list := m.evidence[e.AccountID]
+	for i, existing := range list {
+		if existing.SourceEvidenceID == e.SourceEvidenceID {
+			e.ID = existing.ID
+			list[i] = *e
+			m.evidence[e.AccountID] = list
+			return false, nil
+		}
+	}
+	m.evidence[e.AccountID] = append(list, *e)
+	return true, nil
+}
+
+func testSvc(repo repository.OutreachRepository) Service {
+	cfg := Config{
+		Enabled:              true,
+		RequireHumanApproval: true,
+		DefaultDailyLimit:    10,
+		MaxInitialEmailWords: 120,
+		MaxFeedPayloadBytes:  DefaultMaxPayloadBytes,
+	}
+	return NewService(cfg, repo, nil)
+}
+
+func TestImportNativeFeedCreatesAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	user := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+
+	run, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatalf("import: %v", xerr)
+	}
+	if run.Status != models.OutreachImportCompleted && run.Status != models.OutreachImportPartial {
+		t.Fatalf("status %s counts=%+v errs=%+v", run.Status, run.Counts, run.Errors)
+	}
+	if run.Counts.Creates < 4 {
+		t.Fatalf("want >=4 creates, got %+v", run.Counts)
+	}
+	// No-email company staged as NEEDS_CONTACT
+	acc, err := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if err != nil || acc == nil {
+		t.Fatal("missing no-contact company")
+	}
+	if acc.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("queue_state=%s want NEEDS_CONTACT", acc.QueueState)
+	}
+	// Official contact company ready
+	acme, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acme == nil || acme.QueueState != models.OutreachQueueReadyToGenerate {
+		t.Fatalf("acme state=%v", acme)
+	}
+	// Unverified-only contact is not enrollable => NEEDS_CONTACT
+	cn, _ := repo.GetAccountByCNPJ(context.Background(), org, "66777888000199")
+	if cn == nil || cn.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("unverified-only should be NEEDS_CONTACT, got %v", cn)
+	}
+}
+
+func TestImportDryRunDoesNotPersistAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{DryRun: true})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !run.DryRun {
+		t.Fatal("expected dry_run")
+	}
+	if run.Counts.Creates < 1 {
+		t.Fatalf("dry-run should count creates: %+v", run.Counts)
+	}
+	// accounts map empty of real companies
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc != nil {
+		t.Fatal("dry-run must not persist accounts")
+	}
+}
+
+func TestImportIdempotencySameKeySamePayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-1"}
+	r1, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	r2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if r1.ID != r2.ID {
+		t.Fatalf("idempotent reimport should return same run %s vs %s", r1.ID, r2.ID)
+	}
+}
+
+func TestImportIdempotencyConflictOnDifferentPayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-2"}
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts); xerr != nil {
+		t.Fatal(xerr)
+	}
+	other := []byte(`{"schema_version":"confenge.outreach.v1","source":{"system":"extra-cli"},"leads":[]}`)
+	_, xerr := svc.ImportFromBytes(context.Background(), org, nil, other, opts)
+	if xerr == nil {
+		t.Fatal("expected conflict")
+	}
+}
+
+func TestReimportPreservesDNC(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc == nil {
+		t.Fatal("missing")
+	}
+	acc.DoNotContact = true
+	acc.QueueState = models.OutreachQueueDoNotContact
+	_, _ = repo.UpsertAccount(context.Background(), acc)
+
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	again, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if again == nil || !again.DoNotContact {
+		t.Fatal("DNC must survive reimport")
+	}
+}
+
+func TestReimportIdenticalIsUnchanged(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	run2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run2.Counts.Creates != 0 {
+		t.Fatalf("second import should not create: %+v", run2.Counts)
+	}
+	if run2.Counts.Unchanged < 1 {
+		t.Fatalf("expected unchanged counts: %+v", run2.Counts)
+	}
+}
+
+func TestReimportScoreChangeUpdates(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	// Mutate score in payload
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Priority.Score = 99
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Updates < 1 {
+		t.Fatalf("score change should update: %+v", run.Counts)
+	}
+}
+
+func TestMultiTenantIsolation(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	orgA, orgB := uuid.New(), uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), orgA, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	accB, _ := repo.GetAccountByCNPJ(context.Background(), orgB, "11222333000181")
+	if accB != nil {
+		t.Fatal("org B must not see org A accounts")
+	}
+	accA, _ := repo.GetAccountByCNPJ(context.Background(), orgA, "11222333000181")
+	if accA == nil {
+		t.Fatal("org A should have account")
+	}
+}
+
+func TestDisabledServiceRejects(t *testing.T) {
+	repo := newMemRepo()
+	cfg := Config{Enabled: false}
+	svc := NewService(cfg, repo, nil)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{}`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("disabled must reject")
+	}
+}
+
+func TestLegacyImportWorks(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Creates < 2 {
+		t.Fatalf("legacy creates: %+v errs=%+v", run.Counts, run.Errors)
+	}
+	noContact, _ := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if noContact == nil || noContact.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("legacy no-contact company: %+v", noContact)
+	}
+}
+
+func TestInvalidFeedRejected(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{not json`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("expected invalid feed error")
+	}
+}
+
+func TestEvidenceAddedOnReimport(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Evidence = append(feed.Leads[0].Evidence, FeedEvidence{
+		ID:             "ev-acme-2",
+		Title:          "Nova evidencia",
+		EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	})
+	// Also change a machine field so content hash moves (evidence is in hash)
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.EvidenceAdded < 1 {
+		t.Fatalf("expected new evidence: %+v", run.Counts)
+	}
+}
+
+// local helper avoiding import cycle noise
+func jsonMarshal(v any) ([]byte, error) {
+	return marshalJSON(v)
+}

--- a/internal/app/confenge/testdata/legacy_leads_array.json
+++ b/internal/app/confenge/testdata/legacy_leads_array.json
@@ -1,0 +1,45 @@
+[
+  {
+    "cnpj14": "11222333000181",
+    "razao_social": "Construtora Regional ACME Ltda",
+    "score_total": 80,
+    "priority": "HIGH",
+    "rank_position": 1,
+    "suggested_offer": "ADDITIVE_REVIEW",
+    "next_human_step": "Validar interlocutor de contratos",
+    "commercial_state": "NEW",
+    "municipio": "Florianopolis",
+    "uf": "SC",
+    "signals_fired": ["CONTRACT_EXTENSION"],
+    "email": "ana.silva@acme.example.com",
+    "contact_name": "Ana Silva",
+    "cargo": "Engenheira de contratos",
+    "verification_status": "OFFICIAL_SOURCE"
+  },
+  {
+    "cnpj14": "55444333000122",
+    "razao_social": "Obras do Planalto Ltda",
+    "score_total": 50,
+    "priority": "MEDIUM",
+    "rank_position": 2,
+    "suggested_offer": "BID_READINESS",
+    "commercial_state": "NEW",
+    "municipio": "Brasilia",
+    "uf": "DF"
+  },
+  {
+    "cnpj14": "99888777000166",
+    "razao_social": "Empresa Nacional de Infraestrutura SA",
+    "score_total": 65,
+    "priority": "MEDIUM",
+    "contacts": [
+      {
+        "id": "c1",
+        "name": "Equipe comercial",
+        "email": "contato@eni.example.org",
+        "verification_status": "INSTITUTIONAL_GENERIC",
+        "recommended": true
+      }
+    ]
+  }
+]

--- a/internal/app/confenge/testdata/native_feed_v1.json
+++ b/internal/app/confenge/testdata/native_feed_v1.json
@@ -1,0 +1,312 @@
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "fixture-run-001",
+    "snapshot_hash": "abc123snapshot",
+    "repo_sha": "deadbeef",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": {
+    "cursor": null,
+    "next_cursor": null,
+    "has_more": false
+  },
+  "leads": [
+    {
+      "source_lead_id": "lead-acme-sc",
+      "company": {
+        "cnpj14": "11222333000181",
+        "cnpj_root": "11222333",
+        "razao_social": "Construtora Regional ACME Ltda",
+        "nome_fantasia": "ACME Obras",
+        "municipio": "Florianopolis",
+        "uf": "SC",
+        "website": "https://acme.example.com"
+      },
+      "priority": {
+        "rank": 1,
+        "score": 82.5,
+        "tier": "HIGH",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "CONTRACT_EXTENSION",
+        "summary": "Contrato de obra publica com prorrogacao publicada no PNCP",
+        "observed_at": "2026-07-15",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-acme-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Leitura tecnica do aditivo em curso",
+        "rationale": "Momento de prorrogacao com margem para apoio consultivo"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Prorrogacao do contrato 001/2025 publicada no PNCP em julho/2026",
+        "question_to_ask": "Faz sentido conversarmos sobre o controle de aditivos desta obra?",
+        "cta": "Posso enviar um checklist de 1 pagina?",
+        "claims_to_avoid": ["garantia de economia", "erro na gestao"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-acme-eng",
+          "name": "Ana Silva",
+          "role": "Engenheira de contratos",
+          "email": "ana.silva@acme.example.com",
+          "phone": "",
+          "linkedin_url": "",
+          "source_url": "https://acme.example.com/equipe",
+          "source_document": "",
+          "source_date": "2026-06-01",
+          "verification_status": "OFFICIAL_SOURCE",
+          "confidence": "HIGH",
+          "recommended": true
+        }
+      ],
+      "contracts": [
+        {"id": "c-001", "number": "001/2025", "agency": "Prefeitura Exemplo"}
+      ],
+      "evidence": [
+        {
+          "id": "ev-acme-1",
+          "type": "PNCP_PUBLICATION",
+          "title": "Prorrogacao contrato 001/2025",
+          "url": "https://pncp.example.gov.br/contratos/001-2025",
+          "document": "Termo de prorrogacao",
+          "date": "2026-07-15",
+          "location": "secao 2",
+          "excerpt": "Fica prorrogado o prazo de execucao por 180 dias.",
+          "synthesis": "Prorrogacao formal publicada",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-nacional",
+      "company": {
+        "cnpj14": "99888777000166",
+        "cnpj_root": "99888777",
+        "razao_social": "Empresa Nacional de Infraestrutura SA",
+        "nome_fantasia": "ENI",
+        "municipio": "Sao Paulo",
+        "uf": "SP",
+        "website": "https://eni.example.org"
+      },
+      "priority": {
+        "rank": 2,
+        "score": 70,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "ADDITIVE_SIGNED",
+        "summary": "Aditivo de reajuste publicado",
+        "observed_at": "2026-06-20",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-eni-1"]
+      },
+      "offer": {
+        "service_code": "REAJUSTE_SUPPORT",
+        "service_name": "Apoio a reajustes",
+        "entry_offer": "Parecer resumido sobre clausula de reajuste",
+        "rationale": "Aditivo recente com potencial de segunda opiniao tecnica"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Aditivo de reajuste do contrato 44/2024 publicado em junho/2026",
+        "question_to_ask": "Voces ja fecharam a leitura economica deste aditivo?",
+        "cta": "Posso compartilhar um modelo de memoria de calculo?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-eni-generic",
+          "name": "",
+          "role": "Comercial",
+          "email": "contato@eni.example.org",
+          "verification_status": "INSTITUTIONAL_GENERIC",
+          "confidence": "MEDIUM",
+          "recommended": true
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-eni-1",
+          "type": "CONTRACT_ADDITIVE",
+          "title": "Aditivo reajuste 44/2024",
+          "url": "https://portal.example.gov.br/44-2024",
+          "date": "2026-06-20",
+          "excerpt": "Reajuste conforme indices oficiais.",
+          "synthesis": "Aditivo de reajuste formal",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-no-contact",
+      "company": {
+        "cnpj14": "55444333000122",
+        "cnpj_root": "55444333",
+        "razao_social": "Obras do Planalto Ltda",
+        "nome_fantasia": "Planalto",
+        "municipio": "Brasilia",
+        "uf": "DF",
+        "website": ""
+      },
+      "priority": {
+        "rank": 3,
+        "score": 55,
+        "tier": "MEDIUM",
+        "confidence": "LOW"
+      },
+      "moment": {
+        "code": "TENDER_WIN",
+        "summary": "Homologacao recente em licitacao de reforma",
+        "observed_at": "2026-05-10",
+        "confidence": "MEDIUM",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "BID_READINESS",
+        "service_name": "Preparacao de propostas",
+        "entry_offer": "Checklist de conformidade documental",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Homologacao em licitação de reforma em maio/2026",
+        "question_to_ask": "Quem na equipe cuida da memoria de calculo de aditivos?",
+        "cta": "Posso enviar um checklist curto?",
+        "claims_to_avoid": []
+      },
+      "contacts": [],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-unverified",
+      "company": {
+        "cnpj14": "66777888000199",
+        "cnpj_root": "66777888",
+        "razao_social": "Consorcio Ponte Norte",
+        "nome_fantasia": "Ponte Norte",
+        "municipio": "Curitiba",
+        "uf": "PR",
+        "website": "https://pontenorte.example.net"
+      },
+      "priority": {
+        "rank": 4,
+        "score": 60,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "CONSORTIUM_ACTIVE",
+        "summary": "Consorcio ativo em obra rodoviaria",
+        "observed_at": "2026-04-01",
+        "confidence": "MEDIUM",
+        "evidence_ids": ["ev-cn-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Mapa de riscos de aditivos do consorcio",
+        "rationale": "Estrutura multi-empresa exige cuidado com interlocutor"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Consorcio ativo em obra rodoviaria com publicacoes recentes",
+        "question_to_ask": "Quem e o interlocutor tecnico de aditivos no consorcio?",
+        "cta": "Posso enviar uma pergunta objetiva por e-mail?",
+        "claims_to_avoid": ["vinculo societario"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-cn-cand",
+          "name": "Bruno Costa",
+          "role": "Diretor",
+          "email": "bruno@pontenorte.example.net",
+          "verification_status": "CANDIDATE_UNVERIFIED",
+          "confidence": "LOW",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-cn-1",
+          "type": "PUBLIC_NOTICE",
+          "title": "Ata de consorcio",
+          "url": "https://docs.example.gov.br/consorcio-ponte",
+          "date": "2026-04-01",
+          "excerpt": "Constituido o consorcio Ponte Norte.",
+          "synthesis": "Consorcio formalizado",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "MEDIUM",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-dnc",
+      "company": {
+        "cnpj14": "12345678000195",
+        "cnpj_root": "12345678",
+        "razao_social": "Servicos Tecnicos Beta Ltda",
+        "nome_fantasia": "Beta",
+        "municipio": "Joinville",
+        "uf": "SC",
+        "website": "https://beta.example.com"
+      },
+      "priority": {
+        "rank": 5,
+        "score": 40,
+        "tier": "LOW",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "NO_RECENT_SIGNAL",
+        "summary": "Sem fato gerador recente",
+        "observed_at": "2026-01-01",
+        "confidence": "HIGH",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "DIAGNOSTIC",
+        "service_name": "Diagnostico leve",
+        "entry_offer": "Conversa exploratoria",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Atuacao regional em contratos publicos de engenharia",
+        "question_to_ask": "Faz sentido uma conversa curta sobre controle de aditivos?",
+        "cta": "Posso ligar 10 minutos esta semana?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-beta-dnc",
+          "name": "Carlos Souza",
+          "role": "Socio",
+          "email": "carlos@beta.example.com",
+          "verification_status": "DO_NOT_CONTACT",
+          "confidence": "HIGH",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "DO_NOT_CONTACT"
+    }
+  ]
+}

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS outreach_evidence;
+DROP TABLE IF EXISTS outreach_contact_candidates;
+DROP TABLE IF EXISTS outreach_accounts;
+DROP TABLE IF EXISTS outreach_import_runs;

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
@@ -1,0 +1,227 @@
+-- Outreach staging: multi-tenant company staging queue for intelligence-plane
+-- feeds (e.g. extra-cli confenge.outreach.v1). Companies may exist without a
+-- validated email; they are not forced into the contacts table until promoted.
+-- Feature flag: CONFENGE_OUTREACH_ENABLED (see internal/app/confenge).
+
+CREATE TABLE IF NOT EXISTS outreach_import_runs (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    schema_version      text NOT NULL DEFAULT 'confenge.outreach.v1',
+    snapshot_hash       text NOT NULL DEFAULT '',
+    repo_sha            text NOT NULL DEFAULT '',
+    payload_hash        text NOT NULL DEFAULT '',
+    profile_id          text NOT NULL DEFAULT '',
+    profile_version     text NOT NULL DEFAULT '',
+
+    status              text NOT NULL DEFAULT 'pending',
+    dry_run             boolean NOT NULL DEFAULT false,
+    started_at          timestamptz NOT NULL DEFAULT now(),
+    finished_at         timestamptz,
+    cursor_in           text NOT NULL DEFAULT '',
+    cursor_out          text NOT NULL DEFAULT '',
+
+    counts              jsonb NOT NULL DEFAULT '{}'::jsonb,
+    errors              jsonb NOT NULL DEFAULT '[]'::jsonb,
+    warnings            jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    created_by_user_id  uuid REFERENCES users(id) ON DELETE SET NULL,
+    idempotency_key     text NOT NULL DEFAULT '',
+    source_uri          text NOT NULL DEFAULT '',
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_import_runs_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'partial'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_import_runs_org_idempotency_uidx
+    ON outreach_import_runs (organization_id, idempotency_key)
+    WHERE idempotency_key <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_import_runs_org_started_idx
+    ON outreach_import_runs (organization_id, started_at DESC);
+
+-- Company / account staging (no email required).
+CREATE TABLE IF NOT EXISTS outreach_accounts (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_lead_id      text NOT NULL DEFAULT '',
+    cnpj14              text NOT NULL,
+    cnpj_root           text NOT NULL DEFAULT '',
+    razao_social        text NOT NULL DEFAULT '',
+    nome_fantasia       text NOT NULL DEFAULT '',
+    municipio           text NOT NULL DEFAULT '',
+    uf                  text NOT NULL DEFAULT '',
+    website             text NOT NULL DEFAULT '',
+
+    priority_rank       int NOT NULL DEFAULT 0,
+    priority_score      double precision NOT NULL DEFAULT 0,
+    priority_tier       text NOT NULL DEFAULT '',
+    priority_confidence text NOT NULL DEFAULT '',
+
+    moment_code         text NOT NULL DEFAULT '',
+    moment_summary      text NOT NULL DEFAULT '',
+    moment_observed_at  date,
+    moment_confidence   text NOT NULL DEFAULT '',
+    moment_evidence_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    service_code        text NOT NULL DEFAULT '',
+    service_name        text NOT NULL DEFAULT '',
+    entry_offer         text NOT NULL DEFAULT '',
+    offer_rationale     text NOT NULL DEFAULT '',
+
+    fact_to_mention     text NOT NULL DEFAULT '',
+    question_to_ask     text NOT NULL DEFAULT '',
+    cta                 text NOT NULL DEFAULT '',
+    claims_to_avoid     jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    commercial_state    text NOT NULL DEFAULT 'NEW',
+    queue_state         text NOT NULL DEFAULT 'NEEDS_CONTACT',
+    human_override      boolean NOT NULL DEFAULT false,
+    blocked             boolean NOT NULL DEFAULT false,
+    block_reason        text NOT NULL DEFAULT '',
+    do_not_contact      boolean NOT NULL DEFAULT false,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    last_payload_hash   text NOT NULL DEFAULT '',
+    contracts_json      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    raw_snapshot        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_accounts_cnpj14_check
+        CHECK (cnpj14 ~ '^[0-9]{14}$'),
+    CONSTRAINT outreach_accounts_queue_state_check
+        CHECK (queue_state IN (
+            'NEEDS_CONTACT',
+            'READY_TO_GENERATE',
+            'NEEDS_REVIEW',
+            'APPROVED',
+            'ENROLLED',
+            'SENT',
+            'REPLIED',
+            'MEETING',
+            'PROPOSAL',
+            'WON',
+            'LOST',
+            'BLOCKED',
+            'BOUNCED',
+            'DO_NOT_CONTACT',
+            'SKIPPED'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_accounts_org_cnpj14_uidx
+    ON outreach_accounts (organization_id, cnpj14);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_queue_idx
+    ON outreach_accounts (organization_id, queue_state);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_source_lead_idx
+    ON outreach_accounts (organization_id, source_lead_id)
+    WHERE source_lead_id <> '';
+
+-- Contact candidates (may lack email or verification).
+CREATE TABLE IF NOT EXISTS outreach_contact_candidates (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id              uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_contact_id       text NOT NULL DEFAULT '',
+    name                    text NOT NULL DEFAULT '',
+    role                    text NOT NULL DEFAULT '',
+    email                   text NOT NULL DEFAULT '',
+    phone                   text NOT NULL DEFAULT '',
+    linkedin_url            text NOT NULL DEFAULT '',
+    source_url              text NOT NULL DEFAULT '',
+    source_document         text NOT NULL DEFAULT '',
+    source_date             date,
+    verification_status     text NOT NULL DEFAULT 'NOT_FOUND',
+    confidence              text NOT NULL DEFAULT '',
+    recommended             boolean NOT NULL DEFAULT false,
+
+    warmbly_contact_id      uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    promoted_at             timestamptz,
+    blocked                 boolean NOT NULL DEFAULT false,
+    block_reason            text NOT NULL DEFAULT '',
+    do_not_contact          boolean NOT NULL DEFAULT false,
+    bounced                 boolean NOT NULL DEFAULT false,
+
+    last_import_run_id      uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_contact_candidates_verification_check
+        CHECK (verification_status IN (
+            'OFFICIAL_SOURCE',
+            'PUBLIC_DOCUMENT_RECENT',
+            'MULTIPLE_PUBLIC_SOURCES',
+            'INSTITUTIONAL_GENERIC',
+            'PUBLIC_POSSIBLY_STALE',
+            'CANDIDATE_UNVERIFIED',
+            'NOT_FOUND',
+            'INVALID',
+            'BOUNCED',
+            'DO_NOT_CONTACT'
+        ))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_account_idx
+    ON outreach_contact_candidates (organization_id, account_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_contact_candidates_org_source_uidx
+    ON outreach_contact_candidates (organization_id, account_id, source_contact_id)
+    WHERE source_contact_id <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_email_idx
+    ON outreach_contact_candidates (organization_id, lower(email))
+    WHERE email <> '';
+
+-- Normalized evidence per account (sanitized text only; no raw HTML).
+CREATE TABLE IF NOT EXISTS outreach_evidence (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id          uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_evidence_id  text NOT NULL,
+    evidence_type       text NOT NULL DEFAULT '',
+    title               text NOT NULL DEFAULT '',
+    url                 text NOT NULL DEFAULT '',
+    document            text NOT NULL DEFAULT '',
+    evidence_date       date,
+    location            text NOT NULL DEFAULT '',
+    excerpt             text NOT NULL DEFAULT '',
+    synthesis           text NOT NULL DEFAULT '',
+    epistemic_class     text NOT NULL DEFAULT 'COMMERCIAL_HYPOTHESIS',
+    reliability         text NOT NULL DEFAULT '',
+    consulted_at        date,
+
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_evidence_epistemic_check
+        CHECK (epistemic_class IN (
+            'CONFIRMED_FACT',
+            'STRONG_INFERENCE',
+            'WEAK_INFERENCE',
+            'COMMERCIAL_HYPOTHESIS',
+            'NOT_FOUND',
+            'REQUIRES_COMPANY_CONFIRMATION',
+            'CONTRADICTORY_EVIDENCE'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_evidence_org_source_uidx
+    ON outreach_evidence (organization_id, account_id, source_evidence_id);
+
+CREATE INDEX IF NOT EXISTS outreach_evidence_account_idx
+    ON outreach_evidence (organization_id, account_id);

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -116,6 +116,10 @@ const (
 	// background evaluation that opened or resolved findings. Rides the audit
 	// spine so every teammate's advisor strips and nav badges stay live.
 	AuditEntityAdvisorFinding AuditEntityType = "advisor_finding"
+
+	// CONFENGE / outreach staging (intelligence-plane import + company queue).
+	AuditEntityOutreachImportRun AuditEntityType = "outreach_import_run"
+	AuditEntityOutreachAccount   AuditEntityType = "outreach_account"
 )
 
 // AuditActor is the minimal identity of the member who performed an action,

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -1,0 +1,277 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Outreach staging models: intelligence-plane feed import into a multi-tenant
+// company staging queue. Companies may lack email; they are not forced into
+// contacts until a candidate is promoted.
+
+// Schema versions for the confenge/extra-cli integration contracts.
+const (
+	OutreachSchemaV1        = "confenge.outreach.v1"
+	OutreachOutcomeSchemaV1 = "confenge.outcome.v1"
+)
+
+// Contact verification statuses allowed on outreach contact candidates.
+const (
+	OutreachVerifyOfficialSource       = "OFFICIAL_SOURCE"
+	OutreachVerifyPublicDocumentRecent = "PUBLIC_DOCUMENT_RECENT"
+	OutreachVerifyMultipleSources      = "MULTIPLE_PUBLIC_SOURCES"
+	OutreachVerifyInstitutionalGeneric = "INSTITUTIONAL_GENERIC"
+	OutreachVerifyPublicPossiblyStale  = "PUBLIC_POSSIBLY_STALE"
+	OutreachVerifyCandidateUnverified  = "CANDIDATE_UNVERIFIED"
+	OutreachVerifyNotFound             = "NOT_FOUND"
+	OutreachVerifyInvalid              = "INVALID"
+	OutreachVerifyBounced              = "BOUNCED"
+	OutreachVerifyDoNotContact         = "DO_NOT_CONTACT"
+)
+
+// Epistemic classifications for evidence.
+const (
+	OutreachEpistemicConfirmedFact          = "CONFIRMED_FACT"
+	OutreachEpistemicStrongInference        = "STRONG_INFERENCE"
+	OutreachEpistemicWeakInference          = "WEAK_INFERENCE"
+	OutreachEpistemicCommercialHypothesis   = "COMMERCIAL_HYPOTHESIS"
+	OutreachEpistemicNotFound               = "NOT_FOUND"
+	OutreachEpistemicRequiresCompanyConfirm = "REQUIRES_COMPANY_CONFIRMATION"
+	OutreachEpistemicContradictoryEvidence  = "CONTRADICTORY_EVIDENCE"
+)
+
+// Queue states for outreach accounts (dashboard pipeline).
+const (
+	OutreachQueueNeedsContact    = "NEEDS_CONTACT"
+	OutreachQueueReadyToGenerate = "READY_TO_GENERATE"
+	OutreachQueueNeedsReview     = "NEEDS_REVIEW"
+	OutreachQueueApproved        = "APPROVED"
+	OutreachQueueEnrolled        = "ENROLLED"
+	OutreachQueueSent            = "SENT"
+	OutreachQueueReplied         = "REPLIED"
+	OutreachQueueMeeting         = "MEETING"
+	OutreachQueueProposal        = "PROPOSAL"
+	OutreachQueueWon             = "WON"
+	OutreachQueueLost            = "LOST"
+	OutreachQueueBlocked         = "BLOCKED"
+	OutreachQueueBounced         = "BOUNCED"
+	OutreachQueueDoNotContact    = "DO_NOT_CONTACT"
+	OutreachQueueSkipped         = "SKIPPED"
+)
+
+// Import run statuses.
+const (
+	OutreachImportPending   = "pending"
+	OutreachImportRunning   = "running"
+	OutreachImportCompleted = "completed"
+	OutreachImportFailed    = "failed"
+	OutreachImportPartial   = "partial"
+)
+
+// Verification statuses that must never be enrolled into a campaign.
+var OutreachUnenrollableVerification = map[string]bool{
+	OutreachVerifyCandidateUnverified: true,
+	OutreachVerifyNotFound:            true,
+	OutreachVerifyInvalid:             true,
+	OutreachVerifyBounced:             true,
+	OutreachVerifyDoNotContact:        true,
+}
+
+// OutreachImportCounts is the dry-run / apply summary for one import run.
+type OutreachImportCounts struct {
+	Creates           int `json:"creates"`
+	Updates           int `json:"updates"`
+	Unchanged         int `json:"unchanged"`
+	MissingContact    int `json:"missing_contact"`
+	Invalid           int `json:"invalid"`
+	Blocked           int `json:"blocked"`
+	Conflicts         int `json:"conflicts"`
+	EvidenceAdded     int `json:"evidence_added"`
+	ContactsPromoted  int `json:"contacts_promoted"`
+	Warnings          int `json:"warnings"`
+	LeadsProcessed    int `json:"leads_processed"`
+	LeadsSkippedError int `json:"leads_skipped_error"`
+}
+
+// OutreachImportError is a per-lead error recorded without aborting the run.
+type OutreachImportError struct {
+	SourceLeadID string `json:"source_lead_id,omitempty"`
+	CNPJ14       string `json:"cnpj14,omitempty"`
+	Message      string `json:"message"`
+}
+
+// OutreachImportRun is one feed import attempt (dry-run or apply).
+type OutreachImportRun struct {
+	ID              uuid.UUID             `json:"id"`
+	OrganizationID  uuid.UUID             `json:"organization_id"`
+	SourceSystem    string                `json:"source_system"`
+	SourceRunID     string                `json:"source_run_id"`
+	SchemaVersion   string                `json:"schema_version"`
+	SnapshotHash    string                `json:"snapshot_hash"`
+	RepoSHA         string                `json:"repo_sha"`
+	PayloadHash     string                `json:"payload_hash"`
+	ProfileID       string                `json:"profile_id"`
+	ProfileVersion  string                `json:"profile_version"`
+	Status          string                `json:"status"`
+	DryRun          bool                  `json:"dry_run"`
+	StartedAt       time.Time             `json:"started_at"`
+	FinishedAt      *time.Time            `json:"finished_at,omitempty"`
+	CursorIn        string                `json:"cursor_in,omitempty"`
+	CursorOut       string                `json:"cursor_out,omitempty"`
+	Counts          OutreachImportCounts  `json:"counts"`
+	Errors          []OutreachImportError `json:"errors,omitempty"`
+	Warnings        []string              `json:"warnings,omitempty"`
+	CreatedByUserID *uuid.UUID            `json:"created_by_user_id,omitempty"`
+	IdempotencyKey  string                `json:"idempotency_key,omitempty"`
+	SourceURI       string                `json:"source_uri,omitempty"`
+	CreatedAt       time.Time             `json:"created_at"`
+	UpdatedAt       time.Time             `json:"updated_at"`
+}
+
+// OutreachAccount is a staged company from the intelligence feed.
+type OutreachAccount struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	SourceLeadID       string     `json:"source_lead_id"`
+	CNPJ14             string     `json:"cnpj14"`
+	CNPJRoot           string     `json:"cnpj_root"`
+	RazaoSocial        string     `json:"razao_social"`
+	NomeFantasia       string     `json:"nome_fantasia"`
+	Municipio          string     `json:"municipio"`
+	UF                 string     `json:"uf"`
+	Website            string     `json:"website"`
+	PriorityRank       int        `json:"priority_rank"`
+	PriorityScore      float64    `json:"priority_score"`
+	PriorityTier       string     `json:"priority_tier"`
+	PriorityConfidence string     `json:"priority_confidence"`
+	MomentCode         string     `json:"moment_code"`
+	MomentSummary      string     `json:"moment_summary"`
+	MomentObservedAt   *time.Time `json:"moment_observed_at,omitempty"`
+	MomentConfidence   string     `json:"moment_confidence"`
+	MomentEvidenceIDs  []string   `json:"moment_evidence_ids,omitempty"`
+	ServiceCode        string     `json:"service_code"`
+	ServiceName        string     `json:"service_name"`
+	EntryOffer         string     `json:"entry_offer"`
+	OfferRationale     string     `json:"offer_rationale"`
+	FactToMention      string     `json:"fact_to_mention"`
+	QuestionToAsk      string     `json:"question_to_ask"`
+	CTA                string     `json:"cta"`
+	ClaimsToAvoid      []string   `json:"claims_to_avoid,omitempty"`
+	CommercialState    string     `json:"commercial_state"`
+	QueueState         string     `json:"queue_state"`
+	HumanOverride      bool       `json:"human_override"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	SourceSystem       string     `json:"source_system"`
+	SourceRunID        string     `json:"source_run_id"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	LastPayloadHash    string     `json:"last_payload_hash,omitempty"`
+	ContractsJSON      []byte     `json:"contracts,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+
+	// Joined / computed (not always filled).
+	Contacts  []OutreachContactCandidate `json:"contacts,omitempty"`
+	Evidence  []OutreachEvidence         `json:"evidence,omitempty"`
+	ContactN  int                        `json:"contact_count,omitempty"`
+	EvidenceN int                        `json:"evidence_count,omitempty"`
+}
+
+// OutreachContactCandidate is a possible recipient before promotion to contacts.
+type OutreachContactCandidate struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	AccountID          uuid.UUID  `json:"account_id"`
+	SourceContactID    string     `json:"source_contact_id"`
+	Name               string     `json:"name"`
+	Role               string     `json:"role"`
+	Email              string     `json:"email"`
+	Phone              string     `json:"phone"`
+	LinkedInURL        string     `json:"linkedin_url,omitempty"`
+	SourceURL          string     `json:"source_url,omitempty"`
+	SourceDocument     string     `json:"source_document,omitempty"`
+	SourceDate         *time.Time `json:"source_date,omitempty"`
+	VerificationStatus string     `json:"verification_status"`
+	Confidence         string     `json:"confidence"`
+	Recommended        bool       `json:"recommended"`
+	WarmblyContactID   *uuid.UUID `json:"warmbly_contact_id,omitempty"`
+	PromotedAt         *time.Time `json:"promoted_at,omitempty"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	Bounced            bool       `json:"bounced"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+// CanEnroll reports whether this candidate may be put into a campaign.
+func (c *OutreachContactCandidate) CanEnroll() bool {
+	if c == nil {
+		return false
+	}
+	if c.Blocked || c.DoNotContact || c.Bounced {
+		return false
+	}
+	if c.Email == "" {
+		return false
+	}
+	if OutreachUnenrollableVerification[c.VerificationStatus] {
+		return false
+	}
+	return true
+}
+
+// OutreachEvidence is one sanitized evidence row for an account.
+type OutreachEvidence struct {
+	ID               uuid.UUID  `json:"id"`
+	OrganizationID   uuid.UUID  `json:"organization_id"`
+	AccountID        uuid.UUID  `json:"account_id"`
+	SourceEvidenceID string     `json:"source_evidence_id"`
+	EvidenceType     string     `json:"evidence_type"`
+	Title            string     `json:"title"`
+	URL              string     `json:"url"`
+	Document         string     `json:"document"`
+	EvidenceDate     *time.Time `json:"evidence_date,omitempty"`
+	Location         string     `json:"location"`
+	Excerpt          string     `json:"excerpt"`
+	Synthesis        string     `json:"synthesis"`
+	EpistemicClass   string     `json:"epistemic_class"`
+	Reliability      string     `json:"reliability"`
+	ConsultedAt      *time.Time `json:"consulted_at,omitempty"`
+	LastImportRunID  *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+// OutreachQueueSummary is the dashboard overview counters.
+type OutreachQueueSummary struct {
+	NeedsContact    int `json:"needs_contact"`
+	ReadyToGenerate int `json:"ready_to_generate"`
+	NeedsReview     int `json:"needs_review"`
+	Approved        int `json:"approved"`
+	Enrolled        int `json:"enrolled"`
+	Sent            int `json:"sent"`
+	Replied         int `json:"replied"`
+	Meeting         int `json:"meeting"`
+	Proposal        int `json:"proposal"`
+	Won             int `json:"won"`
+	Blocked         int `json:"blocked"`
+	Bounced         int `json:"bounced"`
+	DoNotContact    int `json:"do_not_contact"`
+	Total           int `json:"total"`
+}
+
+// OutreachAccountListResult is a cursor-paginated account list.
+type OutreachAccountListResult struct {
+	Data       []OutreachAccount `json:"data"`
+	Pagination Pagination        `json:"pagination"`
+}
+
+// OutreachImportRunListResult lists recent import runs.
+type OutreachImportRunListResult struct {
+	Data       []OutreachImportRun `json:"data"`
+	Pagination Pagination          `json:"pagination"`
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1,0 +1,679 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OutreachRepository owns multi-tenant staging tables for intelligence feeds.
+// Every query requires organization_id.
+type OutreachRepository interface {
+	// Import runs
+	CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error)
+	GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error)
+
+	// Accounts
+	GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error)
+	UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (created bool, err error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error)
+	CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error)
+	SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error
+
+	// Contacts
+	ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error)
+	UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (created bool, err error)
+	GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error)
+
+	// Evidence
+	ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error)
+	UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (created bool, err error)
+}
+
+// OutreachAccountFilter filters staged accounts.
+type OutreachAccountFilter struct {
+	QueueState string
+	CNPJ14     string
+	Search     string
+	Limit      int
+	Offset     int
+}
+
+type outreachRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewOutreachRepository constructs the Postgres-backed outreach staging repo.
+func NewOutreachRepository(db *pgxpool.Pool) OutreachRepository {
+	return &outreachRepository{db: db}
+}
+
+func (r *outreachRepository) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	run.CreatedAt = now
+	run.UpdatedAt = now
+	if run.StartedAt.IsZero() {
+		run.StartedAt = now
+	}
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_import_runs (
+			id, organization_id, source_system, source_run_id, schema_version,
+			snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+			status, dry_run, started_at, finished_at, cursor_in, cursor_out,
+			counts, errors, warnings, created_by_user_id, idempotency_key, source_uri,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,$15,$16,
+			$17,$18,$19,$20,$21,$22,
+			$23,$23
+		)`,
+		run.ID, run.OrganizationID, run.SourceSystem, run.SourceRunID, run.SchemaVersion,
+		run.SnapshotHash, run.RepoSHA, run.PayloadHash, run.ProfileID, run.ProfileVersion,
+		run.Status, run.DryRun, run.StartedAt, run.FinishedAt, run.CursorIn, run.CursorOut,
+		counts, errs, warns, run.CreatedByUserID, run.IdempotencyKey, run.SourceURI,
+		now,
+	)
+	return err
+}
+
+func (r *outreachRepository) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	run.UpdatedAt = time.Now().UTC()
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_import_runs SET
+			status=$3, finished_at=$4, cursor_out=$5,
+			counts=$6, errors=$7, warnings=$8, updated_at=$9
+		WHERE id=$1 AND organization_id=$2`,
+		run.ID, run.OrganizationID, run.Status, run.FinishedAt, run.CursorOut,
+		counts, errs, warns, run.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE id=$1 AND organization_id=$2`, id, orgID)
+	return scanImportRun(row)
+}
+
+func (r *outreachRepository) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	if key == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key)
+	run, err := scanImportRun(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return run, err
+}
+
+func (r *outreachRepository) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	rows, err := r.db.Query(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1
+		ORDER BY started_at DESC LIMIT $2`, orgID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachImportRun
+	for rows.Next() {
+		run, err := scanImportRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *run)
+	}
+	return out, rows.Err()
+}
+
+const outreachImportRunSelect = `
+	SELECT id, organization_id, source_system, source_run_id, schema_version,
+		snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+		status, dry_run, started_at, finished_at, COALESCE(cursor_in,''), COALESCE(cursor_out,''),
+		counts, errors, warnings, created_by_user_id, COALESCE(idempotency_key,''), COALESCE(source_uri,''),
+		created_at, updated_at `
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+func scanImportRun(row scannable) (*models.OutreachImportRun, error) {
+	var run models.OutreachImportRun
+	var counts, errs, warns []byte
+	err := row.Scan(
+		&run.ID, &run.OrganizationID, &run.SourceSystem, &run.SourceRunID, &run.SchemaVersion,
+		&run.SnapshotHash, &run.RepoSHA, &run.PayloadHash, &run.ProfileID, &run.ProfileVersion,
+		&run.Status, &run.DryRun, &run.StartedAt, &run.FinishedAt, &run.CursorIn, &run.CursorOut,
+		&counts, &errs, &warns, &run.CreatedByUserID, &run.IdempotencyKey, &run.SourceURI,
+		&run.CreatedAt, &run.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(counts, &run.Counts)
+	_ = json.Unmarshal(errs, &run.Errors)
+	_ = json.Unmarshal(warns, &run.Warnings)
+	return &run, nil
+}
+
+func (r *outreachRepository) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND cnpj14=$2`, orgID, cnpj14)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+func (r *outreachRepository) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND id=$2`, orgID, id)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+const outreachAccountSelect = `
+	SELECT id, organization_id, COALESCE(source_lead_id,''), cnpj14, COALESCE(cnpj_root,''),
+		COALESCE(razao_social,''), COALESCE(nome_fantasia,''), COALESCE(municipio,''), COALESCE(uf,''), COALESCE(website,''),
+		priority_rank, priority_score, COALESCE(priority_tier,''), COALESCE(priority_confidence,''),
+		COALESCE(moment_code,''), COALESCE(moment_summary,''), moment_observed_at, COALESCE(moment_confidence,''), moment_evidence_ids,
+		COALESCE(service_code,''), COALESCE(service_name,''), COALESCE(entry_offer,''), COALESCE(offer_rationale,''),
+		COALESCE(fact_to_mention,''), COALESCE(question_to_ask,''), COALESCE(cta,''), claims_to_avoid,
+		COALESCE(commercial_state,''), queue_state, human_override, blocked, COALESCE(block_reason,''), do_not_contact,
+		COALESCE(source_system,''), COALESCE(source_run_id,''), last_import_run_id, COALESCE(last_payload_hash,''),
+		contracts_json, created_at, updated_at `
+
+func scanAccount(row scannable) (*models.OutreachAccount, error) {
+	var a models.OutreachAccount
+	var momentEvid, claims []byte
+	var contracts []byte
+	err := row.Scan(
+		&a.ID, &a.OrganizationID, &a.SourceLeadID, &a.CNPJ14, &a.CNPJRoot,
+		&a.RazaoSocial, &a.NomeFantasia, &a.Municipio, &a.UF, &a.Website,
+		&a.PriorityRank, &a.PriorityScore, &a.PriorityTier, &a.PriorityConfidence,
+		&a.MomentCode, &a.MomentSummary, &a.MomentObservedAt, &a.MomentConfidence, &momentEvid,
+		&a.ServiceCode, &a.ServiceName, &a.EntryOffer, &a.OfferRationale,
+		&a.FactToMention, &a.QuestionToAsk, &a.CTA, &claims,
+		&a.CommercialState, &a.QueueState, &a.HumanOverride, &a.Blocked, &a.BlockReason, &a.DoNotContact,
+		&a.SourceSystem, &a.SourceRunID, &a.LastImportRunID, &a.LastPayloadHash,
+		&contracts, &a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(momentEvid, &a.MomentEvidenceIDs)
+	_ = json.Unmarshal(claims, &a.ClaimsToAvoid)
+	a.ContractsJSON = contracts
+	return &a, nil
+}
+
+func (r *outreachRepository) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	acc.UpdatedAt = now
+	if acc.CreatedAt.IsZero() {
+		acc.CreatedAt = now
+	}
+	momentEvid, _ := json.Marshal(acc.MomentEvidenceIDs)
+	if momentEvid == nil {
+		momentEvid = []byte("[]")
+	}
+	claims, _ := json.Marshal(acc.ClaimsToAvoid)
+	if claims == nil {
+		claims = []byte("[]")
+	}
+	contracts := acc.ContractsJSON
+	if len(contracts) == 0 {
+		contracts = []byte("[]")
+	}
+	// Machine fields update; human_override / blocked / dnc preserved when set on existing.
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_accounts (
+			id, organization_id, source_lead_id, cnpj14, cnpj_root,
+			razao_social, nome_fantasia, municipio, uf, website,
+			priority_rank, priority_score, priority_tier, priority_confidence,
+			moment_code, moment_summary, moment_observed_at, moment_confidence, moment_evidence_ids,
+			service_code, service_name, entry_offer, offer_rationale,
+			fact_to_mention, question_to_ask, cta, claims_to_avoid,
+			commercial_state, queue_state, human_override, blocked, block_reason, do_not_contact,
+			source_system, source_run_id, last_import_run_id, last_payload_hash, contracts_json,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,
+			$15,$16,$17,$18,$19,
+			$20,$21,$22,$23,
+			$24,$25,$26,$27,
+			$28,$29,$30,$31,$32,$33,
+			$34,$35,$36,$37,$38,
+			$39,$40
+		)
+		ON CONFLICT (organization_id, cnpj14) DO UPDATE SET
+			source_lead_id = EXCLUDED.source_lead_id,
+			cnpj_root = EXCLUDED.cnpj_root,
+			razao_social = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.razao_social ELSE EXCLUDED.razao_social END,
+			nome_fantasia = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.nome_fantasia ELSE EXCLUDED.nome_fantasia END,
+			municipio = EXCLUDED.municipio,
+			uf = EXCLUDED.uf,
+			website = EXCLUDED.website,
+			priority_rank = EXCLUDED.priority_rank,
+			priority_score = EXCLUDED.priority_score,
+			priority_tier = EXCLUDED.priority_tier,
+			priority_confidence = EXCLUDED.priority_confidence,
+			moment_code = EXCLUDED.moment_code,
+			moment_summary = EXCLUDED.moment_summary,
+			moment_observed_at = EXCLUDED.moment_observed_at,
+			moment_confidence = EXCLUDED.moment_confidence,
+			moment_evidence_ids = EXCLUDED.moment_evidence_ids,
+			service_code = EXCLUDED.service_code,
+			service_name = EXCLUDED.service_name,
+			entry_offer = EXCLUDED.entry_offer,
+			offer_rationale = EXCLUDED.offer_rationale,
+			fact_to_mention = EXCLUDED.fact_to_mention,
+			question_to_ask = EXCLUDED.question_to_ask,
+			cta = EXCLUDED.cta,
+			claims_to_avoid = EXCLUDED.claims_to_avoid,
+			commercial_state = EXCLUDED.commercial_state,
+			queue_state = EXCLUDED.queue_state,
+			-- never clear human DNC / block via machine reimport
+			blocked = outreach_accounts.blocked OR EXCLUDED.blocked,
+			block_reason = CASE WHEN outreach_accounts.blocked THEN outreach_accounts.block_reason ELSE EXCLUDED.block_reason END,
+			do_not_contact = outreach_accounts.do_not_contact OR EXCLUDED.do_not_contact,
+			source_system = EXCLUDED.source_system,
+			source_run_id = EXCLUDED.source_run_id,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			last_payload_hash = EXCLUDED.last_payload_hash,
+			contracts_json = EXCLUDED.contracts_json,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_accounts.id
+		RETURNING (xmax = 0) AS inserted, id`,
+		acc.ID, acc.OrganizationID, acc.SourceLeadID, acc.CNPJ14, acc.CNPJRoot,
+		acc.RazaoSocial, acc.NomeFantasia, acc.Municipio, acc.UF, acc.Website,
+		acc.PriorityRank, acc.PriorityScore, acc.PriorityTier, acc.PriorityConfidence,
+		acc.MomentCode, acc.MomentSummary, acc.MomentObservedAt, acc.MomentConfidence, momentEvid,
+		acc.ServiceCode, acc.ServiceName, acc.EntryOffer, acc.OfferRationale,
+		acc.FactToMention, acc.QuestionToAsk, acc.CTA, claims,
+		acc.CommercialState, acc.QueueState, acc.HumanOverride, acc.Blocked, acc.BlockReason, acc.DoNotContact,
+		acc.SourceSystem, acc.SourceRunID, acc.LastImportRunID, acc.LastPayloadHash, contracts,
+		acc.CreatedAt, acc.UpdatedAt,
+	).Scan(&created, &acc.ID)
+	return created, err
+}
+
+func (r *outreachRepository) ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	limit := filter.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	q := outreachAccountSelect + ` FROM outreach_accounts WHERE organization_id=$1`
+	args := []any{orgID}
+	n := 2
+	if filter.QueueState != "" {
+		q += fmt.Sprintf(` AND queue_state=$%d`, n)
+		args = append(args, filter.QueueState)
+		n++
+	}
+	if filter.CNPJ14 != "" {
+		q += fmt.Sprintf(` AND cnpj14=$%d`, n)
+		args = append(args, filter.CNPJ14)
+		n++
+	}
+	if filter.Search != "" {
+		q += fmt.Sprintf(` AND (razao_social ILIKE $%d OR nome_fantasia ILIKE $%d OR cnpj14 LIKE $%d)`, n, n, n)
+		args = append(args, "%"+filter.Search+"%")
+		n++
+	}
+	q += fmt.Sprintf(` ORDER BY priority_rank ASC NULLS LAST, updated_at DESC LIMIT $%d OFFSET $%d`, n, n+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachAccount
+	for rows.Next() {
+		acc, err := scanAccount(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *acc)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT queue_state, COUNT(*)::int
+		FROM outreach_accounts WHERE organization_id=$1
+		GROUP BY queue_state`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	sum := &models.OutreachQueueSummary{}
+	for rows.Next() {
+		var state string
+		var n int
+		if err := rows.Scan(&state, &n); err != nil {
+			return nil, err
+		}
+		sum.Total += n
+		switch state {
+		case models.OutreachQueueNeedsContact:
+			sum.NeedsContact = n
+		case models.OutreachQueueReadyToGenerate:
+			sum.ReadyToGenerate = n
+		case models.OutreachQueueNeedsReview:
+			sum.NeedsReview = n
+		case models.OutreachQueueApproved:
+			sum.Approved = n
+		case models.OutreachQueueEnrolled:
+			sum.Enrolled = n
+		case models.OutreachQueueSent:
+			sum.Sent = n
+		case models.OutreachQueueReplied:
+			sum.Replied = n
+		case models.OutreachQueueMeeting:
+			sum.Meeting = n
+		case models.OutreachQueueProposal:
+			sum.Proposal = n
+		case models.OutreachQueueWon:
+			sum.Won = n
+		case models.OutreachQueueBlocked:
+			sum.Blocked = n
+		case models.OutreachQueueBounced:
+			sum.Bounced = n
+		case models.OutreachQueueDoNotContact:
+			sum.DoNotContact = n
+		}
+	}
+	return sum, rows.Err()
+}
+
+func (r *outreachRepository) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_accounts SET
+			blocked=$3, do_not_contact=$4, block_reason=$5, queue_state=$6,
+			human_override=true, updated_at=now()
+		WHERE organization_id=$1 AND id=$2`,
+		orgID, id, blocked, dnc, reason, queueState,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	rows, err := r.db.Query(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND account_id=$2
+		ORDER BY recommended DESC, created_at ASC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachContactCandidate
+	for rows.Next() {
+		c, err := scanCandidate(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *c)
+	}
+	return out, rows.Err()
+}
+
+const outreachCandidateSelect = `
+	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''),
+		COALESCE(name,''), COALESCE(role,''), COALESCE(email,''), COALESCE(phone,''),
+		COALESCE(linkedin_url,''), COALESCE(source_url,''), COALESCE(source_document,''), source_date,
+		verification_status, COALESCE(confidence,''), recommended,
+		warmbly_contact_id, promoted_at, blocked, COALESCE(block_reason,''), do_not_contact, bounced,
+		last_import_run_id, created_at, updated_at `
+
+func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
+	var c models.OutreachContactCandidate
+	err := row.Scan(
+		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID,
+		&c.Name, &c.Role, &c.Email, &c.Phone,
+		&c.LinkedInURL, &c.SourceURL, &c.SourceDocument, &c.SourceDate,
+		&c.VerificationStatus, &c.Confidence, &c.Recommended,
+		&c.WarmblyContactID, &c.PromotedAt, &c.Blocked, &c.BlockReason, &c.DoNotContact, &c.Bounced,
+		&c.LastImportRunID, &c.CreatedAt, &c.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *outreachRepository) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates WHERE organization_id=$1 AND id=$2`, orgID, id)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return c, err
+}
+
+func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	c.UpdatedAt = now
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	// Prefer unique (org, account, source_contact_id) when source id present.
+	if c.SourceContactID != "" {
+		var created bool
+		err := r.db.QueryRow(ctx, `
+			INSERT INTO outreach_contact_candidates (
+				id, organization_id, account_id, source_contact_id,
+				name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+				verification_status, confidence, recommended,
+				blocked, block_reason, do_not_contact, bounced,
+				last_import_run_id, created_at, updated_at
+			) VALUES (
+				$1,$2,$3,$4,
+				$5,$6,$7,$8,$9,$10,$11,$12,
+				$13,$14,$15,
+				$16,$17,$18,$19,
+				$20,$21,$22
+			)
+			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
+				name = EXCLUDED.name,
+				role = EXCLUDED.role,
+				email = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.email ELSE EXCLUDED.email END,
+				phone = EXCLUDED.phone,
+				linkedin_url = EXCLUDED.linkedin_url,
+				source_url = EXCLUDED.source_url,
+				source_document = EXCLUDED.source_document,
+				source_date = EXCLUDED.source_date,
+				verification_status = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.verification_status ELSE EXCLUDED.verification_status END,
+				confidence = EXCLUDED.confidence,
+				recommended = EXCLUDED.recommended,
+				do_not_contact = outreach_contact_candidates.do_not_contact OR EXCLUDED.do_not_contact,
+				bounced = outreach_contact_candidates.bounced OR EXCLUDED.bounced,
+				blocked = outreach_contact_candidates.blocked OR EXCLUDED.blocked,
+				last_import_run_id = EXCLUDED.last_import_run_id,
+				updated_at = EXCLUDED.updated_at,
+				id = outreach_contact_candidates.id
+			RETURNING (xmax = 0), id`,
+			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+			c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+			c.VerificationStatus, c.Confidence, c.Recommended,
+			c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+			c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+		).Scan(&created, &c.ID)
+		return created, err
+	}
+	// No source id: insert only (cannot safely dedupe).
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_contact_candidates (
+			id, organization_id, account_id, source_contact_id,
+			name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+			verification_status, confidence, recommended,
+			blocked, block_reason, do_not_contact, bounced,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+		)`,
+		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+		c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+		c.VerificationStatus, c.Confidence, c.Recommended,
+		c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+		c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+	)
+	return true, err
+}
+
+func (r *outreachRepository) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	rows, err := r.db.Query(ctx, outreachEvidenceSelect+`
+		FROM outreach_evidence WHERE organization_id=$1 AND account_id=$2
+		ORDER BY evidence_date DESC NULLS LAST, created_at DESC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachEvidence
+	for rows.Next() {
+		e, err := scanEvidence(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *e)
+	}
+	return out, rows.Err()
+}
+
+const outreachEvidenceSelect = `
+	SELECT id, organization_id, account_id, source_evidence_id,
+		COALESCE(evidence_type,''), COALESCE(title,''), COALESCE(url,''), COALESCE(document,''),
+		evidence_date, COALESCE(location,''), COALESCE(excerpt,''), COALESCE(synthesis,''),
+		epistemic_class, COALESCE(reliability,''), consulted_at,
+		last_import_run_id, created_at, updated_at `
+
+func scanEvidence(row scannable) (*models.OutreachEvidence, error) {
+	var e models.OutreachEvidence
+	err := row.Scan(
+		&e.ID, &e.OrganizationID, &e.AccountID, &e.SourceEvidenceID,
+		&e.EvidenceType, &e.Title, &e.URL, &e.Document,
+		&e.EvidenceDate, &e.Location, &e.Excerpt, &e.Synthesis,
+		&e.EpistemicClass, &e.Reliability, &e.ConsultedAt,
+		&e.LastImportRunID, &e.CreatedAt, &e.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *outreachRepository) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	e.UpdatedAt = now
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = now
+	}
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_evidence (
+			id, organization_id, account_id, source_evidence_id,
+			evidence_type, title, url, document, evidence_date, location,
+			excerpt, synthesis, epistemic_class, reliability, consulted_at,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
+		)
+		ON CONFLICT (organization_id, account_id, source_evidence_id) DO UPDATE SET
+			evidence_type = EXCLUDED.evidence_type,
+			title = EXCLUDED.title,
+			url = EXCLUDED.url,
+			document = EXCLUDED.document,
+			evidence_date = EXCLUDED.evidence_date,
+			location = EXCLUDED.location,
+			excerpt = EXCLUDED.excerpt,
+			synthesis = EXCLUDED.synthesis,
+			epistemic_class = EXCLUDED.epistemic_class,
+			reliability = EXCLUDED.reliability,
+			consulted_at = EXCLUDED.consulted_at,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_evidence.id
+		RETURNING (xmax = 0), id`,
+		e.ID, e.OrganizationID, e.AccountID, e.SourceEvidenceID,
+		e.EvidenceType, e.Title, e.URL, e.Document, e.EvidenceDate, e.Location,
+		e.Excerpt, e.Synthesis, e.EpistemicClass, e.Reliability, e.ConsultedAt,
+		e.LastImportRunID, e.CreatedAt, e.UpdatedAt,
+	).Scan(&created, &e.ID)
+	return created, err
+}

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -322,6 +322,8 @@ export function useRealtimeEvents() {
           // or a teammate applying/snoozing/dismissing one. Refreshes every
           // strip and every nav badge at once.
           advisor_finding: [['advisor']],
+          outreach_import_run: [['confenge']],
+          outreach_account: [['confenge']],
           settings: [['organizations', 'current']],
           unibox: [['unibox']],
           crm_note: [['crm'], ['contacts']],


### PR DESCRIPTION
## Summary

- Adds feature-flagged CONFENGE outreach staging (`CONFENGE_OUTREACH_ENABLED=false` by default): multi-tenant tables for import runs, company accounts (CNPJ unique per org), contact candidates, and sanitized evidence.
- Implements the versioned feed contract `confenge.outreach.v1` plus a legacy adapter for `leads.json` / commercial-run shapes from extra-cli. Missing email keeps the company as `NEEDS_CONTACT` (never discarded; never forced into contacts).
- Import API with dry-run counts, payload hashing, `Idempotency-Key`, SSRF-hardened HTTPS fetch + host allowlist, and reimport rules that preserve DNC/block and post-send queue states.
- Docs: `docs/confenge/`, product guide, env.example, upstream maintenance notes. Unit tests cover native/legacy parse, dry-run, idempotency, DNC, multi-tenant isolation, evidence add, invalid feed.

Intelligence stays in extra-cli. Warmbly does not connect to the datalake Postgres or write datalake tables.

## Test plan

- [x] `gofmt -l` clean on touched Go files
- [x] `go test ./internal/app/confenge/ -count=1`
- [x] `go test ./internal/api/handler/ -count=0` (compile)
- [x] `go test ./cmd/backend/ -count=0` (compile)
- [x] `make lint` / golangci-lint
- [ ] With `CONFENGE_OUTREACH_ENABLED=true`, dry-run then apply `internal/app/confenge/testdata/native_feed_v1.json` via `POST /api/v1/confenge/import`
- [ ] Confirm company without email is listed as `NEEDS_CONTACT`
- [ ] Reimport same payload: creates=0, unchanged>0
- [ ] Reimport after marking DNC: flag preserved

## Follow-ups

- PR2: drafts, structured generation, validators, risk class, review UI, campaign bootstrap/enrollment
- PR3: reply/outcome outbox, CRM pipeline bootstrap, metrics, Netcup ops

## Rollback

Disable `CONFENGE_OUTREACH_ENABLED`. Down migration `000080_outreach_staging.down.sql` drops staging tables only.