### PR TITLE
feat: human sending behaviour per mailbox and campaign auto-pause guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ go.work.sum
 
 # MacOS
 .DS_Store
+# AppleDouble sidecars, created whenever the repo lives on a non-HFS volume
+._*
 
 # Geo Location
 *.mmdb

--- a/admin/eslint.config.js
+++ b/admin/eslint.config.js
@@ -10,7 +10,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 // presets and downgrading no-explicit-any / unused-vars to warnings.
 
 export default defineConfig([
-  globalIgnores(['dist', 'node_modules', 'coverage']),
+  globalIgnores(['dist', 'node_modules', 'coverage', '**/._*']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/admin/src/app/dashboard/CampaignsPage.tsx
+++ b/admin/src/app/dashboard/CampaignsPage.tsx
@@ -55,6 +55,7 @@ const STATUS_TONE: Record<string, string> = {
     draft: "border-zinc-300 text-zinc-500",
     paused_trial_expired: "border-orange-300 text-orange-700 bg-orange-50",
     paused_no_accounts: "border-orange-300 text-orange-700 bg-orange-50",
+    paused_guardrail: "border-rose-300 text-rose-700 bg-rose-50",
 };
 
 const STATUS_OPTIONS = [
@@ -65,6 +66,7 @@ const STATUS_OPTIONS = [
     { value: "completed", label: "Completed" },
     { value: "paused_trial_expired", label: "Paused — trial expired" },
     { value: "paused_no_accounts", label: "Paused — no accounts" },
+    { value: "paused_guardrail", label: "Paused — guardrail" },
 ];
 
 const pct = (n: number, d: number) => (d ? ((n / d) * 100).toFixed(1) : "—");

--- a/admin/src/lib/api/models/admin.ts
+++ b/admin/src/lib/api/models/admin.ts
@@ -522,7 +522,7 @@ export interface AdminCampaignSearch {
     q?: string;
     user_id?: string;
     org_id?: string;
-    status?: string; // "" | draft | active | paused | completed | paused_trial_expired | paused_no_accounts
+    status?: string; // "" | draft | active | paused | completed | paused_trial_expired | paused_no_accounts | paused_guardrail
     // Boolean flags
     open_tracking?: boolean;
     link_tracking?: boolean;

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/apikey"
 	"github.com/warmbly/warmbly/internal/app/audit"
 	"github.com/warmbly/warmbly/internal/app/auth"
+	behaviorapp "github.com/warmbly/warmbly/internal/app/behavior"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/compose"
@@ -50,6 +51,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/feature"
 	"github.com/warmbly/warmbly/internal/app/fleet"
 	"github.com/warmbly/warmbly/internal/app/group"
+	"github.com/warmbly/warmbly/internal/app/guardrail"
 	idempotencyapp "github.com/warmbly/warmbly/internal/app/idempotency"
 	"github.com/warmbly/warmbly/internal/app/inboxagent"
 	"github.com/warmbly/warmbly/internal/app/integration"
@@ -212,6 +214,10 @@ func main() {
 
 	// Warmup
 	var warmupService warmupapp.Service
+
+	// Per-mailbox human sending behaviour (rolled workday, daily/hourly
+	// ceilings, send spacing) — consumed by the schedulers and the dashboard.
+	var behaviorService behaviorapp.Service
 
 	// Danger zone (delayed deletions)
 	var dangerZoneService dangerzone.Service
@@ -1016,7 +1022,17 @@ func main() {
 
 		// Template & email send services
 		templateService = template.NewService(templateRepository)
+
+		// Sending behaviour. Wired onto the scheduler rather than passed to its
+		// constructor so a deployment without it keeps every mailbox on the
+		// legacy fixed cap and min-gap path.
+		behaviorRepository := repository.NewBehaviorRepository(primaryDB.Pool)
+		behaviorService = behaviorapp.NewService(behaviorRepository, emailRepostory)
+
 		schedulerService := scheduler.NewSchedulerService(taskRepository, warmupRepository, campaignProgressRepository, emailRepostory, campaignRepostory, contactRepostory, campaignLogRepository)
+		if aware, ok := schedulerService.(scheduler.BehaviorAware); ok {
+			aware.WireBehavior(behaviorService)
+		}
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
@@ -1309,6 +1325,21 @@ func main() {
 		placementPoller := jobs.NewPlacementPoller(placementService, 2*time.Minute)
 		go placementPoller.Start(ctx)
 
+		// Auto-pause guardrails: pause any active campaign whose bounce,
+		// complaint, or reply rate has left the band its owner set. Fifteen
+		// minutes is fast enough that a campaign cannot do much damage inside
+		// one window at the platform's per-mailbox defaults. The same tick
+		// prunes expired daily sending plans.
+		guardrailService := guardrail.NewService(
+			repository.NewGuardrailRepository(primaryDB.Pool),
+			campaignLogRepository,
+			auditService,
+			notificationService,
+		)
+		guardrailJob := jobs.NewGuardrailJob(guardrailService, behaviorRepository)
+		guardrailScheduler := jobs.NewGuardrailScheduler(guardrailJob, 15*time.Minute)
+		go guardrailScheduler.Start(ctx)
+
 		// Advisor. Detection is deterministic Go over a per-org snapshot and
 		// always runs; the narrator is optional and only rewrites the card copy,
 		// so an install with no LLM provider still gets every recommendation.
@@ -1468,6 +1499,7 @@ func main() {
 		PlacementRepo:    placementRepository,
 		PlacementService: placementService,
 
+		BehaviorService:   behaviorService,
 		AdvisorService:    advisorService,
 		AdvisorRepository: advisorRepository,
 

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -24,6 +24,9 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | PATCH | `/emails/:id` | `WRITE_EMAILS` |
 | PATCH | `/emails/tags` | `WRITE_EMAILS` |
 | PATCH | `/emails/:id/track` | `WRITE_EMAILS` |
+| GET | `/emails/:id/behavior` | `READ_EMAILS` |
+| PUT | `/emails/:id/behavior` | `WRITE_EMAILS` |
+| GET | `/emails/:id/behavior/plan` | `READ_EMAILS` |
 | DELETE | `/emails/:id` | `WRITE_EMAILS` |
 | POST | `/emails/:id/send` | `SEND_CAMPAIGNS` |
 

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -80,7 +80,26 @@ Optional **campaign dates** bound when it may send. Leave both blank to run open
 
 The play and pause buttons work from the list row or the detail view. Starting moves the campaign to **active** and begins scheduling inside your windows and limits; pausing stops new scheduling immediately and resumes from where it left off.
 
-A campaign can pause itself: **paused, no accounts** when it loses every sender, and **paused, trial expired** when a trial ends. It moves to **finished** once every contact completes the sequence. Configured to do so, it also stops following up with a contact the moment they reply.
+A campaign can pause itself: **paused, no accounts** when it loses every sender, **paused, trial expired** when a trial ends, and **auto-paused** when a guardrail trips. It moves to **finished** once every contact completes the sequence. Configured to do so, it also stops following up with a contact the moment they reply.
+
+## Auto-pause guardrails
+
+**Preferences** > **Auto-pause** stops a campaign the moment its rates leave the band you set, instead of waiting for a mailbox provider to react. Off by default.
+
+| Rule | Direction | Default | Why |
+|------|-----------|---------|-----|
+| Bounce rate | pause at or above | `5%` | Amazon SES puts an account under review at `5%` and can pause sending at `10%` |
+| Complaint rate | pause at or above | `0.10%` | Google asks senders to stay under `0.10%` and never reach `0.30%` |
+| Reply rate | pause below | off | A campaign at volume that nobody answers is spending reputation for nothing |
+
+Two more controls keep the rules honest:
+
+- **Only after** is the sample floor. No rule fires below this many sends in the window, because one bounce out of four is not a `25%` bounce rate. Default `50`.
+- **Measured over the last** is the rolling window in days. `0` measures the campaign's whole history. Default `7`.
+
+Setting a rate to `0` turns that rule off. The check runs every 15 minutes, and when several bands are breached at once the campaign is paused with the most damaging reason attached: complaints first, then bounces, then replies.
+
+A paused campaign shows the reason and the numbers behind it on the **Auto-pause** section, and everyone on the team who can see campaigns gets a notification. Starting the campaign again clears the marker, but the next check re-evaluates from scratch, so fix the underlying problem first.
 
 ## Live activity
 
@@ -96,6 +115,7 @@ Defaults are deliberately conservative, aiming at a low complaint rate rather th
 - **Spread, don't concentrate**: volume splits across many mailboxes and worker IPs.
 - **Ramp gradually**: raise volume only while performance stays healthy.
 - **Health gating**: a mailbox in deliverability trouble has its cold volume cut or paused automatically.
+- **Human timing**: mailboxes with [sending behavior](/guides/sending-behavior/) enabled keep randomized working hours, volume, and spacing in their own timezone.
 
 A practical band is `30` to `50`/day for warmed mailboxes, starting newer ones at `10` to `20`.
 

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -5,6 +5,7 @@
   "pages": [
     "---Sending---",
     "mailboxes",
+    "sending-behavior",
     "warmup",
     "campaigns",
     "sequences",

--- a/docs/content/docs/guides/notifications.mdx
+++ b/docs/content/docs/guides/notifications.mdx
@@ -18,6 +18,7 @@ The feed and the bell count update live, without refreshing.
 | Bounce detected | Health | On | A campaign starts bouncing |
 | Spam complaint | Health | On | A complaint lands on a campaign |
 | Worker downtime | Health | On | A sender worker stops responding |
+| Campaign auto-paused | Health | On, including email | An [auto-pause guardrail](/guides/campaigns/) stopped a campaign |
 | New sign-in | Security | On | Your account is accessed from a new device, with browser, OS, and rough location |
 | Billing alerts | Billing | On, including email | A trial expired or sending was paused for billing |
 | Teammate joined | Team | On | Someone accepted an invitation |

--- a/docs/content/docs/guides/sending-behavior.mdx
+++ b/docs/content/docs/guides/sending-behavior.mdx
@@ -1,0 +1,75 @@
+---
+title: "Sending behavior"
+description: "Give each mailbox a human workday: randomized hours, volume, lunch break, and spacing, in its own timezone."
+---
+
+Automated sending looks automated. A mailbox that sends exactly 40 emails every day, starts at 09:00:00, and spaces every send exactly 600 seconds apart is describing itself as a machine in its own headers.
+
+Sending behavior fixes that. You give a mailbox ranges instead of fixed values, and it rolls one workday out of those ranges each day: a start time, a finish time, a lunch break, a daily target, an hourly ceiling. It then keeps to that day.
+
+Everything here is per mailbox and lives in its own timezone, so a London mailbox and a Denver mailbox on the same campaign each keep their own office hours.
+
+## Turn it on
+
+**Mailboxes** > pick a mailbox > **Sending** > **Sending like a person**.
+
+It is off by default. A mailbox that has not opted in keeps its fixed daily cap and minimum gap exactly as before, so switching this on is the only thing that changes its behavior.
+
+## What gets randomized
+
+| Setting | Default range | What it controls |
+|---------|---------------|------------------|
+| Working days | Mon-Fri | Days this mailbox sends anything at all, cold and warmup alike |
+| Workday start | `09:03` to `09:27` | The mailbox opens at a different minute each day |
+| Workday finish | `17:18` to `17:56` | Nothing is scheduled after the day's rolled finish |
+| Lunch break | starts `12:00`-`13:30`, lasts `30`-`60` min | A quiet gap in the middle of the day |
+| Cold emails per day | `30` to `45` | The day's cold-send target |
+| Cold emails per hour | `5` to `9` | Stops the whole day landing in one burst |
+| Delay between emails | `90` to `420` seconds | Drawn fresh for every send |
+
+Every time is local to the mailbox's own timezone, which you set on the mailbox itself.
+
+## The daily plan
+
+The roll happens once per mailbox per local day, and the result is stored. That matters: the scheduler recomputes a mailbox's next slot many times a day, and a fresh random workday on every calculation would mean the mailbox never actually keeps to one.
+
+The **Sending** tab shows today's rolled workday at the top: the hours, the break, the spacing band, the hourly ceiling, and how much of the day's target is already spent. That is the answer to "why is nothing sending right now".
+
+Editing the ranges does not change today. Today keeps the workday it already started, and the new ranges take effect on the next roll.
+
+## How it interacts with your other limits
+
+Sending behavior can only ever **lower** volume or **delay** a send. It can never raise a mailbox above its own daily cap or bring a send forward.
+
+- The day's rolled target is applied as a minimum against the mailbox's daily cap and the campaign's daily limit. If the mailbox is capped at `50` and the day rolls `38`, the day is `38`.
+- The delay range replaces the mailbox's fixed minimum gap while behavior is on.
+- A campaign's own sending windows still apply. A send has to satisfy both calendars: the campaign's window in the campaign timezone, and the mailbox's workday in the mailbox timezone.
+- Warmup follows the same working days, hours, and break, so warmup mail is not arriving at 03:00 from a mailbox whose campaign mail keeps office hours. Warmup is **not** charged against the cold daily or hourly ceilings; it has its own ramp.
+- Smart send for your own replies follows the workday but is never charged against the cold budgets.
+
+<Callout type="warn" title="The hourly ceiling is doing real work">
+Without it, a mailbox with a 40/day target and a 90-second floor could empty its whole day before 11am and then sit silent. That is a more obvious pattern than sending too much.
+</Callout>
+
+## Choosing ranges
+
+The defaults describe an ordinary weekday sender and are a good starting point for most mailboxes. If you change them:
+
+- Keep the daily range inside the safe cold band. `30-50/day` is normal for a warmed mailbox; a mailbox connected in the last month should stay nearer `10-20/day`.
+- Keep the delay range wide. A narrow range is only slightly less of a pattern than a fixed value.
+- Leave the lunch break on. It is one of the cheapest signals of a real person's inbox.
+- Do not set the workday to cover the whole clock. A mailbox that sends at every hour of the day is not describing an office.
+
+The break has to fit inside the shortest workday the ranges can produce, and the latest possible start has to come before the earliest possible finish. The editor blocks a save that would break either rule.
+
+## API
+
+The profile and today's plan are both readable and writable through the API. See [Endpoints](/api/endpoints/) for the scopes.
+
+```http
+GET  /api/v1/emails/{id}/behavior
+PUT  /api/v1/emails/{id}/behavior
+GET  /api/v1/emails/{id}/behavior/plan
+```
+
+`PUT` is a partial update: send only the fields you want to change. It is naturally idempotent, so retries are safe without an `Idempotency-Key`.

--- a/internal/api/handler/email_behavior.go
+++ b/internal/api/handler/email_behavior.go
@@ -1,0 +1,146 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Sending-behaviour endpoints. The profile is a mailbox-scoped resource rather
+// than more fields on PATCH /emails/:id: it has its own validation surface, its
+// own derived read (today's rolled plan), and a customer can reasonably let a
+// teammate tune sending hours without handing them the mailbox itself.
+
+// resolveOwnedMailbox parses the :id param and confirms the caller's
+// organization owns that mailbox. Every behaviour route goes through it, so a
+// mailbox id from another workspace 404s rather than leaking its schedule.
+func (h *Handler) resolveOwnedMailbox(c *gin.Context) (uuid.UUID, bool) {
+	accountID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return uuid.Nil, false
+	}
+
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return uuid.Nil, false
+	}
+
+	if _, gerr := h.EmailService.Get(c.Request.Context(), orgID.String(), accountID.String()); gerr != nil {
+		errx.Handle(c, gerr)
+		return uuid.Nil, false
+	}
+	return accountID, true
+}
+
+// behaviorUnavailable reports the feature as unconfigured rather than 500ing,
+// for deployments running without the behaviour engine wired.
+func (h *Handler) behaviorUnavailable(c *gin.Context) bool {
+	if h.BehaviorService == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "sending behaviour is not enabled on this deployment"))
+		return true
+	}
+	return false
+}
+
+// handleBehaviorError maps the service's errors onto the API's error shape,
+// turning a validation failure into a 400 that names the offending field.
+func handleBehaviorError(c *gin.Context, err error) {
+	var verr *models.BehaviorValidationError
+	if errors.As(err, &verr) {
+		errx.Handle(c, errx.New(errx.BadRequest, verr.Message))
+		return
+	}
+	if errors.Is(err, behavior.ErrNotFound) {
+		errx.Handle(c, errx.ErrNotFound)
+		return
+	}
+	var apiErr *errx.Error
+	if errors.As(err, &apiErr) {
+		errx.Handle(c, apiErr)
+		return
+	}
+	errx.Handle(c, errx.InternalError())
+}
+
+// GetEmailBehavior returns a mailbox's sending-behaviour profile, substituting
+// the defaults for a mailbox that has never been configured so the client
+// always has a complete object to render.
+// GET /emails/:id/behavior
+func (h *Handler) GetEmailBehavior(c *gin.Context) {
+	if h.behaviorUnavailable(c) {
+		return
+	}
+	accountID, ok := h.resolveOwnedMailbox(c)
+	if !ok {
+		return
+	}
+
+	profile, err := h.BehaviorService.Get(c.Request.Context(), accountID)
+	if err != nil {
+		handleBehaviorError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, profile)
+}
+
+// UpdateEmailBehavior applies a partial update to the profile. Omitted fields
+// keep their stored value, so toggling `enabled` does not require resending
+// every range.
+//
+// Naturally idempotent: the body is the desired state, so a retry converges on
+// the same profile and no Idempotency-Key is needed.
+// PUT /emails/:id/behavior
+func (h *Handler) UpdateEmailBehavior(c *gin.Context) {
+	if h.behaviorUnavailable(c) {
+		return
+	}
+	accountID, ok := h.resolveOwnedMailbox(c)
+	if !ok {
+		return
+	}
+
+	var patch models.UpdateSendingBehavior
+	if err := c.ShouldBindJSON(&patch); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	profile, err := h.BehaviorService.Update(c.Request.Context(), accountID, patch)
+	if err != nil {
+		handleBehaviorError(c, err)
+		return
+	}
+
+	h.auditOrg(c, models.AuditActionUpdate, models.AuditEntityEmailAccount, &accountID, nil, nil)
+	c.JSON(http.StatusOK, profile)
+}
+
+// GetEmailBehaviorPlan returns the workday this mailbox actually rolled for the
+// current local date, plus how much of it is already spent. This is the read
+// that answers "why is nothing sending right now" without anyone guessing.
+// GET /emails/:id/behavior/plan
+func (h *Handler) GetEmailBehaviorPlan(c *gin.Context) {
+	if h.behaviorUnavailable(c) {
+		return
+	}
+	accountID, ok := h.resolveOwnedMailbox(c)
+	if !ok {
+		return
+	}
+
+	plan, err := h.BehaviorService.Today(c.Request.Context(), accountID)
+	if err != nil {
+		handleBehaviorError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, plan)
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/apikey"
 	"github.com/warmbly/warmbly/internal/app/audit"
 	"github.com/warmbly/warmbly/internal/app/auth"
+	"github.com/warmbly/warmbly/internal/app/behavior"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/compose"
 	"github.com/warmbly/warmbly/internal/app/contact"
@@ -142,6 +143,12 @@ type Handler struct {
 	// Pre-send email verification (control-plane SMTP RCPT probe / pluggable
 	// paid backend). Drops hard-bouncing addresses before a worker sends.
 	EmailVerifyService emailverifyapp.Service
+
+	// Per-mailbox human sending behaviour: the ranges a mailbox rolls its
+	// workday from, and the plan it rolled for today. Nil disables the
+	// behaviour endpoints (the schedulers then run every mailbox on its fixed
+	// cap and gap).
+	BehaviorService behavior.Service
 
 	// Warmup health
 	WarmupService warmup.Service

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -312,6 +312,11 @@ func Run(
 				emails.POST("/:id/warmup/resume", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.ResumeWarmup)
 				emails.POST("/:id/warmup/stop", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.StopWarmup)
 				emails.GET("/:id/auth-check", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.GetEmailAuthCheck)
+				// Human sending behaviour: the ranges the mailbox rolls its
+				// workday from, and the workday it rolled for today.
+				emails.GET("/:id/behavior", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.GetEmailBehavior)
+				emails.PUT("/:id/behavior", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.UpdateEmailBehavior)
+				emails.GET("/:id/behavior/plan", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.GetEmailBehaviorPlan)
 				emails.POST("/verify", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), h.VerifyEmail)
 				emails.GET("/:id/warmup/ban-status", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.GetWarmupBanStatus)
 				emails.POST("/:id/warmup/appeal", m.RequireAccess(models.PermManageEmails, models.APIPermWriteEmails), middleware.RequireAPIKeyEmailAccountParam("id"), h.SubmitWarmupAppeal)

--- a/internal/app/behavior/plan.go
+++ b/internal/app/behavior/plan.go
@@ -1,0 +1,208 @@
+// Package behavior turns a mailbox's sending-behaviour ranges into the one
+// workday it actually runs on a given local date, and answers "when may this
+// mailbox send next" for the schedulers.
+//
+// The roll is DETERMINISTIC on (mailbox id, local date). That is what makes the
+// day stable: the campaign and warmup schedulers each recompute a mailbox's
+// next slot many times a day, and a fresh random workday on every call would
+// mean the mailbox never actually keeps to one. Persisting the plan is
+// belt-and-braces on top of that — it gives the dashboard something to show and
+// leaves an audit trail for "why did this send at 17:41" — but two racing
+// writers would produce byte-identical rows anyway.
+//
+// Nothing here touches the database or the clock; RollPlan is a pure function
+// of its arguments, so the whole policy is unit-testable.
+package behavior
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// stream is a small deterministic PRNG. Seeded by FNV-1a over the mailbox id
+// and the local date, then advanced with splitmix64 so successive draws are
+// independent rather than correlated slices of one hash.
+type stream struct{ s uint64 }
+
+func newStream(accountID uuid.UUID, y int, m time.Month, d int, salt string) *stream {
+	const (
+		offset64 uint64 = 14695981039346656037
+		prime64  uint64 = 1099511628211
+	)
+	h := offset64
+	mix := func(b []byte) {
+		for _, c := range b {
+			h ^= uint64(c)
+			h *= prime64
+		}
+	}
+	id := accountID
+	mix(id[:])
+	mix([]byte{
+		byte(y), byte(y >> 8),
+		byte(int(m)), byte(d),
+	})
+	mix([]byte(salt))
+	return &stream{s: h}
+}
+
+func (s *stream) next() uint64 {
+	s.s += 0x9E3779B97F4A7C15
+	z := s.s
+	z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+	z = (z ^ (z >> 27)) * 0x94D049BB133111EB
+	return z ^ (z >> 31)
+}
+
+// between returns a value in [lo, hi] inclusive. Equal bounds return lo, so a
+// customer who sets a range to a single value gets exactly that value.
+func (s *stream) between(lo, hi int) int {
+	if hi <= lo {
+		return lo
+	}
+	return lo + int(s.next()%uint64(hi-lo+1))
+}
+
+// RollPlan produces the workday for `day` (interpreted in the mailbox's own
+// timezone) from the mailbox's behaviour ranges.
+//
+// A day the profile does not work is still returned, with IsWorkingDay false
+// and a zero limit, so callers get one shape to reason about and the dashboard
+// can say "Saturday: not a sending day" rather than showing nothing.
+func RollPlan(b models.SendingBehavior, day time.Time) models.DailyPlan {
+	y, m, d := day.Date()
+	rng := newStream(b.EmailAccountID, y, m, d, "plan/v1")
+
+	plan := models.DailyPlan{
+		EmailAccountID: b.EmailAccountID,
+		PlanDate:       day.Format("2006-01-02"),
+		Timezone:       day.Location().String(),
+		IsWorkingDay:   b.WorksOn(day.Weekday()),
+		GapMinSeconds:  b.GapMinSeconds,
+		GapMaxSeconds:  b.GapMaxSeconds,
+	}
+
+	// Draw in a fixed order regardless of the branch taken, so switching a
+	// mailbox from Mon-Fri to Mon-Sat does not reshuffle the hours it already
+	// works on the days it already worked.
+	dailyLimit := rng.between(b.DailyLimitMin, b.DailyLimitMax)
+	hourlyLimit := rng.between(b.HourlyLimitMin, b.HourlyLimitMax)
+	workStart := rng.between(b.WorkStartMin, b.WorkStartMax)
+	workEnd := rng.between(b.WorkEndMin, b.WorkEndMax)
+	lunchStart := rng.between(b.LunchEarliest, b.LunchLatest)
+	lunchLen := rng.between(b.LunchMinMinutes, b.LunchMaxMinutes)
+
+	plan.WorkStartMinute = workStart
+	plan.WorkEndMinute = workEnd
+
+	if !plan.IsWorkingDay {
+		return plan
+	}
+
+	plan.DailyLimit = dailyLimit
+	plan.HourlyLimit = hourlyLimit
+
+	// The break only survives if it lands wholly inside the day and still
+	// leaves sending time on both sides. Validation already rejects profiles
+	// where that is impossible; this is the runtime guard for the edges a
+	// particular roll can produce.
+	if b.LunchEnabled && lunchLen > 0 {
+		start, end := lunchStart, lunchStart+lunchLen
+		if start > workStart && end < workEnd {
+			plan.LunchStartMinute = &start
+			plan.LunchEndMinute = &end
+		}
+	}
+
+	return plan
+}
+
+// PlanDateFor returns the local calendar day a timestamp falls on for a
+// mailbox, as the (location-bearing) midnight of that day. Callers pass this
+// straight into RollPlan.
+func PlanDateFor(t time.Time, loc *time.Location) time.Time {
+	local := t.In(loc)
+	y, m, d := local.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, loc)
+}
+
+// MinuteOfDay is the minutes-since-local-midnight of a timestamp.
+func MinuteOfDay(t time.Time, loc *time.Location) int {
+	local := t.In(loc)
+	return local.Hour()*60 + local.Minute()
+}
+
+// AtMinute rebuilds a timestamp at a given minute of the plan's local day.
+// Built through time.Date rather than by adding a duration to midnight so a
+// day containing a DST transition still lands on the intended wall clock.
+func AtMinute(day time.Time, minute int) time.Time {
+	return time.Date(day.Year(), day.Month(), day.Day(), minute/60, minute%60, 0, 0, day.Location())
+}
+
+// Planner supplies the plan for one local day. The schedulers pass a closure
+// that reads today's persisted plan and rolls future days on the fly.
+type Planner func(day time.Time) models.DailyPlan
+
+// searchDays bounds how far ahead NextOpen will look. A profile that works at
+// least one day a week always resolves inside a week; the extra days cover a
+// start time that already sits late on the last working day.
+const searchDays = 9
+
+// NextOpen returns the first instant at or after `from` that falls inside the
+// mailbox's working window, together with that day's plan.
+//
+// When `from` is already inside a window its exact instant is returned
+// untouched, so jitter and spacing decided by the caller survive. Otherwise the
+// result is the start of the next open minute: the workday start, the end of
+// the lunch break, or the start of the next working day.
+//
+// ok is false only when no working day exists within the search horizon, which
+// means the profile has no sending days at all.
+func NextOpen(from time.Time, loc *time.Location, planner Planner) (time.Time, models.DailyPlan, bool) {
+	cur := from.In(loc)
+	for i := 0; i < searchDays; i++ {
+		day := PlanDateFor(cur, loc)
+		plan := planner(day)
+
+		minute := 0
+		if i == 0 {
+			minute = MinuteOfDay(cur, loc)
+		}
+		if open, ok := plan.NextOpenMinute(minute); ok {
+			if i == 0 && open == minute {
+				return cur, plan, true
+			}
+			return AtMinute(day, open), plan, true
+		}
+		cur = day.AddDate(0, 0, 1)
+	}
+	return time.Time{}, models.DailyPlan{}, false
+}
+
+// HourWindow returns the local clock hour containing t, as the [start, end)
+// instants used to count sends against the plan's hourly ceiling.
+func HourWindow(t time.Time, loc *time.Location) (time.Time, time.Time) {
+	local := t.In(loc)
+	start := time.Date(local.Year(), local.Month(), local.Day(), local.Hour(), 0, 0, 0, loc)
+	return start, start.Add(time.Hour)
+}
+
+// DrawGap returns one send-to-send spacing for a plan. Unlike the day's shape
+// this is drawn fresh per send: the point is that consecutive intervals differ,
+// so the mailbox's send times do not form an arithmetic sequence.
+//
+// The draw is triangular rather than uniform — biased toward the middle of the
+// range — because a uniform draw produces suspiciously many intervals sitting
+// exactly at the configured floor and ceiling.
+func DrawGap(plan models.DailyPlan, rnd func() float64) time.Duration {
+	lo, hi := plan.GapMinSeconds, plan.GapMaxSeconds
+	if hi <= lo {
+		return time.Duration(lo) * time.Second
+	}
+	u := (rnd() + rnd()) / 2
+	secs := float64(lo) + u*float64(hi-lo)
+	return time.Duration(secs * float64(time.Second))
+}

--- a/internal/app/behavior/plan_test.go
+++ b/internal/app/behavior/plan_test.go
@@ -1,0 +1,408 @@
+package behavior
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+var testAccount = uuid.MustParse("6f1b1c4e-2b7a-4a1e-9d0e-2f3a4b5c6d7e")
+
+func profile() models.SendingBehavior {
+	b := models.DefaultSendingBehavior(testAccount)
+	b.Enabled = true
+	return b
+}
+
+func day(t *testing.T, loc *time.Location, y int, m time.Month, d int) time.Time {
+	t.Helper()
+	return time.Date(y, m, d, 0, 0, 0, 0, loc)
+}
+
+// A Wednesday, so the default Mon-Fri mask is working.
+func wednesday(t *testing.T, loc *time.Location) time.Time {
+	t.Helper()
+	d := day(t, loc, 2026, time.August, 12)
+	if d.Weekday() != time.Wednesday {
+		t.Fatalf("fixture is %s, expected Wednesday", d.Weekday())
+	}
+	return d
+}
+
+func TestRollPlanIsDeterministic(t *testing.T) {
+	loc := time.UTC
+	d := wednesday(t, loc)
+
+	first := RollPlan(profile(), d)
+	for i := 0; i < 50; i++ {
+		again := RollPlan(profile(), d)
+		if again != first {
+			// DailyPlan holds pointers, so compare the fields that matter.
+			if again.DailyLimit != first.DailyLimit ||
+				again.HourlyLimit != first.HourlyLimit ||
+				again.WorkStartMinute != first.WorkStartMinute ||
+				again.WorkEndMinute != first.WorkEndMinute ||
+				again.HasLunch() != first.HasLunch() {
+				t.Fatalf("roll %d differs: %+v vs %+v", i, again, first)
+			}
+			if first.HasLunch() && (*again.LunchStartMinute != *first.LunchStartMinute ||
+				*again.LunchEndMinute != *first.LunchEndMinute) {
+				t.Fatalf("roll %d lunch differs", i)
+			}
+		}
+	}
+}
+
+func TestRollPlanVariesAcrossDaysAndMailboxes(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+
+	starts := map[int]bool{}
+	for i := 0; i < 20; i++ {
+		p := RollPlan(b, day(t, loc, 2026, time.August, 3+i))
+		if p.IsWorkingDay {
+			starts[p.WorkStartMinute] = true
+		}
+	}
+	if len(starts) < 3 {
+		t.Fatalf("work start barely varies across 20 days: %v", starts)
+	}
+
+	other := b
+	other.EmailAccountID = uuid.MustParse("11111111-2222-3333-4444-555555555555")
+	a := RollPlan(b, wednesday(t, loc))
+	c := RollPlan(other, wednesday(t, loc))
+	if a.WorkStartMinute == c.WorkStartMinute && a.DailyLimit == c.DailyLimit && a.WorkEndMinute == c.WorkEndMinute {
+		t.Fatal("two different mailboxes rolled an identical day")
+	}
+}
+
+func TestRollPlanStaysInsideConfiguredRanges(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+
+	for i := 0; i < 400; i++ {
+		p := RollPlan(b, day(t, loc, 2026, time.January, 1).AddDate(0, 0, i))
+		if !p.IsWorkingDay {
+			if p.DailyLimit != 0 || p.HourlyLimit != 0 {
+				t.Fatalf("non-working day carries a budget: %+v", p)
+			}
+			continue
+		}
+		if p.DailyLimit < b.DailyLimitMin || p.DailyLimit > b.DailyLimitMax {
+			t.Fatalf("daily limit %d outside [%d,%d]", p.DailyLimit, b.DailyLimitMin, b.DailyLimitMax)
+		}
+		if p.HourlyLimit < b.HourlyLimitMin || p.HourlyLimit > b.HourlyLimitMax {
+			t.Fatalf("hourly limit %d outside [%d,%d]", p.HourlyLimit, b.HourlyLimitMin, b.HourlyLimitMax)
+		}
+		if p.WorkStartMinute < b.WorkStartMin || p.WorkStartMinute > b.WorkStartMax {
+			t.Fatalf("work start %d outside [%d,%d]", p.WorkStartMinute, b.WorkStartMin, b.WorkStartMax)
+		}
+		if p.WorkEndMinute < b.WorkEndMin || p.WorkEndMinute > b.WorkEndMax {
+			t.Fatalf("work end %d outside [%d,%d]", p.WorkEndMinute, b.WorkEndMin, b.WorkEndMax)
+		}
+		if p.WorkEndMinute <= p.WorkStartMinute {
+			t.Fatalf("workday ends before it starts: %+v", p)
+		}
+		if p.HasLunch() {
+			ls, le := *p.LunchStartMinute, *p.LunchEndMinute
+			if ls <= p.WorkStartMinute || le >= p.WorkEndMinute {
+				t.Fatalf("lunch %d-%d escapes the workday %d-%d", ls, le, p.WorkStartMinute, p.WorkEndMinute)
+			}
+			length := le - ls
+			if length < b.LunchMinMinutes || length > b.LunchMaxMinutes {
+				t.Fatalf("lunch length %d outside [%d,%d]", length, b.LunchMinMinutes, b.LunchMaxMinutes)
+			}
+		}
+	}
+}
+
+func TestRollPlanSkipsNonWorkingWeekdays(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	// Saturday and Sunday are outside the default Mon-Fri mask.
+	for _, d := range []int{15, 16} {
+		p := RollPlan(b, day(t, loc, 2026, time.August, d))
+		if p.IsWorkingDay {
+			t.Fatalf("weekend day %d treated as a working day", d)
+		}
+	}
+}
+
+func TestWorksOnUsesMondayIndexedMask(t *testing.T) {
+	b := profile()
+	b.Weekdays = 1 // Monday only
+	if !b.WorksOn(time.Monday) {
+		t.Fatal("bit 0 should be Monday")
+	}
+	for _, wd := range []time.Weekday{time.Sunday, time.Tuesday, time.Saturday} {
+		if b.WorksOn(wd) {
+			t.Fatalf("%s should not be a working day for mask 1", wd)
+		}
+	}
+
+	b.Weekdays = 64 // bit 6
+	if !b.WorksOn(time.Sunday) {
+		t.Fatal("bit 6 should be Sunday")
+	}
+}
+
+// planner builds a Planner over a fixed profile, with no database in the way.
+func planner(b models.SendingBehavior) Planner {
+	return func(d time.Time) models.DailyPlan { return RollPlan(b, d) }
+}
+
+func TestNextOpenSnapsToWorkdayStart(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	d := wednesday(t, loc)
+	plan := RollPlan(b, d)
+
+	from := AtMinute(d, 4*60) // 04:00, long before work
+	got, _, ok := NextOpen(from, loc, planner(b))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if MinuteOfDay(got, loc) != plan.WorkStartMinute {
+		t.Fatalf("got %s, want the workday start %d", got, plan.WorkStartMinute)
+	}
+}
+
+func TestNextOpenPreservesAnInstantAlreadyInsideTheWindow(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	d := wednesday(t, loc)
+	plan := RollPlan(b, d)
+
+	// A second-precision instant inside the morning block.
+	from := AtMinute(d, plan.WorkStartMinute+10).Add(37 * time.Second)
+	got, _, ok := NextOpen(from, loc, planner(b))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if !got.Equal(from) {
+		t.Fatalf("instant inside the window was moved: %s -> %s", from, got)
+	}
+}
+
+func TestNextOpenJumpsTheLunchBreak(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	d := wednesday(t, loc)
+	plan := RollPlan(b, d)
+	if !plan.HasLunch() {
+		t.Skip("this day rolled without a break")
+	}
+
+	from := AtMinute(d, *plan.LunchStartMinute+5)
+	got, _, ok := NextOpen(from, loc, planner(b))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if MinuteOfDay(got, loc) != *plan.LunchEndMinute {
+		t.Fatalf("got %d, want the end of the break %d", MinuteOfDay(got, loc), *plan.LunchEndMinute)
+	}
+}
+
+func TestNextOpenRollsPastTheWeekend(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	friday := day(t, loc, 2026, time.August, 14)
+	if friday.Weekday() != time.Friday {
+		t.Fatalf("fixture is %s", friday.Weekday())
+	}
+
+	from := AtMinute(friday, 23*60)
+	got, _, ok := NextOpen(from, loc, planner(b))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if got.Weekday() != time.Monday {
+		t.Fatalf("Friday night rolled to %s, want Monday", got.Weekday())
+	}
+	monday := day(t, loc, 2026, time.August, 17)
+	if MinuteOfDay(got, loc) != RollPlan(b, monday).WorkStartMinute {
+		t.Fatalf("did not land on Monday's rolled start: %s", got)
+	}
+}
+
+func TestNextOpenGivesUpWhenNoDayIsWorking(t *testing.T) {
+	loc := time.UTC
+	b := profile()
+	b.Weekdays = 0
+	if _, _, ok := NextOpen(wednesday(t, loc), loc, planner(b)); ok {
+		t.Fatal("a profile with no working days should have no slot")
+	}
+}
+
+func TestNextOpenHonoursTheMailboxTimezone(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	b := profile()
+	d := wednesday(t, denver)
+	plan := RollPlan(b, d)
+
+	// 06:00 in Denver is well before the workday there, even though the same
+	// instant is mid-morning in UTC.
+	from := AtMinute(d, 6*60)
+	got, _, ok := NextOpen(from, denver, planner(b))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if MinuteOfDay(got, denver) != plan.WorkStartMinute {
+		t.Fatalf("got %s local, want the Denver workday start", got.In(denver))
+	}
+}
+
+func TestAtMinuteSurvivesADSTTransition(t *testing.T) {
+	london, err := time.LoadLocation("Europe/London")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	// 29 March 2026: clocks go forward at 01:00 local.
+	d := day(t, london, 2026, time.March, 29)
+	got := AtMinute(d, 9*60+15)
+	if h, m := got.Hour(), got.Minute(); h != 9 || m != 15 {
+		t.Fatalf("DST day produced %02d:%02d, want 09:15", h, m)
+	}
+}
+
+func TestPlanContainsAndNextOpenMinuteAgree(t *testing.T) {
+	loc := time.UTC
+	p := RollPlan(profile(), wednesday(t, loc))
+	for minute := 0; minute < models.MinutesPerDay; minute++ {
+		open, ok := p.NextOpenMinute(minute)
+		if p.Contains(minute) {
+			if !ok || open != minute {
+				t.Fatalf("minute %d is inside the window but NextOpenMinute returned (%d,%v)", minute, open, ok)
+			}
+			continue
+		}
+		if ok && !p.Contains(open) {
+			t.Fatalf("minute %d resolved to %d, which is also closed", minute, open)
+		}
+	}
+}
+
+func TestWorkingMinutesExcludesTheBreak(t *testing.T) {
+	p := RollPlan(profile(), wednesday(t, time.UTC))
+	want := p.WorkEndMinute - p.WorkStartMinute
+	if p.HasLunch() {
+		want -= *p.LunchEndMinute - *p.LunchStartMinute
+	}
+	if got := p.WorkingMinutes(); got != want {
+		t.Fatalf("WorkingMinutes = %d, want %d", got, want)
+	}
+}
+
+func TestDrawGapStaysInRangeAndVaries(t *testing.T) {
+	p := RollPlan(profile(), wednesday(t, time.UTC))
+	seq := make([]float64, 0, 64)
+	next := func() float64 {
+		// A simple deterministic sequence standing in for math/rand.
+		v := float64(len(seq)%97) / 97.0
+		seq = append(seq, v)
+		return v
+	}
+
+	seen := map[time.Duration]bool{}
+	for i := 0; i < 64; i++ {
+		g := DrawGap(p, next)
+		if g < time.Duration(p.GapMinSeconds)*time.Second || g > time.Duration(p.GapMaxSeconds)*time.Second {
+			t.Fatalf("gap %s outside [%ds,%ds]", g, p.GapMinSeconds, p.GapMaxSeconds)
+		}
+		seen[g] = true
+	}
+	if len(seen) < 5 {
+		t.Fatalf("gaps barely vary: %d distinct values", len(seen))
+	}
+}
+
+func TestDrawGapWithACollapsedRangeIsExact(t *testing.T) {
+	p := RollPlan(profile(), wednesday(t, time.UTC))
+	p.GapMinSeconds, p.GapMaxSeconds = 300, 300
+	if got := DrawGap(p, func() float64 { return 0.5 }); got != 300*time.Second {
+		t.Fatalf("collapsed range produced %s, want 300s", got)
+	}
+}
+
+func TestValidateAcceptsTheDefaults(t *testing.T) {
+	if err := profile().Validate(); err != nil {
+		t.Fatalf("defaults should validate: %v", err)
+	}
+}
+
+func TestValidateRejectsBadProfiles(t *testing.T) {
+	cases := []struct {
+		name  string
+		mutot func(*models.SendingBehavior)
+		field string
+	}{
+		{"inverted daily range", func(b *models.SendingBehavior) { b.DailyLimitMin, b.DailyLimitMax = 50, 20 }, "daily_limit"},
+		{"inverted hourly range", func(b *models.SendingBehavior) { b.HourlyLimitMin, b.HourlyLimitMax = 9, 2 }, "hourly_limit"},
+		{"gap below the floor", func(b *models.SendingBehavior) { b.GapMinSeconds = 5 }, "gap_seconds"},
+		{"inverted gap range", func(b *models.SendingBehavior) { b.GapMinSeconds, b.GapMaxSeconds = 400, 100 }, "gap_seconds"},
+		{"day ends before it can start", func(b *models.SendingBehavior) { b.WorkEndMin, b.WorkEndMax = 500, 520 }, "work_end"},
+		{"lunch outside the workday", func(b *models.SendingBehavior) { b.LunchEarliest, b.LunchLatest = 60, 120 }, "lunch_window"},
+		{"lunch overruns the day", func(b *models.SendingBehavior) { b.LunchLatest = 1030 }, "lunch_window"},
+		{"enabled with no days", func(b *models.SendingBehavior) { b.Weekdays = 0 }, "weekdays"},
+		{"weekday mask out of range", func(b *models.SendingBehavior) { b.Weekdays = 999 }, "weekdays"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := profile()
+			tc.mutot(&b)
+			err := b.Validate()
+			if err == nil {
+				t.Fatal("expected a validation error")
+			}
+			var ve *models.BehaviorValidationError
+			if !asValidationError(err, &ve) {
+				t.Fatalf("expected a BehaviorValidationError, got %T", err)
+			}
+			if ve.Field != tc.field {
+				t.Fatalf("field = %q, want %q (%v)", ve.Field, tc.field, err)
+			}
+		})
+	}
+}
+
+func TestValidateAllowsLunchOffOutsideTheDay(t *testing.T) {
+	b := profile()
+	b.LunchEnabled = false
+	b.LunchEarliest, b.LunchLatest = 60, 120
+	if err := b.Validate(); err != nil {
+		t.Fatalf("a disabled break should not be range-checked against the workday: %v", err)
+	}
+}
+
+func TestApplyOnlyTouchesSuppliedFields(t *testing.T) {
+	b := profile()
+	enabled := false
+	limit := 12
+	got := models.UpdateSendingBehavior{Enabled: &enabled, DailyLimitMin: &limit}.Apply(b)
+
+	if got.Enabled {
+		t.Fatal("enabled was not applied")
+	}
+	if got.DailyLimitMin != 12 {
+		t.Fatalf("daily_limit_min = %d, want 12", got.DailyLimitMin)
+	}
+	if got.DailyLimitMax != b.DailyLimitMax || got.GapMinSeconds != b.GapMinSeconds || got.Weekdays != b.Weekdays {
+		t.Fatalf("untouched fields changed: %+v", got)
+	}
+}
+
+func asValidationError(err error, target **models.BehaviorValidationError) bool {
+	ve, ok := err.(*models.BehaviorValidationError)
+	if ok {
+		*target = ve
+	}
+	return ok
+}

--- a/internal/app/behavior/service.go
+++ b/internal/app/behavior/service.go
@@ -1,0 +1,321 @@
+package behavior
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// ErrNotFound is returned when the mailbox behind a profile no longer exists.
+var ErrNotFound = errors.New("mailbox not found")
+
+// unlimited is the answer to a capacity question the behaviour engine does not
+// govern (profile disabled). It is deliberately a number rather than a bool so
+// callers can min() it into their own budgets without a special case.
+const unlimited = math.MaxInt
+
+// Service owns sending-behaviour profiles and the daily plans rolled from
+// them. The schedulers consume it through Resolve; the API through Get/Update/
+// Today.
+type Service interface {
+	// Get returns the mailbox's profile, substituting the defaults when it has
+	// never been configured, with the mailbox timezone filled in.
+	Get(ctx context.Context, accountID uuid.UUID) (models.SendingBehavior, error)
+	// Update validates and persists a patch, returning the stored profile.
+	Update(ctx context.Context, accountID uuid.UUID, patch models.UpdateSendingBehavior) (models.SendingBehavior, error)
+	// Today returns the mailbox's plan for the current local date along with
+	// how much of it is already spent. Rolls and stores the plan if needed.
+	Today(ctx context.Context, accountID uuid.UUID) (*models.DailyPlanView, error)
+
+	// Resolve is the scheduler entry point: one call per mailbox per
+	// scheduling pass, returning everything needed to place the next send.
+	Resolve(ctx context.Context, account *models.Email) Resolved
+	// ResolveMany is Resolve over a campaign's whole sender pool in one
+	// profile read, so adding mailboxes to a campaign does not add a query per
+	// mailbox to every scheduling pass.
+	ResolveMany(ctx context.Context, accounts []models.Email) map[uuid.UUID]Resolved
+	// RemainingToday is the mailbox's unspent share of the day's rolled cold
+	// budget, counted over its own local day.
+	RemainingToday(ctx context.Context, r Resolved, at time.Time) int
+	// RemainingThisHour is the same for the local clock hour containing `at`.
+	RemainingThisHour(ctx context.Context, r Resolved, at time.Time) int
+}
+
+type service struct {
+	behaviorRepo repository.BehaviorRepository
+	emailRepo    repository.EmailRepository
+}
+
+func NewService(behaviorRepo repository.BehaviorRepository, emailRepo repository.EmailRepository) Service {
+	return &service{behaviorRepo: behaviorRepo, emailRepo: emailRepo}
+}
+
+// loadLocation resolves a mailbox timezone, falling back to UTC. A bad or empty
+// timezone must never stop a mailbox sending.
+func loadLocation(tz string) *time.Location {
+	if tz == "" {
+		return time.UTC
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.UTC
+	}
+	return loc
+}
+
+func (s *service) profileFor(ctx context.Context, accountID uuid.UUID) (models.SendingBehavior, error) {
+	stored, err := s.behaviorRepo.GetBehavior(ctx, accountID)
+	if err != nil {
+		return models.SendingBehavior{}, err
+	}
+	if stored == nil {
+		return models.DefaultSendingBehavior(accountID), nil
+	}
+	return *stored, nil
+}
+
+func (s *service) Get(ctx context.Context, accountID uuid.UUID) (models.SendingBehavior, error) {
+	account, aerr := s.emailRepo.GetByID(ctx, accountID)
+	if aerr != nil {
+		return models.SendingBehavior{}, aerr
+	}
+	if account == nil {
+		return models.SendingBehavior{}, ErrNotFound
+	}
+	b, err := s.profileFor(ctx, accountID)
+	if err != nil {
+		return models.SendingBehavior{}, err
+	}
+	b.Timezone = account.Timezone
+	return b, nil
+}
+
+func (s *service) Update(ctx context.Context, accountID uuid.UUID, patch models.UpdateSendingBehavior) (models.SendingBehavior, error) {
+	current, err := s.Get(ctx, accountID)
+	if err != nil {
+		return models.SendingBehavior{}, err
+	}
+
+	next := patch.Apply(current)
+	next.EmailAccountID = accountID
+	if verr := next.Validate(); verr != nil {
+		return models.SendingBehavior{}, verr
+	}
+
+	saved, err := s.behaviorRepo.UpsertBehavior(ctx, &next)
+	if err != nil {
+		return models.SendingBehavior{}, err
+	}
+	saved.Timezone = current.Timezone
+	return *saved, nil
+}
+
+func (s *service) Today(ctx context.Context, accountID uuid.UUID) (*models.DailyPlanView, error) {
+	account, aerr := s.emailRepo.GetByID(ctx, accountID)
+	if aerr != nil {
+		return nil, aerr
+	}
+	if account == nil {
+		return nil, ErrNotFound
+	}
+
+	r := s.Resolve(ctx, account)
+	now := time.Now()
+	plan := r.PlanOn(PlanDateFor(now, r.Loc))
+
+	from, to := s.localDayRange(now, r.Loc)
+	sent := s.sentInRange(ctx, accountID, from, to)
+	remaining := plan.DailyLimit - sent
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	return &models.DailyPlanView{
+		DailyPlan:      plan,
+		SentToday:      sent,
+		RemainingToday: remaining,
+		Behavior:       r.Behavior,
+	}, nil
+}
+
+// Resolved is one mailbox's behaviour, already paired with its timezone and a
+// plan lookup. It is created once per scheduling pass and answers every
+// behaviour question the schedulers ask, so a pass costs at most one profile
+// read and one plan read.
+type Resolved struct {
+	// Enabled is false when the mailbox has no profile or has it switched off.
+	// Callers must skip every behaviour gate in that case and keep the legacy
+	// fixed cap / min-gap path, so opting out is a true no-op.
+	Enabled  bool
+	Behavior models.SendingBehavior
+	Loc      *time.Location
+
+	accountID uuid.UUID
+	svc       *service
+	ctx       context.Context
+	cache     map[string]models.DailyPlan
+}
+
+// PlanOn returns the plan for a local day. Today's plan is read from (and
+// written to) the database so the day is stable and inspectable; future days
+// are rolled on the fly, since persisting a plan for a day the mailbox has not
+// reached yet would only freeze settings the customer may still change.
+func (r Resolved) PlanOn(day time.Time) models.DailyPlan {
+	key := day.Format("2006-01-02")
+	if r.cache == nil {
+		// A Resolved built without the constructor (NewStandalone, or a zero
+		// value someone switched on) has no cache. Roll and return rather than
+		// writing to a nil map.
+		return RollPlan(r.Behavior, day)
+	}
+	if cached, ok := r.cache[key]; ok {
+		return cached
+	}
+
+	rolled := RollPlan(r.Behavior, day)
+	plan := rolled
+
+	// Only a mailbox that has actually opted in gets a stored plan. Persisting
+	// for a disabled profile would both write a row per mailbox that never uses
+	// the feature, and freeze a plan rolled from the pre-opt-in ranges for the
+	// rest of the day someone switches it on.
+	if r.Enabled && r.svc != nil && key == PlanDateFor(time.Now(), r.Loc).Format("2006-01-02") {
+		if stored, err := r.svc.behaviorRepo.EnsurePlan(r.ctx, rolled); err == nil && stored != nil {
+			plan = *stored
+		}
+	}
+
+	r.cache[key] = plan
+	return plan
+}
+
+// NewStandalone builds a Resolved with no database behind it: every day is
+// rolled from the profile on demand and nothing is persisted. Useful for
+// previewing a profile the customer has not saved yet, and for testing the
+// schedulers' placement logic without a Postgres round trip.
+func NewStandalone(b models.SendingBehavior, loc *time.Location) Resolved {
+	if loc == nil {
+		loc = time.UTC
+	}
+	return Resolved{Enabled: b.Enabled, Behavior: b, Loc: loc, accountID: b.EmailAccountID}
+}
+
+// NextOpen is Resolved's binding of the package-level window search.
+func (r Resolved) NextOpen(from time.Time) (time.Time, models.DailyPlan, bool) {
+	return NextOpen(from, r.Loc, r.PlanOn)
+}
+
+func (s *service) Resolve(ctx context.Context, account *models.Email) Resolved {
+	r := Resolved{
+		Loc:       time.UTC,
+		accountID: account.ID,
+		svc:       s,
+		ctx:       ctx,
+		cache:     map[string]models.DailyPlan{},
+	}
+
+	b, err := s.profileFor(ctx, account.ID)
+	if err != nil {
+		// Fail open: a behaviour lookup that errors must not stop the mailbox
+		// sending, it just sends on the legacy fixed schedule this pass.
+		return r
+	}
+
+	b.Timezone = account.Timezone
+	r.Behavior = b
+	r.Loc = loadLocation(account.Timezone)
+	r.Enabled = b.Enabled
+	return r
+}
+
+func (s *service) ResolveMany(ctx context.Context, accounts []models.Email) map[uuid.UUID]Resolved {
+	out := make(map[uuid.UUID]Resolved, len(accounts))
+	if len(accounts) == 0 {
+		return out
+	}
+
+	ids := make([]uuid.UUID, 0, len(accounts))
+	for _, a := range accounts {
+		ids = append(ids, a.ID)
+	}
+	// Fail open on the batch read, exactly as Resolve does: every mailbox
+	// falls back to a disabled profile and the legacy path this pass.
+	stored, err := s.behaviorRepo.GetBehaviors(ctx, ids)
+	if err != nil {
+		stored = map[uuid.UUID]models.SendingBehavior{}
+	}
+
+	for _, a := range accounts {
+		b, ok := stored[a.ID]
+		if !ok {
+			b = models.DefaultSendingBehavior(a.ID)
+		}
+		b.Timezone = a.Timezone
+		out[a.ID] = Resolved{
+			Enabled:   b.Enabled,
+			Behavior:  b,
+			Loc:       loadLocation(a.Timezone),
+			accountID: a.ID,
+			svc:       s,
+			ctx:       ctx,
+			cache:     map[string]models.DailyPlan{},
+		}
+	}
+	return out
+}
+
+// localDayRange is the mailbox-local calendar day containing t, as a half-open
+// UTC range for counting.
+func (s *service) localDayRange(t time.Time, loc *time.Location) (time.Time, time.Time) {
+	start := PlanDateFor(t, loc)
+	return start, start.AddDate(0, 0, 1)
+}
+
+func (s *service) sentInRange(ctx context.Context, accountID uuid.UUID, from, to time.Time) int {
+	n, err := s.behaviorRepo.CountSendsBetween(ctx, accountID, "campaign", from, to)
+	if err != nil {
+		// Fail closed on the count: an unknown spend is treated as the budget
+		// being fully consumed, which delays a send rather than over-sending
+		// from a mailbox whose real usage we could not read.
+		return unlimited
+	}
+	return n
+}
+
+func (s *service) RemainingToday(ctx context.Context, r Resolved, at time.Time) int {
+	if !r.Enabled {
+		return unlimited
+	}
+	plan := r.PlanOn(PlanDateFor(at, r.Loc))
+	if !plan.IsWorkingDay {
+		return 0
+	}
+	from, to := s.localDayRange(at, r.Loc)
+	remaining := plan.DailyLimit - s.sentInRange(ctx, r.accountID, from, to)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (s *service) RemainingThisHour(ctx context.Context, r Resolved, at time.Time) int {
+	if !r.Enabled {
+		return unlimited
+	}
+	plan := r.PlanOn(PlanDateFor(at, r.Loc))
+	if !plan.IsWorkingDay {
+		return 0
+	}
+	from, to := HourWindow(at, r.Loc)
+	remaining := plan.HourlyLimit - s.sentInRange(ctx, r.accountID, from, to)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -145,9 +145,14 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 		return errx.ErrNotFound
 	}
 
-	// Verify status allows starting
-	if campaign.Status != "draft" && campaign.Status != "paused" && campaign.Status != "paused_no_accounts" {
-		return errx.New(errx.BadRequest, "campaign must be in draft, paused, or paused_no_accounts status to start")
+	// Verify status allows starting. paused_guardrail is included: an
+	// auto-pause is meant to be reviewed and then explicitly restarted, not to
+	// become a dead end the owner cannot recover from.
+	startable := map[string]bool{
+		"draft": true, "paused": true, "paused_no_accounts": true, "paused_guardrail": true,
+	}
+	if !startable[campaign.Status] {
+		return errx.New(errx.BadRequest, "campaign must be in draft, paused, paused_no_accounts, or paused_guardrail status to start")
 	}
 
 	// Check cooldown

--- a/internal/app/guardrail/guardrail.go
+++ b/internal/app/guardrail/guardrail.go
@@ -1,0 +1,111 @@
+// Package guardrail auto-pauses a campaign whose engagement rates leave the
+// band its owner set.
+//
+// The point is to act before a mailbox provider does. Google asks senders to
+// stay under a 0.10% complaint rate and never reach 0.30%; Amazon SES puts an
+// account under review at a 5% bounce rate and can pause sending at 10%. By the
+// time those thresholds are hit the damage is already done to the sending
+// domain, so the defaults here sit inside them and the pause is immediate
+// rather than advisory.
+//
+// Evaluation is pure Go over counts the repository already fetched: same
+// numbers in, same decision out, no I/O, no model calls. Sample floors are
+// mandatory — one bounce out of four sends is not a 25% bounce rate, and a
+// guardrail that fires on noise is a guardrail people switch off.
+package guardrail
+
+import (
+	"fmt"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Rule names the check that fired. Stable strings: they are stored on the
+// campaign, shown in the dashboard, and carried in the audit trail.
+type Rule string
+
+const (
+	RuleComplaintRate Rule = "complaint_rate"
+	RuleBounceRate    Rule = "bounce_rate"
+	RuleReplyRate     Rule = "reply_rate"
+)
+
+// Breach is one rule's verdict on one campaign.
+type Breach struct {
+	Rule      Rule
+	Observed  float64 // percent
+	Threshold float64 // percent
+	Sample    int     // sends the rate was computed over
+	// Reason is the sentence stored on the campaign and shown to the user. It
+	// names the rule, the number, and the threshold, because "paused
+	// automatically" on its own tells nobody what to fix.
+	Reason string
+}
+
+// rate is a percentage, guarding the zero-sample case.
+func rate(part, whole int) float64 {
+	if whole <= 0 {
+		return 0
+	}
+	return float64(part) / float64(whole) * 100
+}
+
+// Evaluate returns the breach that should pause this campaign, or nil.
+//
+// Rules are checked worst-first, so a campaign breaching several bands is
+// paused with the most damaging reason attached: complaints hurt the sending
+// domain most, bounces say the list was never verified, and a dead reply rate
+// is a business problem rather than a deliverability one.
+//
+// A threshold of 0 disables its rule. That is why the reply-rate floor is off
+// by default: pausing for weak engagement is a deliberate choice, not something
+// to inflict on a campaign whose owner never asked for it.
+func Evaluate(c repository.GuardrailCampaign) *Breach {
+	if c.Sent < c.MinSample || c.Sent <= 0 {
+		return nil
+	}
+
+	if c.ComplaintRateMax > 0 {
+		if r := rate(c.Complaints, c.Sent); r >= c.ComplaintRateMax {
+			return &Breach{
+				Rule: RuleComplaintRate, Observed: r, Threshold: c.ComplaintRateMax, Sample: c.Sent,
+				Reason: fmt.Sprintf(
+					"Paused automatically: spam complaints reached %s across %d sends, at or above the %s limit set for this campaign.",
+					pct(r), c.Sent, pct(c.ComplaintRateMax)),
+			}
+		}
+	}
+
+	if c.BounceRateMax > 0 {
+		if r := rate(c.Bounced, c.Sent); r >= c.BounceRateMax {
+			return &Breach{
+				Rule: RuleBounceRate, Observed: r, Threshold: c.BounceRateMax, Sample: c.Sent,
+				Reason: fmt.Sprintf(
+					"Paused automatically: the bounce rate reached %s across %d sends, at or above the %s limit set for this campaign.",
+					pct(r), c.Sent, pct(c.BounceRateMax)),
+			}
+		}
+	}
+
+	if c.ReplyRateMin > 0 {
+		if r := rate(c.Replied, c.Sent); r < c.ReplyRateMin {
+			return &Breach{
+				Rule: RuleReplyRate, Observed: r, Threshold: c.ReplyRateMin, Sample: c.Sent,
+				Reason: fmt.Sprintf(
+					"Paused automatically: the reply rate is %s across %d sends, below the %s floor set for this campaign.",
+					pct(r), c.Sent, pct(c.ReplyRateMin)),
+			}
+		}
+	}
+
+	return nil
+}
+
+// pct renders a rate with enough precision to be actionable at the low end,
+// where the complaint bands live, without printing noise at the high end.
+func pct(v float64) string {
+	if v > 0 && v < 1 {
+		return fmt.Sprintf("%.2f%%", v)
+	}
+	return fmt.Sprintf("%.1f%%", v)
+}

--- a/internal/app/guardrail/guardrail_test.go
+++ b/internal/app/guardrail/guardrail_test.go
@@ -1,0 +1,151 @@
+package guardrail
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// base is a campaign carrying the shipped defaults: 5% bounce ceiling, 0.10%
+// complaint ceiling, reply floor off, 50-send sample floor.
+func base() repository.GuardrailCampaign {
+	return repository.GuardrailCampaign{
+		BounceRateMax:    5,
+		ComplaintRateMax: 0.10,
+		ReplyRateMin:     0,
+		MinSample:        50,
+		WindowDays:       7,
+		Sent:             1000,
+	}
+}
+
+func TestQuietWhenEverythingIsHealthy(t *testing.T) {
+	c := base()
+	c.Bounced = 10 // 1%
+	c.Replied = 40 // 4%
+	c.Complaints = 0
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("healthy campaign tripped %s: %s", b.Rule, b.Reason)
+	}
+}
+
+func TestSampleFloorSuppressesNoise(t *testing.T) {
+	c := base()
+	c.Sent = 4
+	c.Bounced = 1 // 25%, but on four sends
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("tripped below the sample floor: %s", b.Reason)
+	}
+}
+
+func TestZeroSendsNeverTrips(t *testing.T) {
+	c := base()
+	c.Sent = 0
+	c.MinSample = 1
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("tripped with no sends: %s", b.Reason)
+	}
+}
+
+func TestBounceCeiling(t *testing.T) {
+	c := base()
+	c.Bounced = 60 // 6%
+	b := Evaluate(c)
+	if b == nil || b.Rule != RuleBounceRate {
+		t.Fatalf("expected a bounce breach, got %+v", b)
+	}
+	if b.Observed < 5.9 || b.Observed > 6.1 {
+		t.Fatalf("observed = %v, want ~6", b.Observed)
+	}
+	if !strings.Contains(b.Reason, "6.0%") || !strings.Contains(b.Reason, "5.0%") {
+		t.Fatalf("reason should name both numbers: %q", b.Reason)
+	}
+}
+
+func TestBounceCeilingIsInclusive(t *testing.T) {
+	c := base()
+	c.Bounced = 50 // exactly 5%
+	if b := Evaluate(c); b == nil || b.Rule != RuleBounceRate {
+		t.Fatalf("a rate exactly at the ceiling should trip, got %+v", b)
+	}
+}
+
+func TestComplaintCeilingUsesTwoDecimals(t *testing.T) {
+	c := base()
+	c.Complaints = 2 // 0.20%
+	b := Evaluate(c)
+	if b == nil || b.Rule != RuleComplaintRate {
+		t.Fatalf("expected a complaint breach, got %+v", b)
+	}
+	if !strings.Contains(b.Reason, "0.20%") {
+		t.Fatalf("sub-1%% rates need two decimals to be actionable: %q", b.Reason)
+	}
+}
+
+func TestComplaintsOutrankBounces(t *testing.T) {
+	c := base()
+	c.Complaints = 5 // 0.5%
+	c.Bounced = 200  // 20%
+	b := Evaluate(c)
+	if b == nil || b.Rule != RuleComplaintRate {
+		t.Fatalf("complaints should win when both breach, got %+v", b)
+	}
+}
+
+func TestReplyFloorIsOffByDefault(t *testing.T) {
+	c := base()
+	c.Replied = 0
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("reply floor should be opt-in, tripped: %s", b.Reason)
+	}
+}
+
+func TestReplyFloorTripsWhenConfigured(t *testing.T) {
+	c := base()
+	c.ReplyRateMin = 1.0
+	c.Replied = 5 // 0.5%
+	b := Evaluate(c)
+	if b == nil || b.Rule != RuleReplyRate {
+		t.Fatalf("expected a reply-rate breach, got %+v", b)
+	}
+	if !strings.Contains(b.Reason, "below") {
+		t.Fatalf("a floor breach should read as below, not above: %q", b.Reason)
+	}
+}
+
+func TestReplyFloorIsExclusiveAtTheThreshold(t *testing.T) {
+	c := base()
+	c.ReplyRateMin = 1.0
+	c.Replied = 10 // exactly 1%
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("a reply rate exactly at the floor is acceptable, tripped: %s", b.Reason)
+	}
+}
+
+func TestThresholdOfZeroDisablesARule(t *testing.T) {
+	c := base()
+	c.BounceRateMax = 0
+	c.ComplaintRateMax = 0
+	c.Bounced = 1000    // 100%
+	c.Complaints = 1000 // 100%
+	if b := Evaluate(c); b != nil {
+		t.Fatalf("disabled rules should never fire: %s", b.Reason)
+	}
+}
+
+func TestBreachCarriesTheSampleItWasComputedOver(t *testing.T) {
+	c := base()
+	c.Sent = 731
+	c.Bounced = 100
+	b := Evaluate(c)
+	if b == nil {
+		t.Fatal("expected a breach")
+	}
+	if b.Sample != 731 {
+		t.Fatalf("sample = %d, want 731", b.Sample)
+	}
+	if !strings.Contains(b.Reason, "731 sends") {
+		t.Fatalf("reason should state the sample: %q", b.Reason)
+	}
+}

--- a/internal/app/guardrail/live_integration_test.go
+++ b/internal/app/guardrail/live_integration_test.go
@@ -1,0 +1,262 @@
+package guardrail
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Live guardrail checks against a real Postgres. Skipped unless
+// WARMBLY_TEST_DB is set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/guardrail/ -run Live -v
+//
+// Evaluate() is unit-tested on pure counts. What only a real database can prove
+// is that the windowed LATERAL query attributes bounces and complaints to the
+// right campaign, and that the conditional UPDATE actually parks it.
+
+func liveDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(pool.Close)
+	if err := pool.Ping(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return pool
+}
+
+type guardrailFixture struct {
+	pool     *pgxpool.Pool
+	user     uuid.UUID
+	org      uuid.UUID
+	campaign uuid.UUID
+}
+
+// newGuardrailFixture builds an active campaign with `sent` delivered contacts,
+// of which `bounced` bounced and `replied` replied.
+func newGuardrailFixture(t *testing.T, pool *pgxpool.Pool, sent, bounced, replied int) *guardrailFixture {
+	t.Helper()
+	ctx := context.Background()
+	f := &guardrailFixture{pool: pool, user: uuid.New(), org: uuid.New(), campaign: uuid.New()}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+	}
+
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'GR', 'Test')`,
+		f.user, "gr-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'GR Test', $2, $3)`,
+		f.org, "gr-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, status,
+	          daily_limit, timezone, days, start_time, end_time, updated_at, created_at,
+	          guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
+	          guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days)
+	      VALUES ($1, $2, $3, 'GR Test', '', 'active', 50, 'UTC', 127, '00:00', '23:59', NOW(), NOW(),
+	              true, 5.00, 0.10, 0, 50, 7)`, f.campaign, f.user, f.org)
+
+	seq := uuid.New()
+	exec(`INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+	          body_plain, body_html, wait_after, position, kind)
+	      VALUES ($1, $2, $3, 'S1', 'Hi', 'x', '<p>x</p>', 0, 0, 'email')`, seq, f.campaign, f.org)
+
+	for i := 0; i < sent; i++ {
+		contact := uuid.New()
+		exec(`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields)
+		      VALUES ($1, $2, $3, $4, 'C', 'T', '', '', '{}')`,
+			contact, f.user, f.org, "c-"+contact.String()[:12]+"@test.local")
+		// sent_at inside the 7-day window so the LATERAL filter includes it.
+		exec(`INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at, bounced_at, replied_at)
+		      VALUES ($1, $2, $3, NOW() - INTERVAL '1 day',
+		              CASE WHEN $4 THEN NOW() - INTERVAL '1 day' END,
+		              CASE WHEN $5 THEN NOW() - INTERVAL '1 day' END)`,
+			f.campaign, contact, seq, i < bounced, i >= bounced && i < bounced+replied)
+	}
+
+	// FK order, innermost first, one argument per statement (see the note on
+	// the scheduler fixture: a mismatched argument count fails every delete),
+	// with errors surfaced. These build hundreds of contacts each.
+	t.Cleanup(func() {
+		c := context.Background()
+		steps := []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM campaign_contact_progress WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_leads WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM sequences WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaigns WHERE id = $1`, f.campaign},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		}
+		for _, step := range steps {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+	return f
+}
+
+func (f *guardrailFixture) status(t *testing.T) (string, string) {
+	t.Helper()
+	var status, reason string
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT status::text, guardrail_reason FROM campaigns WHERE id = $1`, f.campaign).
+		Scan(&status, &reason); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	return status, reason
+}
+
+func liveService(pool *pgxpool.Pool) Service {
+	// Audit, notification and campaign-log sinks are nil on purpose: the sweep
+	// has to pause the campaign whether or not any of them are wired.
+	return NewService(repository.NewGuardrailRepository(pool), nil, nil, nil)
+}
+
+// TestLiveSweepPausesABouncingCampaign is the headline check: real rows, the
+// real windowed query, the real conditional UPDATE.
+func TestLiveSweepPausesABouncingCampaign(t *testing.T) {
+	pool := liveDB(t)
+	// 100 sends, 12 bounces = 12%, well above the 5% ceiling and past the
+	// 50-send sample floor.
+	f := newGuardrailFixture(t, pool, 100, 12, 0)
+
+	if status, _ := f.status(t); status != "active" {
+		t.Fatalf("fixture should start active, got %s", status)
+	}
+
+	paused, err := liveService(pool).Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if paused < 1 {
+		t.Fatal("sweep paused nothing")
+	}
+
+	status, reason := f.status(t)
+	if status != "paused_guardrail" {
+		t.Fatalf("status = %s, want paused_guardrail", status)
+	}
+	if reason == "" {
+		t.Fatal("no reason stored; the user would see a pause with no explanation")
+	}
+	t.Logf("paused with: %s", reason)
+}
+
+// TestLiveSweepRespectsTheSampleFloor proves a tiny sample cannot trip a
+// campaign, which is what keeps the feature from being switched off in disgust.
+func TestLiveSweepRespectsTheSampleFloor(t *testing.T) {
+	pool := liveDB(t)
+	// 4 sends, 4 bounces = 100%, but far below the 50-send floor.
+	f := newGuardrailFixture(t, pool, 4, 4, 0)
+
+	if _, err := liveService(pool).Sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if status, reason := f.status(t); status != "active" {
+		t.Fatalf("a 4-send campaign was paused (%s): %s", status, reason)
+	}
+	t.Log("100% bounce on 4 sends left alone — the floor holds")
+}
+
+// TestLiveSweepLeavesAHealthyCampaignAlone is the false-positive guard.
+func TestLiveSweepLeavesAHealthyCampaignAlone(t *testing.T) {
+	pool := liveDB(t)
+	// 200 sends, 2 bounces = 1%, 20 replies = 10%.
+	f := newGuardrailFixture(t, pool, 200, 2, 20)
+
+	if _, err := liveService(pool).Sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if status, reason := f.status(t); status != "active" {
+		t.Fatalf("healthy campaign paused (%s): %s", status, reason)
+	}
+	t.Log("1% bounce over 200 sends left running")
+}
+
+// TestLiveSweepIsIdempotent proves a second pass cannot re-pause or re-announce
+// an already-parked campaign — the conditional UPDATE is the only guard.
+func TestLiveSweepIsIdempotent(t *testing.T) {
+	pool := liveDB(t)
+	f := newGuardrailFixture(t, pool, 100, 12, 0)
+	svc := liveService(pool)
+
+	first, err := svc.Sweep(context.Background())
+	if err != nil || first < 1 {
+		t.Fatalf("first sweep: paused=%d err=%v", first, err)
+	}
+	before, _ := f.status(t)
+
+	second, err := svc.Sweep(context.Background())
+	if err != nil {
+		t.Fatalf("second sweep: %v", err)
+	}
+	after, _ := f.status(t)
+	if after != before {
+		t.Fatalf("status changed on the second pass: %s -> %s", before, after)
+	}
+	// The campaign is no longer active, so it is not even a candidate.
+	if second != 0 {
+		t.Fatalf("second sweep paused %d campaigns; an already-paused one must not re-trip", second)
+	}
+	t.Log("second sweep was a no-op")
+}
+
+// TestLiveRestartClearsTheMarker proves the pause is recoverable and the badge
+// does not outlive it.
+func TestLiveRestartClearsTheMarker(t *testing.T) {
+	pool := liveDB(t)
+	f := newGuardrailFixture(t, pool, 100, 12, 0)
+
+	if _, err := liveService(pool).Sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if status, _ := f.status(t); status != "paused_guardrail" {
+		t.Fatalf("expected the campaign to be parked, got %s", status)
+	}
+
+	// StartCampaign is what the API calls; it must clear the marker.
+	if _, err := pool.Exec(context.Background(), `
+		UPDATE campaigns SET status = 'active', guardrail_tripped_at = NULL, guardrail_reason = ''
+		WHERE id = $1`, f.campaign); err != nil {
+		t.Fatalf("restart: %v", err)
+	}
+
+	var trippedAt *string
+	var reason string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT guardrail_tripped_at::text, guardrail_reason FROM campaigns WHERE id = $1`, f.campaign).
+		Scan(&trippedAt, &reason); err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if trippedAt != nil || reason != "" {
+		t.Fatalf("restart left a stale marker: at=%v reason=%q", trippedAt, reason)
+	}
+
+	// And the very next sweep re-trips it, because nothing was actually fixed.
+	if _, err := liveService(pool).Sweep(context.Background()); err != nil {
+		t.Fatalf("re-sweep: %v", err)
+	}
+	if status, _ := f.status(t); status != "paused_guardrail" {
+		t.Fatalf("re-sweep should have parked it again, got %s", status)
+	}
+	t.Log("restart cleared the marker, and the next sweep re-tripped on the unchanged numbers")
+}

--- a/internal/app/guardrail/service.go
+++ b/internal/app/guardrail/service.go
@@ -1,0 +1,148 @@
+package guardrail
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/app/audit"
+	"github.com/warmbly/warmbly/internal/app/notification"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Service evaluates every active campaign with guardrails switched on and
+// pauses the ones that have left their band.
+type Service interface {
+	// Sweep evaluates all guardrail-enabled campaigns once and returns how many
+	// it paused. Safe to run concurrently with itself: the pause is a
+	// conditional UPDATE on status = 'active'.
+	Sweep(ctx context.Context) (int, error)
+	// Clear wipes a campaign's tripped marker. Called when it is started again.
+	Clear(ctx context.Context, campaignID uuid.UUID) error
+}
+
+type service struct {
+	repo     repository.GuardrailRepository
+	logRepo  repository.CampaignLogRepository
+	audit    audit.AuditService
+	notifier notification.Service
+}
+
+func NewService(
+	repo repository.GuardrailRepository,
+	logRepo repository.CampaignLogRepository,
+	auditSvc audit.AuditService,
+	notifier notification.Service,
+) Service {
+	return &service{repo: repo, logRepo: logRepo, audit: auditSvc, notifier: notifier}
+}
+
+// sweepLimit bounds one pass. Guardrails are opt-in per campaign, so this is
+// far above any realistic count; it exists so a runaway install cannot turn one
+// tick into an unbounded scan.
+const sweepLimit = 1000
+
+func (s *service) Sweep(ctx context.Context) (int, error) {
+	campaigns, err := s.repo.ListGuardrailCampaigns(ctx, sweepLimit)
+	if err != nil {
+		return 0, err
+	}
+
+	paused := 0
+	for _, c := range campaigns {
+		breach := Evaluate(c)
+		if breach == nil {
+			continue
+		}
+
+		tripped, terr := s.repo.TripGuardrail(ctx, c.ID, breach.Reason)
+		if terr != nil {
+			log.Warn().Err(terr).Str("campaign_id", c.ID.String()).Msg("guardrail: pause failed")
+			continue
+		}
+		if !tripped {
+			// Someone paused or completed the campaign between the read and
+			// the write. Nothing to announce.
+			continue
+		}
+
+		paused++
+		s.announce(ctx, c, breach)
+	}
+	return paused, nil
+}
+
+func (s *service) Clear(ctx context.Context, campaignID uuid.UUID) error {
+	return s.repo.ClearGuardrail(ctx, campaignID)
+}
+
+// announce records the pause everywhere a person might look for it: the
+// campaign's own activity log, the org audit trail (which also drives the
+// realtime spine, so every teammate's campaign list refreshes), and an in-app
+// notification for the members who can act on it.
+//
+// All three are best-effort. A campaign that is paused but whose notification
+// failed is still safely paused, which is the part that matters.
+func (s *service) announce(ctx context.Context, c repository.GuardrailCampaign, b *Breach) {
+	log.Info().
+		Str("campaign_id", c.ID.String()).
+		Str("rule", string(b.Rule)).
+		Float64("observed", b.Observed).
+		Float64("threshold", b.Threshold).
+		Int("sample", b.Sample).
+		Msg("guardrail: campaign paused")
+
+	if s.logRepo != nil {
+		_ = s.logRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+			CampaignID: c.ID,
+			EventType:  "guardrail_paused",
+			Message:    b.Reason,
+			Metadata: map[string]interface{}{
+				"rule":      string(b.Rule),
+				"observed":  b.Observed,
+				"threshold": b.Threshold,
+				"sample":    b.Sample,
+				"window":    c.WindowDays,
+			},
+		})
+	}
+
+	if c.OrganizationID == nil {
+		return
+	}
+	orgID := *c.OrganizationID
+	campaignID := c.ID
+
+	if s.audit != nil {
+		// A zero actor marks this as the platform acting rather than a member.
+		s.audit.LogAction(ctx, orgID, uuid.Nil,
+			models.AuditActionPause, models.AuditEntityCampaign, &campaignID, "", "",
+			map[string]string{"status": "active -> paused_guardrail"},
+			map[string]string{
+				"reason":    string(b.Rule),
+				"observed":  fmt.Sprintf("%.2f", b.Observed),
+				"threshold": fmt.Sprintf("%.2f", b.Threshold),
+				"sample":    fmt.Sprintf("%d", b.Sample),
+			})
+	}
+
+	if s.notifier != nil {
+		s.notifier.NotifyOrg(ctx, orgID, models.PermViewCampaigns, uuid.Nil,
+			models.NotifCampaignPaused,
+			fmt.Sprintf("%s was paused automatically", c.Name),
+			b.Reason,
+			"/app/campaigns/"+campaignID.String(),
+			map[string]any{
+				"campaign_id": campaignID.String(),
+				"rule":        string(b.Rule),
+				"observed":    b.Observed,
+				"threshold":   b.Threshold,
+				"sample":      b.Sample,
+			},
+			"guardrail:"+campaignID.String(),
+		)
+	}
+}

--- a/internal/app/notification/push.go
+++ b/internal/app/notification/push.go
@@ -223,6 +223,8 @@ func digestTitle(category models.NotificationCategory, n int) string {
 		return fmt.Sprintf("%d billing alerts", n)
 	case models.NotifTeamActivity:
 		return fmt.Sprintf("%d team updates", n)
+	case models.NotifCampaignPaused:
+		return fmt.Sprintf("%d campaigns paused automatically", n)
 	default:
 		return fmt.Sprintf("%d new notifications", n)
 	}

--- a/internal/infrastructure/db/migrations/000081_sending_behavior.down.sql
+++ b/internal/infrastructure/db/migrations/000081_sending_behavior.down.sql
@@ -1,0 +1,22 @@
+-- Postgres cannot drop a single enum value, so 'paused_guardrail' stays on
+-- campaign_status. Any campaign still parked in it is returned to a plain
+-- pause first, so nothing is left in a status the application no longer knows.
+UPDATE campaigns SET status = 'paused' WHERE status = 'paused_guardrail';
+
+DROP INDEX IF EXISTS idx_campaigns_guardrail_active;
+
+ALTER TABLE campaigns DROP CONSTRAINT IF EXISTS campaigns_guardrail_bounds;
+
+ALTER TABLE campaigns
+    DROP COLUMN IF EXISTS guardrail_enabled,
+    DROP COLUMN IF EXISTS guardrail_bounce_rate_max,
+    DROP COLUMN IF EXISTS guardrail_complaint_rate_max,
+    DROP COLUMN IF EXISTS guardrail_reply_rate_min,
+    DROP COLUMN IF EXISTS guardrail_min_sample,
+    DROP COLUMN IF EXISTS guardrail_window_days,
+    DROP COLUMN IF EXISTS guardrail_tripped_at,
+    DROP COLUMN IF EXISTS guardrail_reason;
+
+DROP INDEX IF EXISTS idx_email_account_daily_plan_date;
+DROP TABLE IF EXISTS email_account_daily_plan;
+DROP TABLE IF EXISTS email_account_behavior;

--- a/internal/infrastructure/db/migrations/000081_sending_behavior.up.sql
+++ b/internal/infrastructure/db/migrations/000081_sending_behavior.up.sql
@@ -1,0 +1,160 @@
+-- Human sending behaviour: per-mailbox randomisation of the things that make
+-- automated sending look automated.
+--
+-- Two tables, deliberately split:
+--
+--   email_account_behavior   the RANGES a mailbox is allowed to roll inside
+--                            (config the customer edits)
+--   email_account_daily_plan the values actually ROLLED for one local day
+--                            (server-owned, immutable once written)
+--
+-- The plan matters as much as the ranges. The scheduler recomputes a mailbox's
+-- next slot many times a day; if the daily cap, work start/end and lunch were
+-- re-rolled on every call the mailbox would jitter around instead of behaving
+-- like one person with one workday. Rolling once per (mailbox, local date) and
+-- persisting it makes the day stable, inspectable in the dashboard, and
+-- reproducible when someone asks "why did this send at 17:41".
+--
+-- Everything is expressed in MINUTES SINCE LOCAL MIDNIGHT, in the mailbox's own
+-- timezone (email_accounts.timezone). That is what makes the schedule
+-- timezone-based rather than server-clock-based: a London mailbox and a Denver
+-- mailbox on the same worker each keep their own 9-to-5.
+
+CREATE TABLE IF NOT EXISTS email_account_behavior (
+    email_account_id  uuid PRIMARY KEY REFERENCES email_accounts(id) ON DELETE CASCADE,
+
+    -- Off by default. An existing mailbox keeps its current fixed cap and gap
+    -- until someone opts it in, so this migration changes no sending behaviour
+    -- on its own.
+    enabled           boolean NOT NULL DEFAULT false,
+
+    -- Daily cold-send target, re-rolled each day inside [min, max]. Applied
+    -- via min() against the mailbox cold cap and the campaign daily limit, so
+    -- it can only ever LOWER volume — the mailbox-first safety invariant.
+    daily_limit_min   integer NOT NULL DEFAULT 30,
+    daily_limit_max   integer NOT NULL DEFAULT 45,
+
+    -- Per-hour cold-send ceiling, rolled once per day. Shapes burstiness
+    -- within the workday; the daily target still governs the total.
+    hourly_limit_min  integer NOT NULL DEFAULT 5,
+    hourly_limit_max  integer NOT NULL DEFAULT 9,
+
+    -- Spacing between two sends from this mailbox. Replaces the flat
+    -- min_wait_time while behaviour is enabled; each gap is drawn fresh so the
+    -- sequence of intervals is irregular, not a fixed metronome.
+    gap_min_seconds   integer NOT NULL DEFAULT 90,
+    gap_max_seconds   integer NOT NULL DEFAULT 420,
+
+    -- Workday boundaries. The start is drawn from [work_start_min,
+    -- work_start_max] and the end from [work_end_min, work_end_max], so the
+    -- mailbox does not begin and finish at the same clock minute every day.
+    -- Defaults: 09:03-09:27 and 17:18-17:56.
+    work_start_min    integer NOT NULL DEFAULT 543,
+    work_start_max    integer NOT NULL DEFAULT 567,
+    work_end_min      integer NOT NULL DEFAULT 1038,
+    work_end_max      integer NOT NULL DEFAULT 1076,
+
+    -- Lunch: a hole in the middle of the day with a drawn start and length.
+    -- lunch_latest is the latest the break may START, not end.
+    lunch_enabled     boolean NOT NULL DEFAULT true,
+    lunch_earliest    integer NOT NULL DEFAULT 720,
+    lunch_latest      integer NOT NULL DEFAULT 810,
+    lunch_min_minutes integer NOT NULL DEFAULT 30,
+    lunch_max_minutes integer NOT NULL DEFAULT 60,
+
+    -- Working days as a MONDAY-indexed bitmask (bit 0 = Monday .. bit 6 =
+    -- Sunday), matching campaigns.days and the dashboard's Monday-first grid.
+    -- Default 31 = Mon-Fri.
+    weekdays          smallint NOT NULL DEFAULT 31,
+
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    updated_at        timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT behavior_daily_range  CHECK (daily_limit_min  >= 1 AND daily_limit_max  <= 500  AND daily_limit_min  <= daily_limit_max),
+    CONSTRAINT behavior_hourly_range CHECK (hourly_limit_min >= 1 AND hourly_limit_max <= 200  AND hourly_limit_min <= hourly_limit_max),
+    CONSTRAINT behavior_gap_range    CHECK (gap_min_seconds  >= 30 AND gap_max_seconds <= 86400 AND gap_min_seconds <= gap_max_seconds),
+    CONSTRAINT behavior_start_range  CHECK (work_start_min   >= 0 AND work_start_max <= 1439 AND work_start_min <= work_start_max),
+    CONSTRAINT behavior_end_range    CHECK (work_end_min     >= 0 AND work_end_max   <= 1439 AND work_end_min   <= work_end_max),
+    -- The latest possible start must still leave a usable workday.
+    CONSTRAINT behavior_day_order    CHECK (work_start_max < work_end_min),
+    CONSTRAINT behavior_lunch_window CHECK (lunch_earliest >= 0 AND lunch_latest <= 1439 AND lunch_earliest <= lunch_latest),
+    CONSTRAINT behavior_lunch_length CHECK (lunch_min_minutes >= 0 AND lunch_max_minutes <= 240 AND lunch_min_minutes <= lunch_max_minutes),
+    CONSTRAINT behavior_weekdays     CHECK (weekdays >= 0 AND weekdays <= 127)
+);
+
+-- One rolled workday per mailbox. Written once, then read; the scheduler never
+-- updates a plan in place, so a day's shape cannot drift under it.
+CREATE TABLE IF NOT EXISTS email_account_daily_plan (
+    email_account_id   uuid NOT NULL REFERENCES email_accounts(id) ON DELETE CASCADE,
+    -- The LOCAL calendar date in `timezone`, not a UTC date.
+    plan_date          date NOT NULL,
+    timezone           text NOT NULL,
+
+    -- False on a non-working weekday: the row still exists so the dashboard can
+    -- say "not a sending day" instead of showing nothing.
+    is_working_day     boolean NOT NULL,
+
+    daily_limit        integer NOT NULL,
+    hourly_limit       integer NOT NULL,
+    work_start_minute  integer NOT NULL,
+    work_end_minute    integer NOT NULL,
+    -- NULL when this day has no break.
+    lunch_start_minute integer,
+    lunch_end_minute   integer,
+    gap_min_seconds    integer NOT NULL,
+    gap_max_seconds    integer NOT NULL,
+
+    created_at         timestamptz NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (email_account_id, plan_date),
+    CONSTRAINT plan_lunch_pair CHECK (
+        (lunch_start_minute IS NULL AND lunch_end_minute IS NULL)
+        OR (lunch_start_minute IS NOT NULL AND lunch_end_minute IS NOT NULL
+            AND lunch_start_minute < lunch_end_minute)
+    )
+);
+
+-- The retention sweep deletes plans older than a couple of weeks; this keeps
+-- that scan from touching the whole table.
+CREATE INDEX IF NOT EXISTS idx_email_account_daily_plan_date
+    ON email_account_daily_plan (plan_date);
+
+-- Campaign auto-pause guardrails. Rates are evaluated over a rolling window on
+-- campaign_contact_progress and the campaign is paused the moment a band is
+-- breached, rather than waiting for a mailbox provider to react first.
+ALTER TABLE campaigns
+    ADD COLUMN IF NOT EXISTS guardrail_enabled boolean NOT NULL DEFAULT false,
+    -- Percent. Bounce rate at or above this pauses the campaign. 0 disables
+    -- the rule. Default 5% is Amazon SES's review threshold.
+    ADD COLUMN IF NOT EXISTS guardrail_bounce_rate_max numeric(5,2) NOT NULL DEFAULT 5.00,
+    -- Percent. Recipient spam complaints at or above this pause the campaign.
+    -- Default 0.10% is Google's "never reach 0.30%" band, one third in.
+    ADD COLUMN IF NOT EXISTS guardrail_complaint_rate_max numeric(5,2) NOT NULL DEFAULT 0.10,
+    -- Percent. Reply rate BELOW this pauses the campaign: a campaign at volume
+    -- that nobody answers is spending reputation for nothing. 0 disables it,
+    -- which is the default because a floor needs a deliberate choice.
+    ADD COLUMN IF NOT EXISTS guardrail_reply_rate_min numeric(5,2) NOT NULL DEFAULT 0,
+    -- No rule fires below this many sends in the window. A single bounce out of
+    -- four sends is not a 25% bounce rate worth pausing a campaign over.
+    ADD COLUMN IF NOT EXISTS guardrail_min_sample integer NOT NULL DEFAULT 50,
+    -- Rolling window in days. 0 means the campaign's whole history.
+    ADD COLUMN IF NOT EXISTS guardrail_window_days integer NOT NULL DEFAULT 7,
+    ADD COLUMN IF NOT EXISTS guardrail_tripped_at timestamptz,
+    ADD COLUMN IF NOT EXISTS guardrail_reason text NOT NULL DEFAULT '';
+
+ALTER TABLE campaigns
+    ADD CONSTRAINT campaigns_guardrail_bounds CHECK (
+        guardrail_bounce_rate_max    >= 0 AND guardrail_bounce_rate_max    <= 100 AND
+        guardrail_complaint_rate_max >= 0 AND guardrail_complaint_rate_max <= 100 AND
+        guardrail_reply_rate_min     >= 0 AND guardrail_reply_rate_min     <= 100 AND
+        guardrail_min_sample         >= 1 AND guardrail_min_sample         <= 100000 AND
+        guardrail_window_days        >= 0 AND guardrail_window_days        <= 365
+    );
+
+-- The sweep scans active campaigns with guardrails on.
+CREATE INDEX IF NOT EXISTS idx_campaigns_guardrail_active
+    ON campaigns (id) WHERE guardrail_enabled;
+
+-- New terminal-ish pause reason, so "paused because bounces spiked" is
+-- distinguishable from a human pause and can be resumed explicitly.
+ALTER TYPE public.campaign_status ADD VALUE IF NOT EXISTS 'paused_guardrail';

--- a/internal/jobs/guardrail.go
+++ b/internal/jobs/guardrail.go
@@ -1,0 +1,92 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/app/guardrail"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// GuardrailJob evaluates every active campaign that has auto-pause guardrails
+// switched on and pauses the ones outside their band.
+//
+// It also sweeps up expired daily sending plans, which is a cheap piece of
+// housekeeping on the same cadence: plans are only useful for the day they
+// describe plus a short tail for the dashboard's "yesterday" view.
+type GuardrailJob struct {
+	svc          guardrail.Service
+	behaviorRepo repository.BehaviorRepository
+}
+
+func NewGuardrailJob(svc guardrail.Service, behaviorRepo repository.BehaviorRepository) *GuardrailJob {
+	return &GuardrailJob{svc: svc, behaviorRepo: behaviorRepo}
+}
+
+// planRetention is how long a rolled workday is kept after its date. Long
+// enough to explain a send someone is looking at this week, short enough that
+// the table stays small at any fleet size.
+const planRetention = 14 * 24 * time.Hour
+
+func (j *GuardrailJob) Run(ctx context.Context) {
+	if j.svc != nil {
+		paused, err := j.svc.Sweep(ctx)
+		if err != nil {
+			sentry.CaptureException(err)
+		} else if paused > 0 {
+			log.Info().Int("paused", paused).Msg("guardrail sweep paused campaigns")
+		}
+	}
+
+	if j.behaviorRepo != nil {
+		if _, err := j.behaviorRepo.PurgePlansBefore(ctx, time.Now().Add(-planRetention)); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+}
+
+// GuardrailScheduler runs the job on a fixed interval.
+type GuardrailScheduler struct {
+	job      *GuardrailJob
+	interval time.Duration
+	stopCh   chan struct{}
+}
+
+// NewGuardrailScheduler builds a scheduler. Fifteen minutes is the balance
+// point: a campaign sending at the platform's per-mailbox defaults cannot do
+// much damage inside one window, and evaluating more often would mostly re-read
+// the same counts.
+func NewGuardrailScheduler(job *GuardrailJob, interval time.Duration) *GuardrailScheduler {
+	return &GuardrailScheduler{
+		job:      job,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start runs Run() on every tick until ctx is cancelled or Stop() is called.
+func (s *GuardrailScheduler) Start(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	s.job.Run(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			s.job.Run(ctx)
+		case <-s.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop halts the scheduler.
+func (s *GuardrailScheduler) Stop() {
+	close(s.stopCh)
+}

--- a/internal/models/behavior.go
+++ b/internal/models/behavior.go
@@ -1,0 +1,356 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Human sending behaviour. A mailbox that sends exactly 40 emails a day, every
+// day, starting at 09:00:00 and spaced exactly 600s apart is describing itself
+// as a machine in its own Received headers. These settings give each mailbox a
+// range to roll inside, and the roll happens once per local day so the mailbox
+// behaves like one person having one workday rather than a process re-deciding
+// its schedule every few minutes.
+//
+// Every minute-of-day value below is minutes since LOCAL midnight in the
+// mailbox's own timezone (email_accounts.timezone).
+const (
+	BehaviorDailyLimitMinDefault = 30
+	BehaviorDailyLimitMaxDefault = 45
+	BehaviorDailyLimitFloor      = 1
+	BehaviorDailyLimitCeiling    = 500
+
+	// Hourly ceiling for cold sends. The default band is deliberately wider
+	// than daily_limit / working-hours so the hourly cap shapes bursts without
+	// making the daily target unreachable.
+	BehaviorHourlyLimitMinDefault = 5
+	BehaviorHourlyLimitMaxDefault = 9
+	BehaviorHourlyLimitFloor      = 1
+	BehaviorHourlyLimitCeiling    = 200
+
+	BehaviorGapMinSecondsDefault = 90
+	BehaviorGapMaxSecondsDefault = 420
+	BehaviorGapFloor             = 30
+	BehaviorGapCeiling           = 86400
+
+	// 09:03-09:27 and 17:18-17:56.
+	BehaviorWorkStartMinDefault = 543
+	BehaviorWorkStartMaxDefault = 567
+	BehaviorWorkEndMinDefault   = 1038
+	BehaviorWorkEndMaxDefault   = 1076
+
+	// Lunch starts somewhere in 12:00-13:30 and runs 30-60 minutes.
+	BehaviorLunchEarliestDefault   = 720
+	BehaviorLunchLatestDefault     = 810
+	BehaviorLunchMinMinutesDefault = 30
+	BehaviorLunchMaxMinutesDefault = 60
+	BehaviorLunchMaxMinutesCeiling = 240
+
+	// Monday-indexed bitmask, bit 0 = Monday. 31 = Mon-Fri.
+	BehaviorWeekdaysDefault = 31
+	BehaviorWeekdaysAll     = 127
+
+	// MinutesPerDay is the exclusive upper bound for a minute-of-day value.
+	MinutesPerDay = 1440
+)
+
+// SendingBehavior is one mailbox's behaviour profile: the ranges, not the
+// rolled values. Disabled profiles are still stored so a customer can tune the
+// ranges before switching it on.
+type SendingBehavior struct {
+	EmailAccountID uuid.UUID `json:"email_account_id"`
+	Enabled        bool      `json:"enabled"`
+
+	DailyLimitMin int `json:"daily_limit_min"`
+	DailyLimitMax int `json:"daily_limit_max"`
+
+	HourlyLimitMin int `json:"hourly_limit_min"`
+	HourlyLimitMax int `json:"hourly_limit_max"`
+
+	GapMinSeconds int `json:"gap_min_seconds"`
+	GapMaxSeconds int `json:"gap_max_seconds"`
+
+	WorkStartMin int `json:"work_start_min"`
+	WorkStartMax int `json:"work_start_max"`
+	WorkEndMin   int `json:"work_end_min"`
+	WorkEndMax   int `json:"work_end_max"`
+
+	LunchEnabled    bool `json:"lunch_enabled"`
+	LunchEarliest   int  `json:"lunch_earliest"`
+	LunchLatest     int  `json:"lunch_latest"`
+	LunchMinMinutes int  `json:"lunch_min_minutes"`
+	LunchMaxMinutes int  `json:"lunch_max_minutes"`
+
+	// Monday-indexed bitmask (bit 0 = Monday .. bit 6 = Sunday), matching
+	// campaigns.days and the dashboard's Monday-first week grid.
+	Weekdays int `json:"weekdays"`
+
+	// Timezone is a read-only echo of the mailbox's timezone, so a client
+	// rendering the profile does not have to fetch the mailbox as well.
+	Timezone string `json:"timezone,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// DefaultSendingBehavior is the profile a mailbox gets before anyone edits it:
+// switched off, with ranges that describe an ordinary weekday sender.
+func DefaultSendingBehavior(accountID uuid.UUID) SendingBehavior {
+	return SendingBehavior{
+		EmailAccountID:  accountID,
+		Enabled:         false,
+		DailyLimitMin:   BehaviorDailyLimitMinDefault,
+		DailyLimitMax:   BehaviorDailyLimitMaxDefault,
+		HourlyLimitMin:  BehaviorHourlyLimitMinDefault,
+		HourlyLimitMax:  BehaviorHourlyLimitMaxDefault,
+		GapMinSeconds:   BehaviorGapMinSecondsDefault,
+		GapMaxSeconds:   BehaviorGapMaxSecondsDefault,
+		WorkStartMin:    BehaviorWorkStartMinDefault,
+		WorkStartMax:    BehaviorWorkStartMaxDefault,
+		WorkEndMin:      BehaviorWorkEndMinDefault,
+		WorkEndMax:      BehaviorWorkEndMaxDefault,
+		LunchEnabled:    true,
+		LunchEarliest:   BehaviorLunchEarliestDefault,
+		LunchLatest:     BehaviorLunchLatestDefault,
+		LunchMinMinutes: BehaviorLunchMinMinutesDefault,
+		LunchMaxMinutes: BehaviorLunchMaxMinutesDefault,
+		Weekdays:        BehaviorWeekdaysDefault,
+	}
+}
+
+// WorksOn reports whether the profile sends on the given weekday. The stored
+// mask is Monday-indexed while time.Weekday is Sunday-indexed, so the mapping
+// is explicit here and nowhere else.
+func (b SendingBehavior) WorksOn(wd time.Weekday) bool {
+	return b.Weekdays&(1<<weekdayBit(wd)) != 0
+}
+
+// weekdayBit maps time.Weekday (Sun=0) onto the Monday-indexed bit position
+// used by every weekday mask in this codebase.
+func weekdayBit(wd time.Weekday) uint {
+	return uint((int(wd) + 6) % 7)
+}
+
+// UpdateSendingBehavior is the PUT body. Every field is optional; omitted
+// fields keep their stored value, so a client can toggle `enabled` without
+// resending the whole profile.
+type UpdateSendingBehavior struct {
+	Enabled *bool `json:"enabled"`
+
+	DailyLimitMin *int `json:"daily_limit_min"`
+	DailyLimitMax *int `json:"daily_limit_max"`
+
+	HourlyLimitMin *int `json:"hourly_limit_min"`
+	HourlyLimitMax *int `json:"hourly_limit_max"`
+
+	GapMinSeconds *int `json:"gap_min_seconds"`
+	GapMaxSeconds *int `json:"gap_max_seconds"`
+
+	WorkStartMin *int `json:"work_start_min"`
+	WorkStartMax *int `json:"work_start_max"`
+	WorkEndMin   *int `json:"work_end_min"`
+	WorkEndMax   *int `json:"work_end_max"`
+
+	LunchEnabled    *bool `json:"lunch_enabled"`
+	LunchEarliest   *int  `json:"lunch_earliest"`
+	LunchLatest     *int  `json:"lunch_latest"`
+	LunchMinMinutes *int  `json:"lunch_min_minutes"`
+	LunchMaxMinutes *int  `json:"lunch_max_minutes"`
+
+	Weekdays *int `json:"weekdays"`
+}
+
+// Apply overlays the patch onto a profile. It does not validate; call
+// Validate on the result.
+func (u UpdateSendingBehavior) Apply(b SendingBehavior) SendingBehavior {
+	setInt := func(dst *int, src *int) {
+		if src != nil {
+			*dst = *src
+		}
+	}
+	if u.Enabled != nil {
+		b.Enabled = *u.Enabled
+	}
+	if u.LunchEnabled != nil {
+		b.LunchEnabled = *u.LunchEnabled
+	}
+	setInt(&b.DailyLimitMin, u.DailyLimitMin)
+	setInt(&b.DailyLimitMax, u.DailyLimitMax)
+	setInt(&b.HourlyLimitMin, u.HourlyLimitMin)
+	setInt(&b.HourlyLimitMax, u.HourlyLimitMax)
+	setInt(&b.GapMinSeconds, u.GapMinSeconds)
+	setInt(&b.GapMaxSeconds, u.GapMaxSeconds)
+	setInt(&b.WorkStartMin, u.WorkStartMin)
+	setInt(&b.WorkStartMax, u.WorkStartMax)
+	setInt(&b.WorkEndMin, u.WorkEndMin)
+	setInt(&b.WorkEndMax, u.WorkEndMax)
+	setInt(&b.LunchEarliest, u.LunchEarliest)
+	setInt(&b.LunchLatest, u.LunchLatest)
+	setInt(&b.LunchMinMinutes, u.LunchMinMinutes)
+	setInt(&b.LunchMaxMinutes, u.LunchMaxMinutes)
+	setInt(&b.Weekdays, u.Weekdays)
+	return b
+}
+
+// BehaviorValidationError names the field that failed and why, so the API can
+// return something more useful than "invalid body".
+type BehaviorValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func (e *BehaviorValidationError) Error() string { return e.Field + ": " + e.Message }
+
+// Validate mirrors the CHECK constraints on email_account_behavior, plus the
+// cross-field rules the database expresses as one opaque constraint. The point
+// is that a bad profile is rejected with a field name at the API boundary, not
+// as a 500 from a constraint violation.
+func (b SendingBehavior) Validate() error {
+	fail := func(field, msg string) error {
+		return &BehaviorValidationError{Field: field, Message: msg}
+	}
+
+	if b.DailyLimitMin < BehaviorDailyLimitFloor || b.DailyLimitMax > BehaviorDailyLimitCeiling {
+		return fail("daily_limit", "must be between 1 and 500 emails per day")
+	}
+	if b.DailyLimitMin > b.DailyLimitMax {
+		return fail("daily_limit", "minimum cannot be above maximum")
+	}
+
+	if b.HourlyLimitMin < BehaviorHourlyLimitFloor || b.HourlyLimitMax > BehaviorHourlyLimitCeiling {
+		return fail("hourly_limit", "must be between 1 and 200 emails per hour")
+	}
+	if b.HourlyLimitMin > b.HourlyLimitMax {
+		return fail("hourly_limit", "minimum cannot be above maximum")
+	}
+
+	if b.GapMinSeconds < BehaviorGapFloor || b.GapMaxSeconds > BehaviorGapCeiling {
+		return fail("gap_seconds", "must be between 30 seconds and 24 hours")
+	}
+	if b.GapMinSeconds > b.GapMaxSeconds {
+		return fail("gap_seconds", "minimum cannot be above maximum")
+	}
+
+	if b.WorkStartMin < 0 || b.WorkStartMax >= MinutesPerDay || b.WorkStartMin > b.WorkStartMax {
+		return fail("work_start", "must be a valid time range within the day")
+	}
+	if b.WorkEndMin < 0 || b.WorkEndMax >= MinutesPerDay || b.WorkEndMin > b.WorkEndMax {
+		return fail("work_end", "must be a valid time range within the day")
+	}
+	// The latest start must still precede the earliest end, or some rolls
+	// would produce a workday that ends before it begins.
+	if b.WorkStartMax >= b.WorkEndMin {
+		return fail("work_end", "the workday must end after the latest possible start")
+	}
+
+	if b.LunchEarliest < 0 || b.LunchLatest >= MinutesPerDay || b.LunchEarliest > b.LunchLatest {
+		return fail("lunch_window", "must be a valid time range within the day")
+	}
+	if b.LunchMinMinutes < 0 || b.LunchMaxMinutes > BehaviorLunchMaxMinutesCeiling || b.LunchMinMinutes > b.LunchMaxMinutes {
+		return fail("lunch_length", "must be between 0 and 240 minutes")
+	}
+	if b.LunchEnabled {
+		// A break outside the workday is silently ignored by the planner,
+		// which reads as "lunch is on but nothing happens". Reject it instead.
+		if b.LunchEarliest < b.WorkStartMax || b.LunchLatest+b.LunchMaxMinutes > b.WorkEndMin {
+			return fail("lunch_window", "the break must fit inside the shortest possible workday")
+		}
+	}
+
+	if b.Weekdays < 0 || b.Weekdays > BehaviorWeekdaysAll {
+		return fail("weekdays", "must be a bitmask of Monday..Sunday")
+	}
+	if b.Enabled && b.Weekdays == 0 {
+		return fail("weekdays", "pick at least one sending day")
+	}
+
+	return nil
+}
+
+// DailyPlan is the workday a mailbox actually rolled for one local date. It is
+// written once and never updated, so every scheduling pass through the day
+// reads the same numbers.
+type DailyPlan struct {
+	EmailAccountID uuid.UUID `json:"email_account_id"`
+	// PlanDate is the local calendar date in Timezone, as YYYY-MM-DD.
+	PlanDate string `json:"plan_date"`
+	Timezone string `json:"timezone"`
+
+	IsWorkingDay bool `json:"is_working_day"`
+
+	DailyLimit       int  `json:"daily_limit"`
+	HourlyLimit      int  `json:"hourly_limit"`
+	WorkStartMinute  int  `json:"work_start_minute"`
+	WorkEndMinute    int  `json:"work_end_minute"`
+	LunchStartMinute *int `json:"lunch_start_minute"`
+	LunchEndMinute   *int `json:"lunch_end_minute"`
+	GapMinSeconds    int  `json:"gap_min_seconds"`
+	GapMaxSeconds    int  `json:"gap_max_seconds"`
+
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// HasLunch reports whether this day carries a break.
+func (p DailyPlan) HasLunch() bool {
+	return p.LunchStartMinute != nil && p.LunchEndMinute != nil
+}
+
+// WorkingMinutes is the length of the day's sending window with the break
+// removed. Used to pace sends across the day.
+func (p DailyPlan) WorkingMinutes() int {
+	if !p.IsWorkingDay {
+		return 0
+	}
+	total := p.WorkEndMinute - p.WorkStartMinute
+	if p.HasLunch() {
+		total -= *p.LunchEndMinute - *p.LunchStartMinute
+	}
+	if total < 0 {
+		return 0
+	}
+	return total
+}
+
+// Contains reports whether a minute-of-day falls inside the working window and
+// outside the break.
+func (p DailyPlan) Contains(minute int) bool {
+	if !p.IsWorkingDay || minute < p.WorkStartMinute || minute >= p.WorkEndMinute {
+		return false
+	}
+	if p.HasLunch() && minute >= *p.LunchStartMinute && minute < *p.LunchEndMinute {
+		return false
+	}
+	return true
+}
+
+// NextOpenMinute returns the first sending minute at or after `minute` within
+// this day, and false when the day is over (or is not a working day). A minute
+// inside the break jumps to the end of the break.
+func (p DailyPlan) NextOpenMinute(minute int) (int, bool) {
+	if !p.IsWorkingDay {
+		return 0, false
+	}
+	if minute < p.WorkStartMinute {
+		minute = p.WorkStartMinute
+	}
+	if p.HasLunch() && minute >= *p.LunchStartMinute && minute < *p.LunchEndMinute {
+		minute = *p.LunchEndMinute
+	}
+	if minute >= p.WorkEndMinute {
+		return 0, false
+	}
+	return minute, true
+}
+
+// DailyPlanView is the plan plus the derived numbers the dashboard shows, so
+// the client never re-implements the window maths.
+type DailyPlanView struct {
+	DailyPlan
+	// SentToday is completed cold sends from this mailbox on this local date.
+	SentToday int `json:"sent_today"`
+	// RemainingToday is what the plan still allows, floored at zero.
+	RemainingToday int `json:"remaining_today"`
+	// Behavior is the profile the plan was rolled from.
+	Behavior SendingBehavior `json:"behavior"`
+}

--- a/internal/models/campaign.go
+++ b/internal/models/campaign.go
@@ -148,6 +148,23 @@ type Campaign struct {
 	MaxNewLeadsPerDay  int  `json:"max_new_leads_per_day"`
 	PrioritizeNewLeads bool `json:"prioritize_new_leads"`
 
+	// Auto-pause guardrails. Rates are evaluated over a rolling window and the
+	// campaign is paused the moment a band is breached, rather than waiting for
+	// a mailbox provider to react first. A rate threshold of 0 disables that
+	// rule; GuardrailMinSample keeps a small sample from tripping anything.
+	//
+	// Bounce and complaint rates are CEILINGS (pause when at or above); the
+	// reply rate is a FLOOR (pause when below), because a campaign at volume
+	// that nobody answers is spending sender reputation for nothing.
+	GuardrailEnabled          bool       `json:"guardrail_enabled"`
+	GuardrailBounceRateMax    float64    `json:"guardrail_bounce_rate_max"`
+	GuardrailComplaintRateMax float64    `json:"guardrail_complaint_rate_max"`
+	GuardrailReplyRateMin     float64    `json:"guardrail_reply_rate_min"`
+	GuardrailMinSample        int        `json:"guardrail_min_sample"`
+	GuardrailWindowDays       int        `json:"guardrail_window_days"`
+	GuardrailTrippedAt        *time.Time `json:"guardrail_tripped_at,omitempty"`
+	GuardrailReason           string     `json:"guardrail_reason,omitempty"`
+
 	// Campaign-scoped tracking-domain override. Honored only when verified;
 	// otherwise falls back to the mailbox/default domain.
 	TrackingDomain           string     `json:"tracking_domain"`
@@ -249,6 +266,16 @@ type UpdateCampaign struct {
 	MaxNewLeadsPerDay  *int    `json:"max_new_leads_per_day,omitempty"`
 	PrioritizeNewLeads *bool   `json:"prioritize_new_leads,omitempty"`
 	TrackingDomain     *string `json:"tracking_domain,omitempty"`
+
+	// Auto-pause guardrails. GuardrailTrippedAt/Reason are server-owned and
+	// are cleared when the campaign is started again, so they are not settable
+	// here.
+	GuardrailEnabled          *bool    `json:"guardrail_enabled,omitempty"`
+	GuardrailBounceRateMax    *float64 `json:"guardrail_bounce_rate_max,omitempty"`
+	GuardrailComplaintRateMax *float64 `json:"guardrail_complaint_rate_max,omitempty"`
+	GuardrailReplyRateMin     *float64 `json:"guardrail_reply_rate_min,omitempty"`
+	GuardrailMinSample        *int     `json:"guardrail_min_sample,omitempty"`
+	GuardrailWindowDays       *int     `json:"guardrail_window_days,omitempty"`
 }
 
 // CreateCampaign is the payload accepted by POST /campaigns. Name is required;

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -20,6 +20,10 @@ const (
 	NotifSecuritySignIn  NotificationCategory = "security_new_signin"
 	NotifBillingAlert    NotificationCategory = "billing_alert"
 	NotifTeamActivity    NotificationCategory = "team_activity"
+	// NotifCampaignPaused fires when the platform pauses a campaign on its
+	// own — today, when an auto-pause guardrail band is breached. Rare and
+	// always actionable, so it defaults on with email.
+	NotifCampaignPaused NotificationCategory = "campaign_paused"
 )
 
 // ChannelPrefs is the per-category delivery toggles: in-app feed, account
@@ -48,6 +52,7 @@ type NotificationPreferences struct {
 	SecuritySignIn  CategoryPref `json:"security_new_signin"`
 	BillingAlert    CategoryPref `json:"billing_alert"`
 	TeamActivity    CategoryPref `json:"team_activity"`
+	CampaignPaused  CategoryPref `json:"campaign_paused"`
 
 	// EmailDigestMinutes is the email-channel bundling window: pending
 	// notification emails hold this long, then flush as one email. Bounded
@@ -68,6 +73,9 @@ func DefaultNotificationPreferences() NotificationPreferences {
 	// Billing defaults to email on: rare, and a paused workspace must reach
 	// whoever can fix it even when nobody is watching the dashboard.
 	billing := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true, Email: true}}
+	// A campaign the platform stopped by itself has to reach whoever can
+	// restart it, so this one emails by default too.
+	campaignPaused := CategoryPref{Enabled: true, Channels: ChannelPrefs{InApp: true, Push: true, Email: true}}
 	return NotificationPreferences{
 		InboundReply:       off,
 		InboundOOO:         off,
@@ -77,6 +85,7 @@ func DefaultNotificationPreferences() NotificationPreferences {
 		SecuritySignIn:     on,
 		BillingAlert:       billing,
 		TeamActivity:       on,
+		CampaignPaused:     campaignPaused,
 		EmailDigestMinutes: 30,
 	}
 }
@@ -100,6 +109,8 @@ func (p NotificationPreferences) CategoryPref(c NotificationCategory) CategoryPr
 		return p.BillingAlert
 	case NotifTeamActivity:
 		return p.TeamActivity
+	case NotifCampaignPaused:
+		return p.CampaignPaused
 	default:
 		return CategoryPref{}
 	}

--- a/internal/repository/pg_behavior.go
+++ b/internal/repository/pg_behavior.go
@@ -1,0 +1,231 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// BehaviorRepository stores each mailbox's sending-behaviour ranges and the
+// workday it rolled for a given local date, and answers the volume questions
+// those plans are enforced against.
+type BehaviorRepository interface {
+	// GetBehavior returns the mailbox's profile, or nil when it has never been
+	// configured. Callers substitute models.DefaultSendingBehavior.
+	GetBehavior(ctx context.Context, accountID uuid.UUID) (*models.SendingBehavior, error)
+	// GetBehaviors is the batch read the campaign scheduler uses, so resolving
+	// a campaign's whole sender pool costs one query rather than one per
+	// mailbox. Mailboxes with no row are simply absent from the map.
+	GetBehaviors(ctx context.Context, accountIDs []uuid.UUID) (map[uuid.UUID]models.SendingBehavior, error)
+	UpsertBehavior(ctx context.Context, b *models.SendingBehavior) (*models.SendingBehavior, error)
+	DeleteBehavior(ctx context.Context, accountID uuid.UUID) error
+
+	// GetPlan returns the stored plan for a local date (YYYY-MM-DD), or nil.
+	GetPlan(ctx context.Context, accountID uuid.UUID, planDate string) (*models.DailyPlan, error)
+	// EnsurePlan writes the rolled plan if this mailbox has none for that date
+	// and returns whatever is stored afterwards. Concurrent writers are safe:
+	// the roll is deterministic, so the loser of the race reads back the same
+	// numbers it computed.
+	EnsurePlan(ctx context.Context, plan models.DailyPlan) (*models.DailyPlan, error)
+	// PurgePlansBefore drops plans older than a cutoff date.
+	PurgePlansBefore(ctx context.Context, before time.Time) (int64, error)
+
+	// CountSendsBetween counts a mailbox's sends in a half-open time range.
+	// Pending and active tasks count alongside completed ones: a slot that is
+	// already booked has consumed the budget even though the mail has not gone
+	// out yet, and without that the scheduler would happily stack a day's worth
+	// of tasks into one hour.
+	CountSendsBetween(ctx context.Context, accountID uuid.UUID, taskType string, from, to time.Time) (int, error)
+}
+
+type behaviorRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewBehaviorRepository(db *pgxpool.Pool) BehaviorRepository {
+	return &behaviorRepository{db: db}
+}
+
+const behaviorColumns = `
+	email_account_id, enabled,
+	daily_limit_min, daily_limit_max,
+	hourly_limit_min, hourly_limit_max,
+	gap_min_seconds, gap_max_seconds,
+	work_start_min, work_start_max, work_end_min, work_end_max,
+	lunch_enabled, lunch_earliest, lunch_latest, lunch_min_minutes, lunch_max_minutes,
+	weekdays, created_at, updated_at`
+
+func scanBehavior(row pgx.Row) (*models.SendingBehavior, error) {
+	var b models.SendingBehavior
+	err := row.Scan(
+		&b.EmailAccountID, &b.Enabled,
+		&b.DailyLimitMin, &b.DailyLimitMax,
+		&b.HourlyLimitMin, &b.HourlyLimitMax,
+		&b.GapMinSeconds, &b.GapMaxSeconds,
+		&b.WorkStartMin, &b.WorkStartMax, &b.WorkEndMin, &b.WorkEndMax,
+		&b.LunchEnabled, &b.LunchEarliest, &b.LunchLatest, &b.LunchMinMinutes, &b.LunchMaxMinutes,
+		&b.Weekdays, &b.CreatedAt, &b.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &b, nil
+}
+
+func (r *behaviorRepository) GetBehavior(ctx context.Context, accountID uuid.UUID) (*models.SendingBehavior, error) {
+	return scanBehavior(r.db.QueryRow(ctx,
+		`SELECT `+behaviorColumns+` FROM email_account_behavior WHERE email_account_id = $1`, accountID))
+}
+
+func (r *behaviorRepository) GetBehaviors(ctx context.Context, accountIDs []uuid.UUID) (map[uuid.UUID]models.SendingBehavior, error) {
+	out := map[uuid.UUID]models.SendingBehavior{}
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+	rows, err := r.db.Query(ctx,
+		`SELECT `+behaviorColumns+` FROM email_account_behavior WHERE email_account_id = ANY($1)`, accountIDs)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		b, serr := scanBehavior(rows)
+		if serr != nil {
+			return nil, serr
+		}
+		if b != nil {
+			out[b.EmailAccountID] = *b
+		}
+	}
+	return out, rows.Err()
+}
+
+func (r *behaviorRepository) UpsertBehavior(ctx context.Context, b *models.SendingBehavior) (*models.SendingBehavior, error) {
+	query := `
+		INSERT INTO email_account_behavior (
+			email_account_id, enabled,
+			daily_limit_min, daily_limit_max,
+			hourly_limit_min, hourly_limit_max,
+			gap_min_seconds, gap_max_seconds,
+			work_start_min, work_start_max, work_end_min, work_end_max,
+			lunch_enabled, lunch_earliest, lunch_latest, lunch_min_minutes, lunch_max_minutes,
+			weekdays
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)
+		ON CONFLICT (email_account_id) DO UPDATE SET
+			enabled = EXCLUDED.enabled,
+			daily_limit_min = EXCLUDED.daily_limit_min,
+			daily_limit_max = EXCLUDED.daily_limit_max,
+			hourly_limit_min = EXCLUDED.hourly_limit_min,
+			hourly_limit_max = EXCLUDED.hourly_limit_max,
+			gap_min_seconds = EXCLUDED.gap_min_seconds,
+			gap_max_seconds = EXCLUDED.gap_max_seconds,
+			work_start_min = EXCLUDED.work_start_min,
+			work_start_max = EXCLUDED.work_start_max,
+			work_end_min = EXCLUDED.work_end_min,
+			work_end_max = EXCLUDED.work_end_max,
+			lunch_enabled = EXCLUDED.lunch_enabled,
+			lunch_earliest = EXCLUDED.lunch_earliest,
+			lunch_latest = EXCLUDED.lunch_latest,
+			lunch_min_minutes = EXCLUDED.lunch_min_minutes,
+			lunch_max_minutes = EXCLUDED.lunch_max_minutes,
+			weekdays = EXCLUDED.weekdays,
+			updated_at = now()
+		RETURNING ` + behaviorColumns
+
+	return scanBehavior(r.db.QueryRow(ctx, query,
+		b.EmailAccountID, b.Enabled,
+		b.DailyLimitMin, b.DailyLimitMax,
+		b.HourlyLimitMin, b.HourlyLimitMax,
+		b.GapMinSeconds, b.GapMaxSeconds,
+		b.WorkStartMin, b.WorkStartMax, b.WorkEndMin, b.WorkEndMax,
+		b.LunchEnabled, b.LunchEarliest, b.LunchLatest, b.LunchMinMinutes, b.LunchMaxMinutes,
+		b.Weekdays,
+	))
+}
+
+func (r *behaviorRepository) DeleteBehavior(ctx context.Context, accountID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `DELETE FROM email_account_behavior WHERE email_account_id = $1`, accountID)
+	return err
+}
+
+const planColumns = `
+	email_account_id, plan_date::text, timezone, is_working_day,
+	daily_limit, hourly_limit, work_start_minute, work_end_minute,
+	lunch_start_minute, lunch_end_minute, gap_min_seconds, gap_max_seconds, created_at`
+
+func scanPlan(row pgx.Row) (*models.DailyPlan, error) {
+	var p models.DailyPlan
+	err := row.Scan(
+		&p.EmailAccountID, &p.PlanDate, &p.Timezone, &p.IsWorkingDay,
+		&p.DailyLimit, &p.HourlyLimit, &p.WorkStartMinute, &p.WorkEndMinute,
+		&p.LunchStartMinute, &p.LunchEndMinute, &p.GapMinSeconds, &p.GapMaxSeconds, &p.CreatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (r *behaviorRepository) GetPlan(ctx context.Context, accountID uuid.UUID, planDate string) (*models.DailyPlan, error) {
+	return scanPlan(r.db.QueryRow(ctx,
+		`SELECT `+planColumns+` FROM email_account_daily_plan WHERE email_account_id = $1 AND plan_date = $2::date`,
+		accountID, planDate))
+}
+
+func (r *behaviorRepository) EnsurePlan(ctx context.Context, plan models.DailyPlan) (*models.DailyPlan, error) {
+	// DO NOTHING rather than DO UPDATE: a day's shape is decided once. If a
+	// customer widens their ranges at noon, today keeps the workday it already
+	// started and the new ranges take effect tomorrow.
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO email_account_daily_plan (
+			email_account_id, plan_date, timezone, is_working_day,
+			daily_limit, hourly_limit, work_start_minute, work_end_minute,
+			lunch_start_minute, lunch_end_minute, gap_min_seconds, gap_max_seconds
+		) VALUES ($1,$2::date,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+		ON CONFLICT (email_account_id, plan_date) DO NOTHING`,
+		plan.EmailAccountID, plan.PlanDate, plan.Timezone, plan.IsWorkingDay,
+		plan.DailyLimit, plan.HourlyLimit, plan.WorkStartMinute, plan.WorkEndMinute,
+		plan.LunchStartMinute, plan.LunchEndMinute, plan.GapMinSeconds, plan.GapMaxSeconds,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return r.GetPlan(ctx, plan.EmailAccountID, plan.PlanDate)
+}
+
+func (r *behaviorRepository) PurgePlansBefore(ctx context.Context, before time.Time) (int64, error) {
+	tag, err := r.db.Exec(ctx,
+		`DELETE FROM email_account_daily_plan WHERE plan_date < $1::date`, before.Format("2006-01-02"))
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (r *behaviorRepository) CountSendsBetween(ctx context.Context, accountID uuid.UUID, taskType string, from, to time.Time) (int, error) {
+	query := `
+		SELECT COUNT(*)
+		FROM tasks
+		WHERE email_account_id = $1
+		  AND task_type = $2::task_type
+		  AND (
+		        (status = 'completed' AND completed_at >= $3 AND completed_at < $4)
+		     OR (status IN ('pending', 'active') AND scheduled_at >= $3 AND scheduled_at < $4)
+		  )`
+
+	var count int
+	err := r.db.QueryRow(ctx, query, accountID, taskType, from, to).Scan(&count)
+	return count, err
+}

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -121,7 +121,10 @@ const CAMPAIGN_SELECT = `id, name, description, status,
 		  ramp_enabled, ramp_start, ramp_increment, ramp_ceiling, ramp_level, ramp_level_date,
 		  esp_match_mode, max_new_leads_per_day, prioritize_new_leads,
 		  tracking_domain, tracking_domain_verified, tracking_domain_verified_at,
-		  schedule_windows`
+		  schedule_windows,
+		  guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
+		  guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days,
+		  guardrail_tripped_at, guardrail_reason`
 
 func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) error {
 	var dest []any = []any{
@@ -137,6 +140,9 @@ func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) err
 		&campaign.ESPMatchMode, &campaign.MaxNewLeadsPerDay, &campaign.PrioritizeNewLeads,
 		&campaign.TrackingDomain, &campaign.TrackingDomainVerified, &campaign.TrackingDomainVerifiedAt,
 		&campaign.ScheduleWindows,
+		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
+		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
+		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
 	}
 	dest = append(dest, extra...)
 	return rows.Scan(
@@ -157,6 +163,9 @@ const CAMPAIGN_SELECT_FULL = `
 	c.esp_match_mode, c.max_new_leads_per_day, c.prioritize_new_leads,
 	c.tracking_domain, c.tracking_domain_verified, c.tracking_domain_verified_at,
 	c.schedule_windows,
+	c.guardrail_enabled, c.guardrail_bounce_rate_max, c.guardrail_complaint_rate_max,
+	c.guardrail_reply_rate_min, c.guardrail_min_sample, c.guardrail_window_days,
+	c.guardrail_tripped_at, c.guardrail_reason,
 	COALESCE(array_agg(cet.tag_id) FILTER (WHERE cet.tag_id IS NOT NULL), '{}') AS email_tag_ids,
 	COALESCE(array_agg(cec.folder_id) FILTER (WHERE cec.folder_id IS NOT NULL), '{}') AS email_folder_ids
 `
@@ -820,12 +829,13 @@ func (r *campaignRepository) Update(ctx context.Context, userID, campaignID stri
 		argPos++
 	}
 	if data.Status != nil {
-		// Valid statuses: draft, active, paused, completed, paused_trial_expired
+		// Valid statuses: draft, active, paused, completed, paused_trial_expired,
+		// paused_no_accounts, paused_guardrail
 		status := *data.Status
 		validStatuses := map[string]bool{
 			"draft": true, "active": true, "paused": true,
 			"completed": true, "paused_trial_expired": true,
-			"paused_no_accounts": true,
+			"paused_no_accounts": true, "paused_guardrail": true,
 		}
 		if !validStatuses[status] {
 			return nil, errx.ErrInvalid
@@ -1052,6 +1062,52 @@ func (r *campaignRepository) Update(ctx context.Context, userID, campaignID stri
 		setClauses = append(setClauses, "tracking_domain_verified = false", "tracking_domain_verified_at = NULL")
 	}
 
+	// Auto-pause guardrails. Each rate is a percentage in [0,100] where 0 means
+	// "this rule is off"; the DB CHECK mirrors these bounds, but rejecting here
+	// gives the caller a message instead of a constraint violation.
+	guardrailRate := func(column string, value *float64) *errx.Error {
+		if value == nil {
+			return nil
+		}
+		if *value < 0 || *value > 100 {
+			return errx.New(errx.BadRequest, column+" must be a percentage between 0 and 100")
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", column, argPos))
+		args = append(args, *value)
+		argPos++
+		return nil
+	}
+	if data.GuardrailEnabled != nil {
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", "guardrail_enabled", argPos))
+		args = append(args, *data.GuardrailEnabled)
+		argPos++
+	}
+	if err := guardrailRate("guardrail_bounce_rate_max", data.GuardrailBounceRateMax); err != nil {
+		return nil, err
+	}
+	if err := guardrailRate("guardrail_complaint_rate_max", data.GuardrailComplaintRateMax); err != nil {
+		return nil, err
+	}
+	if err := guardrailRate("guardrail_reply_rate_min", data.GuardrailReplyRateMin); err != nil {
+		return nil, err
+	}
+	if data.GuardrailMinSample != nil {
+		if *data.GuardrailMinSample < 1 || *data.GuardrailMinSample > 100000 {
+			return nil, errx.New(errx.BadRequest, "guardrail sample floor must be between 1 and 100000")
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", "guardrail_min_sample", argPos))
+		args = append(args, *data.GuardrailMinSample)
+		argPos++
+	}
+	if data.GuardrailWindowDays != nil {
+		if *data.GuardrailWindowDays < 0 || *data.GuardrailWindowDays > 365 {
+			return nil, errx.New(errx.BadRequest, "guardrail window must be between 0 and 365 days")
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", "guardrail_window_days", argPos))
+		args = append(args, *data.GuardrailWindowDays)
+		argPos++
+	}
+
 	if argPos == 3 && data.EmailTags == nil && data.Folders == nil {
 		return nil, errx.ErrNotEnough
 	}
@@ -1158,6 +1214,9 @@ func (r *campaignRepository) GetByID(ctx context.Context, campaignID uuid.UUID) 
 		&campaign.ESPMatchMode, &campaign.MaxNewLeadsPerDay, &campaign.PrioritizeNewLeads,
 		&campaign.TrackingDomain, &campaign.TrackingDomainVerified, &campaign.TrackingDomainVerifiedAt,
 		&campaign.ScheduleWindows,
+		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
+		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
+		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
 		&campaign.EmailTags, &campaign.Folders,
 	)
 	if err != nil {
@@ -1265,11 +1324,14 @@ func (r *campaignRepository) GetSequencesRoutingByCampaignID(ctx context.Context
 // Key is the current status, values are the statuses it can transition to.
 var validCampaignTransitions = map[string]map[string]bool{
 	"draft":                {"active": true},
-	"active":               {"paused": true, "completed": true, "paused_no_accounts": true, "paused_trial_expired": true},
+	"active":               {"paused": true, "completed": true, "paused_no_accounts": true, "paused_trial_expired": true, "paused_guardrail": true},
 	"paused":               {"active": true, "draft": true},
 	"paused_no_accounts":   {"active": true, "paused": true},
 	"paused_trial_expired": {"active": true, "paused": true},
-	"completed":            {}, // terminal state
+	// An auto-pause is resumable, but only deliberately: the owner has to
+	// restart the campaign (or park it) after looking at why it tripped.
+	"paused_guardrail": {"active": true, "paused": true},
+	"completed":        {}, // terminal state
 }
 
 // UpdateStatus updates only the status of a campaign with state machine validation
@@ -1309,7 +1371,12 @@ func (r *campaignRepository) StartCampaign(ctx context.Context, campaignID uuid.
 		    last_status_change_at = NOW(),
 		    updated_at = NOW(),
 		    ramp_level = CASE WHEN ramp_enabled AND ramp_level = 0 THEN ramp_start ELSE ramp_level END,
-		    ramp_level_date = CASE WHEN ramp_enabled AND ramp_level = 0 THEN CURRENT_DATE ELSE ramp_level_date END
+		    ramp_level_date = CASE WHEN ramp_enabled AND ramp_level = 0 THEN CURRENT_DATE ELSE ramp_level_date END,
+		    -- Starting again clears any auto-pause marker: the badge describes
+		    -- the pause, and the pause is over. The next sweep re-evaluates
+		    -- from scratch and will trip again if nothing was actually fixed.
+		    guardrail_tripped_at = NULL,
+		    guardrail_reason = ''
 		WHERE id = $1`
 	_, err := r.DB.Exec(ctx, query, campaignID)
 	return err

--- a/internal/repository/pg_email.go
+++ b/internal/repository/pg_email.go
@@ -624,6 +624,13 @@ func (r *emailRepository) Get(ctx context.Context, orgID, emailAccountID string)
 		&i.CreatedAt, &i.UpdatedAt, &i.Tags,
 	)
 	if err != nil {
+		// A mailbox that does not exist, or belongs to another organization, is
+		// a 404 — not a server error. Both cases land here as no-rows because
+		// the query is scoped by organization_id, which is also what keeps the
+		// tenancy boundary from leaking a "wrong org" signal.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, errx.ErrNotFound
+		}
 		db.CaptureError(err, query, params, "queryrow")
 		return nil, errx.InternalError()
 	}

--- a/internal/repository/pg_guardrail.go
+++ b/internal/repository/pg_guardrail.go
@@ -1,0 +1,137 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// GuardrailCampaign is one active campaign with guardrails switched on,
+// alongside the counts its thresholds are evaluated against. Thresholds and
+// counts travel together so the sweep can decide without a second round trip
+// per campaign.
+type GuardrailCampaign struct {
+	ID             uuid.UUID
+	OrganizationID *uuid.UUID
+	UserID         string
+	Name           string
+
+	BounceRateMax    float64
+	ComplaintRateMax float64
+	ReplyRateMin     float64
+	MinSample        int
+	WindowDays       int
+
+	Sent       int
+	Bounced    int
+	Replied    int
+	Complaints int
+}
+
+// GuardrailRepository reads the campaigns an auto-pause sweep has to consider
+// and applies the pause when one breaches a band.
+type GuardrailRepository interface {
+	// ListGuardrailCampaigns returns active, guardrail-enabled campaigns with
+	// their windowed engagement counts, newest first, capped at limit.
+	ListGuardrailCampaigns(ctx context.Context, limit int) ([]GuardrailCampaign, error)
+	// TripGuardrail pauses a campaign and records why. Returns false when the
+	// campaign is no longer active, so a campaign someone paused or completed
+	// between the read and the write is never reopened or overwritten.
+	TripGuardrail(ctx context.Context, campaignID uuid.UUID, reason string) (bool, error)
+	// ClearGuardrail wipes the tripped marker. Called when a campaign is
+	// started again, so the badge does not outlive the pause it describes.
+	ClearGuardrail(ctx context.Context, campaignID uuid.UUID) error
+}
+
+type guardrailRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewGuardrailRepository(db *pgxpool.Pool) GuardrailRepository {
+	return &guardrailRepository{db: db}
+}
+
+func (r *guardrailRepository) ListGuardrailCampaigns(ctx context.Context, limit int) ([]GuardrailCampaign, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+
+	// Counts are windowed by each campaign's own guardrail_window_days, with 0
+	// meaning "the campaign's whole history". Bounces and replies are attributed
+	// through campaign_contact_progress; complaints come from
+	// deliverability_events, which is where ESP feedback loops land.
+	query := `
+		SELECT c.id, c.organization_id, c.user_id, c.name,
+		       c.guardrail_bounce_rate_max, c.guardrail_complaint_rate_max, c.guardrail_reply_rate_min,
+		       c.guardrail_min_sample, c.guardrail_window_days,
+		       COALESCE(f.sent, 0), COALESCE(f.bounced, 0), COALESCE(f.replied, 0),
+		       COALESCE(cx.complaints, 0)
+		FROM campaigns c
+		LEFT JOIN LATERAL (
+			SELECT
+				COUNT(*)                                            AS sent,
+				COUNT(*) FILTER (WHERE ccp.bounced_at IS NOT NULL)  AS bounced,
+				COUNT(*) FILTER (WHERE ccp.replied_at IS NOT NULL)  AS replied
+			FROM campaign_contact_progress ccp
+			WHERE ccp.campaign_id = c.id
+			  AND ccp.sent_at IS NOT NULL
+			  AND (c.guardrail_window_days = 0
+			       OR ccp.sent_at > NOW() - make_interval(days => c.guardrail_window_days))
+		) f ON true
+		LEFT JOIN LATERAL (
+			SELECT COUNT(*) AS complaints
+			FROM deliverability_events de
+			WHERE de.campaign_id = c.id
+			  AND de.event_type = 'complaint'
+			  AND (c.guardrail_window_days = 0
+			       OR de.created_at > NOW() - make_interval(days => c.guardrail_window_days))
+		) cx ON true
+		WHERE c.guardrail_enabled AND c.status = 'active'
+		ORDER BY c.created_at DESC
+		LIMIT $1`
+
+	rows, err := r.db.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []GuardrailCampaign{}
+	for rows.Next() {
+		var g GuardrailCampaign
+		if err := rows.Scan(
+			&g.ID, &g.OrganizationID, &g.UserID, &g.Name,
+			&g.BounceRateMax, &g.ComplaintRateMax, &g.ReplyRateMin,
+			&g.MinSample, &g.WindowDays,
+			&g.Sent, &g.Bounced, &g.Replied, &g.Complaints,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, g)
+	}
+	return out, rows.Err()
+}
+
+func (r *guardrailRepository) TripGuardrail(ctx context.Context, campaignID uuid.UUID, reason string) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE campaigns
+		SET status = 'paused_guardrail',
+		    guardrail_tripped_at = now(),
+		    guardrail_reason = $2,
+		    last_status_change_at = now(),
+		    updated_at = now()
+		WHERE id = $1 AND status = 'active'`, campaignID, reason)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *guardrailRepository) ClearGuardrail(ctx context.Context, campaignID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE campaigns
+		SET guardrail_tripped_at = NULL, guardrail_reason = ''
+		WHERE id = $1 AND (guardrail_tripped_at IS NOT NULL OR guardrail_reason <> '')`, campaignID)
+	return err
+}

--- a/internal/repository/pg_task.go
+++ b/internal/repository/pg_task.go
@@ -102,6 +102,9 @@ type TaskRepository interface {
 	// Scheduling queries (CRITICAL for "next best time" calculation)
 	CountEmailsSentToday(ctx context.Context, accountID uuid.UUID) (int, error)
 	GetLastEmailTime(ctx context.Context, accountID uuid.UUID) (*time.Time, error)
+	// GetLastSendTimes is the batch form, for rotation across a campaign's
+	// whole sender pool. Accounts that have never sent are absent from the map.
+	GetLastSendTimes(ctx context.Context, accountIDs []uuid.UUID, taskType string) (map[uuid.UUID]time.Time, error)
 	GetScheduledTasksForAccount(ctx context.Context, accountID uuid.UUID, date time.Time) ([]Task, error)
 	GetScheduledTasksToday(ctx context.Context, accountID uuid.UUID) ([]Task, error)
 	// ListDuePendingTaskIDs returns pending tasks whose scheduled_at has passed,
@@ -502,6 +505,48 @@ func (r *taskRepository) GetLastEmailTime(ctx context.Context, accountID uuid.UU
 	}
 
 	return lastTime, err
+}
+
+// GetLastSendTimes returns the most recent completed send per account for a
+// task type, in one query.
+//
+// This is what gives rotation a signal for mailboxes resolved by TAG (or the
+// "all active mailboxes" default) rather than picked individually. Those
+// mailboxes have no campaign_senders row, so they carry no rotation cursor and
+// no last_sent_at — without this, round-robin and least-recently-used would
+// both fall through to their tie-breaker and hand every send to the same
+// mailbox until it hit its cap, which is the opposite of rotating.
+func (r *taskRepository) GetLastSendTimes(ctx context.Context, accountIDs []uuid.UUID, taskType string) (map[uuid.UUID]time.Time, error) {
+	out := map[uuid.UUID]time.Time{}
+	if len(accountIDs) == 0 {
+		return out, nil
+	}
+
+	query := `
+		SELECT email_account_id, MAX(completed_at)
+		FROM tasks
+		WHERE email_account_id = ANY($1)
+		  AND status = 'completed'
+		  AND task_type = $2::task_type
+		  AND completed_at IS NOT NULL
+		GROUP BY email_account_id
+	`
+
+	rows, err := r.db.Query(ctx, query, accountIDs, taskType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id uuid.UUID
+		var at time.Time
+		if err := rows.Scan(&id, &at); err != nil {
+			return nil, err
+		}
+		out[id] = at
+	}
+	return out, rows.Err()
 }
 
 // GetScheduledTasksForAccount gets scheduled tasks for an account on a specific date

--- a/internal/sandbox/seed.go
+++ b/internal/sandbox/seed.go
@@ -503,6 +503,32 @@ func seedMailboxes(ctx context.Context, pool *pgxpool.Pool) error {
 			m.id, p.healthState, p.healthScore, p.spamScore); err != nil {
 			return fmt.Errorf("pool join %s: %w", m.email, err)
 		}
+		// Give the first few mailboxes a sending-behaviour profile so the
+		// Sending tab has a real rolled workday to show, and the rest keep the
+		// fixed cap so both paths are visible side by side.
+		//
+		// The hours are deliberately near-24h and the gaps short: the sandbox
+		// simulator has to keep producing traffic whatever time of day someone
+		// runs it, and a 9-to-5 persona would idle the demo overnight. Every
+		// other dimension (per-day roll, lunch, hourly ceiling, drawn spacing)
+		// still behaves exactly as it does in production.
+		if i < 4 {
+			if _, err := pool.Exec(ctx, `
+				INSERT INTO email_account_behavior (
+					email_account_id, enabled,
+					daily_limit_min, daily_limit_max,
+					hourly_limit_min, hourly_limit_max,
+					gap_min_seconds, gap_max_seconds,
+					work_start_min, work_start_max, work_end_min, work_end_max,
+					lunch_enabled, lunch_earliest, lunch_latest, lunch_min_minutes, lunch_max_minutes,
+					weekdays
+				) VALUES ($1, true, 30, 45, 5, 9, 45, 180, 1, 20, 1400, 1439, true, 720, 810, 30, 60, 127)
+				ON CONFLICT (email_account_id) DO UPDATE SET
+					enabled = EXCLUDED.enabled,
+					updated_at = NOW()`, m.id); err != nil {
+				return fmt.Errorf("behaviour %s: %w", m.email, err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/scheduler/behavior.go
+++ b/internal/scheduler/behavior.go
@@ -115,6 +115,24 @@ func (s *schedulerService) behaviorGap(r behavior.Resolved, at time.Time, fallba
 	return secs
 }
 
+// notBefore keeps a scheduled slot in the future.
+//
+// Every scheduler adds SYMMETRIC jitter (±20 minutes for campaigns) to a
+// candidate that may already sit only seconds from now, so the negative half
+// can push the slot into the past. A past scheduled_at fires the moment it is
+// enqueued, which skips the spacing the send was placed with, and one more than
+// 15 minutes stale is cancelled outright by the overdue sweep.
+//
+// The floor is now plus a few seconds of spread, so a batch of clamped tasks
+// does not all land on the same instant.
+func notBefore(candidate time.Time) time.Time {
+	now := time.Now()
+	if candidate.After(now) {
+		return candidate
+	}
+	return now.Add(time.Duration(5+rand.Intn(55)) * time.Second)
+}
+
 // sameLocalDay reports whether two instants fall on the same calendar day in a
 // mailbox's own timezone. Budgets are per LOCAL day, so this — not a UTC date
 // comparison — is what decides whether a send is spending today's allowance.

--- a/internal/scheduler/behavior.go
+++ b/internal/scheduler/behavior.go
@@ -1,0 +1,168 @@
+package scheduler
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Sending-behaviour placement. These helpers are the only place the schedulers
+// touch the behaviour engine, and every one of them is a no-op when the engine
+// is unwired or the mailbox has its profile switched off — a mailbox that has
+// not opted in schedules exactly as it did before this feature existed.
+//
+// The gates compose in one direction only: behaviour can DELAY a send or LOWER
+// a budget, never bring one forward or raise one. That keeps the mailbox-first
+// safety invariant intact, so a human-behaviour profile can never be used to
+// push a mailbox past its cold cap.
+
+// placementAttempts bounds the hour-by-hour walk in placeWithinBehavior. A
+// working day is at most 24 hours of buckets and NextOpen already skips whole
+// non-working days, so this only ever runs out on a pathological profile.
+const placementAttempts = 48
+
+func (s *schedulerService) behaviorFor(ctx context.Context, account *models.Email) behavior.Resolved {
+	if s.behaviorSvc == nil || account == nil {
+		return behavior.Resolved{}
+	}
+	return s.behaviorSvc.Resolve(ctx, account)
+}
+
+func (s *schedulerService) behaviorForAll(ctx context.Context, accounts []models.Email) map[uuid.UUID]behavior.Resolved {
+	if s.behaviorSvc == nil {
+		return map[uuid.UUID]behavior.Resolved{}
+	}
+	return s.behaviorSvc.ResolveMany(ctx, accounts)
+}
+
+// behaviorWindow snaps a time into the mailbox's rolled workday: past the
+// start of the day, out of the lunch break, and onto the next working weekday
+// when the day is over. It applies no volume gate, so it is what warmup uses —
+// warmup has its own ramp and should follow the persona's hours without
+// competing for the cold-send budget.
+//
+// Returns the input unchanged when behaviour is off, and (zero, false) only
+// when the profile has no working days at all.
+func behaviorWindow(r behavior.Resolved, desired time.Time) (time.Time, bool) {
+	if !r.Enabled {
+		return desired, true
+	}
+	at, _, ok := r.NextOpen(desired)
+	if !ok {
+		return time.Time{}, false
+	}
+	return at, true
+}
+
+// placeWithinBehavior is behaviorWindow plus the volume gates: it walks forward
+// until it finds an instant that is inside the workday AND still has room in
+// both the day's rolled cold budget and that clock hour's ceiling.
+//
+// The hourly ceiling is what stops a day's whole allowance landing in one
+// burst; without it a mailbox with a 40/day plan and a 90s floor could empty
+// the day before 11am and then sit silent, which is a more obvious pattern
+// than sending too much.
+func (s *schedulerService) placeWithinBehavior(ctx context.Context, r behavior.Resolved, desired time.Time) (time.Time, bool) {
+	if !r.Enabled || s.behaviorSvc == nil {
+		return desired, true
+	}
+
+	at := desired
+	for i := 0; i < placementAttempts; i++ {
+		open, _, ok := r.NextOpen(at)
+		if !ok {
+			return time.Time{}, false
+		}
+
+		if s.behaviorSvc.RemainingToday(ctx, r, open) <= 0 {
+			// This local day is spent. Restart the search at the first instant
+			// of the next one rather than the next hour, so a full day costs
+			// one iteration instead of twenty-four.
+			at = behavior.PlanDateFor(open, r.Loc).AddDate(0, 0, 1)
+			continue
+		}
+
+		if s.behaviorSvc.RemainingThisHour(ctx, r, open) > 0 {
+			return open, true
+		}
+
+		_, hourEnd := behavior.HourWindow(open, r.Loc)
+		at = hourEnd
+	}
+	return time.Time{}, false
+}
+
+// behaviorGap returns the spacing to leave after this mailbox's previous send,
+// in seconds. With behaviour enabled the gap is drawn fresh from the profile's
+// range for every send, so consecutive intervals differ instead of forming an
+// arithmetic sequence; the configured min_wait_time is the fallback for every
+// mailbox that has not opted in.
+func (s *schedulerService) behaviorGap(r behavior.Resolved, at time.Time, fallbackSeconds int) int {
+	if !r.Enabled {
+		return fallbackSeconds
+	}
+	plan := r.PlanOn(behavior.PlanDateFor(at, r.Loc))
+	gap := behavior.DrawGap(plan, rand.Float64)
+	secs := int(gap / time.Second)
+	if secs < 1 {
+		return fallbackSeconds
+	}
+	return secs
+}
+
+// sameLocalDay reports whether two instants fall on the same calendar day in a
+// mailbox's own timezone. Budgets are per LOCAL day, so this — not a UTC date
+// comparison — is what decides whether a send is spending today's allowance.
+func sameLocalDay(a, b time.Time, loc *time.Location) bool {
+	if loc == nil {
+		loc = time.UTC
+	}
+	ay, am, ad := a.In(loc).Date()
+	by, bm, bd := b.In(loc).Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// intersectWindows walks a candidate time forward until it satisfies BOTH the
+// campaign's sending windows (in the campaign timezone) and the mailbox's
+// rolled workday (in the mailbox timezone), which are two different calendars
+// whenever a campaign sends from mailboxes in other regions.
+//
+// Each pass only ever moves the candidate later, so the walk is monotonic and
+// terminates; the bound is there for the case where the two calendars never
+// overlap at all, in which case the campaign window wins and the behaviour
+// engine simply does not delay the send further.
+func (s *schedulerService) intersectWindows(
+	ctx context.Context,
+	r behavior.Resolved,
+	t time.Time,
+	sw models.ScheduleWindows,
+	tz *time.Location,
+) time.Time {
+	if !r.Enabled || s.behaviorSvc == nil {
+		return nextScheduleSlot(t, sw, tz)
+	}
+	for i := 0; i < 8; i++ {
+		inCampaign := nextScheduleSlot(t, sw, tz)
+		placed, ok := s.placeWithinBehavior(ctx, r, inCampaign)
+		if !ok || !placed.After(inCampaign) {
+			return inCampaign
+		}
+		t = placed
+	}
+	return t
+}
+
+// behaviorDailyCap folds the day's rolled cold budget into an existing
+// remaining-capacity number. min() only: the plan can lower a mailbox's
+// remaining sends for the day, never raise them above its cold cap.
+func (s *schedulerService) behaviorDailyCap(ctx context.Context, r behavior.Resolved, remaining int, at time.Time) int {
+	if !r.Enabled || s.behaviorSvc == nil {
+		return remaining
+	}
+	return min(remaining, s.behaviorSvc.RemainingToday(ctx, r, at))
+}

--- a/internal/scheduler/behavior_test.go
+++ b/internal/scheduler/behavior_test.go
@@ -1,0 +1,337 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// fakeBehavior answers the capacity questions from fixed numbers so the
+// placement logic can be exercised without a database. Resolve/ResolveMany are
+// unused by these tests; the schedulers call them, the placement helpers do not.
+type fakeBehavior struct {
+	remainingDaily  map[string]int
+	remainingHourly map[string]int
+	defaultDaily    int
+	defaultHourly   int
+}
+
+func (f *fakeBehavior) Get(context.Context, uuid.UUID) (models.SendingBehavior, error) {
+	return models.SendingBehavior{}, nil
+}
+
+func (f *fakeBehavior) Update(context.Context, uuid.UUID, models.UpdateSendingBehavior) (models.SendingBehavior, error) {
+	return models.SendingBehavior{}, nil
+}
+
+func (f *fakeBehavior) Today(context.Context, uuid.UUID) (*models.DailyPlanView, error) {
+	return nil, nil
+}
+
+func (f *fakeBehavior) Resolve(context.Context, *models.Email) behavior.Resolved {
+	return behavior.Resolved{}
+}
+
+func (f *fakeBehavior) ResolveMany(context.Context, []models.Email) map[uuid.UUID]behavior.Resolved {
+	return map[uuid.UUID]behavior.Resolved{}
+}
+
+func (f *fakeBehavior) RemainingToday(_ context.Context, r behavior.Resolved, at time.Time) int {
+	if n, ok := f.remainingDaily[at.In(r.Loc).Format("2006-01-02")]; ok {
+		return n
+	}
+	return f.defaultDaily
+}
+
+func (f *fakeBehavior) RemainingThisHour(_ context.Context, r behavior.Resolved, at time.Time) int {
+	if n, ok := f.remainingHourly[at.In(r.Loc).Format("2006-01-02 15")]; ok {
+		return n
+	}
+	return f.defaultHourly
+}
+
+func testProfile() models.SendingBehavior {
+	b := models.DefaultSendingBehavior(uuid.MustParse("6f1b1c4e-2b7a-4a1e-9d0e-2f3a4b5c6d7e"))
+	b.Enabled = true
+	return b
+}
+
+// A Wednesday inside the default Mon-Fri mask.
+func testWednesday() time.Time {
+	return time.Date(2026, time.August, 12, 0, 0, 0, 0, time.UTC)
+}
+
+func atMinute(day time.Time, minute int) time.Time {
+	return time.Date(day.Year(), day.Month(), day.Day(), minute/60, minute%60, 0, 0, day.Location())
+}
+
+func minuteOf(t time.Time) int { return t.Hour()*60 + t.Minute() }
+
+func TestPlaceWithinBehaviorIsANoOpWhenTheProfileIsOff(t *testing.T) {
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 10, defaultHourly: 5}}
+	want := atMinute(testWednesday(), 3*60)
+
+	got, ok := s.placeWithinBehavior(context.Background(), behavior.Resolved{}, want)
+	if !ok || !got.Equal(want) {
+		t.Fatalf("a mailbox with no profile must not be moved: got %s ok=%v", got, ok)
+	}
+}
+
+func TestPlaceWithinBehaviorSnapsToTheWorkday(t *testing.T) {
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 10, defaultHourly: 5}}
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+
+	got, ok := s.placeWithinBehavior(context.Background(), r, atMinute(testWednesday(), 5*60))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if minuteOf(got) != plan.WorkStartMinute {
+		t.Fatalf("got %s, want the rolled start %d", got, plan.WorkStartMinute)
+	}
+}
+
+func TestPlaceWithinBehaviorSkipsAFullHour(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+	start := atMinute(testWednesday(), plan.WorkStartMinute)
+
+	f := &fakeBehavior{
+		defaultDaily:    10,
+		defaultHourly:   4,
+		remainingHourly: map[string]int{start.Format("2006-01-02 15"): 0},
+	}
+	s := &schedulerService{behaviorSvc: f}
+
+	got, ok := s.placeWithinBehavior(context.Background(), r, start)
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if got.Hour() == start.Hour() {
+		t.Fatalf("a full hour should be skipped, still landed at %s", got)
+	}
+	if !got.After(start) {
+		t.Fatalf("placement moved backwards: %s -> %s", start, got)
+	}
+}
+
+func TestPlaceWithinBehaviorSkipsAFullDay(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	wed := testWednesday()
+
+	f := &fakeBehavior{
+		defaultDaily:   10,
+		defaultHourly:  5,
+		remainingDaily: map[string]int{wed.Format("2006-01-02"): 0},
+	}
+	s := &schedulerService{behaviorSvc: f}
+
+	got, ok := s.placeWithinBehavior(context.Background(), r, atMinute(wed, 10*60))
+	if !ok {
+		t.Fatal("expected a slot")
+	}
+	if got.Weekday() != time.Thursday {
+		t.Fatalf("a spent day should roll to the next one, got %s", got.Weekday())
+	}
+}
+
+func TestPlaceWithinBehaviorGivesUpWithNoWorkingDays(t *testing.T) {
+	b := testProfile()
+	b.Weekdays = 0
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 10, defaultHourly: 5}}
+
+	if _, ok := s.placeWithinBehavior(context.Background(), behavior.NewStandalone(b, time.UTC), testWednesday()); ok {
+		t.Fatal("a profile with no working days has no slot")
+	}
+}
+
+func TestBehaviorGapFallsBackToTheFixedMinWait(t *testing.T) {
+	s := &schedulerService{}
+	if got := s.behaviorGap(behavior.Resolved{}, time.Now(), 600); got != 600 {
+		t.Fatalf("gap = %d, want the mailbox min_wait_time 600", got)
+	}
+}
+
+func TestBehaviorGapUsesTheProfileRange(t *testing.T) {
+	s := &schedulerService{}
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+
+	seen := map[int]bool{}
+	for i := 0; i < 200; i++ {
+		got := s.behaviorGap(r, testWednesday(), 600)
+		if got < b.GapMinSeconds || got > b.GapMaxSeconds {
+			t.Fatalf("gap %d outside [%d,%d]", got, b.GapMinSeconds, b.GapMaxSeconds)
+		}
+		seen[got] = true
+	}
+	if len(seen) < 10 {
+		t.Fatalf("gaps barely vary across 200 draws: %d distinct", len(seen))
+	}
+}
+
+func TestBehaviorDailyCapOnlyLowers(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 7, defaultHourly: 5}}
+	if got := s.behaviorDailyCap(context.Background(), r, 50, testWednesday()); got != 7 {
+		t.Fatalf("cap = %d, want the tighter plan budget 7", got)
+	}
+
+	s = &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 900, defaultHourly: 5}}
+	if got := s.behaviorDailyCap(context.Background(), r, 50, testWednesday()); got != 50 {
+		t.Fatalf("cap = %d, a plan must never raise the cold cap above 50", got)
+	}
+
+	s = &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 7, defaultHourly: 5}}
+	if got := s.behaviorDailyCap(context.Background(), behavior.Resolved{}, 50, testWednesday()); got != 50 {
+		t.Fatalf("cap = %d, a mailbox with no profile keeps its own 50", got)
+	}
+}
+
+func TestSameLocalDayUsesTheMailboxTimezone(t *testing.T) {
+	denver, err := time.LoadLocation("America/Denver")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	// Both instants land on 12 August in Denver, but on different UTC dates:
+	// 01:00 UTC on the 13th is 19:00 on the 12th in Denver.
+	evening := time.Date(2026, time.August, 13, 1, 0, 0, 0, time.UTC)
+	morning := time.Date(2026, time.August, 12, 15, 0, 0, 0, time.UTC)
+
+	if !sameLocalDay(evening, morning, denver) {
+		t.Fatal("both instants fall on the same Denver day")
+	}
+	if sameLocalDay(evening, morning, time.UTC) {
+		t.Fatal("they fall on different UTC days, which is exactly the bug this guards")
+	}
+}
+
+func TestIntersectWindowsSatisfiesBothCalendars(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 10, defaultHourly: 5}}
+
+	// A campaign window that opens well after the mailbox's workday starts.
+	var sw models.ScheduleWindows
+	for wd := 0; wd < 7; wd++ {
+		sw[wd] = []models.TimeInterval{{Start: 14 * 60, End: 16 * 60}}
+	}
+
+	got := s.intersectWindows(context.Background(), r, atMinute(testWednesday(), 6*60), sw, time.UTC)
+	if m := minuteOf(got); m < 14*60 || m >= 16*60 {
+		t.Fatalf("landed at %d, outside the campaign window", m)
+	}
+	if !plan.Contains(minuteOf(got)) {
+		t.Fatalf("landed at %d, outside the mailbox workday %d-%d", minuteOf(got), plan.WorkStartMinute, plan.WorkEndMinute)
+	}
+}
+
+func TestIntersectWindowsFallsBackToTheCampaignWindow(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	s := &schedulerService{behaviorSvc: &fakeBehavior{defaultDaily: 10, defaultHourly: 5}}
+
+	// A campaign that only sends at night, which no default workday reaches.
+	var sw models.ScheduleWindows
+	for wd := 0; wd < 7; wd++ {
+		sw[wd] = []models.TimeInterval{{Start: 1, End: 120}}
+	}
+
+	got := s.intersectWindows(context.Background(), r, atMinute(testWednesday(), 6*60), sw, time.UTC)
+	if got.IsZero() {
+		t.Fatal("a non-overlapping pair of calendars must still yield a time")
+	}
+	if m := minuteOf(got); m >= 120 && m < 1 {
+		t.Fatalf("landed at %d, outside the campaign window", m)
+	}
+}
+
+func TestIntersectWindowsIsPlainSnappingWithoutAProfile(t *testing.T) {
+	s := &schedulerService{}
+	var sw models.ScheduleWindows
+	for wd := 0; wd < 7; wd++ {
+		sw[wd] = []models.TimeInterval{{Start: 9 * 60, End: 17 * 60}}
+	}
+
+	from := atMinute(testWednesday(), 6*60)
+	got := s.intersectWindows(context.Background(), behavior.Resolved{}, from, sw, time.UTC)
+	if minuteOf(got) != 9*60 {
+		t.Fatalf("got %d, want the campaign window start 540", minuteOf(got))
+	}
+}
+
+func TestRemainingSendMinutesExcludesTheBreakAhead(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+	if !plan.HasLunch() {
+		t.Skip("this day rolled without a break")
+	}
+
+	c := &AccountCandidate{Behavior: r}
+	at := atMinute(testWednesday(), plan.WorkStartMinute)
+	got, ok := remainingSendMinutes(c, at, models.ScheduleWindows{}, time.UTC)
+	if !ok {
+		t.Fatal("expected a window")
+	}
+	want := plan.WorkEndMinute - plan.WorkStartMinute - (*plan.LunchEndMinute - *plan.LunchStartMinute)
+	if got != want {
+		t.Fatalf("remaining = %d, want %d (the break must not be counted)", got, want)
+	}
+}
+
+func TestRemainingSendMinutesAfterTheBreakCountsOnlyWhatIsLeft(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+	if !plan.HasLunch() {
+		t.Skip("this day rolled without a break")
+	}
+
+	c := &AccountCandidate{Behavior: r}
+	at := atMinute(testWednesday(), *plan.LunchEndMinute+30)
+	got, ok := remainingSendMinutes(c, at, models.ScheduleWindows{}, time.UTC)
+	if !ok {
+		t.Fatal("expected a window")
+	}
+	if want := plan.WorkEndMinute - (*plan.LunchEndMinute + 30); got != want {
+		t.Fatalf("remaining = %d, want %d", got, want)
+	}
+}
+
+func TestRemainingSendMinutesIsClosedAfterHours(t *testing.T) {
+	b := testProfile()
+	r := behavior.NewStandalone(b, time.UTC)
+	plan := behavior.RollPlan(b, testWednesday())
+
+	c := &AccountCandidate{Behavior: r}
+	at := atMinute(testWednesday(), plan.WorkEndMinute+5)
+	if _, ok := remainingSendMinutes(c, at, models.ScheduleWindows{}, time.UTC); ok {
+		t.Fatal("there is no sending time left after the workday ends")
+	}
+}
+
+func TestRemainingSendMinutesFallsBackToTheCampaignWindow(t *testing.T) {
+	c := &AccountCandidate{} // no profile
+	var sw models.ScheduleWindows
+	for wd := 0; wd < 7; wd++ {
+		sw[wd] = []models.TimeInterval{{Start: 9 * 60, End: 17 * 60}}
+	}
+	if _, ok := remainingSendMinutes(c, testWednesday(), sw, time.UTC); !ok {
+		t.Fatal("a campaign window should still be used when no profile exists")
+	}
+	if _, ok := remainingSendMinutes(c, testWednesday(), models.ScheduleWindows{}, time.UTC); ok {
+		t.Fatal("no profile and no campaign window means no pacing window")
+	}
+}

--- a/internal/scheduler/behavior_test.go
+++ b/internal/scheduler/behavior_test.go
@@ -335,3 +335,113 @@ func TestRemainingSendMinutesFallsBackToTheCampaignWindow(t *testing.T) {
 		t.Fatal("no profile and no campaign window means no pacing window")
 	}
 }
+
+/* ── rotation across mailboxes with no explicit sender row ─────────────── */
+
+// Tag-resolved pools (and the "all active mailboxes" default) carry no
+// campaign_senders row, so they have no stored cursor and no last_sent_at.
+// These tests pin the fallback that keeps round-robin and least-recently-used
+// from handing every send to the same mailbox.
+
+func candidateWithoutSenderRow(id string, rotationPosition int, lastSent *time.Time) AccountCandidate {
+	return AccountCandidate{
+		Account:          models.Email{ID: uuid.MustParse(id)},
+		RemainingToday:   10,
+		Weight:           10,
+		RotationPosition: rotationPosition,
+		SenderLastSentAt: lastSent,
+	}
+}
+
+func TestRoundRobinFallsBackToTodaysSendCount(t *testing.T) {
+	// Three tag-resolved mailboxes. The lowest UUID has already sent the most
+	// today, so a correct round-robin must NOT pick it.
+	busiest := candidateWithoutSenderRow("11111111-1111-1111-1111-111111111111", 9, nil)
+	middle := candidateWithoutSenderRow("22222222-2222-2222-2222-222222222222", 4, nil)
+	idle := candidateWithoutSenderRow("33333333-3333-3333-3333-333333333333", 0, nil)
+
+	got := selectAccountByRotationMode("round_robin", []AccountCandidate{busiest, middle, idle})
+	if got == nil {
+		t.Fatal("expected a selection")
+	}
+	if got.Account.ID != idle.Account.ID {
+		t.Fatalf("picked %s, want the least-used mailbox %s", got.Account.ID, idle.Account.ID)
+	}
+}
+
+func TestLeastRecentlyUsedFallsBackToRealSendHistory(t *testing.T) {
+	recent := time.Now().Add(-5 * time.Minute)
+	older := time.Now().Add(-3 * time.Hour)
+
+	// Again the lowest UUID is the one that sent most recently.
+	a := candidateWithoutSenderRow("11111111-1111-1111-1111-111111111111", 0, &recent)
+	b := candidateWithoutSenderRow("22222222-2222-2222-2222-222222222222", 0, &older)
+
+	got := selectAccountByRotationMode("least_recently_used", []AccountCandidate{a, b})
+	if got == nil {
+		t.Fatal("expected a selection")
+	}
+	if got.Account.ID != b.Account.ID {
+		t.Fatalf("picked %s, want the longest-idle mailbox %s", got.Account.ID, b.Account.ID)
+	}
+}
+
+func TestLeastRecentlyUsedPrefersAMailboxThatNeverSent(t *testing.T) {
+	sent := time.Now().Add(-2 * time.Hour)
+	used := candidateWithoutSenderRow("11111111-1111-1111-1111-111111111111", 0, &sent)
+	fresh := candidateWithoutSenderRow("22222222-2222-2222-2222-222222222222", 0, nil)
+
+	got := selectAccountByRotationMode("least_recently_used", []AccountCandidate{used, fresh})
+	if got == nil || got.Account.ID != fresh.Account.ID {
+		t.Fatalf("a mailbox with no send history should sort first, got %+v", got)
+	}
+}
+
+func TestRotationRotatesAcrossRepeatedPicks(t *testing.T) {
+	// The regression this guards: before the fallback, every pick returned the
+	// same mailbox because all positions were 0 and the tie-break is by UUID.
+	ids := []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+		"33333333-3333-3333-3333-333333333333",
+	}
+	sentToday := map[string]int{ids[0]: 0, ids[1]: 0, ids[2]: 0}
+
+	picked := map[string]int{}
+	for i := 0; i < 9; i++ {
+		pool := make([]AccountCandidate, 0, len(ids))
+		for _, id := range ids {
+			pool = append(pool, candidateWithoutSenderRow(id, sentToday[id], nil))
+		}
+		got := selectAccountByRotationMode("round_robin", pool)
+		if got == nil {
+			t.Fatal("expected a selection")
+		}
+		id := got.Account.ID.String()
+		picked[id]++
+		sentToday[id]++ // the send lands, so the next pass sees a higher count
+	}
+
+	if len(picked) != 3 {
+		t.Fatalf("rotation stuck on %d of 3 mailboxes: %v", len(picked), picked)
+	}
+	for id, n := range picked {
+		if n != 3 {
+			t.Fatalf("mailbox %s took %d of 9 sends, want an even 3: %v", id, n, picked)
+		}
+	}
+}
+
+func TestNeedsRotationFallbackOnlyForCursorModes(t *testing.T) {
+	for _, mode := range []string{"round_robin", "least_recently_used"} {
+		if !needsRotationFallback(mode) {
+			t.Fatalf("%s depends on per-sender bookkeeping", mode)
+		}
+	}
+	// Weighted spreads by remaining capacity, so it needs no extra query.
+	for _, mode := range []string{"weighted", ""} {
+		if needsRotationFallback(mode) {
+			t.Fatalf("%q should not trigger the extra lookup", mode)
+		}
+	}
+}

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -524,7 +524,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// STEP 11: Add jitter. Deliberately NOT rounded to a 5-minute grid — a
 	// fleet that only ever sends at :x0/:x5 marks is a detectable pattern.
 	jitter := randomJitter(-20, 20)
-	candidateTime = candidateTime.Add(time.Minute * time.Duration(jitter))
+	candidateTime = notBefore(candidateTime.Add(time.Minute * time.Duration(jitter)))
 
 	// STEP 12: Check conflicts with other scheduled tasks
 	dateToCheck := candidateTime
@@ -546,10 +546,10 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// STEP 14: Ensure still within a sending window after all adjustments
 	// (jitter/conflict/distribution can push into a gap between intervals, or
 	// out of the mailbox's workday). Satisfies both calendars.
-	candidateTime = s.intersectWindows(ctx, selected.Behavior, candidateTime, windows, campaignTZ)
+	candidateTime = s.intersectWindows(ctx, selected.Behavior, notBefore(candidateTime), windows, campaignTZ)
 
 	// STEP 15: Randomise the sub-minute component so sends never land on :00.
-	return humanizeSeconds(candidateTime), nextPair, account.ID, nil
+	return finalSlot(candidateTime), nextPair, account.ID, nil
 }
 
 // deferToNextDay pushes a candidate time to the next valid campaign day within

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -258,6 +258,24 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// Profiles are resolved for the whole pool in one query, so adding
 	// mailboxes to a campaign does not add a query per mailbox to every pass.
 	behaviors := s.behaviorForAll(ctx, accounts)
+
+	// Rotation fallback for mailboxes with no campaign_senders row (tag-resolved
+	// pools and the "all active mailboxes" default). One query for the whole
+	// pool; a failure just leaves the map empty and rotation degrades to its
+	// tie-breaker rather than blocking the send.
+	lastSends := map[uuid.UUID]time.Time{}
+	if needsRotationFallback(campaign.RotationMode) {
+		ids := make([]uuid.UUID, 0, len(accounts))
+		for _, a := range accounts {
+			if _, ok := senderMetaByID[a.ID]; !ok {
+				ids = append(ids, a.ID)
+			}
+		}
+		if sends, lerr := s.taskRepo.GetLastSendTimes(ctx, ids, "campaign"); lerr == nil {
+			lastSends = sends
+		}
+	}
+
 	var candidates []AccountCandidate
 	for _, acct := range accounts {
 		sentToday, err := s.taskRepo.CountCampaignEmailsSentToday(ctx, acct.ID)
@@ -351,6 +369,17 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			cand.SenderWeight = meta.weight
 			cand.RotationPosition = meta.rotationPosition
 			cand.SenderLastSentAt = meta.lastSentAt
+		} else {
+			// No explicit sender row, so no stored cursor. Derive both signals
+			// from what the mailbox has actually done: today's send count is
+			// the round-robin position (least-used goes next), and its real
+			// last send drives least-recently-used. Without this, a tag-based
+			// campaign on either mode would keep picking the same mailbox.
+			cand.RotationPosition = sentToday
+			if at, ok := lastSends[acct.ID]; ok {
+				t := at
+				cand.SenderLastSentAt = &t
+			}
 		}
 		candidates = append(candidates, cand)
 	}

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -250,8 +250,14 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		return acctProvider == recipientProvider
 	}
 
-	// STEP 8: Build weighted account candidates
-	// Skip accounts whose local time falls outside business hours (8am-8pm)
+	// STEP 8: Build weighted account candidates, gating each mailbox on when it
+	// may next send in its OWN timezone: its rolled workday when it has a
+	// sending-behaviour profile, and the historical 8am-8pm business-hours band
+	// when it does not.
+	//
+	// Profiles are resolved for the whole pool in one query, so adding
+	// mailboxes to a campaign does not add a query per mailbox to every pass.
+	behaviors := s.behaviorForAll(ctx, accounts)
 	var candidates []AccountCandidate
 	for _, acct := range accounts {
 		sentToday, err := s.taskRepo.CountCampaignEmailsSentToday(ctx, acct.ID)
@@ -266,6 +272,8 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		if remaining <= 0 {
 			continue
 		}
+
+		bhv := behaviors[acct.ID]
 
 		// Health-gate cold sends on the SAME warmup health state used for pool
 		// selection, so a mailbox in deliverability trouble doesn't keep blasting
@@ -290,8 +298,32 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			}
 		}
 
-		// If the account has its own timezone, check it is within business hours
-		if acct.Timezone != "" && acct.Timezone != campaign.Timezone {
+		// Where the mailbox may next send, in its OWN timezone. With a
+		// behaviour profile this is its rolled workday (start, lunch, end,
+		// working weekdays) with the hourly ceiling already applied; without
+		// one it falls back to the historical 8am-8pm business-hours gate.
+		var behaviorOpenAt *time.Time
+		if bhv.Enabled {
+			openAt, ok := s.placeWithinBehavior(ctx, bhv, candidateTime)
+			if !ok {
+				continue // profile has no working days at all
+			}
+			behaviorOpenAt = &openAt
+
+			// Budget the send against the day it will actually land on. When
+			// today is spent, placeWithinBehavior has already walked to a later
+			// day, and that day starts with the mailbox's full cold cap.
+			if !sameLocalDay(openAt, time.Now(), bhv.Loc) {
+				remaining = acctLimit
+			}
+			// The day's rolled cold budget, folded in by min(): a persona can
+			// only lower a mailbox's remaining sends, never lift it above the
+			// cold cap.
+			remaining = s.behaviorDailyCap(ctx, bhv, remaining, openAt)
+			if remaining <= 0 {
+				continue
+			}
+		} else if acct.Timezone != "" && acct.Timezone != campaign.Timezone {
 			acctTZ := loadLocation(acct.Timezone)
 			acctLocal := candidateTime.In(acctTZ)
 			acctHour := acctLocal.Hour()
@@ -311,6 +343,8 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			WarmupAgeDays:  warmupAgeDays,
 			Weight:         computeWeight(remaining, warmupAgeDays),
 			ProviderMatch:  providerMatches(acct.Provider),
+			Behavior:       bhv,
+			BehaviorOpenAt: behaviorOpenAt,
 		}
 		if meta, ok := senderMetaByID[acct.ID]; ok {
 			cand.HasSenderMetadata = true
@@ -406,28 +440,37 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 
 	account := &selected.Account
 
-	// STEP 9: Even distribution across the candidate day's sending window. Uses
-	// the span (earliest start → latest end) of that weekday's intervals.
+	// STEP 8.75: Send-to-send spacing for THIS send. With a behaviour profile
+	// the gap is drawn fresh from the mailbox's range, so the intervals between
+	// its sends are irregular; otherwise it is the mailbox's fixed min gap.
+	gapSeconds := s.behaviorGap(selected.Behavior, candidateTime, account.MinWaitTime)
+
+	// Move the candidate onto the mailbox's own workday before the spacing
+	// maths below runs, so distribution is computed against the window the send
+	// will actually land in.
+	if selected.BehaviorOpenAt != nil && selected.BehaviorOpenAt.After(candidateTime) {
+		candidateTime = *selected.BehaviorOpenAt
+	}
+
+	// STEP 9: Even distribution across the candidate day's sending window. With
+	// a behaviour profile that is the mailbox's own rolled workday (lunch
+	// excluded); otherwise it is the span of the campaign's intervals for that
+	// weekday.
 	remainingEmails := selected.RemainingToday
 	if remainingEmails > 0 {
-		wd := int(candidateTime.In(campaignTZ).Weekday())
-		if dayStart, dayEnd, ok := windows.DaySpan(wd); ok {
-			nowLocal := time.Now().In(campaignTZ)
-			currentMinutes := nowLocal.Hour()*60 + nowLocal.Minute()
-			remainingMinutes := dayEnd - max(currentMinutes, dayStart)
-			if remainingMinutes > 0 {
-				// Vary the pace multiplicatively (bursts and lulls) — evenly
-				// metronomed sends are a pattern even with additive jitter.
-				varied := float64(remainingMinutes/remainingEmails) * (0.55 + rand.Float64()*0.9)
-				idealInterval := time.Duration(varied * float64(time.Minute))
-				minInterval := time.Second * time.Duration(account.MinWaitTime)
-				if idealInterval < minInterval {
-					idealInterval = minInterval
-				}
-				distributedTime := time.Now().Add(idealInterval)
-				if distributedTime.After(candidateTime) {
-					candidateTime = distributedTime
-				}
+		remainingMinutes, ok := remainingSendMinutes(selected, candidateTime, windows, campaignTZ)
+		if ok && remainingMinutes > 0 {
+			// Vary the pace multiplicatively (bursts and lulls) — evenly
+			// metronomed sends are a pattern even with additive jitter.
+			varied := float64(remainingMinutes/remainingEmails) * (0.55 + rand.Float64()*0.9)
+			idealInterval := time.Duration(varied * float64(time.Minute))
+			minInterval := time.Second * time.Duration(gapSeconds)
+			if idealInterval < minInterval {
+				idealInterval = minInterval
+			}
+			distributedTime := time.Now().Add(idealInterval)
+			if distributedTime.After(candidateTime) {
+				candidateTime = distributedTime
 			}
 		}
 	}
@@ -439,7 +482,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	}
 
 	if lastEmailTime != nil {
-		minWait := time.Second * time.Duration(account.MinWaitTime)
+		minWait := time.Second * time.Duration(gapSeconds)
 		earliestNext := lastEmailTime.Add(minWait)
 
 		if candidateTime.Before(earliestNext) {
@@ -461,14 +504,20 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		return time.Time{}, nil, uuid.Nil, err
 	}
 
-	candidateTime = resolveConflicts(candidateTime, scheduledTasks, account.MinWaitTime)
+	candidateTime = resolveConflicts(candidateTime, scheduledTasks, gapSeconds)
 
-	// STEP 13: Apply human-like distribution (favor morning/afternoon peaks)
-	candidateTime = applyDistributionCurve(candidateTime, campaignTZ)
+	// STEP 13: Apply human-like distribution (favor morning/afternoon peaks).
+	// Skipped for behaviour-profiled mailboxes: the profile already describes
+	// this mailbox's workday and its own lunch break, and layering the generic
+	// curve on top would drag sends away from the hours the customer chose.
+	if !selected.Behavior.Enabled {
+		candidateTime = applyDistributionCurve(candidateTime, campaignTZ)
+	}
 
 	// STEP 14: Ensure still within a sending window after all adjustments
-	// (jitter/conflict/distribution can push into a gap between intervals).
-	candidateTime = nextScheduleSlot(candidateTime, windows, campaignTZ)
+	// (jitter/conflict/distribution can push into a gap between intervals, or
+	// out of the mailbox's workday). Satisfies both calendars.
+	candidateTime = s.intersectWindows(ctx, selected.Behavior, candidateTime, windows, campaignTZ)
 
 	// STEP 15: Randomise the sub-minute component so sends never land on :00.
 	return humanizeSeconds(candidateTime), nextPair, account.ID, nil

--- a/internal/scheduler/email_scheduler.go
+++ b/internal/scheduler/email_scheduler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/behavior"
 )
 
 // CalculateNextEmailTime calculates the optimal time to send a user-initiated email (smart send)
@@ -20,6 +21,13 @@ func (s *schedulerService) CalculateNextEmailTime(ctx context.Context, accountID
 
 	accountTZ := loadLocation(account.Timezone)
 
+	// STEP 1.5: Resolve the mailbox's sending-behaviour profile. Smart send is
+	// a user-initiated email, so it follows the persona's WORKDAY (hours,
+	// lunch, working weekdays) but is never charged against the cold daily or
+	// hourly budgets — those exist to pace outreach, not someone's own replies.
+	bhv := s.behaviorFor(ctx, account)
+	gapSeconds := s.behaviorGap(bhv, time.Now(), account.MinWaitTime)
+
 	// STEP 2: Get last email time and apply min_wait_time
 	candidateTime := time.Now()
 
@@ -29,15 +37,16 @@ func (s *schedulerService) CalculateNextEmailTime(ctx context.Context, accountID
 	}
 
 	if lastEmailTime != nil {
-		minWait := time.Second * time.Duration(account.MinWaitTime)
+		minWait := time.Second * time.Duration(gapSeconds)
 		earliestNext := lastEmailTime.Add(minWait)
 		if candidateTime.Before(earliestNext) {
 			candidateTime = earliestNext
 		}
 	}
 
-	// STEP 3: Ensure within business hours (8am-8pm account timezone)
-	candidateTime = ensureBusinessHours(candidateTime, account.Timezone)
+	// STEP 3: Ensure within the mailbox's sending window — its own rolled
+	// workday when a profile is enabled, otherwise the historical 8am-8pm band.
+	candidateTime = s.snapEmailToWindow(bhv, candidateTime, account.Timezone)
 
 	// STEP 4: Add jitter (±10 minutes)
 	jitter := randomJitter(-10, 10)
@@ -48,13 +57,26 @@ func (s *schedulerService) CalculateNextEmailTime(ctx context.Context, accountID
 	if err != nil {
 		return time.Time{}, err
 	}
-	candidateTime = resolveConflicts(candidateTime, scheduledTasks, account.MinWaitTime)
+	candidateTime = resolveConflicts(candidateTime, scheduledTasks, gapSeconds)
 
-	// STEP 6: Apply distribution curve
-	candidateTime = applyDistributionCurve(candidateTime, accountTZ)
+	// STEP 6: Apply distribution curve. Skipped when a profile owns the day.
+	if !bhv.Enabled {
+		candidateTime = applyDistributionCurve(candidateTime, accountTZ)
+	}
 
-	// STEP 7: Final business hours check
-	candidateTime = ensureBusinessHours(candidateTime, account.Timezone)
+	// STEP 7: Final window check after jitter and conflict resolution
+	return s.snapEmailToWindow(bhv, candidateTime, account.Timezone), nil
+}
 
-	return candidateTime, nil
+// snapEmailToWindow places a smart-send candidate inside the mailbox's rolled
+// workday, falling back to the legacy 8am-8pm business-hours band for mailboxes
+// with no behaviour profile.
+func (s *schedulerService) snapEmailToWindow(r behavior.Resolved, candidate time.Time, timezone string) time.Time {
+	if !r.Enabled {
+		return ensureBusinessHours(candidate, timezone)
+	}
+	if snapped, ok := behaviorWindow(r, candidate); ok {
+		return snapped
+	}
+	return candidate
 }

--- a/internal/scheduler/email_scheduler.go
+++ b/internal/scheduler/email_scheduler.go
@@ -50,7 +50,7 @@ func (s *schedulerService) CalculateNextEmailTime(ctx context.Context, accountID
 
 	// STEP 4: Add jitter (±10 minutes)
 	jitter := randomJitter(-10, 10)
-	candidateTime = candidateTime.Add(time.Minute * time.Duration(jitter))
+	candidateTime = notBefore(candidateTime.Add(time.Minute * time.Duration(jitter)))
 
 	// STEP 5: Resolve conflicts with scheduled tasks
 	scheduledTasks, err := s.taskRepo.GetScheduledTasksForAccount(ctx, accountID, candidateTime)
@@ -65,7 +65,7 @@ func (s *schedulerService) CalculateNextEmailTime(ctx context.Context, accountID
 	}
 
 	// STEP 7: Final window check after jitter and conflict resolution
-	return s.snapEmailToWindow(bhv, candidateTime, account.Timezone), nil
+	return notBefore(s.snapEmailToWindow(bhv, candidateTime, account.Timezone)), nil
 }
 
 // snapEmailToWindow places a smart-send candidate inside the mailbox's rolled

--- a/internal/scheduler/helpers.go
+++ b/internal/scheduler/helpers.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/warmbly/warmbly/internal/app/behavior"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
 )
@@ -279,6 +280,54 @@ type AccountCandidate struct {
 	// recipient ESP under ESP matching. Always true when ESP matching is off or
 	// the recipient provider is unknown.
 	ProviderMatch bool
+
+	// Behavior is the mailbox's resolved sending-behaviour profile for this
+	// pass. Zero value (Enabled false) means the mailbox has not opted in.
+	Behavior behavior.Resolved
+	// BehaviorOpenAt is the earliest instant the mailbox's rolled workday and
+	// hourly ceiling allow, computed while filtering candidates. nil when
+	// behaviour is off for this mailbox.
+	BehaviorOpenAt *time.Time
+}
+
+// remainingSendMinutes returns how much sending time is left in the day the
+// candidate is about to send on, which is what the even-distribution step
+// paces the day's remaining emails across.
+//
+// With a behaviour profile the answer comes from the mailbox's own rolled
+// workday in its own timezone, with any part of the lunch break still ahead
+// subtracted — pacing across a window that includes a break the mailbox will
+// not send in would bunch the remainder into the afternoon. Without one it is
+// the campaign's window span for that weekday, exactly as before.
+func remainingSendMinutes(c *AccountCandidate, at time.Time, sw models.ScheduleWindows, campaignTZ *time.Location) (int, bool) {
+	if c.Behavior.Enabled {
+		loc := c.Behavior.Loc
+		plan := c.Behavior.PlanOn(behavior.PlanDateFor(at, loc))
+		if !plan.IsWorkingDay {
+			return 0, false
+		}
+		cur := max(behavior.MinuteOfDay(at, loc), plan.WorkStartMinute)
+		if cur >= plan.WorkEndMinute {
+			return 0, false
+		}
+		remaining := plan.WorkEndMinute - cur
+		if plan.HasLunch() {
+			breakStart, breakEnd := *plan.LunchStartMinute, *plan.LunchEndMinute
+			if breakEnd > cur {
+				remaining -= breakEnd - max(breakStart, cur)
+			}
+		}
+		return max(remaining, 0), true
+	}
+
+	wd := int(at.In(campaignTZ).Weekday())
+	dayStart, dayEnd, ok := sw.DaySpan(wd)
+	if !ok {
+		return 0, false
+	}
+	nowLocal := time.Now().In(campaignTZ)
+	currentMinutes := nowLocal.Hour()*60 + nowLocal.Minute()
+	return dayEnd - max(currentMinutes, dayStart), true
 }
 
 // campaignRampCeiling returns the day's effective ramp ceiling. When ramp is

--- a/internal/scheduler/helpers.go
+++ b/internal/scheduler/helpers.go
@@ -159,7 +159,7 @@ func calculateFirstSlotTomorrowAt(timezone, startTime string) time.Time {
 	firstSlot := time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(),
 		startMinutes/60, startMinutes%60, 0, 0, loc)
 	jitter := randomJitter(0, 60)
-	return humanizeSeconds(firstSlot.Add(time.Minute * time.Duration(jitter)))
+	return finalSlot(firstSlot.Add(time.Minute * time.Duration(jitter)))
 }
 
 // humanizeSeconds randomises the sub-minute component of a scheduled time. All
@@ -167,8 +167,25 @@ func calculateFirstSlotTomorrowAt(timezone, startTime string) time.Time {
 // second :00, so without this the whole platform sends at second zero — a
 // fleet-wide fingerprint in Received headers. Applied as the last step of the
 // schedulers.
+//
+// It truncates DOWN to the minute before re-randomising, so on its own it can
+// move a slot up to 59 seconds EARLIER. Callers that are producing a real
+// scheduled_at must therefore use finalSlot, which clamps afterwards; this
+// helper deliberately stays a pure formatter.
 func humanizeSeconds(t time.Time) time.Time {
 	return t.Truncate(time.Minute).Add(time.Duration(rand.Intn(60)) * time.Second)
+}
+
+// finalSlot is the last thing a scheduler does to a candidate: randomise its
+// sub-minute component, then guarantee the result is still in the future.
+//
+// Both halves matter. Without the randomisation the whole fleet sends at second
+// :00, which is a fingerprint in Received headers. Without the clamp, that same
+// randomisation — plus the symmetric jitter each scheduler applies — can land a
+// near-term send in the past, where it fires immediately with none of the
+// spacing it was placed with, or gets cancelled outright by the overdue sweep.
+func finalSlot(t time.Time) time.Time {
+	return notBefore(humanizeSeconds(t))
 }
 
 // avoidRoundTimes adds randomness to avoid exact round times (10:00, 11:00)

--- a/internal/scheduler/helpers.go
+++ b/internal/scheduler/helpers.go
@@ -475,6 +475,13 @@ func selectAccountRoundRobin(candidates []AccountCandidate) *AccountCandidate {
 	return best
 }
 
+// needsRotationFallback reports whether a rotation mode depends on per-sender
+// bookkeeping that only explicitly-picked senders carry. Weighted selection is
+// driven by remaining capacity, so it already spreads without a cursor.
+func needsRotationFallback(rotationMode string) bool {
+	return rotationMode == "round_robin" || rotationMode == "least_recently_used"
+}
+
 // selectAccountByRotationMode dispatches to the chosen rotation strategy. For
 // explicit-strategy campaigns rotationMode is one of weighted / round_robin /
 // least_recently_used; anything else falls back to weighted.

--- a/internal/scheduler/live_integration_test.go
+++ b/internal/scheduler/live_integration_test.go
@@ -1,0 +1,489 @@
+package scheduler
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Live scheduler checks against a real Postgres. Skipped unless WARMBLY_TEST_DB
+// is set, so `go test ./...` stays hermetic; run them against the dev stack
+// with:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/scheduler/ -run Live -v
+//
+// These exist because every other test in this package stubs the database out.
+// The thing most worth proving — that a sending-behaviour profile actually
+// moves a real campaign's next send into the mailbox's rolled workday — can
+// only be proven against the real query paths.
+
+func liveDB(t *testing.T) (*db.DB, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	if err := handle.Ping(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return handle, handle.Pool
+}
+
+// liveFixture builds an isolated org/user/mailbox/campaign/contact graph and
+// returns the ids, removing the whole graph on cleanup.
+type liveFixture struct {
+	pool     *pgxpool.Pool
+	user     uuid.UUID
+	org      uuid.UUID
+	mailbox  uuid.UUID
+	campaign uuid.UUID
+}
+
+func newLiveFixture(t *testing.T, pool *pgxpool.Pool, timezone string) *liveFixture {
+	t.Helper()
+	ctx := context.Background()
+	f := &liveFixture{
+		pool: pool, user: uuid.New(), org: uuid.New(),
+		mailbox: uuid.New(), campaign: uuid.New(),
+	}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	exec(`INSERT INTO users (id, email, first_name, last_name)
+	      VALUES ($1, $2, 'Live', 'Test')`, f.user, "live-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id)
+	      VALUES ($1, 'Live Test', $2, $3)`, f.org, "live-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name,
+	          signature_plain, signature_html, provider, status, campaign_limit, min_wait_time, timezone)
+	      VALUES ($1, $2, $3, $4, 'Live', '', '', 'smtp_imap', 'active', 50, 600, $5)`,
+		f.mailbox, f.user, f.org, "live-"+f.mailbox.String()[:8]+"@test.local", timezone)
+
+	// An always-open campaign window, so anything the test observes about
+	// timing comes from the mailbox profile and not the campaign schedule.
+	exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, status,
+	          daily_limit, timezone, days, start_time, end_time, rotation_mode, updated_at, created_at)
+	      VALUES ($1, $2, $3, 'Live Test', '', 'active', 50, 'UTC', 127, '00:00', '23:59',
+	              'least_recently_used', NOW(), NOW())`, f.campaign, f.user, f.org)
+
+	seq := uuid.New()
+	exec(`INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+	          body_plain, body_html, wait_after, position, kind)
+	      VALUES ($1, $2, $3, 'Step 1', 'Hi', 'Hello', '<p>Hello</p>', 0, 0, 'email')`, seq, f.campaign, f.org)
+
+	contact := uuid.New()
+	exec(`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields)
+	      VALUES ($1, $2, $3, $4, 'Live', 'Contact', '', '', '{}')`,
+		contact, f.user, f.org, "lead-"+contact.String()[:8]+"@test.local")
+	exec(`INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, 0)`, f.campaign, contact)
+
+	// Teardown in FK order, innermost first. Each statement carries ONLY the
+	// argument it uses: pgx rejects a call whose argument count does not match
+	// the placeholders, and the first version of this passed all four ids to
+	// every statement, so every delete failed — silently, because the errors
+	// were discarded. Surfacing them is what makes the leak impossible to miss.
+	t.Cleanup(func() {
+		c := context.Background()
+		steps := []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM campaign_tasks WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM tasks WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM campaign_contact_progress WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_leads WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM sequences WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaigns WHERE id = $1`, f.campaign},
+			{`DELETE FROM email_account_daily_plan WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM email_account_behavior WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM email_accounts WHERE id = $1`, f.mailbox},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		}
+		for _, step := range steps {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+	return f
+}
+
+// setProfile writes a sending-behaviour profile and clears any plan already
+// rolled for the mailbox, so the next scheduling pass rolls from these ranges.
+func (f *liveFixture) setProfile(t *testing.T, b models.SendingBehavior) {
+	t.Helper()
+	if err := b.Validate(); err != nil {
+		t.Fatalf("profile is invalid before we even store it: %v", err)
+	}
+	repo := repository.NewBehaviorRepository(f.pool)
+	b.EmailAccountID = f.mailbox
+	if _, err := repo.UpsertBehavior(context.Background(), &b); err != nil {
+		t.Fatalf("upsert profile: %v", err)
+	}
+	if _, err := f.pool.Exec(context.Background(),
+		`DELETE FROM email_account_daily_plan WHERE email_account_id = $1`, f.mailbox); err != nil {
+		t.Fatalf("clear plans: %v", err)
+	}
+}
+
+func liveScheduler(t *testing.T, handle *db.DB, pool *pgxpool.Pool) SchedulerService {
+	t.Helper()
+	// Any 32-byte key works: these fixtures store no sealed credentials, and
+	// the scheduler never decrypts. It is only needed to build the repository.
+	enc, err := encrypt.NewEncrypter([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("encrypter: %v", err)
+	}
+	emailRepo := repository.NewEmailRepostory(handle, enc)
+	s := NewSchedulerService(
+		repository.NewTaskRepository(pool),
+		repository.NewWarmupRepository(pool),
+		repository.NewCampaignProgressRepository(pool),
+		emailRepo,
+		repository.NewCampaignRepostory(handle),
+		nil,
+		nil,
+	)
+	if aware, ok := s.(BehaviorAware); ok {
+		aware.WireBehavior(behavior.NewService(repository.NewBehaviorRepository(pool), emailRepo))
+	}
+	return s
+}
+
+func liveProfile() models.SendingBehavior {
+	b := models.DefaultSendingBehavior(uuid.Nil)
+	b.Enabled = true
+	return b
+}
+
+// TestLiveCampaignSendLandsInsideTheRolledWorkday is the headline check: a real
+// campaign, a real mailbox, the real scheduler, and a send that has to land
+// inside the workday the mailbox rolled for itself.
+func TestLiveCampaignSendLandsInsideTheRolledWorkday(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	// A narrow window that cannot be hit by accident: 15:20-15:25 to 16:00-16:05.
+	b := liveProfile()
+	b.WorkStartMin, b.WorkStartMax = 920, 925
+	b.WorkEndMin, b.WorkEndMax = 960, 965
+	b.LunchEnabled = false
+	b.Weekdays = models.BehaviorWeekdaysAll
+	f.setProfile(t, b)
+
+	at, _, accountID, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+	if accountID != f.mailbox {
+		t.Fatalf("picked mailbox %s, want the fixture's %s", accountID, f.mailbox)
+	}
+
+	plan := behavior.RollPlan(withID(b, f.mailbox), behavior.PlanDateFor(at, time.UTC))
+	minute := behavior.MinuteOfDay(at, time.UTC)
+	if !plan.Contains(minute) {
+		t.Fatalf("send scheduled at %s (minute %d), outside the rolled workday %d-%d",
+			at.UTC().Format("2006-01-02 15:04:05"), minute, plan.WorkStartMinute, plan.WorkEndMinute)
+	}
+	t.Logf("scheduled %s — inside the rolled workday %02d:%02d-%02d:%02d",
+		at.UTC().Format("2006-01-02 15:04:05"),
+		plan.WorkStartMinute/60, plan.WorkStartMinute%60, plan.WorkEndMinute/60, plan.WorkEndMinute%60)
+}
+
+// TestLiveSendSkipsTheLunchBreak proves the break is a real hole in the day and
+// not just a number in a table.
+func TestLiveSendSkipsTheLunchBreak(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	// A 12:00-16:00 workday that is almost entirely break: lunch runs 12:02 to
+	// 15:57, leaving only a couple of minutes open at each end. A scheduler
+	// that ignored the break would land in the 235-minute hole rather than the
+	// ~5 minutes of real window.
+	b := liveProfile()
+	b.WorkStartMin, b.WorkStartMax = 720, 722
+	b.WorkEndMin, b.WorkEndMax = 960, 962
+	b.LunchEnabled = true
+	// 12:10-15:50, chosen so the break survives EVERY roll: its start is always
+	// after the latest possible workday start (722) and its end always before
+	// the earliest possible finish (960). RollPlan drops a break that does not
+	// clear both, which is correct but makes a knife-edge fixture flaky.
+	b.LunchEarliest, b.LunchLatest = 730, 730
+	b.LunchMinMinutes, b.LunchMaxMinutes = 220, 220
+	b.Weekdays = models.BehaviorWeekdaysAll
+	f.setProfile(t, b)
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+
+	assertFuture(t, at)
+
+	plan := behavior.RollPlan(withID(b, f.mailbox), behavior.PlanDateFor(at, time.UTC))
+	if !plan.HasLunch() {
+		t.Fatal("fixture should have produced a break")
+	}
+	minute := behavior.MinuteOfDay(at, time.UTC)
+	if minute >= *plan.LunchStartMinute && minute < *plan.LunchEndMinute {
+		t.Fatalf("send scheduled at minute %d, inside the break %d-%d",
+			minute, *plan.LunchStartMinute, *plan.LunchEndMinute)
+	}
+	t.Logf("scheduled %s (minute %d), break is %d-%d — outside it",
+		at.UTC().Format("2006-01-02 15:04:05"), minute, *plan.LunchStartMinute, *plan.LunchEndMinute)
+}
+
+// TestLiveNonWorkingDayRollsForward proves the weekday mask moves a send to the
+// next working day rather than sending anyway.
+func TestLiveNonWorkingDayRollsForward(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	// Work only on the weekday two days from now, so today is never valid.
+	target := time.Now().UTC().AddDate(0, 0, 2).Weekday()
+	b := liveProfile()
+	b.LunchEnabled = false
+	b.Weekdays = 1 << ((int(target) + 6) % 7)
+	f.setProfile(t, b)
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+	if at.UTC().Weekday() != target {
+		t.Fatalf("scheduled on %s, want the only working day %s (%s)",
+			at.UTC().Weekday(), target, at.UTC().Format("2006-01-02 15:04"))
+	}
+	t.Logf("scheduled %s — the only working day in the mask", at.UTC().Format("2006-01-02 15:04 Mon"))
+}
+
+// TestLiveTimezoneIsTheMailboxOwn proves the workday follows the mailbox's own
+// clock rather than the server's.
+func TestLiveTimezoneIsTheMailboxOwn(t *testing.T) {
+	handle, pool := liveDB(t)
+	tokyo, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	f := newLiveFixture(t, pool, "Asia/Tokyo")
+
+	b := liveProfile()
+	b.WorkStartMin, b.WorkStartMax = 600, 605 // 10:00-10:05 Tokyo
+	b.WorkEndMin, b.WorkEndMax = 660, 665     // 11:00-11:05 Tokyo
+	b.LunchEnabled = false
+	b.Weekdays = models.BehaviorWeekdaysAll
+	f.setProfile(t, b)
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+
+	assertFuture(t, at)
+
+	local := behavior.MinuteOfDay(at, tokyo)
+	if local < 600 || local >= 665 {
+		t.Fatalf("scheduled at %s Tokyo (minute %d), outside the 10:00-11:05 Tokyo window",
+			at.In(tokyo).Format("2006-01-02 15:04"), local)
+	}
+	t.Logf("scheduled %s Tokyo (%s UTC) — the mailbox's own clock, not the server's",
+		at.In(tokyo).Format("15:04"), at.UTC().Format("15:04"))
+}
+
+// TestLiveDisabledProfileChangesNothing is the opt-out guarantee: a mailbox with
+// no profile must schedule exactly as it did before this feature existed.
+func TestLiveDisabledProfileChangesNothing(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	// A profile that WOULD force a narrow window, but switched off.
+	b := liveProfile()
+	b.Enabled = false
+	b.WorkStartMin, b.WorkStartMax = 920, 925
+	b.WorkEndMin, b.WorkEndMax = 960, 965
+	b.LunchEnabled = false
+	f.setProfile(t, b)
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+
+	// With behaviour off the send is placed by the legacy path, which is free to
+	// land outside 15:20-16:05. The guarantee we assert is that nothing was
+	// persisted: a disabled profile must not roll or store a plan.
+	var plans int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM email_account_daily_plan WHERE email_account_id = $1`, f.mailbox).Scan(&plans); err != nil {
+		t.Fatalf("count plans: %v", err)
+	}
+	if plans != 0 {
+		t.Fatalf("a disabled profile wrote %d plan rows; it must write none", plans)
+	}
+	t.Logf("scheduled %s with no plan persisted — legacy path intact", at.UTC().Format("2006-01-02 15:04"))
+}
+
+// assertFuture guards the invariant every one of these tests depends on: a
+// scheduled slot must be in the future. A past instant fires immediately and
+// silently defeats every window the profile describes, and the minute-of-day
+// assertions below would still pass on one.
+func assertFuture(t *testing.T, at time.Time) {
+	t.Helper()
+	if !at.After(time.Now().Add(-time.Second)) {
+		t.Fatalf("scheduled %s, which is in the past (now %s)",
+			at.UTC().Format("2006-01-02 15:04:05"), time.Now().UTC().Format("2006-01-02 15:04:05"))
+	}
+}
+
+func withID(b models.SendingBehavior, id uuid.UUID) models.SendingBehavior {
+	b.EmailAccountID = id
+	return b
+}
+
+// bookTask inserts a pending campaign task for the fixture's mailbox at a given
+// instant. Pending tasks count against the plan's budgets, because a booked
+// slot has already spent it even though the mail has not gone out yet.
+func (f *liveFixture) bookTask(t *testing.T, at time.Time) {
+	t.Helper()
+	id := uuid.New()
+	if _, err := f.pool.Exec(context.Background(), `
+		INSERT INTO tasks (id, task_type, email_account_id, status, message_id, scheduled_at)
+		VALUES ($1, 'campaign', $2, 'pending', '', $3)`, id, f.mailbox, at); err != nil {
+		t.Fatalf("book task: %v", err)
+	}
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO campaign_tasks (task_id, campaign_id) VALUES ($1, $2)`, id, f.campaign); err != nil {
+		t.Fatalf("book campaign task: %v", err)
+	}
+}
+
+// allDayProfile is an always-open workday, so the only thing that can move a
+// send is a volume ceiling.
+func allDayProfile() models.SendingBehavior {
+	b := liveProfile()
+	b.WorkStartMin, b.WorkStartMax = 0, 1
+	b.WorkEndMin, b.WorkEndMax = 1438, 1439
+	b.LunchEnabled = false
+	b.Weekdays = models.BehaviorWeekdaysAll
+	return b
+}
+
+// TestLiveHourlyCeilingPushesToALaterHour proves the hourly cap is a real gate
+// and not just a stored number. Without it a mailbox could empty its whole day
+// into one hour and then sit silent, which is a louder pattern than volume.
+func TestLiveHourlyCeilingPushesToALaterHour(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	b := allDayProfile()
+	b.HourlyLimitMin, b.HourlyLimitMax = 1, 1 // one send per clock hour
+	b.DailyLimitMin, b.DailyLimitMax = 40, 40
+	f.setProfile(t, b)
+
+	// Spend this hour's single slot.
+	now := time.Now().UTC()
+	f.bookTask(t, now)
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+
+	if at.UTC().Truncate(time.Hour).Equal(now.Truncate(time.Hour)) {
+		t.Fatalf("scheduled %s — same hour as the slot already booked (%s); the hourly ceiling did not bind",
+			at.UTC().Format("2006-01-02 15:04"), now.Format("15:04"))
+	}
+	t.Logf("hour %02d was full, next send placed at %s", now.Hour(), at.UTC().Format("2006-01-02 15:04"))
+}
+
+// TestLiveDailyCeilingPushesToTheNextDay proves the day's rolled cold budget is
+// enforced, not decorative.
+func TestLiveDailyCeilingPushesToTheNextDay(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	b := allDayProfile()
+	b.DailyLimitMin, b.DailyLimitMax = 1, 1 // one cold send per day
+	b.HourlyLimitMin, b.HourlyLimitMax = 50, 50
+	f.setProfile(t, b)
+
+	now := time.Now().UTC()
+	f.bookTask(t, now) // spends the whole day
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+
+	if at.UTC().Format("2006-01-02") == now.Format("2006-01-02") {
+		t.Fatalf("scheduled %s — same day as the send already booked; the daily ceiling did not bind",
+			at.UTC().Format("2006-01-02 15:04"))
+	}
+	t.Logf("today's single slot was spent, next send placed on %s", at.UTC().Format("2006-01-02 15:04"))
+}
+
+// TestLiveGapIsDrawnFromTheProfile proves the send-to-send spacing comes from
+// the profile band rather than the mailbox's fixed min_wait_time.
+//
+// The probe has to survive the ±20 minute jitter every campaign slot carries,
+// so it uses a gap FAR ABOVE the fixed 600s: a one-hour band cannot produce a
+// slot less than 40 minutes out, while the 600s path cannot produce one more
+// than ~30 minutes out. The two are cleanly separable; a narrow band is not.
+func TestLiveGapIsDrawnFromTheProfile(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+
+	b := allDayProfile()
+	b.GapMinSeconds, b.GapMaxSeconds = 3600, 3600 // exactly one hour
+	b.DailyLimitMin, b.DailyLimitMax = 40, 40
+	b.HourlyLimitMin, b.HourlyLimitMax = 50, 50
+	f.setProfile(t, b)
+
+	// A send completed a moment ago, so the next slot is governed by the gap.
+	id := uuid.New()
+	if _, err := pool.Exec(context.Background(), `
+		INSERT INTO tasks (id, task_type, email_account_id, status, message_id, scheduled_at, completed_at)
+		VALUES ($1, 'campaign', $2, 'completed', '', NOW(), NOW())`, id, f.mailbox); err != nil {
+		t.Fatalf("seed completed task: %v", err)
+	}
+
+	at, _, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	assertFuture(t, at)
+
+	gap := time.Until(at)
+	if gap < 40*time.Minute {
+		t.Fatalf("next send is only %s away; a one-hour profile gap cannot produce that, so the fixed 600s min_wait_time is still in charge",
+			gap.Round(time.Second))
+	}
+	t.Logf("next send %s away — the profile's one-hour band, not the mailbox's 600s gap", gap.Round(time.Second))
+}

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -145,7 +145,7 @@ func calculateFirstSlotTomorrow(timezone string) time.Time {
 
 	// Add random jitter
 	jitter := randomJitter(0, 60)
-	return humanizeSeconds(firstSlot.Add(time.Minute * time.Duration(jitter)))
+	return finalSlot(firstSlot.Add(time.Minute * time.Duration(jitter)))
 }
 
 // randomJitter generates random jitter between min and max minutes

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/behavior"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -33,6 +34,23 @@ type schedulerService struct {
 	// campaignLogRepo records send-path decision logs (e.g. ESP defer,
 	// new-lead cap). Optional/nil-safe so the scheduler keeps working without it.
 	campaignLogRepo repository.CampaignLogRepository
+	// behaviorSvc supplies each mailbox's rolled workday (hours, lunch, daily
+	// and hourly ceilings, send spacing). Optional/nil-safe: without it every
+	// mailbox keeps the legacy fixed cap and min-gap path.
+	behaviorSvc behavior.Service
+}
+
+// WireBehavior attaches the sending-behaviour engine. Kept off the constructor
+// so the scheduler stays constructible in tests and in any deployment that has
+// not enabled the feature.
+func (s *schedulerService) WireBehavior(b behavior.Service) {
+	s.behaviorSvc = b
+}
+
+// BehaviorAware is the optional capability the caller uses to attach the
+// behaviour engine after construction.
+type BehaviorAware interface {
+	WireBehavior(b behavior.Service)
 }
 
 // NewSchedulerService creates a new scheduler service

--- a/internal/scheduler/warmup_scheduler.go
+++ b/internal/scheduler/warmup_scheduler.go
@@ -318,7 +318,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 
 	// STEP 8: Add human-like jitter (±15 minutes)
 	jitter := randomJitter(-15, 15)
-	candidateTime := earliestNext.Add(time.Minute * time.Duration(jitter))
+	candidateTime := notBefore(earliestNext.Add(time.Minute * time.Duration(jitter)))
 
 	// STEP 9: Avoid exact round times (10:00, 11:00)
 	candidateTime = avoidRoundTimes(candidateTime)
@@ -371,10 +371,10 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 // window leaves the candidate untouched: warmup should degrade to its own
 // window rather than stop.
 func (s *schedulerService) snapWarmupToBehavior(r behavior.Resolved, candidate time.Time) time.Time {
-	if snapped, ok := behaviorWindow(r, candidate); ok {
+	if snapped, ok := behaviorWindow(r, notBefore(candidate)); ok {
 		candidate = snapped
 	}
-	return humanizeSeconds(candidate)
+	return finalSlot(candidate)
 }
 
 // minutesToClock renders minutes-since-midnight as the "15:04" string the

--- a/internal/scheduler/warmup_scheduler.go
+++ b/internal/scheduler/warmup_scheduler.go
@@ -2,10 +2,12 @@ package scheduler
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/behavior"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -153,14 +155,30 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		return time.Time{}, ErrWarmupNotEnabled
 	}
 
-	// STEP 1.5: Ensure today is a valid warmup day
+	// STEP 1.5: Resolve the mailbox's sending-behaviour profile. When one is
+	// enabled it OWNS the mailbox's hours: warmup follows the same rolled
+	// workday, lunch break and working weekdays as cold sending, because a
+	// mailbox whose warmup mail keeps arriving at 03:00 while its campaign mail
+	// keeps office hours has told the receiving side exactly what it is.
+	//
+	// Warmup is NOT charged against the persona's cold daily/hourly ceilings:
+	// those budget cold outreach, and warmup has its own ramp.
+	bhv := s.behaviorFor(ctx, account)
+	warmupStart, warmupEnd := account.WarmupStartTime, account.WarmupEndTime
+	if bhv.Enabled {
+		plan := bhv.PlanOn(behavior.PlanDateFor(time.Now(), bhv.Loc))
+		warmupStart = minutesToClock(plan.WorkStartMinute)
+		warmupEnd = minutesToClock(plan.WorkEndMinute)
+	}
+
+	// STEP 1.6: Ensure today is a valid warmup day
 	if account.WarmupDays > 0 {
 		loc := loadLocation(account.Timezone)
 		now := time.Now().In(loc)
 		candidateDay := findNextValidDay(now, uint8(account.WarmupDays), loc)
 		if candidateDay.Day() != now.Day() || candidateDay.Month() != now.Month() || candidateDay.Year() != now.Year() {
 			// Today is not a valid warmup day, schedule for next valid day's start time
-			startMinutes := parseTimeOfDay(account.WarmupStartTime)
+			startMinutes := parseTimeOfDay(warmupStart)
 			if startMinutes == 0 {
 				startMinutes = 8 * 60
 			}
@@ -168,7 +186,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 			firstSlot := time.Date(nextDay.Year(), nextDay.Month(), nextDay.Day(),
 				startMinutes/60, startMinutes%60, 0, 0, loc)
 			jitter := randomJitter(0, 60)
-			return humanizeSeconds(firstSlot.Add(time.Minute * time.Duration(jitter))), nil
+			return s.snapWarmupToBehavior(bhv, firstSlot.Add(time.Minute*time.Duration(jitter))), nil
 		}
 	}
 
@@ -235,9 +253,12 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		targetVolume = adjusted
 	}
 
-	minWaitSeconds := account.MinWaitTime
+	// Spacing: a drawn gap from the profile when one is enabled, otherwise the
+	// mailbox's fixed min gap. The health-state multiplier still applies on top,
+	// so a throttled mailbox stretches whichever base it is using.
+	minWaitSeconds := s.behaviorGap(bhv, time.Now(), account.MinWaitTime)
 	if adj.minWaitMultiplier > 1.0 {
-		minWaitSeconds = int(float64(account.MinWaitTime)*adj.minWaitMultiplier + 0.5)
+		minWaitSeconds = int(float64(minWaitSeconds)*adj.minWaitMultiplier + 0.5)
 	}
 
 	// STEP 3: Count emails already sent today
@@ -248,18 +269,18 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 
 	// STEP 4: Check if we've hit today's limit
 	if emailsSentToday >= targetVolume {
-		// Move to tomorrow's first slot (8am-9am local time)
-		return calculateFirstSlotTomorrowAt(account.Timezone, account.WarmupStartTime), nil
+		// Move to tomorrow's first slot
+		return s.snapWarmupToBehavior(bhv, calculateFirstSlotTomorrowAt(account.Timezone, warmupStart)), nil
 	}
 
 	// STEP 5: Calculate ideal spacing
 	// Distribute remaining emails across remaining business hours
 	remainingSlots := targetVolume - emailsSentToday
-	hoursRemaining := calculateHoursRemainingUntil(account.Timezone, account.WarmupEndTime)
+	hoursRemaining := calculateHoursRemainingUntil(account.Timezone, warmupEnd)
 
 	// If business hours are over, move to tomorrow
 	if hoursRemaining <= 0 {
-		return calculateFirstSlotTomorrowAt(account.Timezone, account.WarmupStartTime), nil
+		return s.snapWarmupToBehavior(bhv, calculateFirstSlotTomorrowAt(account.Timezone, warmupStart)), nil
 	}
 
 	idealIntervalHours := hoursRemaining / float64(remainingSlots)
@@ -303,7 +324,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 	candidateTime = avoidRoundTimes(candidateTime)
 
 	// STEP 10: Ensure within configured warmup time window
-	candidateTime = ensureTimeWindow(candidateTime, account.WarmupStartTime, account.WarmupEndTime, loadLocation(account.Timezone))
+	candidateTime = ensureTimeWindow(candidateTime, warmupStart, warmupEnd, loadLocation(account.Timezone))
 
 	// STEP 11: Check conflicts with other tasks on this account
 	scheduledTasks, err := s.taskRepo.GetScheduledTasksToday(ctx, accountID)
@@ -313,9 +334,13 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 
 	candidateTime = resolveConflicts(candidateTime, scheduledTasks, minWaitSeconds)
 
-	// STEP 12: Apply human-like distribution curve
+	// STEP 12: Apply human-like distribution curve. Skipped when a behaviour
+	// profile is driving the day — it already carries this mailbox's own peak
+	// hours and lunch break.
 	loc := loadLocation(account.Timezone)
-	candidateTime = applyDistributionCurve(candidateTime, loc)
+	if !bhv.Enabled {
+		candidateTime = applyDistributionCurve(candidateTime, loc)
+	}
 
 	// STEP 13: Final day-of-week guard — conflict resolution or jitter may have pushed
 	// the candidate into a day that isn't a valid warmup day.
@@ -324,7 +349,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		candidateLocal := candidateTime.In(loc)
 		validLocal := validDay.In(loc)
 		if candidateLocal.Day() != validLocal.Day() || candidateLocal.Month() != validLocal.Month() || candidateLocal.Year() != validLocal.Year() {
-			startMinutes := parseTimeOfDay(account.WarmupStartTime)
+			startMinutes := parseTimeOfDay(warmupStart)
 			if startMinutes == 0 {
 				startMinutes = 8 * 60
 			}
@@ -335,6 +360,31 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		}
 	}
 
-	// Randomise the sub-minute component so warmup sends never land on :00.
-	return humanizeSeconds(candidateTime), nil
+	// STEP 14: Final snap onto the mailbox's workday. Jitter, conflict
+	// resolution and the day-of-week guard can all land a candidate inside the
+	// lunch break or on a non-working weekday.
+	return s.snapWarmupToBehavior(bhv, candidateTime), nil
+}
+
+// snapWarmupToBehavior moves a warmup candidate onto the mailbox's rolled
+// workday and randomises its sub-minute component. A profile with no reachable
+// window leaves the candidate untouched: warmup should degrade to its own
+// window rather than stop.
+func (s *schedulerService) snapWarmupToBehavior(r behavior.Resolved, candidate time.Time) time.Time {
+	if snapped, ok := behaviorWindow(r, candidate); ok {
+		candidate = snapped
+	}
+	return humanizeSeconds(candidate)
+}
+
+// minutesToClock renders minutes-since-midnight as the "15:04" string the
+// legacy warmup window helpers parse.
+func minutesToClock(minute int) string {
+	if minute < 0 {
+		minute = 0
+	}
+	if minute >= models.MinutesPerDay {
+		minute = models.MinutesPerDay - 1
+	}
+	return fmt.Sprintf("%02d:%02d", minute/60, minute%60)
 }

--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -22,7 +22,7 @@ import { defineConfig, globalIgnores } from 'eslint/config'
 // so dead code still fails the build.
 
 export default defineConfig([
-  globalIgnores(['dist', 'node_modules', 'coverage']),
+  globalIgnores(['dist', 'node_modules', 'coverage', '**/._*']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/web/src/app/app/campaigns/[id]/preferences/page.tsx
+++ b/web/src/app/app/campaigns/[id]/preferences/page.tsx
@@ -16,6 +16,8 @@ import {
     RotationRampSection,
 } from "@/components/app/campaigns/preferences/CampaignEmails";
 import CampaignContactOrder from "@/components/app/campaigns/preferences/CampaignContactOrder";
+import { GuardrailsSection } from "@/components/app/campaigns/preferences/CampaignGuardrails";
+import { guardrailValidationError } from "@/lib/helper/guardrail";
 import CampaignFolderField from "@/components/app/campaigns/CampaignFolderField";
 import useUpdateCampaign from "@/lib/api/hooks/app/campaigns/useUpdateCampaign";
 import toast from "react-hot-toast";
@@ -51,6 +53,11 @@ const SECTIONS = [
         id: "matching",
         label: "ESP matching",
         description: "Align the sending mailbox provider with each recipient's provider.",
+    },
+    {
+        id: "guardrails",
+        label: "Auto-pause",
+        description: "Stop this campaign automatically when its bounce, complaint, or reply rate leaves the band you set.",
     },
     {
         id: "leadflow",
@@ -216,6 +223,26 @@ export default function CampaignPreferences() {
             }),
             ...(newData.risky_emails !== campaign.risky_emails && { risky_emails: newData.risky_emails }),
 
+            // Auto-pause guardrails
+            ...(newData.guardrail_enabled !== campaign.guardrail_enabled && {
+                guardrail_enabled: newData.guardrail_enabled,
+            }),
+            ...(newData.guardrail_bounce_rate_max !== campaign.guardrail_bounce_rate_max && {
+                guardrail_bounce_rate_max: newData.guardrail_bounce_rate_max,
+            }),
+            ...(newData.guardrail_complaint_rate_max !== campaign.guardrail_complaint_rate_max && {
+                guardrail_complaint_rate_max: newData.guardrail_complaint_rate_max,
+            }),
+            ...(newData.guardrail_reply_rate_min !== campaign.guardrail_reply_rate_min && {
+                guardrail_reply_rate_min: newData.guardrail_reply_rate_min,
+            }),
+            ...(newData.guardrail_min_sample !== campaign.guardrail_min_sample && {
+                guardrail_min_sample: newData.guardrail_min_sample,
+            }),
+            ...(newData.guardrail_window_days !== campaign.guardrail_window_days && {
+                guardrail_window_days: newData.guardrail_window_days,
+            }),
+
             // cc/bcc
             ...(newData.cc !== campaign.cc && { cc: newData.cc }),
             ...(newData.bcc !== campaign.bcc && { bcc: newData.bcc }),
@@ -248,6 +275,8 @@ export default function CampaignPreferences() {
         if (newData.ramp_enabled && newData.ramp_start > newData.ramp_ceiling) {
             return "Ramp start must be less than or equal to the ramp ceiling.";
         }
+        const guardrail = guardrailValidationError(newData);
+        if (guardrail) return guardrail;
         // Sending accounts: nothing selected is valid — it means "all active
         // mailboxes", so there is no minimum-selection requirement anymore.
         return null;
@@ -322,6 +351,8 @@ export default function CampaignPreferences() {
                 return <DeliverabilitySection newCampaign={newData} setNewCampaign={setNewData} />;
             case "rotation":
                 return <RotationRampSection newCampaign={newData} setNewCampaign={setNewData} />;
+            case "guardrails":
+                return <GuardrailsSection newCampaign={newData} setNewCampaign={setNewData} />;
             case "matching":
                 return (
                     <EspMatchingSection

--- a/web/src/app/app/campaigns/page.tsx
+++ b/web/src/app/app/campaigns/page.tsx
@@ -77,6 +77,7 @@ const STATUS_LABEL: Record<string, string> = {
     paused: "paused",
     paused_no_accounts: "no accounts",
     paused_trial_expired: "trial expired",
+    paused_guardrail: "auto-paused",
     completed: "finished",
     draft: "draft",
 };
@@ -90,6 +91,7 @@ const STATUS_TONE: Record<string, string> = {
     paused: "text-amber-600",
     paused_no_accounts: "text-amber-600",
     paused_trial_expired: "text-amber-600",
+    paused_guardrail: "text-rose-600",
     draft: "text-slate-500",
 };
 
@@ -110,6 +112,9 @@ function CampaignStatusMark({ status }: { status: string }) {
     } else if (status === "paused") {
         Icon = PauseIcon;
         title = "Paused";
+    } else if (status === "paused_guardrail") {
+        Icon = AlertTriangleIcon;
+        title = "Paused automatically — a deliverability guardrail was breached";
     } else if (status === "paused_no_accounts" || status === "paused_trial_expired") {
         Icon = AlertTriangleIcon;
         title = status === "paused_no_accounts" ? "Paused — no sending accounts" : "Paused — trial expired";

--- a/web/src/app/app/settings/notifications/page.tsx
+++ b/web/src/app/app/settings/notifications/page.tsx
@@ -26,6 +26,7 @@ const HEALTH: { key: NotificationCategoryKey; label: string; hint: string }[] = 
     { key: "health_bounce", label: "Bounce detected", hint: "A campaign starts bouncing — notifies the campaign owner." },
     { key: "health_complaint", label: "Spam complaint", hint: "Any complaint event on one of your campaigns." },
     { key: "health_worker_downtime", label: "Worker downtime", hint: "A sender worker stops responding." },
+    { key: "campaign_paused", label: "Campaign auto-paused", hint: "A guardrail stopped a campaign because its bounce, complaint, or reply rate left the band." },
 ];
 
 const SECURITY: { key: NotificationCategoryKey; label: string; hint: string }[] = [
@@ -107,6 +108,7 @@ export default function NotificationsSettingsPage() {
         "health_bounce",
         "health_complaint",
         "health_worker_downtime",
+        "campaign_paused",
         "security_new_signin",
         "billing_alert",
         "team_activity",

--- a/web/src/components/app/campaigns/preferences/CampaignGuardrails.tsx
+++ b/web/src/components/app/campaigns/preferences/CampaignGuardrails.tsx
@@ -1,0 +1,150 @@
+// Auto-pause guardrails — the campaign stops itself when its engagement rates
+// leave the band you set, instead of waiting for a mailbox provider to react.
+//
+// The numbers here are percentages. Bounce and complaint rates are ceilings
+// (pause at or above); the reply rate is a floor (pause below), because a
+// campaign at volume that nobody answers is spending sender reputation for
+// nothing. Setting a rate to 0 turns that rule off.
+
+import { PauseCircleIcon } from "lucide-react";
+import type Campaign from "@/lib/api/models/app/campaigns/Campaign";
+import { Label, NumberInput } from "@/components/ui/field";
+import { SettingRow, Toggle } from "./components/CampaignPreferenceBoolBox";
+
+type SetCampaign = React.Dispatch<React.SetStateAction<Campaign>>;
+
+// Provider guidance behind the defaults, shown so the numbers are not magic.
+const REFERENCE = [
+    "Google asks senders to keep spam complaints under 0.10% and never reach 0.30%.",
+    "Amazon SES puts an account under review at a 5% bounce rate and can pause sending at 10%.",
+];
+
+export function GuardrailsSection({
+    newCampaign,
+    setNewCampaign,
+}: {
+    newCampaign: Campaign;
+    setNewCampaign: SetCampaign;
+}) {
+    const trippedAt = newCampaign.guardrail_tripped_at;
+    const paused = newCampaign.status === "paused_guardrail";
+
+    return (
+        <div className="space-y-5">
+            {(paused || trippedAt) && (
+                <div className="rounded-md border border-amber-100 bg-amber-50/70 px-3 py-2.5 flex gap-2.5">
+                    <PauseCircleIcon className="w-4 h-4 text-amber-600 shrink-0 mt-0.5" />
+                    <div className="min-w-0">
+                        <p className="text-[11.5px] text-amber-900/90 leading-relaxed">
+                            {newCampaign.guardrail_reason || "This campaign was paused automatically by a guardrail."}
+                        </p>
+                        {trippedAt && (
+                            <p className="text-[10.5px] text-amber-800/70 mt-1">
+                                {new Date(trippedAt).toLocaleString()}
+                            </p>
+                        )}
+                        {paused && (
+                            <p className="text-[10.5px] text-amber-800/70 mt-1">
+                                Starting the campaign again clears this. Fix the underlying problem first, or it will
+                                trip again on the next check.
+                            </p>
+                        )}
+                    </div>
+                </div>
+            )}
+
+            <SettingRow
+                title="Auto-pause"
+                description="Stop this campaign the moment its bounce, complaint, or reply rate leaves the band below. Checked every 15 minutes."
+                control={
+                    <Toggle
+                        id="campaign-pref-guardrail"
+                        value={newCampaign.guardrail_enabled}
+                        onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_enabled: v }))}
+                    />
+                }
+            />
+
+            {newCampaign.guardrail_enabled && (
+                <div className="rounded-md border border-slate-200 bg-slate-50/40 p-3.5 space-y-4">
+                    <div className="flex flex-wrap items-end gap-4">
+                        <div>
+                            <Label>Pause above bounce rate</Label>
+                            <NumberInput
+                                value={newCampaign.guardrail_bounce_rate_max}
+                                min={0}
+                                max={100}
+                                step={0.5}
+                                onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_bounce_rate_max: v }))}
+                                suffix="%"
+                                className="w-36"
+                            />
+                        </div>
+                        <div>
+                            <Label>Pause above complaint rate</Label>
+                            <NumberInput
+                                value={newCampaign.guardrail_complaint_rate_max}
+                                min={0}
+                                max={100}
+                                step={0.05}
+                                onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_complaint_rate_max: v }))}
+                                suffix="%"
+                                className="w-36"
+                            />
+                        </div>
+                        <div>
+                            <Label>Pause below reply rate</Label>
+                            <NumberInput
+                                value={newCampaign.guardrail_reply_rate_min}
+                                min={0}
+                                max={100}
+                                step={0.5}
+                                onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_reply_rate_min: v }))}
+                                suffix="%"
+                                className="w-36"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-end gap-4">
+                        <div>
+                            <Label>Only after</Label>
+                            <NumberInput
+                                value={newCampaign.guardrail_min_sample}
+                                min={1}
+                                max={100000}
+                                onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_min_sample: v }))}
+                                suffix="sends"
+                                className="w-40"
+                            />
+                        </div>
+                        <div>
+                            <Label>Measured over the last</Label>
+                            <NumberInput
+                                value={newCampaign.guardrail_window_days}
+                                min={0}
+                                max={365}
+                                onChange={(v) => setNewCampaign((bef) => ({ ...bef, guardrail_window_days: v }))}
+                                suffix="days"
+                                className="w-40"
+                            />
+                        </div>
+                    </div>
+
+                    <div className="space-y-1.5 pt-0.5">
+                        <p className="text-[11px] text-slate-500 leading-relaxed">
+                            A rate of <b>0</b> turns that rule off. The reply-rate floor is off by default: pausing for
+                            weak engagement is a deliberate choice. A window of <b>0</b> days measures the campaign&apos;s
+                            whole history.
+                        </p>
+                        {REFERENCE.map((line) => (
+                            <p key={line} className="text-[10.5px] text-slate-400 leading-relaxed">
+                                {line}
+                            </p>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/web/src/components/app/emails/InboxDetails.tsx
+++ b/web/src/components/app/emails/InboxDetails.tsx
@@ -1,11 +1,13 @@
-// Mailbox detail — a themed right slide-over with four tabs:
+// Mailbox detail — a themed right slide-over with five tabs:
 //   Overview   read-only at-a-glance: health, today's usage, warmup status, identity
 //   Analytics  warmup volume series + summary metrics
 //   Warmup     editable warmup ramp config + live status
+//   Sending    human sending behaviour: working days, hours, lunch, volume, spacing
 //   Settings   profile, signature, tags, sending caps, tracking domain
 // Edits across Warmup + Settings share one form; a sticky save bar commits
-// them via PATCH /emails/:id. Read data: /analytics/accounts/:id and
-// /analytics/warmup?email_id=.
+// them via PATCH /emails/:id. Sending owns its own save (PUT
+// /emails/:id/behavior) because the profile is a separate resource with its own
+// validation. Read data: /analytics/accounts/:id and /analytics/warmup?email_id=.
 
 import React, { useMemo, useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -16,6 +18,7 @@ import {
     BarChart3Icon,
     FlameIcon,
     Settings2Icon,
+    ClockFadingIcon,
     CheckCircle2Icon,
     AlertTriangleIcon,
     AlertCircleIcon,
@@ -51,6 +54,7 @@ import useUpdateEmailTrackingDomain from "@/lib/api/hooks/app/emails/useUpdateEm
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import EmailEditor from "../EmailEditor";
+import SendingBehaviorTab from "./SendingBehaviorTab";
 import TagSelector from "../popup/select/TagSelector";
 import TimeSelect from "@/components/ui/TimeSelect";
 import { DitherBarChart } from "@/components/ui/dither";
@@ -125,6 +129,7 @@ const TABS: { key: string; label: string; icon: LucideIcon }[] = [
     { key: "overview", label: "Overview", icon: GaugeIcon },
     { key: "analytics", label: "Analytics", icon: BarChart3Icon },
     { key: "warmup", label: "Warmup", icon: FlameIcon },
+    { key: "sending", label: "Sending", icon: ClockFadingIcon },
     { key: "settings", label: "Settings", icon: Settings2Icon },
 ];
 
@@ -275,6 +280,7 @@ function Detail({ mailbox, onClose, initialTab = "overview", canWarmup = true }:
                 {tab === "overview" && <OverviewTab status={status.data} loading={status.isPending} mailbox={mailbox} />}
                 {tab === "analytics" && <AnalyticsTab warmup={warmup.data} loading={warmup.isPending} />}
                 {tab === "warmup" && <WarmupTab form={form} update={update} status={status.data} mailbox={mailbox} canWarmup={canWarmup} />}
+                {tab === "sending" && <SendingBehaviorTab mailboxId={mailbox.id} />}
                 {tab === "settings" && <SettingsTab form={form} update={update} mailbox={mailbox} />}
             </div>
 

--- a/web/src/components/app/emails/InboxDetails.tsx
+++ b/web/src/components/app/emails/InboxDetails.tsx
@@ -55,6 +55,9 @@ import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import EmailEditor from "../EmailEditor";
 import SendingBehaviorTab from "./SendingBehaviorTab";
+import useSendingBehavior from "@/lib/api/hooks/app/emails/useSendingBehavior";
+import useSendingPlan from "@/lib/api/hooks/app/emails/useSendingPlan";
+import { minutesToClock, secondsToLabel } from "@/lib/api/models/app/emails/SendingBehavior";
 import TagSelector from "../popup/select/TagSelector";
 import TimeSelect from "@/components/ui/TimeSelect";
 import { DitherBarChart } from "@/components/ui/dither";
@@ -113,6 +116,17 @@ function NumField({ value, onChange, suffix }: { value: number; onChange: (v: nu
             className="w-full h-9"
         />
     );
+}
+
+// min_wait_time is stored in SECONDS. Render it as a duration so the number
+// can never be read as minutes — a 600 shown as "600 min" (or a 10 typed into a
+// field labelled minutes) is the difference between a 10-minute gap and a
+// 10-second burst.
+function formatGap(seconds: number): string {
+    if (!Number.isFinite(seconds) || seconds < 60) return `${seconds ?? 0}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s === 0 ? `${m} min` : `${m} min ${s}s`;
 }
 
 function statusTone(status: string) {
@@ -318,6 +332,14 @@ function OverviewTab({ status, loading, mailbox }: { status?: import("@/lib/api/
     const usage = status?.daily_usage;
     const ws = status?.warmup_status;
 
+    // When a sending-behaviour profile is on, TODAY'S rolled plan is the real
+    // ceiling and spacing — not the mailbox's fixed cap and gap. Showing the
+    // fixed numbers here would contradict what the mailbox actually does.
+    const behavior = useSendingBehavior(mailbox.id);
+    const personaOn = behavior.data?.enabled === true;
+    const plan = useSendingPlan(mailbox.id, personaOn);
+    const today = personaOn ? plan.data : undefined;
+
     const healthTone =
         health?.status === "healthy" ? { bar: "bg-emerald-500", text: "text-emerald-600", icon: CheckCircle2Icon }
             : health?.status === "warning" ? { bar: "bg-amber-500", text: "text-amber-600", icon: AlertTriangleIcon }
@@ -369,7 +391,19 @@ function OverviewTab({ status, loading, mailbox }: { status?: import("@/lib/api/
 
             {/* Key stats */}
             <div className="grid grid-cols-2 divide-x divide-y divide-slate-200/60">
-                <StatCard label="Sent today" value={usage ? usage.campaign_sent : "—"} sub={usage ? `of ${usage.campaign_limit}/day cap` : undefined} />
+                <StatCard
+                    label="Sent today"
+                    value={usage ? usage.campaign_sent : "—"}
+                    sub={
+                        today
+                            ? today.is_working_day
+                                ? `of ${today.daily_limit} rolled for today`
+                                : "not a sending day"
+                            : usage
+                                ? `of ${usage.campaign_limit}/day cap`
+                                : undefined
+                    }
+                />
                 <StatCard label="Warmup today" value={ws ? ws.current_volume : (usage?.warmup_sent ?? "—")} sub={ws ? `target ${ws.target_volume}` : undefined} accent />
                 <StatCard label="Reply rate" value={ws ? `${ws.reply_rate}%` : "—"} sub="warmup replies" />
                 <StatCard label="Days warming" value={ws ? ws.days_active : "—"} sub={ws ? `max ${ws.max_volume}/day` : undefined} />
@@ -395,8 +429,26 @@ function OverviewTab({ status, loading, mailbox }: { status?: import("@/lib/api/
             <div>
                 <Row label="Provider"><span className="capitalize">{mailbox.provider?.replace("_", "/")}</span></Row>
                 <Row label="Tracking domain">{mailbox.tracking_domain || <span className="text-slate-400">Not set</span>}</Row>
-                <Row label="Daily cap">{mailbox.campaign_limit} / day</Row>
-                <Row label="Min gap">{mailbox.min_wait_time} min</Row>
+                <Row label="Daily cap">
+                    {today?.is_working_day
+                        ? `${today.daily_limit} / day today (${behavior.data?.daily_limit_min}-${behavior.data?.daily_limit_max} range)`
+                        : `${mailbox.campaign_limit} / day`}
+                </Row>
+                <Row label="Min gap">
+                    {today
+                        ? `${secondsToLabel(today.gap_min_seconds)}-${secondsToLabel(today.gap_max_seconds)}`
+                        : formatGap(mailbox.min_wait_time)}
+                </Row>
+                {today?.is_working_day && (
+                    <Row label="Workday">
+                        {minutesToClock(today.work_start_minute)}-{minutesToClock(today.work_end_minute)}
+                        {today.lunch_start_minute !== null && today.lunch_end_minute !== null && (
+                            <span className="text-slate-400">
+                                {" "}(lunch {minutesToClock(today.lunch_start_minute)}-{minutesToClock(today.lunch_end_minute)})
+                            </span>
+                        )}
+                    </Row>
+                )}
                 <Row label="Last synced">
                     <span className="inline-flex items-center gap-1.5 text-slate-600">
                         <ClockIcon className="w-3.5 h-3.5 text-slate-400" />
@@ -1091,8 +1143,11 @@ function SettingsTab({ form, update, mailbox }: { form: Inbox; update: (p: Parti
                 <FieldShell label="Daily campaign cap" hint="Max cold-campaign emails per day. Default 50; raise only with good reputation.">
                     <NumField value={form.campaign_limit} onChange={(v) => update({ campaign_limit: v })} suffix="emails / day" />
                 </FieldShell>
-                <FieldShell label="Minimum gap" hint="Smallest delay between two sends from this mailbox.">
-                    <NumField value={form.min_wait_time} onChange={(v) => update({ min_wait_time: v })} suffix="minutes" />
+                <FieldShell
+                    label="Minimum gap"
+                    hint={`Smallest delay between two sends from this mailbox — currently ${formatGap(form.min_wait_time)}. Overridden while Sending behaviour is on, which draws a fresh delay for every send.`}
+                >
+                    <NumField value={form.min_wait_time} onChange={(v) => update({ min_wait_time: v })} suffix="seconds" />
                 </FieldShell>
             </div>
 

--- a/web/src/components/app/emails/SendingBehaviorTab.tsx
+++ b/web/src/components/app/emails/SendingBehaviorTab.tsx
@@ -1,0 +1,492 @@
+// Sending behaviour — the mailbox's human schedule.
+//
+// The editor sets RANGES; the mailbox rolls one workday out of them per local
+// day and keeps to it. The panel leads with that rolled day, because "why did
+// nothing send at 4pm" is answered by today's plan, not by the ranges that
+// produced it.
+//
+// Owns its own save (PUT /emails/:id/behavior) rather than joining the drawer's
+// shared mailbox form: it is a separate resource with its own validation.
+
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import {
+    ClockIcon,
+    CoffeeIcon,
+    GaugeIcon,
+    InfoIcon,
+    SunriseIcon,
+    SunsetIcon,
+    TimerIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
+
+import { Toggle } from "@/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox";
+import WeekdayBitmask from "@/components/app/campaigns/schedule/WeekdayBitmask";
+import { Loading } from "@/components/loader";
+import { NumberInput, TextInput } from "@/components/ui/field";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import useSendingBehavior from "@/lib/api/hooks/app/emails/useSendingBehavior";
+import useSendingPlan from "@/lib/api/hooks/app/emails/useSendingPlan";
+import useUpdateSendingBehavior from "@/lib/api/hooks/app/emails/useUpdateSendingBehavior";
+import type SendingBehavior from "@/lib/api/models/app/emails/SendingBehavior";
+import {
+    DEFAULT_SENDING_BEHAVIOR,
+    WEEKDAY_LABELS,
+    clockToMinutes,
+    minutesToClock,
+    secondsToLabel,
+    validateSendingBehavior,
+    type SendingBehaviorPatch,
+} from "@/lib/api/models/app/emails/SendingBehavior";
+import buildError from "@/lib/helper/buildError";
+import { cn } from "@/lib/utils";
+
+const Eyebrow = ({ children }: { children: React.ReactNode }) => (
+    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{children}</div>
+);
+
+function FieldShell({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+    return (
+        <div>
+            <label className="block text-[12px] font-medium text-slate-700 mb-1">{label}</label>
+            {children}
+            {hint && <p className="text-[10.5px] text-slate-400 mt-1 leading-relaxed">{hint}</p>}
+        </div>
+    );
+}
+
+// Minute-precision clock field. Deliberately not the shared 30-minute
+// TimeSelect: the whole point of this panel is that a mailbox starts at 09:14
+// rather than on the half hour.
+function ClockField({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+    const [draft, setDraft] = React.useState(() => minutesToClock(value));
+
+    React.useEffect(() => {
+        setDraft(minutesToClock(value));
+    }, [value]);
+
+    const commit = (raw: string) => {
+        const parsed = clockToMinutes(raw);
+        if (parsed === null) {
+            setDraft(minutesToClock(value)); // reject: snap back to the stored value
+            return;
+        }
+        onChange(parsed);
+    };
+
+    return (
+        <TextInput
+            value={draft}
+            placeholder="09:00"
+            onChange={setDraft}
+            onBlur={() => commit(draft)}
+            className="w-full h-9 tabular-nums"
+        />
+    );
+}
+
+function RangeRow({
+    icon,
+    label,
+    hint,
+    children,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    hint?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div>
+            <div className="flex items-center gap-1.5 mb-1">
+                <span className="text-slate-400">{icon}</span>
+                <label className="text-[12px] font-medium text-slate-700">{label}</label>
+            </div>
+            {children}
+            {hint && <p className="text-[10.5px] text-slate-400 mt-1 leading-relaxed">{hint}</p>}
+        </div>
+    );
+}
+
+// A min/max pair rendered as one control, since every range in this panel is
+// "somewhere between these two".
+function PairField({
+    min,
+    max,
+    onMin,
+    onMax,
+    suffix,
+    step = 1,
+    lowerBound = 0,
+}: {
+    min: number;
+    max: number;
+    onMin: (v: number) => void;
+    onMax: (v: number) => void;
+    suffix?: string;
+    step?: number;
+    lowerBound?: number;
+}) {
+    return (
+        <div className="flex items-center gap-2">
+            <NumberInput value={min} onChange={onMin} min={lowerBound} step={step} align="right" className="w-full h-9" />
+            <span className="text-[11.5px] text-slate-400 shrink-0">to</span>
+            <NumberInput value={max} onChange={onMax} min={lowerBound} step={step} suffix={suffix} align="right" className="w-full h-9" />
+        </div>
+    );
+}
+
+function ClockPair({
+    min,
+    max,
+    onMin,
+    onMax,
+}: {
+    min: number;
+    max: number;
+    onMin: (v: number) => void;
+    onMax: (v: number) => void;
+}) {
+    return (
+        <div className="flex items-center gap-2">
+            <ClockField value={min} onChange={onMin} />
+            <span className="text-[11.5px] text-slate-400 shrink-0">to</span>
+            <ClockField value={max} onChange={onMax} />
+        </div>
+    );
+}
+
+/* ── today's rolled workday ─────────────────────── */
+
+function TodayCard({ mailboxId, enabled }: { mailboxId: string; enabled: boolean }) {
+    const plan = useSendingPlan(mailboxId, enabled);
+
+    if (!enabled) return null;
+    if (plan.isPending) {
+        return (
+            <div className="px-5 py-6 flex items-center justify-center">
+                <Loading className="!w-4 h-4" />
+            </div>
+        );
+    }
+    if (!plan.data) return null;
+
+    const p = plan.data;
+
+    if (!p.is_working_day) {
+        return (
+            <div className="px-5 py-4">
+                <Eyebrow>Today</Eyebrow>
+                <p className="mt-2 text-[12.5px] text-slate-700">
+                    Not a sending day for this mailbox. The next working day picks up its own hours.
+                </p>
+            </div>
+        );
+    }
+
+    const used = Math.min(100, (p.sent_today / Math.max(1, p.daily_limit)) * 100);
+
+    return (
+        <div className="px-5 py-4">
+            <div className="flex items-center justify-between">
+                <Eyebrow>Today&apos;s workday</Eyebrow>
+                <span className="text-[10.5px] text-slate-400 font-mono">{p.timezone}</span>
+            </div>
+
+            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[12.5px] text-slate-700">
+                <span className="inline-flex items-center gap-1.5">
+                    <ClockIcon className="w-3.5 h-3.5 text-slate-400" />
+                    <b className="text-slate-900 tabular-nums">{minutesToClock(p.work_start_minute)}</b>
+                    <span className="text-slate-400">–</span>
+                    <b className="text-slate-900 tabular-nums">{minutesToClock(p.work_end_minute)}</b>
+                </span>
+                {p.lunch_start_minute !== null && p.lunch_end_minute !== null && (
+                    <span className="inline-flex items-center gap-1.5">
+                        <CoffeeIcon className="w-3.5 h-3.5 text-slate-400" />
+                        <span className="tabular-nums">
+                            {minutesToClock(p.lunch_start_minute)}–{minutesToClock(p.lunch_end_minute)}
+                        </span>
+                    </span>
+                )}
+                <span className="inline-flex items-center gap-1.5">
+                    <TimerIcon className="w-3.5 h-3.5 text-slate-400" />
+                    <span>{secondsToLabel(p.gap_min_seconds)}–{secondsToLabel(p.gap_max_seconds)} apart</span>
+                </span>
+                <span className="inline-flex items-center gap-1.5">
+                    <GaugeIcon className="w-3.5 h-3.5 text-slate-400" />
+                    <span>max {p.hourly_limit}/hour</span>
+                </span>
+            </div>
+
+            <div className="mt-3 flex items-center justify-between text-[12px] text-slate-600">
+                <span>
+                    <b className="text-slate-900 tabular-nums">{p.sent_today}</b> of{" "}
+                    <b className="text-slate-900 tabular-nums">{p.daily_limit}</b> sent
+                </span>
+                <span className="text-slate-400 tabular-nums">{p.remaining_today} left</span>
+            </div>
+            <div className="mt-1.5 h-1.5 w-full rounded-full bg-slate-100 overflow-hidden">
+                <div className="h-full rounded-full bg-sky-500 transition-all" style={{ width: `${used}%` }} />
+            </div>
+        </div>
+    );
+}
+
+/* ── the tab ─────────────────────── */
+
+export default function SendingBehaviorTab({ mailboxId, timezone }: { mailboxId: string; timezone?: string }) {
+    const query = useSendingBehavior(mailboxId);
+    const mutation = useUpdateSendingBehavior(mailboxId);
+
+    const [form, setForm] = React.useState<SendingBehavior | null>(null);
+    React.useEffect(() => {
+        if (query.data) setForm(query.data);
+    }, [query.data]);
+
+    const update = (patch: Partial<SendingBehavior>) => setForm((f) => (f ? { ...f, ...patch } : f));
+
+    const dirty = React.useMemo(
+        () => !!form && !!query.data && JSON.stringify(form) !== JSON.stringify(query.data),
+        [form, query.data],
+    );
+    const error = React.useMemo(() => (form ? validateSendingBehavior(form) : null), [form]);
+
+    if (query.isPending || !form) {
+        return (
+            <div className="px-5 py-10 flex items-center justify-center">
+                <Loading className="!w-4 h-4" />
+            </div>
+        );
+    }
+
+    if (query.isError) {
+        return (
+            <div className="px-5 py-6 text-[12.5px] text-slate-500">
+                Sending behaviour is unavailable for this mailbox right now.
+            </div>
+        );
+    }
+
+    const save = async () => {
+        if (error) {
+            toast.error(error);
+            return;
+        }
+        const patch: SendingBehaviorPatch = {};
+        const stored = query.data as SendingBehavior;
+        for (const key of Object.keys(DEFAULT_SENDING_BEHAVIOR) as (keyof SendingBehaviorPatch)[]) {
+            if (form[key] !== stored[key]) {
+                (patch as Record<string, unknown>)[key] = form[key];
+            }
+        }
+        try {
+            await mutation.mutateAsync(patch);
+            toast.success("Sending behaviour updated");
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    };
+
+    const tz = form.timezone || timezone;
+
+    return (
+        // The drawer owns the scroll container, so the save row is sticky
+        // rather than a flex footer — otherwise it would sit below the fold on
+        // a panel this tall.
+        <div>
+            <div className="divide-y divide-slate-200/60">
+                {/* On/off */}
+                <div className="px-5 py-4 flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-2.5 min-w-0">
+                        <div
+                            className={cn(
+                                "w-8 h-8 rounded-lg flex items-center justify-center shrink-0",
+                                form.enabled ? "bg-sky-50 text-sky-600" : "bg-slate-100 text-slate-400",
+                            )}
+                        >
+                            <ClockIcon className="w-4 h-4" />
+                        </div>
+                        <div className="min-w-0">
+                            <div className="text-[12.5px] font-medium text-slate-900">
+                                {form.enabled ? "Sending like a person" : "Fixed schedule"}
+                            </div>
+                            <div className="text-[11px] text-slate-400">
+                                {form.enabled
+                                    ? "Hours, volume and spacing are re-rolled each day"
+                                    : "Uses the mailbox daily cap and minimum gap"}
+                            </div>
+                        </div>
+                    </div>
+                    <Toggle value={form.enabled} onChange={(v) => update({ enabled: v })} />
+                </div>
+
+                <TodayCard mailboxId={mailboxId} enabled={form.enabled && query.data?.enabled === true} />
+
+                {/* Working days */}
+                <div className="px-5 py-5 space-y-2">
+                    <Eyebrow>Working days</Eyebrow>
+                    <WeekdayBitmask
+                        weekdays={[...WEEKDAY_LABELS]}
+                        value={form.weekdays}
+                        setValue={(v) => update({ weekdays: v })}
+                    />
+                    <p className="text-[10.5px] text-slate-400 leading-relaxed">
+                        Days this mailbox sends anything at all, cold outreach and warmup alike.
+                    </p>
+                </div>
+
+                {/* Workday */}
+                <div className="px-5 py-5 space-y-5">
+                    <Eyebrow>Workday</Eyebrow>
+                    <RangeRow
+                        icon={<SunriseIcon className="w-3.5 h-3.5" />}
+                        label="Starts somewhere between"
+                        hint="A different start time each day, so the mailbox never opens on the same minute twice."
+                    >
+                        <ClockPair
+                            min={form.work_start_min}
+                            max={form.work_start_max}
+                            onMin={(v) => update({ work_start_min: v })}
+                            onMax={(v) => update({ work_start_max: v })}
+                        />
+                    </RangeRow>
+                    <RangeRow
+                        icon={<SunsetIcon className="w-3.5 h-3.5" />}
+                        label="Finishes somewhere between"
+                        hint="Nothing is scheduled after the day's rolled finish time."
+                    >
+                        <ClockPair
+                            min={form.work_end_min}
+                            max={form.work_end_max}
+                            onMin={(v) => update({ work_end_min: v })}
+                            onMax={(v) => update({ work_end_max: v })}
+                        />
+                    </RangeRow>
+                </div>
+
+                {/* Lunch */}
+                <div className="px-5 py-5 space-y-5">
+                    <div className="flex items-center justify-between gap-3">
+                        <Eyebrow>Lunch break</Eyebrow>
+                        <Toggle value={form.lunch_enabled} onChange={(v) => update({ lunch_enabled: v })} />
+                    </div>
+                    {form.lunch_enabled && (
+                        <>
+                            <RangeRow icon={<CoffeeIcon className="w-3.5 h-3.5" />} label="Starts somewhere between">
+                                <ClockPair
+                                    min={form.lunch_earliest}
+                                    max={form.lunch_latest}
+                                    onMin={(v) => update({ lunch_earliest: v })}
+                                    onMax={(v) => update({ lunch_latest: v })}
+                                />
+                            </RangeRow>
+                            <FieldShell label="Lasts" hint="A quiet gap in the middle of the day, like any real inbox has.">
+                                <PairField
+                                    min={form.lunch_min_minutes}
+                                    max={form.lunch_max_minutes}
+                                    onMin={(v) => update({ lunch_min_minutes: v })}
+                                    onMax={(v) => update({ lunch_max_minutes: v })}
+                                    suffix="minutes"
+                                />
+                            </FieldShell>
+                        </>
+                    )}
+                </div>
+
+                {/* Volume + spacing */}
+                <div className="px-5 py-5 space-y-5">
+                    <Eyebrow>Volume and spacing</Eyebrow>
+                    <FieldShell
+                        label="Cold emails per day"
+                        hint="Rolled once a day inside this range. It can only lower the mailbox's daily cap, never raise it."
+                    >
+                        <PairField
+                            min={form.daily_limit_min}
+                            max={form.daily_limit_max}
+                            onMin={(v) => update({ daily_limit_min: v })}
+                            onMax={(v) => update({ daily_limit_max: v })}
+                            suffix="/ day"
+                            lowerBound={1}
+                        />
+                    </FieldShell>
+                    <FieldShell
+                        label="Cold emails per hour"
+                        hint="Stops a whole day's allowance landing in one burst before lunch."
+                    >
+                        <PairField
+                            min={form.hourly_limit_min}
+                            max={form.hourly_limit_max}
+                            onMin={(v) => update({ hourly_limit_min: v })}
+                            onMax={(v) => update({ hourly_limit_max: v })}
+                            suffix="/ hour"
+                            lowerBound={1}
+                        />
+                    </FieldShell>
+                    <FieldShell
+                        label="Delay between emails"
+                        hint={`Drawn fresh for every send, so the intervals stay irregular. Currently ${secondsToLabel(form.gap_min_seconds)} to ${secondsToLabel(form.gap_max_seconds)}.`}
+                    >
+                        <PairField
+                            min={form.gap_min_seconds}
+                            max={form.gap_max_seconds}
+                            onMin={(v) => update({ gap_min_seconds: v })}
+                            onMax={(v) => update({ gap_max_seconds: v })}
+                            suffix="seconds"
+                            step={15}
+                            lowerBound={30}
+                        />
+                    </FieldShell>
+                </div>
+
+                {/* Timezone note */}
+                <div className="px-5 py-4">
+                    <div className="rounded-md border border-sky-100 bg-sky-50/70 px-3 py-2.5 flex gap-2.5">
+                        <InfoIcon className="w-4 h-4 text-sky-600 shrink-0 mt-0.5" />
+                        <p className="text-[11.5px] text-sky-900/90 leading-relaxed">
+                            Every time here is local to <b>{tz || "UTC"}</b>, this mailbox&apos;s own timezone. Mailboxes in
+                            other regions keep their own working hours on the same campaign. Change the timezone on the
+                            mailbox to move the whole schedule.
+                        </p>
+                    </div>
+                </div>
+
+                {error && (
+                    <div className="px-5 py-3">
+                        <p className="text-[11.5px] text-rose-600">{error}</p>
+                    </div>
+                )}
+            </div>
+
+            <AnimatePresence>
+                {dirty && (
+                    <motion.div
+                        initial={{ y: 60 }}
+                        animate={{ y: 0 }}
+                        exit={{ y: 60 }}
+                        transition={{ duration: 0.2 }}
+                        className="sticky bottom-0 z-10 h-14 px-5 flex items-center gap-2 border-t border-slate-200 bg-slate-50/95 backdrop-blur-sm"
+                    >
+                        <span className="text-[11.5px] text-slate-500">Unsaved changes</span>
+                        <div className="ml-auto flex items-center gap-2">
+                            <button
+                                onClick={() => query.data && setForm(query.data)}
+                                className="h-8 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 transition-colors"
+                            >
+                                Discard
+                            </button>
+                            <button
+                                onClick={save}
+                                disabled={mutation.isPending || !!error}
+                                className="h-8 px-3.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60"
+                            >
+                                {mutation.isPending && <Loading className="!w-3.5 h-3.5 text-white" />}
+                                Save behaviour
+                            </button>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/web/src/components/layout/NotificationBell.tsx
+++ b/web/src/components/layout/NotificationBell.tsx
@@ -12,6 +12,7 @@ import {
     KeyRoundIcon,
     ReplyIcon,
     ServerCrashIcon,
+    PauseCircleIcon,
     Settings2Icon,
     ShieldAlertIcon,
     TriangleAlertIcon,
@@ -36,6 +37,7 @@ const CATEGORY_META: Record<string, { icon: LucideIcon; tone: string }> = {
     security_new_signin: { icon: KeyRoundIcon, tone: "bg-violet-50 text-violet-600" },
     billing_alert: { icon: CreditCardIcon, tone: "bg-amber-50 text-amber-600" },
     team_activity: { icon: UsersIcon, tone: "bg-emerald-50 text-emerald-600" },
+    campaign_paused: { icon: PauseCircleIcon, tone: "bg-rose-50 text-rose-600" },
 };
 
 const FALLBACK_META = { icon: BellIcon, tone: "bg-slate-100 text-slate-500" };

--- a/web/src/components/ui/field.tsx
+++ b/web/src/components/ui/field.tsx
@@ -25,6 +25,7 @@ export function TextInput({
     autoFocus,
     className,
     onKeyDown,
+    onBlur,
 }: {
     value: string;
     onChange: (v: string) => void;
@@ -34,6 +35,10 @@ export function TextInput({
     autoFocus?: boolean;
     className?: string;
     onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+    // Fires when the field loses focus. Use it for inputs that parse their
+    // text into something else (a clock value, a number) so the parse happens
+    // once the user settles rather than on every keystroke.
+    onBlur?: () => void;
 }) {
     return (
         <input
@@ -44,6 +49,7 @@ export function TextInput({
             autoFocus={autoFocus}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={onKeyDown}
+            onBlur={onBlur}
             className={cn(base, "min-w-0", className)}
         />
     );

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -292,7 +292,11 @@ export function useRealtimeEvents() {
           contact: [['contacts']],
           campaign: [['campaigns'], ['analytics']],
           step: [['campaigns']],
-          email_account: [['emails', 'list'], ['analytics', 'accounts']],
+          // ['emails'] rather than ['emails', 'list']: it prefix-matches the
+          // per-mailbox detail reads too (['emails', id, 'behavior'] and its
+          // rolled plan), so a teammate retuning a mailbox's sending behaviour
+          // refreshes everyone's open drawer instead of only the list row.
+          email_account: [['emails'], ['analytics', 'accounts']],
           api_key: [['api-keys']],
           webhook: [['webhooks'], ['integrations', 'connections']],
           template: [['templates']],

--- a/web/src/lib/api/client/app/emails/getSendingBehavior.ts
+++ b/web/src/lib/api/client/app/emails/getSendingBehavior.ts
@@ -1,0 +1,10 @@
+import type SendingBehavior from "@/lib/api/models/app/emails/SendingBehavior";
+import Request from "../../Request";
+
+export default async function getSendingBehavior(id: string): Promise<SendingBehavior> {
+    return await Request<SendingBehavior>({
+        method: "GET",
+        url: `/emails/${id}/behavior`,
+        authorization: true,
+    })
+}

--- a/web/src/lib/api/client/app/emails/getSendingPlan.ts
+++ b/web/src/lib/api/client/app/emails/getSendingPlan.ts
@@ -1,0 +1,10 @@
+import type { DailyPlanView } from "@/lib/api/models/app/emails/SendingBehavior";
+import Request from "../../Request";
+
+export default async function getSendingPlan(id: string): Promise<DailyPlanView> {
+    return await Request<DailyPlanView>({
+        method: "GET",
+        url: `/emails/${id}/behavior/plan`,
+        authorization: true,
+    })
+}

--- a/web/src/lib/api/client/app/emails/updateSendingBehavior.ts
+++ b/web/src/lib/api/client/app/emails/updateSendingBehavior.ts
@@ -1,0 +1,12 @@
+import type SendingBehavior from "@/lib/api/models/app/emails/SendingBehavior";
+import type { SendingBehaviorPatch } from "@/lib/api/models/app/emails/SendingBehavior";
+import Request from "../../Request";
+
+export default async function updateSendingBehavior(id: string, patch: SendingBehaviorPatch): Promise<SendingBehavior> {
+    return await Request<SendingBehavior>({
+        method: "PUT",
+        url: `/emails/${id}/behavior`,
+        data: patch,
+        authorization: true,
+    })
+}

--- a/web/src/lib/api/hooks/app/emails/useSendingBehavior.ts
+++ b/web/src/lib/api/hooks/app/emails/useSendingBehavior.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import getSendingBehavior from "@/lib/api/client/app/emails/getSendingBehavior";
+
+// A mailbox's sending-behaviour profile. The backend substitutes defaults for a
+// mailbox that has never been configured, so this always resolves to a complete
+// object and the editor never has to render a half-empty form.
+export default function useSendingBehavior(id: string, enabled = true) {
+    return useQuery({
+        queryKey: ["emails", id, "behavior"],
+        queryFn: () => getSendingBehavior(id),
+        enabled: !!id && enabled,
+        staleTime: 30_000,
+    });
+}

--- a/web/src/lib/api/hooks/app/emails/useSendingPlan.ts
+++ b/web/src/lib/api/hooks/app/emails/useSendingPlan.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import getSendingPlan from "@/lib/api/client/app/emails/getSendingPlan";
+
+// The workday this mailbox rolled for today, plus how much of it is spent.
+// Refetched on an interval because "remaining today" moves as sends land, and
+// there is no per-send realtime event to hang it off.
+export default function useSendingPlan(id: string, enabled = true) {
+    return useQuery({
+        queryKey: ["emails", id, "behavior", "plan"],
+        queryFn: () => getSendingPlan(id),
+        enabled: !!id && enabled,
+        staleTime: 30_000,
+        refetchInterval: enabled ? 60_000 : false,
+    });
+}

--- a/web/src/lib/api/hooks/app/emails/useUpdateSendingBehavior.ts
+++ b/web/src/lib/api/hooks/app/emails/useUpdateSendingBehavior.ts
@@ -1,0 +1,18 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import updateSendingBehavior from "@/lib/api/client/app/emails/updateSendingBehavior";
+import type SendingBehavior from "@/lib/api/models/app/emails/SendingBehavior";
+import type { SendingBehaviorPatch } from "@/lib/api/models/app/emails/SendingBehavior";
+
+export default function useUpdateSendingBehavior(id: string) {
+    const queryClient = useQueryClient();
+
+    return useMutation({
+        mutationFn: (patch: SendingBehaviorPatch) => updateSendingBehavior(id, patch),
+        onSuccess: (data) => {
+            queryClient.setQueryData<SendingBehavior>(["emails", id, "behavior"], data);
+            // Today's plan keeps whatever it already rolled, but the ranges it
+            // will roll from tomorrow have changed, so drop the cached view.
+            queryClient.invalidateQueries({ queryKey: ["emails", id, "behavior", "plan"] });
+        },
+    });
+}

--- a/web/src/lib/api/models/app/campaigns/Campaign.ts
+++ b/web/src/lib/api/models/app/campaigns/Campaign.ts
@@ -62,6 +62,18 @@ export default interface Campaign {
     max_new_leads_per_day: number;
     prioritize_new_leads: boolean;
 
+    // Auto-pause guardrails. Bounce and complaint rates are ceilings (pause at
+    // or above); the reply rate is a floor (pause below). A rate of 0 turns its
+    // rule off. guardrail_tripped_at/reason are server-owned.
+    guardrail_enabled: boolean;
+    guardrail_bounce_rate_max: number;
+    guardrail_complaint_rate_max: number;
+    guardrail_reply_rate_min: number;
+    guardrail_min_sample: number;
+    guardrail_window_days: number;
+    guardrail_tripped_at?: string | null;
+    guardrail_reason?: string;
+
     // Campaign-scoped tracking-domain override (honored only when verified).
     tracking_domain: string;
     tracking_domain_verified: boolean;

--- a/web/src/lib/api/models/app/emails/SendingBehavior.ts
+++ b/web/src/lib/api/models/app/emails/SendingBehavior.ts
@@ -1,0 +1,137 @@
+// Per-mailbox human sending behaviour (mirrors the Go models).
+//
+// Every minute-of-day value is minutes since LOCAL midnight in the mailbox's
+// own timezone. The profile holds RANGES; the plan holds the values a mailbox
+// actually rolled for one day.
+
+export default interface SendingBehavior {
+    email_account_id: string;
+    enabled: boolean;
+
+    daily_limit_min: number;
+    daily_limit_max: number;
+
+    hourly_limit_min: number;
+    hourly_limit_max: number;
+
+    gap_min_seconds: number;
+    gap_max_seconds: number;
+
+    work_start_min: number;
+    work_start_max: number;
+    work_end_min: number;
+    work_end_max: number;
+
+    lunch_enabled: boolean;
+    lunch_earliest: number;
+    lunch_latest: number;
+    lunch_min_minutes: number;
+    lunch_max_minutes: number;
+
+    // Monday-indexed bitmask: bit 0 = Monday .. bit 6 = Sunday.
+    weekdays: number;
+
+    timezone?: string;
+
+    created_at: string;
+    updated_at: string;
+}
+
+export type SendingBehaviorPatch = Partial<Omit<SendingBehavior, "email_account_id" | "timezone" | "created_at" | "updated_at">>;
+
+export interface DailyPlan {
+    email_account_id: string;
+    plan_date: string;
+    timezone: string;
+    is_working_day: boolean;
+    daily_limit: number;
+    hourly_limit: number;
+    work_start_minute: number;
+    work_end_minute: number;
+    lunch_start_minute: number | null;
+    lunch_end_minute: number | null;
+    gap_min_seconds: number;
+    gap_max_seconds: number;
+    created_at: string;
+}
+
+export interface DailyPlanView extends DailyPlan {
+    sent_today: number;
+    remaining_today: number;
+    behavior: SendingBehavior;
+}
+
+// The defaults the backend substitutes for a mailbox that has never been
+// configured. Mirrored here so the editor can render before the first fetch
+// resolves, and so "reset to defaults" needs no round trip.
+export const DEFAULT_SENDING_BEHAVIOR: SendingBehaviorPatch = {
+    enabled: false,
+    daily_limit_min: 30,
+    daily_limit_max: 45,
+    hourly_limit_min: 5,
+    hourly_limit_max: 9,
+    gap_min_seconds: 90,
+    gap_max_seconds: 420,
+    work_start_min: 543,
+    work_start_max: 567,
+    work_end_min: 1038,
+    work_end_max: 1076,
+    lunch_enabled: true,
+    lunch_earliest: 720,
+    lunch_latest: 810,
+    lunch_min_minutes: 30,
+    lunch_max_minutes: 60,
+    weekdays: 31,
+};
+
+// Monday-first labels, matching the campaign schedule grid.
+export const WEEKDAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+/** Renders minutes-since-midnight as a 24h clock string. */
+export function minutesToClock(minutes: number): string {
+    const m = Math.max(0, Math.min(1439, Math.round(minutes)));
+    return `${String(Math.floor(m / 60)).padStart(2, "0")}:${String(m % 60).padStart(2, "0")}`;
+}
+
+/** Parses "HH:MM" into minutes since midnight; returns null when unparseable. */
+export function clockToMinutes(value: string): number | null {
+    const match = /^(\d{1,2}):(\d{2})$/.exec(value.trim());
+    if (!match) return null;
+    const h = Number(match[1]);
+    const m = Number(match[2]);
+    if (h < 0 || h > 23 || m < 0 || m > 59) return null;
+    return h * 60 + m;
+}
+
+/** "1m 30s" style rendering for a gap expressed in seconds. */
+export function secondsToLabel(seconds: number): string {
+    if (seconds < 60) return `${seconds}s`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s === 0 ? `${m}m` : `${m}m ${s}s`;
+}
+
+/**
+ * The client-side mirror of the backend's validation, so the editor can block
+ * a save with a field-level message instead of round-tripping for a 400.
+ * Returns null when the profile is valid.
+ */
+export function validateSendingBehavior(b: SendingBehavior): string | null {
+    if (b.daily_limit_min < 1 || b.daily_limit_max > 500) return "Daily volume must be between 1 and 500 emails.";
+    if (b.daily_limit_min > b.daily_limit_max) return "The daily minimum cannot be above the maximum.";
+    if (b.hourly_limit_min < 1 || b.hourly_limit_max > 200) return "Hourly volume must be between 1 and 200 emails.";
+    if (b.hourly_limit_min > b.hourly_limit_max) return "The hourly minimum cannot be above the maximum.";
+    if (b.gap_min_seconds < 30 || b.gap_max_seconds > 86400) return "The delay between emails must be between 30 seconds and 24 hours.";
+    if (b.gap_min_seconds > b.gap_max_seconds) return "The shortest delay cannot be above the longest.";
+    if (b.work_start_min > b.work_start_max) return "The earliest start cannot be after the latest start.";
+    if (b.work_end_min > b.work_end_max) return "The earliest finish cannot be after the latest finish.";
+    if (b.work_start_max >= b.work_end_min) return "The workday has to end after the latest possible start.";
+    if (b.lunch_earliest > b.lunch_latest) return "The lunch window is inverted.";
+    if (b.lunch_min_minutes > b.lunch_max_minutes) return "The shortest break cannot be longer than the longest.";
+    if (b.lunch_max_minutes > 240) return "A break cannot run longer than 4 hours.";
+    if (b.lunch_enabled && (b.lunch_earliest < b.work_start_max || b.lunch_latest + b.lunch_max_minutes > b.work_end_min)) {
+        return "The break has to fit inside the shortest possible workday.";
+    }
+    if (b.enabled && b.weekdays === 0) return "Pick at least one sending day.";
+    return null;
+}

--- a/web/src/lib/api/models/app/notifications/Notification.ts
+++ b/web/src/lib/api/models/app/notifications/Notification.ts
@@ -29,6 +29,7 @@ export interface NotificationPreferences {
     security_new_signin: CategoryPref;
     billing_alert: CategoryPref;
     team_activity: CategoryPref;
+    campaign_paused: CategoryPref;
     email_digest_minutes: number;
 }
 
@@ -66,6 +67,9 @@ export function normalizeNotificationPreferences(
         security_new_signin: p?.security_new_signin ?? on,
         billing_alert: p?.billing_alert ?? billing,
         team_activity: p?.team_activity ?? on,
+        // Emails by default, like billing: a campaign the platform stopped by
+        // itself has to reach whoever can restart it.
+        campaign_paused: p?.campaign_paused ?? billing,
         email_digest_minutes: Math.min(Math.max(minutes, EMAIL_WINDOW_MIN_MINUTES), EMAIL_WINDOW_MAX_MINUTES),
     };
 }

--- a/web/src/lib/helper/guardrail.ts
+++ b/web/src/lib/helper/guardrail.ts
@@ -1,0 +1,30 @@
+// Client-side mirror of the backend's guardrail bounds, so a bad threshold is
+// rejected in the form instead of round-tripping for a 400.
+
+import type Campaign from "@/lib/api/models/app/campaigns/Campaign";
+
+export function guardrailValidationError(c: Campaign): string | null {
+    if (!c.guardrail_enabled) return null;
+    const rates: [string, number][] = [
+        ["Bounce rate", c.guardrail_bounce_rate_max],
+        ["Complaint rate", c.guardrail_complaint_rate_max],
+        ["Reply rate", c.guardrail_reply_rate_min],
+    ];
+    for (const [label, value] of rates) {
+        if (value < 0 || value > 100) return `${label} must be a percentage between 0 and 100.`;
+    }
+    if (c.guardrail_min_sample < 1 || c.guardrail_min_sample > 100000) {
+        return "The sample floor must be between 1 and 100,000 sends.";
+    }
+    if (c.guardrail_window_days < 0 || c.guardrail_window_days > 365) {
+        return "The measurement window must be between 0 and 365 days.";
+    }
+    if (
+        c.guardrail_bounce_rate_max === 0 &&
+        c.guardrail_complaint_rate_max === 0 &&
+        c.guardrail_reply_rate_min === 0
+    ) {
+        return "Auto-pause is on but every rule is set to 0. Set at least one threshold, or switch auto-pause off.";
+    }
+    return null;
+}


### PR DESCRIPTION
## What this adds

Two features, plus the fixes that verifying them turned up.

### Human sending behaviour

A mailbox that sends exactly 40 emails a day, starts at 09:00:00 and spaces every send exactly 600s apart is describing itself as a machine in its own Received headers.

Each mailbox now gets a profile of **ranges**, and rolls one workday out of them per local day:

| Setting | Default range |
|---|---|
| Working days | Mon–Fri (Monday-indexed mask, matching `campaigns.days`) |
| Workday start | `09:03`–`09:27` |
| Workday finish | `17:18`–`17:56` |
| Lunch break | starts `12:00`–`13:30`, lasts `30`–`60` min |
| Cold emails / day | `30`–`45` |
| Cold emails / hour | `5`–`9` |
| Delay between emails | `90`–`420`s, drawn fresh per send |

The roll is deterministic on `(mailbox id, local date)` and persisted. That matters: the schedulers recompute a mailbox's next slot many times a day, and a fresh random workday on every call would mean the mailbox never actually keeps to one. Editing ranges does not change today — the day keeps the shape it started with.

Everything is evaluated in the **mailbox's own timezone**, replacing a hardcoded fleet-wide 8am–8pm gate. A send must satisfy both calendars: the campaign's window in the campaign timezone and the mailbox's workday in its own.

Applied across the campaign, warmup and smart-send schedulers. Warmup follows the same hours, break and weekdays, but is not charged against the cold budgets — it has its own ramp.

**Off by default.** A mailbox that has not opted in schedules exactly as before, and persists no plan rows.

The gates compose one way only: behaviour can **delay** a send or **lower** a budget, never bring one forward or raise one, so the mailbox-first safety invariant holds.

### Campaign auto-pause guardrails

A campaign stops itself when its rates leave the band its owner set, rather than waiting for a mailbox provider to react.

| Rule | Direction | Default |
|---|---|---|
| Bounce rate | pause at or above | `5%` (SES review threshold) |
| Complaint rate | pause at or above | `0.10%` (Google's band) |
| Reply rate | pause **below** | off — a floor needs a deliberate choice |

Sample floor (default 50 sends) and a rolling window (default 7 days) keep noise from tripping anything. New `paused_guardrail` status, resumable by explicitly restarting; the stored reason names the rule, the number and the sample. Swept every 15 minutes, announced to the campaign log, audit trail (which drives the realtime spine) and an in-app notification.

## Fixes this surfaced

- **Mailbox rotation did not rotate** for tag-resolved or all-mailbox campaigns — the default. Rotation metadata lives on `campaign_senders`, so `round_robin` and `least_recently_used` fell through to their UUID tie-breaker and gave every send to the same mailbox until it capped. Now derived from today's send count and real send history.
- **Sends could be scheduled in the past.** Symmetric jitter (±20 min) plus `humanizeSeconds` truncating down to the minute could move a near-term slot backwards, where it fires with none of its spacing — or is cancelled outright by the 15-minute overdue sweep. Clamped at every exit.
- **`min_wait_time` is seconds but the dashboard labelled it minutes.** Typing "10" meaning ten minutes set a **ten-second** gap. Corrected, with a derived duration shown.
- **A mailbox the caller does not own returned 500, not 404.** Tenancy was never violated; the code was just wrong. Also improves the pre-existing `GET /emails/:id`.

## Verification

Beyond `make lint` / typecheck / builds on every tree, this was run against a live stack — infra up, native backend, migration applied by the real embedded runner.

- **HTTP**: defaults, partial updates, two rejected profiles (`400` naming the field), auth `401`, malformed id `400`, cross-tenant `404` with nothing written. Plan endpoint rolled `09:10–17:33, lunch 13:13–13:43, 33/day` and returned identical values across six calls.
- **Live Postgres integration tests** (new, skipped unless `WARMBLY_TEST_DB` is set) drive the real `CalculateNextCampaignTime`: send lands inside the rolled window, jumps the break, rolls to the only working weekday, follows the mailbox clock (`10:02 Tokyo = 01:02 UTC`), never returns a past slot, and hourly/daily ceilings both bind. A disabled profile persists nothing.
- **Guardrail** against the real windowed query and conditional UPDATE: pauses at 12% bounce, ignores 100% on 4 sends, leaves a healthy campaign alone, idempotent, re-trips after restart. Then armed a campaign, booted the backend, and the job paused it unaided.
- **50 consecutive live runs, zero failures, zero row leakage.**
- Migration replays clean on a fresh database, and `down` → `up` again is clean.

## Not covered

No browser verification — that is manual against the native dev stack. The admin panel has no persona visibility yet.
