### PR TITLE
feat: self-hosted auth (SMTP transport, OIDC, bootstrap owner, per-IP limiter)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROTO_DIR := internal/tasks/proto
 PROTO_GEN_FILES := $(PROTO_DIR)/tasks.pb.go
 
 .PHONY: setup-tools fmt lint proto check-proto \
-        up seed seed-plan sandbox sandbox-seed sandbox-simulate reset logs status stop down test-seed \
+        up claim seed-demo seed seed-plan sandbox sandbox-seed sandbox-simulate reset logs status stop down test-seed \
         restart restart-go restart-all infra infra-down app app-down app-logs \
         backend consumer worker run dev tracking realtime web \
         admin site docs grant-admin revoke-admin gen-key
@@ -67,18 +67,42 @@ up:
 	@command -v docker >/dev/null || { echo "docker is required: https://docs.docker.com/get-docker/"; exit 1; }
 	$(COMPOSE) up -d --build
 	@echo ""
-	@echo "Warmbly is starting (the first build compiles the images once)."
-	@echo "  Dashboard: http://localhost:5173"
-	@echo "  Admin:     http://localhost:5174"
-	@echo "  API:       http://localhost:8080"
+	@echo "Warmbly is starting. The first run builds the images once."
 	@echo ""
-	@echo "  Sign up, then read your 6-digit code in Mailpit: http://localhost:18025"
-	@echo "  (every login sends one; a fresh install has no real mail relay)"
+	@$(MAKE) --no-print-directory claim
+	@echo "  Dashboard: http://localhost:5173     Admin: http://localhost:5174"
+	@echo "  Demo data: make seed-demo            Logs:  make logs"
+	@echo "  Guide:     https://docs.warmbly.com/development/deployment-guide/"
+
+# Print the one-time link that claims a fresh instance, waiting for the backend
+# to finish migrating first so `make up` ends with something actionable rather
+# than an instruction to go and grep the logs.
+claim:
+	@printf "  Waiting for the backend"; \
+	for i in $$(seq 1 60); do \
+		if $(COMPOSE) logs backend 2>/dev/null | grep -qE "Claim this instance|Bootstrap: created owner"; then break; fi; \
+		printf "."; sleep 2; \
+	done; echo ""; echo ""
+	@claimed=$$($(COMPOSE) exec -T postgres psql -U warmbly -d warmbly_dev -tA \
+		-c "SELECT EXISTS (SELECT 1 FROM users LIMIT 1);" 2>/dev/null | tr -d '[:space:]'); \
+	link=$$($(COMPOSE) logs backend 2>/dev/null | grep -oE 'http[^ ]*/setup\?token=[a-f0-9]+' | tail -1); \
+	if [ "$$claimed" = "t" ]; then \
+		echo "  This instance already has an account. Sign in:"; \
+		echo "    http://localhost:5173"; \
+	elif [ -n "$$link" ]; then \
+		echo "  Open this link to claim your instance and become its admin."; \
+		echo "  Single use, valid for 24 hours:"; \
+		echo ""; \
+		echo "    $$link"; \
+	else \
+		echo "  The backend has not finished starting."; \
+		echo "  Run 'make claim' again shortly, or 'make logs backend' to see why."; \
+	fi
 	@echo ""
-	@echo "  Admin access: make grant-admin EMAIL=you@example.com"
-	@echo "  Demo data:    $(COMPOSE) --profile seed run --rm --build seed"
-	@echo "  Logs:         make logs        Stop: make down"
-	@echo "  Guide:        https://docs.warmbly.com/development/deployment-guide/"
+
+# Seed the showcase workspace into the running docker stack.
+seed-demo:
+	$(COMPOSE) --profile seed run --rm --build seed
 
 # One-command demo. Seeds the "Sunrise Labs" showcase org (live mailboxes on
 # mailpit + dovecot, active/paused/completed/draft campaigns, a warmup pool, and
@@ -424,7 +448,13 @@ GO_DEV_ENV := \
 	PUBSUB_ENABLED=false \
 	ENCRYPTED_KEYS_PROVIDER=postgres \
 	PRIMARY_DB=postgres://warmbly:warmbly@$(INFRA_HOST):15432/warmbly_dev?sslmode=disable \
-	REDIS=redis://$(INFRA_HOST):16379
+	REDIS=redis://$(INFRA_HOST):16379 \
+	MAIL_TRANSPORT=smtp \
+	EMAIL_NAME='Warmbly Dev' \
+	EMAIL_ADDRESS=dev@warmbly.local \
+	SMTP_HOST=$(INFRA_HOST) \
+	SMTP_PORT=11025 \
+	SMTP_SECURITY=none
 
 # Worker: NATS + local KMS + shared filesystem blobs; no Postgres by design
 # (relational access is via the backend internal API).
@@ -456,8 +486,11 @@ backend:
 	EMAIL_NAME='Warmbly Dev' \
 	EMAIL_ADDRESS=dev@warmbly.local \
 	TRACKING_DOMAIN=t.warmbly.com \
+	MAIL_TRANSPORT=smtp \
 	SMTP_HOST=$(INFRA_HOST) \
 	SMTP_PORT=11025 \
+	SMTP_SECURITY=none \
+	AUTH_LOGIN_CODE=always \
 	GEODB_PATH=data/GeoLite2-City.mmdb \
 	INTERNAL_API_TOKEN=local-dev-internal-token \
 	go run ./cmd/backend

--- a/README.md
+++ b/README.md
@@ -107,22 +107,33 @@ Kafka. One command brings up the whole platform on local, open-source pieces:
 
 ```bash
 git clone https://github.com/warmbly/warmbly && cd warmbly
-make up               # or: docker compose up --build
+make up
 ```
 
-You need Docker with Compose v2 and about 10 GB of free disk; the first build
-takes roughly 6 minutes. Then open `http://localhost:5173` and register.
+That is the whole install. `make up` waits for the backend and prints a
+one-time link that claims the instance and makes you its admin. Open it, pick a
+password, and you are in.
 
-> [!IMPORTANT]
-> Warmbly emails a 6-digit code to finish signup and on every login. A fresh
-> install has no mail relay, so that code lands in the bundled Mailpit catcher
-> at `http://localhost:18025`, not in your inbox.
+You need Docker with Compose v2 and about 10 GB of free disk; the first run
+builds the images once, which takes roughly 6 minutes.
+
+Nothing else is required. No SMTP relay, no captcha keys, no cloud account, no
+`.env` to hand-write, and no separate command to grant yourself admin. To skip
+the link entirely, set `WARMBLY_BOOTSTRAP_EMAIL` and
+`WARMBLY_BOOTSTRAP_PASSWORD_HASH` in `.env` before the first start and the owner
+account exists when it comes up.
+
+> [!NOTE]
+> Signing in never depends on outbound mail. Platform email defaults to
+> `MAIL_TRANSPORT=log`, so password resets and invitations are written to the
+> backend logs until you point `SMTP_*` at a real relay. Configure one when you
+> are ready, not to get started.
 
 **➡️ Follow the [step-by-step self-hosting guide](https://docs.warmbly.com/development/deployment-guide/)**
 for the full walkthrough: setting your own secrets, verifying the stack is
-healthy, granting the first admin, exposing it on your network or behind HTTPS,
-connecting Gmail and Microsoft mailboxes, scaling workers, backups, and a
-troubleshooting table for the errors people actually hit.
+healthy, configuring mail and single sign-on, exposing it on your network or
+behind HTTPS, connecting Gmail and Microsoft mailboxes, scaling workers,
+backups, and a troubleshooting table for the errors people actually hit.
 
 Every external dependency is picked by an environment variable, so you swap in a
 cloud service only if you want one:

--- a/admin/src/app/auth/LoginPage.tsx
+++ b/admin/src/app/auth/LoginPage.tsx
@@ -21,7 +21,8 @@ import { Label } from "@/components/ui/label";
 import { InputOTP, InputOTPGroup, InputOTPSlot } from "@/components/ui/input-otp";
 import { Logo } from "@/components/Logo";
 import { TurnstileModal } from "@/components/captcha/TurnstileModal";
-import { login, loginConfirm } from "@/lib/api/client/auth";
+import { login, loginConfirm, verifyTwoFA } from "@/lib/api/client/auth";
+import type { LoginResponse } from "@/lib/api/models/auth";
 import { setToken } from "@/lib/auth/storage";
 import { APIError } from "@/lib/api/client";
 import { DASHBOARD_URL, ENV_LABEL } from "@/lib/env";
@@ -42,7 +43,8 @@ function errorMessage(err: unknown): string {
 export default function LoginPage() {
     const nav = useNavigate();
     const loc = useLocation();
-    const [phase, setPhase] = useState<"credentials" | "code">("credentials");
+    const [phase, setPhase] = useState<"credentials" | "code" | "twofa">("credentials");
+    const [pendingToken, setPendingToken] = useState("");
     const [email, setEmail] = useState("");
     const [password, setPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
@@ -83,7 +85,24 @@ export default function LoginPage() {
         const fresh = phase === "credentials";
         try {
             const res = await login({ email, password, turnstile: token });
-            setSession(res.session);
+            // Nothing was emailed: this deployment has the login code off, or
+            // already knows this device. The login is already resolved.
+            if (!res.code_required) {
+                if (res.two_fa_required && res.pending_token) {
+                    setPendingToken(res.pending_token);
+                    setCode("");
+                    setPhase("twofa");
+                    return;
+                }
+                if (res.token) {
+                    setToken(res.token);
+                    const dest = (loc.state as { from?: string } | null)?.from ?? "/";
+                    nav(dest, { replace: true });
+                    return;
+                }
+                throw new Error("The server returned an unexpected sign-in response.");
+            }
+            setSession(res.session ?? "");
             setCode("");
             setResendIn(RESEND_SECONDS);
             if (fresh) setPhase("code");
@@ -113,7 +132,39 @@ export default function LoginPage() {
         setError(null);
         setSubmitting(true);
         try {
-            const tok = await loginConfirm({ session, code: value });
+            const res = await loginConfirm({ session, code: value });
+            // 2FA gate. Without this branch an operator with TOTP enrolled got
+            // a response carrying no access token and was silently stuck.
+            if (res.two_fa_required) {
+                if (!res.pending_token) throw new Error("The server returned an unexpected sign-in response.");
+                setPendingToken(res.pending_token);
+                setCode("");
+                setPhase("twofa");
+                return;
+            }
+            if (!res.access_token) throw new Error("The server returned an unexpected sign-in response.");
+            setToken(res as LoginResponse);
+            const dest = (loc.state as { from?: string } | null)?.from ?? "/";
+            nav(dest, { replace: true });
+        } catch (err) {
+            const msg = errorMessage(err);
+            setError(msg);
+            toast.error(msg);
+            setCode("");
+        } finally {
+            confirmInFlight.current = false;
+            setSubmitting(false);
+        }
+    }
+
+    // ── Step 3: TOTP or recovery code -> /auth/2fa/verify ──
+    async function submitTwoFA(value: string) {
+        if (confirmInFlight.current || value.length < 6) return;
+        confirmInFlight.current = true;
+        setError(null);
+        setSubmitting(true);
+        try {
+            const tok = await verifyTwoFA({ pending_token: pendingToken, code: value });
             setToken(tok);
             const dest = (loc.state as { from?: string } | null)?.from ?? "/";
             nav(dest, { replace: true });
@@ -273,22 +324,30 @@ export default function LoginPage() {
                                         className="text-center"
                                     >
                                         <div className="mx-auto mt-1 grid size-12 place-items-center rounded-xl bg-red-50 text-red-600">
-                                            <MailCheck className="size-6" />
+                                            {phase === "twofa" ? <ShieldCheck className="size-6" /> : <MailCheck className="size-6" />}
                                         </div>
-                                        <h1 className="mt-4 text-[20px] font-semibold tracking-tight">Check your email</h1>
+                                        <h1 className="mt-4 text-[20px] font-semibold tracking-tight">
+                                            {phase === "twofa" ? "Two-factor authentication" : "Check your email"}
+                                        </h1>
                                         <p className="mt-1 text-[13px] text-muted-foreground">
-                                            We sent a 6-digit code to{" "}
-                                            <span className="font-medium text-foreground">{email}</span>.
+                                            {phase === "twofa" ? (
+                                                <>Enter the 6-digit code from your authenticator app, or a recovery code.</>
+                                            ) : (
+                                                <>
+                                                    We sent a 6-digit code to{" "}
+                                                    <span className="font-medium text-foreground">{email}</span>.
+                                                </>
+                                            )}
                                         </p>
 
-                                        <form className="mt-6 flex flex-col items-center gap-4" onSubmit={(e) => { e.preventDefault(); submitCode(code); }}>
+                                        <form className="mt-6 flex flex-col items-center gap-4" onSubmit={(e) => { e.preventDefault(); phase === "twofa" ? submitTwoFA(code) : submitCode(code); }}>
                                             <InputOTP
                                                 maxLength={6}
                                                 value={code}
                                                 onChange={(v) => {
                                                     setCode(v);
                                                     if (error) setError(null);
-                                                    if (v.length === 6) submitCode(v);
+                                                    if (v.length === 6) { if (phase === "twofa") submitTwoFA(v); else submitCode(v); }
                                                 }}
                                                 disabled={submitting}
                                                 containerClassName="gap-2"
@@ -311,7 +370,7 @@ export default function LoginPage() {
 
                                             {errorLine}
 
-                                            <div className="text-[12px] text-muted-foreground">
+                                            <div className={cn("text-[12px] text-muted-foreground", phase === "twofa" && "hidden")}>
                                                 {resendIn > 0 ? (
                                                     <span>
                                                         Resend code in <span className="font-medium text-foreground">{resendIn}s</span>
@@ -329,7 +388,7 @@ export default function LoginPage() {
                                                 )}
                                             </div>
 
-                                            {import.meta.env.DEV && (
+                                            {import.meta.env.DEV && phase === "code" && (
                                                 <p className="text-[11px] text-muted-foreground">
                                                     Dev: the code is in mailpit →{" "}
                                                     <a

--- a/admin/src/app/dashboard/MailStatusCard.tsx
+++ b/admin/src/app/dashboard/MailStatusCard.tsx
@@ -1,0 +1,121 @@
+// Platform mail transport: what it is, whether it dials, and a way to send a
+// real message through it.
+//
+// Platform mail is not a backing service that merely degrades. Login codes,
+// password resets and team invitations all go through it, so a relay that
+// cannot authenticate locks everyone out, and the only symptom used to be a
+// generic 500 on the login screen. Mattermost, Gitea, Vaultwarden and Zulip all
+// ship an equivalent, and it is consistently their most deflected support
+// ticket.
+
+import { useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { CheckCircle2, Mail, RefreshCw, Send, XCircle } from "lucide-react";
+import toast from "react-hot-toast";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getMailStatus, sendTestEmail } from "@/lib/api/client/admin/system";
+import { APIError } from "@/lib/api/client";
+
+export function MailStatusCard() {
+    const [to, setTo] = useState("");
+
+    const statusQ = useQuery({
+        queryKey: ["admin", "mail", "status"],
+        queryFn: getMailStatus,
+        retry: false,
+    });
+
+    const testM = useMutation({
+        mutationFn: (address: string) => sendTestEmail(address),
+        onSuccess: (result) => {
+            if (!result.sent) {
+                toast.error(result.error || "The send failed.");
+                return;
+            }
+            toast.success(result.note || `Sent through the ${result.transport} transport.`);
+        },
+        onError: (err) => toast.error(err instanceof APIError ? err.message : "The send failed."),
+    });
+
+    const status = statusQ.data;
+
+    return (
+        <Card className={status && !status.healthy ? "border-red-200 bg-red-50/60" : ""}>
+            <CardHeader className="flex flex-row items-center justify-between">
+                <CardTitle className="flex items-center gap-2 text-[13px]">
+                    <Mail className="size-4" />
+                    Platform mail
+                </CardTitle>
+                <div className="flex items-center gap-2">
+                    {status && (
+                        <Badge variant={status.healthy ? "outline" : "destructive"}>
+                            {status.healthy ? "Reachable" : "Failing"}
+                        </Badge>
+                    )}
+                    <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => statusQ.refetch()}
+                        disabled={statusQ.isFetching}
+                    >
+                        <RefreshCw className={`size-4 ${statusQ.isFetching ? "animate-spin" : ""}`} />
+                    </Button>
+                </div>
+            </CardHeader>
+
+            <CardContent className="space-y-3">
+                {statusQ.isLoading && <Skeleton className="h-16 w-full" />}
+
+                {status && (
+                    <>
+                        <div className="flex items-start gap-2 text-[13px]">
+                            {status.healthy ? (
+                                <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                            ) : (
+                                <XCircle className="mt-0.5 size-4 shrink-0 text-red-600" />
+                            )}
+                            <span className="text-muted-foreground">{status.detail}</span>
+                        </div>
+
+                        {status.error && (
+                            <pre className="overflow-x-auto rounded-md border border-red-200 bg-white p-2 text-[11px] leading-relaxed text-red-700">
+                                {status.error}
+                            </pre>
+                        )}
+
+                        {!status.delivers && (
+                            <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-relaxed text-amber-800">
+                                Nothing is being delivered. Every platform email, including login
+                                codes, is written to the backend logs. Set MAIL_TRANSPORT=smtp and
+                                the SMTP_ variables before anyone else relies on this instance.
+                            </p>
+                        )}
+
+                        <div className="flex items-center gap-2 pt-1">
+                            <Input
+                                type="email"
+                                value={to}
+                                onChange={(e) => setTo(e.target.value)}
+                                placeholder="you@example.com"
+                                className="h-9 text-[13px]"
+                            />
+                            <Button
+                                size="sm"
+                                onClick={() => testM.mutate(to)}
+                                disabled={!to || testM.isPending}
+                            >
+                                <Send className="size-4" />
+                                {testM.isPending ? "Sending..." : "Send test"}
+                            </Button>
+                        </div>
+                    </>
+                )}
+            </CardContent>
+        </Card>
+    );
+}

--- a/admin/src/app/dashboard/SystemStatusPage.tsx
+++ b/admin/src/app/dashboard/SystemStatusPage.tsx
@@ -16,6 +16,7 @@ import {
     CardTitle,
 } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { MailStatusCard } from "./MailStatusCard";
 import {
     getSystemStatus,
     type SystemComponentStatus,
@@ -124,6 +125,7 @@ export default function SystemStatusPage() {
                     )}
 
                     <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+                        <MailStatusCard />
                         {components.map((c) => (
                             <ComponentCard key={c.name} component={c} />
                         ))}

--- a/admin/src/lib/api/client/admin/system.ts
+++ b/admin/src/lib/api/client/admin/system.ts
@@ -24,3 +24,41 @@ export function getSystemStatus(): Promise<SystemStatusResult> {
         authorization: true,
     });
 }
+
+// /admin/mail/status and /admin/mail/test — the platform's own mail transport.
+//
+// This is separate from the component probes above because platform mail is
+// not a backing service that degrades: login codes, password resets and
+// invitations all go through it, so a broken relay is a lockout.
+
+export interface MailStatusResult {
+    transport: string;
+    delivers: boolean;
+    healthy: boolean;
+    detail: string;
+    error?: string;
+}
+
+export function getMailStatus(): Promise<MailStatusResult> {
+    return Request({
+        method: "GET",
+        url: "/admin/mail/status",
+        authorization: true,
+    });
+}
+
+export interface SendTestEmailResult {
+    sent: boolean;
+    transport: string;
+    error?: string;
+    note?: string;
+}
+
+export function sendTestEmail(to: string): Promise<SendTestEmailResult> {
+    return Request({
+        method: "POST",
+        url: "/admin/mail/test",
+        data: { to },
+        authorization: true,
+    });
+}

--- a/admin/src/lib/api/client/auth/index.ts
+++ b/admin/src/lib/api/client/auth/index.ts
@@ -7,7 +7,9 @@ import type {
     LoginRequest,
     LoginStartResponse,
     LoginConfirmRequest,
+    LoginConfirmResponse,
     LoginResponse,
+    TwoFAVerifyRequest,
     AdminProfile,
 } from "@/lib/api/models/auth";
 
@@ -22,10 +24,22 @@ export function login(input: LoginRequest): Promise<LoginStartResponse> {
 }
 
 // Step 2: exchange the session + emailed code for the access/refresh token pair.
-export function loginConfirm(input: LoginConfirmRequest): Promise<LoginResponse> {
-    return Request<LoginResponse>({
+export function loginConfirm(input: LoginConfirmRequest): Promise<LoginConfirmResponse> {
+    return Request<LoginConfirmResponse>({
         method: "POST",
         url: "/v1/auth/login/confirm",
+        data: input,
+        timeout: 15_000,
+    });
+}
+
+// Exchanges the single-use pending token + a TOTP or recovery code for the
+// real token pair. The admin panel had no 2FA step at all, so an operator who
+// enrolled TOTP was locked out of it entirely.
+export function verifyTwoFA(input: TwoFAVerifyRequest): Promise<LoginResponse> {
+    return Request<LoginResponse>({
+        method: "POST",
+        url: "/v1/auth/2fa/verify",
         data: input,
         timeout: 15_000,
     });

--- a/admin/src/lib/api/models/auth.ts
+++ b/admin/src/lib/api/models/auth.ts
@@ -10,10 +10,32 @@ export interface LoginRequest {
     turnstile: string;
 }
 
-// Step 1 (/auth/login) verifies the password + captcha, emails a one-time
-// code, and returns a short-lived session token — NOT the access token.
+// Step 1 (/auth/login) verifies the password + captcha.
+//
+// With code_required true it emailed a one-time code and returned a short-lived
+// session token, not the access token. With code_required false the deployment
+// has AUTH_LOGIN_CODE off (or already knows this device), so nothing was sent
+// and the login is already resolved: either token, or a 2FA challenge.
 export interface LoginStartResponse {
-    session: string;
+    session?: string;
+    code_required: boolean;
+    token?: LoginResponse;
+    two_fa_required?: boolean;
+    pending_token?: string;
+    expires_in?: number;
+}
+
+// Returned by /auth/login/confirm: the token pair, or a 2FA challenge when the
+// operator has TOTP enrolled.
+export interface LoginConfirmResponse extends Partial<AdminToken> {
+    two_fa_required?: boolean;
+    pending_token?: string;
+    expires_in?: number;
+}
+
+export interface TwoFAVerifyRequest {
+    pending_token: string;
+    code: string;
 }
 
 // Step 2 (/auth/login/confirm) exchanges that session + the emailed code for

--- a/cmd/backend/boot.go
+++ b/cmd/backend/boot.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/notify"
+)
+
+// insecureDefaults are the working secret values shipped in docker-compose.yml
+// and the Makefile so `docker compose up` boots with no .env. They are public
+// in this repository, so a deployment still running on one is not protected by
+// it at all: a forged AUTH_SECRET JWT is accepted by the realtime service, and
+// the local KMS master key unwraps every organization DEK offline.
+//
+// The map is keyed by env var so the check is exact rather than a heuristic.
+var insecureDefaults = map[string]string{
+	"AUTH_SECRET":                "local-dev-auth-secret-minimum-32-characters-long",
+	"KMS_LOCAL_MASTER_KEY":       "Xr0JA7gqF2POy29a7MRByyqddivTNt8WOyKsOXklazk=",
+	"CREDENTIALS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	"INTERNAL_API_TOKEN":         "local-dev-internal-token",
+	"SECRET_KEY_BASE":            "local-development-secret-key-base-minimum-64-characters-for-phoenix",
+}
+
+// checkSecrets refuses to start a deployment that reaches the network while
+// still using a published default secret. Local development is exempt: that is
+// what the defaults exist for.
+//
+// ALLOW_INSECURE_DEFAULTS=true downgrades the refusal to a warning, for an
+// operator who genuinely wants a throwaway instance on a trusted LAN.
+func checkSecrets() {
+	var offenders []string
+	for env, def := range insecureDefaults {
+		if os.Getenv(env) == def {
+			offenders = append(offenders, env)
+		}
+	}
+	if len(offenders) == 0 {
+		return
+	}
+
+	list := strings.Join(offenders, ", ")
+	if isDevEnv() || strings.EqualFold(os.Getenv("ALLOW_INSECURE_DEFAULTS"), "true") {
+		log.Printf("Warning: using the published default value for %s. Anyone can read these from the Warmbly repository. Generate real values before this instance is reachable by other people (make gen-key).", list)
+		return
+	}
+
+	log.Fatalf("Refusing to start: %s still hold the published default value from docker-compose.yml. "+
+		"Those defaults are public, so they provide no protection. Generate real values (make gen-key) and put them in .env, "+
+		"or set ALLOW_INSECURE_DEFAULTS=true if this instance is genuinely disposable.", list)
+}
+
+func isDevEnv() bool {
+	env := strings.ToLower(strings.TrimSpace(os.Getenv("APP_ENV")))
+	return env == "" || env == "dev" || env == "development" || env == "local"
+}
+
+// passkeysUsableFor reports whether WebAuthn can work on this deployment's
+// origin. Passkeys require a secure context and an RP ID that is a real
+// domain, so a plain-http LAN address fails in the browser with an opaque
+// error. Detecting it here lets GET /auth/config hide the button instead.
+func passkeysUsableFor(appURL string) bool {
+	if appURL == "" {
+		return false
+	}
+	u, err := url.Parse(appURL)
+	if err != nil {
+		return false
+	}
+	if u.Scheme == "https" {
+		return true
+	}
+	// http is a secure context only on loopback.
+	host := u.Hostname()
+	return host == "localhost" || host == "127.0.0.1" || host == "::1" || strings.HasSuffix(host, ".localhost")
+}
+
+// oidcRedirectURL is where the provider sends the browser back. Explicit
+// OIDC_REDIRECT_URL wins; otherwise it derives from the backend's public base,
+// which is where the callback handler actually lives.
+func oidcRedirectURL() string {
+	if v := strings.TrimSpace(os.Getenv("OIDC_REDIRECT_URL")); v != "" {
+		return v
+	}
+	base := strings.TrimRight(os.Getenv("API_PUBLIC_URL"), "/")
+	if base == "" {
+		return ""
+	}
+	return base + "/api/v1/auth/oidc/callback"
+}
+
+// splitList parses a comma-separated env list.
+func splitList(v string) []string {
+	out := []string{}
+	for _, part := range strings.Split(v, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func mailTransportKind(t *notify.Transport) string {
+	if t == nil {
+		return ""
+	}
+	return t.Kind
+}
+
+// warnDeploymentURLs surfaces the configuration mistakes that silently break
+// auth once an operator moves off localhost, each of which previously appeared
+// only as a failure in the browser.
+func warnDeploymentURLs(ctx context.Context, appURL string) {
+	if appURL == "" {
+		log.Printf("Warning: APP_URL is not set. Password reset and team invitation emails will link to %s, which is almost certainly not this deployment.", config.AppBaseURL())
+		return
+	}
+	if !passkeysUsableFor(appURL) {
+		log.Printf("Warning: APP_URL is %s. Passkeys need a secure context, so they are disabled: browsers refuse WebAuthn on plain http outside localhost, and an IP address cannot be a relying-party ID. Put the dashboard behind HTTPS to enable them.", appURL)
+	}
+}

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/audit"
 	"github.com/warmbly/warmbly/internal/app/auth"
 	behaviorapp "github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/app/bootstrap"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/compose"
@@ -60,6 +61,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/nativeactions"
 	"github.com/warmbly/warmbly/internal/app/notification"
 	"github.com/warmbly/warmbly/internal/app/oauth"
+	"github.com/warmbly/warmbly/internal/app/oidcauth"
 	"github.com/warmbly/warmbly/internal/app/organization"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
@@ -122,6 +124,12 @@ import (
 )
 
 func main() {
+	// Before anything else: refuse to run a networked deployment on the
+	// published default secrets. They are in this repository, so they protect
+	// nothing, and a forged token signed with the default AUTH_SECRET is
+	// accepted by the realtime service.
+	checkSecrets()
+
 	var addr string
 	var ginMode string
 	var websocketURI string
@@ -211,6 +219,19 @@ func main() {
 
 	// Notifications
 	var emailNotificationService notify.EmailNotificationService
+	// mailTransport is the same sender plus its metadata, kept so the auth
+	// config endpoint and admin diagnostics can report what mail is doing.
+	var mailTransport *notify.Transport
+	// Deployment auth facts resolved during boot and served by /auth/config.
+	var authPolicy *config.AuthPolicy
+	var passkeysUsable bool
+	var googleWebSignIn, appleWebSignIn bool
+	var bootstrapService *bootstrap.Service
+	// oidcLogin is nil unless OIDC_ISSUER_URL is configured.
+	var oidcLogin *oidcauth.Service
+	// authCache is the same Redis client the services use, hoisted so the
+	// middleware handler can reach it for the pre-login per-IP limiter.
+	var authCache *cache.Cache
 
 	// Warmup
 	var warmupService warmupapp.Service
@@ -319,18 +340,17 @@ func main() {
 			log.Fatal(err)
 		}
 
+		// GeoIP is optional everywhere. It only labels session and audit records
+		// with a city, so a missing database is a cosmetic loss, not a reason to
+		// refuse to start: requiring a MaxMind licence to run APP_ENV=prod made
+		// self-hosting depend on an account nobody asked for.
 		var geoloc *geo.Client
 		geoloc, err = geo.New(geoPath)
 		if err != nil {
-			if cfg.Env == "dev" {
-				log.Printf("Warning: GeoIP database not found at %s, geo lookups disabled", geoPath)
-				// geo.New returns a nil client on error; fall back to a usable,
-				// geo-disabled client so downstream callers never deref nil.
-				geoloc, _ = geo.New("")
-			} else {
-				sentry.CaptureException(err)
-				log.Fatal(err)
-			}
+			log.Printf("GeoIP database not found at %s; location lookups are disabled.", geoPath)
+			// geo.New returns a nil client on error; fall back to a usable,
+			// geo-disabled client so downstream callers never deref nil.
+			geoloc, _ = geo.New("")
 		}
 
 		s3, err := storage.NewFromEnv(ctx, awscfg, "main")
@@ -408,24 +428,23 @@ func main() {
 			log.Fatal(err)
 		}
 
-		smtpCfg := cfg.LoadSMTPConfig(ctx)
-		if smtpCfg != nil {
-			emailNotificationService = notify.NewSMTPEmailNotificationService(
-				emailCfg.EmailName,
-				emailCfg.EmailAddress,
-				smtpCfg.Host,
-				smtpCfg.Port,
-			)
+		mailTransport, err = notify.NewTransport(ctx, cfg, emailCfg.EmailName, emailCfg.EmailAddress)
+		if err != nil {
+			sentry.CaptureException(err)
+			log.Fatal(err)
+		}
+		emailNotificationService = mailTransport
+		// Dial the relay once at boot. A broken relay used to surface only as a
+		// 500 on the login screen, which is the one screen the operator needs
+		// when they cannot log in.
+		if perr := mailTransport.Preflight(ctx); perr != nil {
+			log.Printf("Warning: platform mail preflight FAILED (%s): %v", mailTransport.Description, perr)
+			log.Printf("Warning: login codes, password resets and invitations will not be delivered. Set MAIL_TRANSPORT=log to read them from these logs instead.")
 		} else {
-			emailNotificationService, err = notify.NewEmailNotficiationService(
-				ctx,
-				emailCfg.EmailName,
-				emailCfg.EmailAddress,
-			)
-			if err != nil {
-				sentry.CaptureException(err)
-				log.Fatal(err)
-			}
+			log.Printf("Platform mail transport: %s", mailTransport.Description)
+		}
+		if !mailTransport.Delivers {
+			log.Printf("Warning: MAIL_TRANSPORT=log — every platform email, including login codes, is printed here and never delivered. Do not use this on a deployment other people can reach.")
 		}
 
 		authCfg, err := cfg.LoadAuthConfig(ctx)
@@ -491,11 +510,16 @@ func main() {
 			log.Fatal(err)
 		}
 
+		// The bypass token must be set explicitly. It used to fall back to a
+		// hardcoded literal whenever APP_ENV was "dev", which is the shipped
+		// default in both compose and env.example, so any deployment that
+		// turned captcha on while leaving APP_ENV alone had a universal,
+		// publicly known bypass on login, registration and password reset.
 		turnstileBypassToken := ""
 		if cfg.Env == "dev" {
 			turnstileBypassToken = authCfg.TurnstileBypass
-			if turnstileBypassToken == "" {
-				turnstileBypassToken = "warmbly-local-turnstile-bypass"
+			if turnstileBypassToken != "" && authCfg.TurnstileSecret != "" {
+				log.Printf("Warning: TURNSTILE_BYPASS_TOKEN is set alongside a real TURNSTILE_SECRET. Anyone who learns the token skips the captcha entirely.")
 			}
 		}
 
@@ -727,6 +751,15 @@ func main() {
 		twofaService = twofa.NewService(repository.NewTOTPRepository(primaryDB.Pool), userRepostory, tokenService, cache, twofa.DeriveKey(authCfg.TwoFASecret))
 		authService.WireTwoFA(twofaService)
 
+		// Deployment-level auth policy: whether an emailed code gates a login,
+		// whether signups are open, whether verification is required. Resolved
+		// against the mail transport, because a code nobody can receive cannot
+		// be a login requirement.
+		authPolicy = config.LoadAuthPolicy(mailTransport != nil && mailTransport.Delivers)
+		authService.WireDeployment(authPolicy, mailTransport != nil && mailTransport.Delivers)
+		log.Printf("Auth policy: login_code=%s registration=%s email_verification=%t",
+			authPolicy.LoginCode, authPolicy.Registration, authPolicy.RequireEmailVerification)
+
 		// Native-app social sign-in. Declared as the interface type so an
 		// unconfigured provider stays a true nil (no typed-nil pitfall) and
 		// the service reports it as unavailable.
@@ -738,6 +771,34 @@ func main() {
 			googleIDTokens = idtoken.GoogleVerifier(authCfg.GoogleIOSClientID)
 		}
 		authService.WireExternalIDTokens(appleIDTokens, googleIDTokens)
+
+		// Federated identities keyed on (issuer, subject). Without this,
+		// external sign-in resolves accounts by email alone, which is only safe
+		// for issuers that control their own email namespace.
+		authService.WireIdentities(repository.NewIdentityRepository(primaryDB.Pool))
+
+		// Generic OIDC. Discovery runs at boot: an unreachable issuer is a
+		// configuration error worth surfacing now rather than as a login button
+		// that always fails.
+		if issuer := os.Getenv("OIDC_ISSUER_URL"); issuer != "" {
+			oidcSvc, oerr := oidcauth.New(ctx, oidcauth.Config{
+				IssuerURL:      issuer,
+				ClientID:       os.Getenv("OIDC_CLIENT_ID"),
+				ClientSecret:   os.Getenv("OIDC_CLIENT_SECRET"),
+				RedirectURL:    oidcRedirectURL(),
+				Scopes:         splitList(os.Getenv("OIDC_SCOPES")),
+				AllowedDomains: splitList(os.Getenv("OIDC_ALLOWED_DOMAINS")),
+				DefaultOrgID:   os.Getenv("OIDC_DEFAULT_ORG"),
+				ProviderName:   os.Getenv("OIDC_PROVIDER_NAME"),
+			})
+			if oerr != nil {
+				log.Printf("Warning: OIDC disabled: %v", oerr)
+			} else {
+				oidcLogin = oidcSvc
+				authService.WireOIDC(oidcSvc)
+				log.Printf("OIDC login enabled (issuer %s)", oidcSvc.Issuer())
+			}
+		}
 		externalAuthProviders = models.ExternalAuthProviders{
 			AppleBundleID:     authCfg.AppleIOSBundleID,
 			GoogleIOSClientID: authCfg.GoogleIOSClientID,
@@ -773,6 +834,27 @@ func main() {
 			sentry.CaptureException(passkeyErr)
 			log.Fatal(passkeyErr)
 		}
+		passkeysUsable = passkeysUsableFor(os.Getenv("APP_URL"))
+		googleWebSignIn = authCfg.GoogleClientID != ""
+		appleWebSignIn = authCfg.AppleAppID != ""
+		authCache = cache
+		warnDeploymentURLs(ctx, os.Getenv("APP_URL"))
+
+		// First-owner bootstrap. A no-op once any user exists, so it runs on
+		// every boot and only ever does something on a fresh install.
+		bootstrapService = bootstrap.NewService(
+			userRepostory,
+			userService,
+			organizationService,
+			trialService,
+			repository.NewAdminRepository(primaryDB.Pool),
+			cache,
+		)
+		if berr := bootstrapService.Run(ctx); berr != nil {
+			sentry.CaptureException(berr)
+			log.Printf("Warning: bootstrap failed: %v", berr)
+		}
+
 		cipherService = cipher.NewService(kms, cache, encryptedKeys)
 
 		// Third-party integrations: OAuth connect flows + encrypted token
@@ -1406,6 +1488,15 @@ func main() {
 		AuthService:           authService,
 		ExternalAuthProviders: externalAuthProviders,
 
+		GoogleWebSignIn:  googleWebSignIn,
+		AppleWebSignIn:   appleWebSignIn,
+		OIDCEnabled:      oidcLogin != nil,
+		MailDelivers:     mailTransport != nil && mailTransport.Delivers,
+		MailTransport:    mailTransportKind(mailTransport),
+		MailTransportRef: mailTransport,
+		BootstrapService: bootstrapService,
+		PasskeysUsable:   passkeysUsable,
+
 		TokenService:     tokenService,
 		PasskeyService:   passkeyService,
 		UserService:      userService,
@@ -1549,6 +1640,7 @@ func main() {
 		IdempotencyService:  idempotencyService,
 		OrganizationService: organizationService,
 		OAuthService:        oauthService,
+		Cache:               authCache,
 	}
 
 	oidcH := &middleware.OidcHandler{

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -314,11 +314,14 @@ func main() {
 	// channel. Slack reuses the integration service (token decryption).
 	var notifEmail notification.EmailSender
 	if emailCfg, ecErr := cfg.LoadEmailConfig(ctx); ecErr == nil {
-		if smtpCfg := cfg.LoadSMTPConfig(ctx); smtpCfg != nil {
-			notifEmail = notify.NewSMTPEmailNotificationService(emailCfg.EmailName, emailCfg.EmailAddress, smtpCfg.Host, smtpCfg.Port)
-		} else if ses, sErr := notify.NewEmailNotficiationService(ctx, emailCfg.EmailName, emailCfg.EmailAddress); sErr == nil {
-			notifEmail = ses
+		if transport, tErr := notify.NewTransport(ctx, cfg, emailCfg.EmailName, emailCfg.EmailAddress); tErr == nil {
+			notifEmail = transport
+			log.Printf("Notification mail transport: %s", transport.Description)
+		} else {
+			log.Printf("Warning: notification email disabled: %v", tErr)
 		}
+	} else {
+		log.Printf("Warning: notification email disabled, EMAIL_NAME/EMAIL_ADDRESS not set: %v", ecErr)
 	}
 	notificationService.WireDelivery(notifEmail, integrationServiceC, repository.NewUserRepostory(primaryDB, kmsClient), orgRepoConsumer)
 	// Mobile push (APNs) fires from THIS process too: reply/bounce/complaint

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -1,16 +1,26 @@
 # ============================================
 # Warmbly environment reference
 # ============================================
-# Defaults are no-cloud: with just the four secrets in the "Required" block set,
+# You do not need this file to start. `make up` boots the whole platform with
+# no .env at all and prints a link to claim the instance. Copy this file when
+# you are ready to run something other people can reach.
+#
+# Defaults are no-cloud: with just the secrets in the "Required" block set,
 # Warmbly runs with no AWS, GCP, Stripe, or Kafka. Each subsystem is a provider
-# switch — flip one to opt into a cloud service.
+# switch, flip one to opt into a cloud service.
 #
 # Config priority: env var first, then AWS SSM/Secrets Manager (only when
 # AWS_CONFIG_ENABLED=true).
 # ============================================
 
 # === Required ===
-APP_ENV=dev                          # dev | prod (no other value enables prod behavior)
+# dev | prod. dev allows the published default secrets, so set prod for
+# anything other people can reach. prod needs no cloud account: error reporting
+# and GeoIP are used when configured and skipped with a logged note when not.
+APP_ENV=prod
+# cloud | self_hosted. Picks the auth defaults (login code, signup lockdown,
+# email verification); each stays individually overridable below.
+DEPLOYMENT_MODE=self_hosted
 # JWT / session signing. Min 32 chars. MUST match the realtime service JWT_SECRET.
 AUTH_SECRET=change-me-min-32-characters-long
 # 64 hex chars (32 bytes). Seals mailbox SMTP/IMAP credentials at rest.
@@ -93,7 +103,7 @@ APP_URL=http://localhost:5173
 CORS_ALLOW_ORIGINS=http://localhost:5173,http://localhost:5174
 WEBSOCKET_URL=ws://localhost:4000/socket/websocket
 ENCRYPTED_KEYS_PROVIDER=postgres     # backend/consumer: postgres; workers: http (below)
-GEODB_PATH=/app/data/GeoLite2-City.mmdb   # optional in dev
+GEODB_PATH=/app/data/GeoLite2-City.mmdb   # optional everywhere; missing = no location labels
 
 # === Mailbox connections ===
 # Gmail mailboxes need YOUR Google Cloud OAuth client (a "Web application" client)
@@ -128,12 +138,87 @@ BOX_OUTLOOK_CLIENT_SECRET=
 # ENCRYPTED_KEYS_WORKER_TOKEN=<same as INTERNAL_API_TOKEN>
 # WORKER_ID=<uuid>                   # stable identity; otherwise derived from hostname
 
-# === Notification email (outbound platform mail) ===
+# === Platform email (login codes, resets, invitations, digests) ===
+#
+# MAIL_TRANSPORT is the primary switch: smtp | log | ses.
+#
+#   log  — writes every message to the backend logs and delivers nothing. The
+#          default for a fresh install so first login works with no relay.
+#   smtp — a real submission relay. Set SMTP_HOST plus the credentials below.
+#   ses  — AWS SES; needs AWS credentials and a verified identity.
+MAIL_TRANSPORT=log
 EMAIL_NAME=Warmbly
 EMAIL_ADDRESS=noreply@example.com
 TRACKING_DOMAIN=localhost:3000
-SMTP_HOST=mailpit                    # a real SMTP relay in production
-SMTP_PORT=1025
+
+# SMTP_SECURITY is starttls | tls | none. starttls is submission on 587 and the
+# right answer for almost every provider; tls is implicit TLS on 465; none is
+# cleartext and only legitimate for a sink on the same host. The port defaults
+# per mode, so setting either one alone is enough.
+#
+# Credentials are never sent over an unencrypted connection.
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_SECURITY=starttls
+# SMTP_AUTH=auto                     # auto | plain | login | cram-md5 | none
+# SMTP_EHLO_NAME=                    # defaults to the sender domain
+# SMTP_TLS_INSECURE_SKIP_VERIFY=false  # only for a relay with a private CA
+
+# === Auth policy ===
+#
+# AUTH_LOGIN_CODE: always | new_device | off. Self-host defaults to off, so a
+# login never depends on outbound mail. Registration and password reset still
+# use emailed codes, which is what NIST SP 800-63B permits email for.
+# AUTH_LOGIN_CODE=off
+# REQUIRE_EMAIL_VERIFICATION=false
+#
+# DISABLE_REGISTRATION: true | false | invite_only. Self-host defaults to
+# invite_only, with a first-launch exemption so the very first signup works.
+# DISABLE_REGISTRATION=invite_only
+# DISABLE_PASSWORD_LOGIN=false       # OIDC-only deployments
+# AUTH_IP_RATE_LIMIT=60              # unauthenticated auth requests per IP per 15 min
+#
+# CIDRs allowed to set X-Forwarded-For. Empty trusts nothing, which is correct
+# for a directly exposed backend. Set it when a reverse proxy sits in front, or
+# rate limits and audit IPs are attacker-controlled.
+# TRUSTED_PROXIES=10.0.0.0/8
+
+# First owner, read only while the users table is empty. Leave unset and the
+# backend prints a single-use setup link to its logs on first boot.
+# WARMBLY_BOOTSTRAP_EMAIL=you@example.com
+# WARMBLY_BOOTSTRAP_PASSWORD_HASH=   # argon2 PHC string; preferred
+# WARMBLY_BOOTSTRAP_PASSWORD=        # plaintext convenience; warns at boot
+# WARMBLY_BOOTSTRAP_ORG=My Organization
+
+# === Single sign-on (generic OpenID Connect) ===
+#
+# The only sign-in path with no dependency on outbound mail, so it is the
+# recommended posture for a deployment with no relay. Works with Authentik,
+# Keycloak, Zitadel, Pocket ID, Dex and anything else that publishes a
+# discovery document. RS256 ID tokens only.
+# OIDC_ISSUER_URL=https://id.example.com/application/o/warmbly/
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_REDIRECT_URL=                 # defaults to API_PUBLIC_URL/api/v1/auth/oidc/callback
+# OIDC_SCOPES=openid,profile,email
+# OIDC_ALLOWED_DOMAINS=example.com
+# OIDC_DEFAULT_ORG=                  # org every SSO user joins; without it each
+#                                    # new user gets their own single-member org
+# OIDC_PROVIDER_NAME=Single sign-on
+
+# === Transactional email branding ===
+# A self-hosted install should not send mail attributed to another company.
+# EMAIL_BRAND_NAME=Acme
+# EMAIL_BRAND_LEGAL_ENTITY=Acme Ltd
+# EMAIL_BRAND_COMPANY_NUMBER=
+# EMAIL_BRAND_PLACE_OF_REG=
+# EMAIL_BRAND_ADDRESS=
+# EMAIL_BRAND_WEBSITE_URL=https://acme.example.com
+# EMAIL_BRAND_SUPPORT_EMAIL=support@acme.example.com
+# EMAIL_BRAND_TERMS_URL=
+# EMAIL_BRAND_PRIVACY_URL=
 
 # === Tracking service (open/click) ===
 TRACKING_HOST=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,81 @@ x-selfhost-env: &selfhost-env
   CAPTCHA_PROVIDER: ${CAPTCHA_PROVIDER:-none}
   TURNSTILE_SECRET: ${TURNSTILE_SECRET:-}
 
+  # Deployment mode. Picks the auth defaults below; every one stays
+  # individually overridable.
+  DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-self_hosted}
+
+  # ── Platform email (login codes, resets, invitations, digests) ──────────
+  #
+  # log is the default so a fresh install can complete first login with no
+  # relay: the code is printed to `docker compose logs backend`. Switch to smtp
+  # before anyone else uses this instance.
+  #
+  #   MAIL_TRANSPORT=smtp
+  #   SMTP_HOST=smtp.example.com  SMTP_USERNAME=...  SMTP_PASSWORD=...
+  #
+  # SMTP_SECURITY is starttls (587), tls (implicit, 465) or none (a local sink
+  # only). The port defaults per mode, and credentials are never sent over an
+  # unencrypted connection.
+  MAIL_TRANSPORT: ${MAIL_TRANSPORT:-log}
+  EMAIL_NAME: ${EMAIL_NAME:-Warmbly}
+  EMAIL_ADDRESS: ${EMAIL_ADDRESS:-noreply@localhost}
+  SMTP_HOST: ${SMTP_HOST:-}
+  SMTP_PORT: ${SMTP_PORT:-}
+  SMTP_USERNAME: ${SMTP_USERNAME:-}
+  SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+  SMTP_SECURITY: ${SMTP_SECURITY:-}
+  SMTP_AUTH: ${SMTP_AUTH:-auto}
+  SMTP_EHLO_NAME: ${SMTP_EHLO_NAME:-}
+  SMTP_TLS_INSECURE_SKIP_VERIFY: ${SMTP_TLS_INSECURE_SKIP_VERIFY:-false}
+
+  # ── Auth policy ────────────────────────────────────────────────────────
+  #
+  # AUTH_LOGIN_CODE is always, new_device or off. Self-host defaults to off:
+  # emailing a code on every login makes the relay a single point of failure
+  # for all authentication, and neither NIST SP 800-63B nor OWASP ASVS counts
+  # email as a second factor. TOTP and passkeys both remain available.
+  AUTH_LOGIN_CODE: ${AUTH_LOGIN_CODE:-}
+  REQUIRE_EMAIL_VERIFICATION: ${REQUIRE_EMAIL_VERIFICATION:-}
+  # true | false | invite_only. Self-host defaults to invite_only, with a
+  # first-launch exemption so the very first signup always works.
+  DISABLE_REGISTRATION: ${DISABLE_REGISTRATION:-}
+  DISABLE_PASSWORD_LOGIN: ${DISABLE_PASSWORD_LOGIN:-false}
+  AUTH_IP_RATE_LIMIT: ${AUTH_IP_RATE_LIMIT:-60}
+  # CIDRs allowed to set X-Forwarded-For. Empty trusts nothing, which is
+  # correct for a directly exposed backend; set it when you run a proxy.
+  TRUSTED_PROXIES: ${TRUSTED_PROXIES:-}
+
+  # First owner, read only while the users table is empty. Leave unset and the
+  # backend prints a single-use setup link to its logs instead.
+  WARMBLY_BOOTSTRAP_EMAIL: ${WARMBLY_BOOTSTRAP_EMAIL:-}
+  WARMBLY_BOOTSTRAP_PASSWORD_HASH: ${WARMBLY_BOOTSTRAP_PASSWORD_HASH:-}
+  WARMBLY_BOOTSTRAP_PASSWORD: ${WARMBLY_BOOTSTRAP_PASSWORD:-}
+  WARMBLY_BOOTSTRAP_ORG: ${WARMBLY_BOOTSTRAP_ORG:-}
+
+  # Generic OpenID Connect. The one sign-in path with no mail dependency, so
+  # it is the recommended posture for a deployment with no relay.
+  OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
+  OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+  OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+  OIDC_REDIRECT_URL: ${OIDC_REDIRECT_URL:-}
+  OIDC_SCOPES: ${OIDC_SCOPES:-}
+  OIDC_ALLOWED_DOMAINS: ${OIDC_ALLOWED_DOMAINS:-}
+  OIDC_DEFAULT_ORG: ${OIDC_DEFAULT_ORG:-}
+  OIDC_PROVIDER_NAME: ${OIDC_PROVIDER_NAME:-}
+
+  # Transactional email branding. A self-hosted install should not send mail
+  # attributed to someone else's company.
+  EMAIL_BRAND_NAME: ${EMAIL_BRAND_NAME:-}
+  EMAIL_BRAND_LEGAL_ENTITY: ${EMAIL_BRAND_LEGAL_ENTITY:-}
+  EMAIL_BRAND_COMPANY_NUMBER: ${EMAIL_BRAND_COMPANY_NUMBER:-}
+  EMAIL_BRAND_PLACE_OF_REG: ${EMAIL_BRAND_PLACE_OF_REG:-}
+  EMAIL_BRAND_ADDRESS: ${EMAIL_BRAND_ADDRESS:-}
+  EMAIL_BRAND_WEBSITE_URL: ${EMAIL_BRAND_WEBSITE_URL:-}
+  EMAIL_BRAND_SUPPORT_EMAIL: ${EMAIL_BRAND_SUPPORT_EMAIL:-}
+  EMAIL_BRAND_TERMS_URL: ${EMAIL_BRAND_TERMS_URL:-}
+  EMAIL_BRAND_PRIVACY_URL: ${EMAIL_BRAND_PRIVACY_URL:-}
+
   PRIMARY_DB: ${PRIMARY_DB:-postgres://warmbly:warmbly@postgres:5432/warmbly_dev?sslmode=disable}
   REDIS: ${REDIS:-redis://redis:6379}
   AUTH_SECRET: ${AUTH_SECRET:-local-dev-auth-secret-minimum-32-characters-long}
@@ -151,13 +226,22 @@ services:
       timeout: 3s
       retries: 10
 
-  # Local SMTP sink + web UI so outbound mail is visible without a real relay.
-  # Point mailbox SMTP at mailpit:1025 (or use it as the notification relay).
+  # SMTP sink for testing campaign sends without a real mailbox.
+  #
+  # In the `sandbox` profile, so `make up` never starts it: platform mail goes
+  # to the logs (MAIL_TRANSPORT=log) or to your relay, and a real install sends
+  # campaign mail through the mailboxes you connect. `make sandbox`, `make dev`
+  # and `make infra` start it by naming it explicitly.
+  #
+  # Bound to loopback when it does run. Its web UI has no authentication, so
+  # publishing it would hand every captured message to anyone who can reach the
+  # host. Set MAILPIT_BIND=0.0.0.0 if you deliberately want it reachable.
   mailpit:
     image: axllent/mailpit:latest
+    profiles: ["sandbox"]
     ports:
-      - "18025:8025"
-      - "11025:1025"
+      - "${MAILPIT_BIND:-127.0.0.1}:18025:8025"
+      - "${MAILPIT_BIND:-127.0.0.1}:11025:1025"
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
@@ -202,12 +286,9 @@ services:
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://${PUBLIC_HOST:-localhost}:5173,http://${PUBLIC_HOST:-localhost}:5174}
       WEBSOCKET_URL: ${WEBSOCKET_URL:-ws://${PUBLIC_HOST:-localhost}:4000/socket/websocket}
       ENCRYPTED_KEYS_PROVIDER: postgres
-      EMAIL_NAME: ${EMAIL_NAME:-Warmbly}
-      EMAIL_ADDRESS: ${EMAIL_ADDRESS:-noreply@warmbly.local}
-      SMTP_HOST: ${SMTP_HOST:-mailpit}
-      SMTP_PORT: ${SMTP_PORT:-1025}
-      SMTP_USERNAME: ${SMTP_USERNAME:-}
-      SMTP_PASSWORD: ${SMTP_PASSWORD:-}
+      # Mail and auth policy live in the shared anchor above, so the consumer
+      # gets them too. It previously received neither, which silently disabled
+      # every notification and digest email in this stack.
       TRACKING_DOMAIN: ${TRACKING_DOMAIN:-${PUBLIC_HOST:-localhost}:3000}
       GEODB_PATH: ${GEODB_PATH:-/app/data/GeoLite2-City.mmdb}
       # Gmail mailbox OAuth (leave unset to connect only SMTP/IMAP + Outlook

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -229,7 +229,10 @@ Mutating API requests may include an `Idempotency-Key` header. Warmbly stores th
 These never accept an API key. They depend on a human-bound session: billing flows, governance, OAuth onboarding, websocket bootstrap, and operational destruction.
 
 - `POST /auth/login`, `/auth/login/confirm`, `/auth/register`, `/auth/register/confirm`, `/auth/refresh`, `/auth/reset-password`, `/auth/reset-password/confirm`
+- `GET /auth/config` (public deployment capabilities: which sign-in methods this backend has enabled, whether a login code step follows, whether signups are open, whether the instance still needs claiming)
+- `POST /auth/setup` (first-run claim: exchanges the one-time token printed at boot for the owner account. Refused once any account exists)
 - `GET /auth/providers`, `POST /auth/apple`, `POST /auth/google` (native-app social sign-in)
+- `POST /auth/oidc/begin`, `GET /auth/oidc/callback` (generic OpenID Connect sign-in)
 - `POST /auth/logout`, `POST /auth/logout-all`, `GET /auth/me`, `PATCH /auth/me/onboarding`
 - `POST /auth/me/avatar`, `DELETE /auth/me/avatar`
 - `POST /emails/onboarding/oauth/start`, `POST /emails/onboarding/oauth/finish`, `POST /emails/onboarding/smtp-imap`

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -226,6 +226,19 @@ Returned when an unexpected error occurs on the server.
 - Retry the request after a short delay
 - If persistent, contact support with request details
 
+One `internal_error` variant is worth distinguishing. When an authentication endpoint cannot send its email, the message names that specifically rather than reporting a generic fault:
+
+```json
+{
+  "error": "Internal Server Error",
+  "message": "We couldn't send the email. If you administer this server, check the mail transport configuration.",
+  "code": "internal_error",
+  "request_id": "4bbbd1b2-8f86-47dd-8a7f-9476501ad20e"
+}
+```
+
+On a self-hosted deployment that means `MAIL_TRANSPORT` and the `SMTP_` variables. See [self-hosting](/development/deployment-guide/).
+
 ### 503 Service Unavailable
 
 Returned when the service is temporarily unavailable.

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -5,7 +5,7 @@ description: A step-by-step guide to running the whole Warmbly platform yourself
 
 Warmbly self-hosts with **no cloud account of any kind**: no AWS, no GCP, no Stripe, no Kafka. One `docker-compose.yml` runs everything on local, open-source pieces, and every external dependency is an environment variable you can flip later.
 
-Follow the seven steps below in order and you will have a working install. Everything after them is optional.
+Three commands give you a working install. Everything after them is optional, and nothing below is needed before you have seen it running.
 
 <Mermaid
   chart={`
@@ -35,14 +35,16 @@ flowchart LR
 | Git | To clone the repository |
 | ~10 GB free disk | The first build produces about 3.7 GB of images plus 2.5 GB of build cache |
 | 4 GB RAM | The running stack idles near 300 MB; the first build is the demanding part |
-| Free ports | 5173, 5174, 8080, 4000, 3000, 4222, 8222, 11025, 15432, 16379, 18025 |
+| Free ports | 5173, 5174, 8080, 4000, 3000, 4222, 15432, 16379 |
 
 The first build compiles Go, Rust, and Elixir services and builds two frontends. On a modern laptop that takes about **6 minutes**. Later builds reuse the cache and are much faster.
 
-Nothing else is required to install. Two things are worth gathering before you get far, because they are the only credentials that come from outside Warmbly:
+That is the whole list. No SMTP relay, no captcha keys, no cloud account, and no `.env` to write before the first run.
 
-- **An SMTP relay** for the platform's own mail. Warmbly emails a login code on every sign-in, and until you set one those go to the bundled Mailpit catcher instead of real inboxes. See [notification email](#notification-email).
-- **OAuth clients** if you want to connect Gmail, Google Workspace, or Microsoft 365 mailboxes. Plain SMTP and IMAP mailboxes need nothing. See [connect mailboxes](#connect-mailboxes).
+Two things come from outside Warmbly, and both can wait until after you have it running:
+
+- **An SMTP relay** for password resets, invitations and digests. Without one those messages go to the backend logs, and signing in never needs them. See [platform email](#platform-email).
+- **OAuth clients** if you want to connect Gmail, Google Workspace or Microsoft 365 mailboxes. Plain SMTP and IMAP mailboxes need nothing. See [connect mailboxes](#connect-mailboxes).
 
 All configuration lives in a single `.env` at the repository root, covered in [environment configuration](#environment-configuration) with a [complete example](#a-complete-env).
 
@@ -66,16 +68,71 @@ git clone https://github.com/warmbly/warmbly && cd warmbly
 
 <Step>
 
-### Set your secrets
+### Start it
 
-**One `.env` next to `docker-compose.yml` configures the entire stack.** Every variable is optional and falls back to a working no-cloud default, so an absent or empty `.env` still boots. You set only what you want to change, and it reaches every service that needs it: the backend, consumer, worker, tracking, and realtime.
+```bash
+make up
+```
 
-The compose file ships working dev defaults for every secret, so you can skip this step to try Warmbly on your own machine. **Do not skip it for anything reachable by other people.**
+That is `docker compose -p warmbly up -d --build`. It builds the images and starts ten containers in the background, then waits for the backend and prints the link that claims your instance. The first run is the slow one.
 
-Generate your own values and put them in a `.env` file next to `docker-compose.yml`:
+Only what a running install needs is started. The mail catcher and the local IMAP server belong to the demo environment and stay out of the way until you ask for them with `make sandbox`.
+
+</Step>
+
+<Step>
+
+### Claim it
+
+`make up` prints a one-time link when it finishes. Open it, pick a password, and you are the owner and platform admin of the instance.
+
+If you missed it, print it again:
+
+```bash
+make claim
+```
+
+The link is single use, valid for 24 hours, and only its hash is stored, so reading the database does not yield a working one. It is invalidated the moment you use it.
+
+Signing in never depends on mail. The emailed login code is off on a self-hosted install (`AUTH_LOGIN_CODE`), because a relay you have not configured should not stand between you and your own instance. TOTP and passkeys are both available once you are in.
+
+Two things you get for free at this point: the dashboard at `http://localhost:5173`, and the admin panel at `http://localhost:5174` with the same account, because the owner is already an admin.
+
+<Callout title="Automating the install?">
+Set `WARMBLY_BOOTSTRAP_EMAIL` and `WARMBLY_BOOTSTRAP_PASSWORD_HASH` in `.env` before the first start and the account exists when the stack comes up, with no link to click. Both are read only while the users table is empty, so they are a no-op on every later restart.
+</Callout>
+
+</Step>
+
+<Step>
+
+### Load demo data (optional)
+
+To explore a populated workspace instead of an empty one:
+
+```bash
+make seed-demo
+```
+
+That creates `dev@warmbly.com` / `password123` along with mailboxes, campaigns, contacts, and two weeks of history. It builds the seed image each time on purpose: `compose run` otherwise reuses a stale one, which fails against a newer database schema.
+
+For a demo where mail actually flows end to end, with sends, replies, opens, and clicks, see the [sandbox](/development/sandbox/).
+
+</Step>
+
+</Steps>
+
+![The dashboard after your first login](/dashboard-campaigns.png)
+
+## Before you expose it
+
+Everything above works with zero configuration because the compose file ships working defaults for every secret. Those defaults are published in this repository, so they protect nothing. The backend refuses to start on them once `APP_ENV` is anything other than `dev`.
+
+Before anyone else can reach the instance, generate real values into a `.env` next to `docker-compose.yml`:
 
 ```bash
 cat > .env <<EOF
+APP_ENV=prod
 AUTH_SECRET=$(openssl rand -base64 32)
 INTERNAL_API_TOKEN=$(openssl rand -hex 24)
 SECRET_KEY_BASE=$(openssl rand -base64 64 | tr -d '\n')
@@ -92,35 +149,23 @@ EOF
 | `KMS_LOCAL_MASTER_KEY` | base64, exactly 32 bytes | The root key that seals every per-organization data key |
 | `CREDENTIALS_ENCRYPTION_KEY` | exactly 64 hex chars | Mailbox SMTP and IMAP credentials at rest |
 
+`APP_ENV=prod` requires no cloud account. Error reporting and GeoIP lookups are used when configured and skipped with a logged note when they are not.
+
 <Callout type="warn" title="Back up the last two keys before you store a single mailbox">
 `KMS_LOCAL_MASTER_KEY` and `CREDENTIALS_ENCRYPTION_KEY` seal every stored credential. Losing them is unrecoverable, and a database backup without them cannot be decrypted.
 </Callout>
 
-</Step>
+Rotating the secrets means recreating the containers, which `make up` does. Changing the two encryption keys after mailboxes exist does not: those credentials were sealed with the old values.
 
-<Step>
-
-### Start the stack
-
-```bash
-make up
-```
-
-That is `docker compose -p warmbly up -d --build`. It builds the images and starts eleven containers in the background. The first run is the slow one.
-
-</Step>
-
-<Step>
-
-### Check that everything is healthy
+## Checking the stack
 
 ```bash
 make status
 ```
 
-Wait until `backend`, `postgres`, `redis`, `nats`, `realtime`, `tracking`, and `mailpit` all report `(healthy)`. The backend applies its database migrations on boot, so it takes a few seconds longer than the rest.
+`backend`, `postgres`, `redis` and `nats` report `(healthy)`. The backend applies its migrations on boot, so it takes a few seconds longer than the rest. `realtime` and `tracking` have no healthcheck and show as `running`.
 
-Then confirm each entry point answers:
+Each entry point answers on its own port:
 
 ```bash
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/health   # backend
@@ -129,61 +174,9 @@ curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4000/health   # realti
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5173          # dashboard
 ```
 
-All four should print `200`. If one does not, `make logs backend` (or the service in question) will say why, and the [troubleshooting](#troubleshooting) table covers the usual causes.
+If one does not print `200`, `make logs backend` (or the service in question) will say why, and [troubleshooting](#troubleshooting) covers the usual causes.
 
-</Step>
-
-<Step>
-
-### Create your account
-
-Open `http://localhost:5173` and register. Captcha is off by default, so any email address works.
-
-**Warmbly emails you a 6-digit code to finish signing up, and again on every login.** A fresh install has no real mail relay, so that code goes to the bundled Mailpit catcher instead of a real inbox:
-
-1. Open `http://localhost:18025`
-2. Open the newest message ("Your Verification Code", then "Your Login Code" on later sign-ins)
-3. Copy the 6-digit code back into the dashboard
-
-This is the step people miss most often. Point `SMTP_HOST` at a real relay ([notification email](#notification-email)) once you are past setup, and the codes go to your actual inbox.
-
-</Step>
-
-<Step>
-
-### Make yourself a platform admin
-
-Nothing grants the first platform admin automatically, so do it from the host after your account exists:
-
-```bash
-make grant-admin EMAIL=you@example.com          # ROLE=super|support|ops|analyst, default super
-```
-
-Then sign in at `http://localhost:5174` with the same account and code flow.
-
-</Step>
-
-<Step>
-
-### Load demo data (optional)
-
-To explore a populated workspace instead of an empty one:
-
-```bash
-docker compose -p warmbly --profile seed run --rm --build seed
-```
-
-That creates `dev@warmbly.com` / `password123` along with mailboxes, campaigns, contacts, and two weeks of history. Login still needs the code from Mailpit.
-
-Keep the `--build` flag. `compose run` reuses whatever seed image already exists, and a stale one fails against a newer database schema.
-
-For a demo where mail actually flows end to end, with sends, replies, opens, and clicks, see the [sandbox](/development/sandbox/).
-
-</Step>
-
-</Steps>
-
-![The dashboard after your first login](/dashboard-campaigns.png)
+The admin panel's **System Status** page shows the same probes plus the platform mail transport, with a live connection check and a send-test button.
 
 ## What is running
 
@@ -196,7 +189,9 @@ For a demo where mail actually flows end to end, with sends, replies, opens, and
 | consumer / worker | none | Event processor; send and sync executor |
 | postgres / redis | 15432 / 16379 | PostgreSQL 16; cache and realtime bridge |
 | nats | 4222 (monitoring 8222) | Event bus (JetStream) |
-| mailpit | 18025 (SMTP 11025) | Mail catcher for platform email, including login codes |
+| mailpit | 18025 (SMTP 11025), bound to localhost | Not started by `make up`. An SMTP sink for the demo environment, in the `sandbox` profile. Its UI has no authentication, so it is never published to the network |
+
+Ten containers, idling near 300 MB in total. Nothing that only the demo environment needs is started: the mail catcher and the local IMAP server sit in the `sandbox` profile and come up only when `make sandbox`, `make dev` or `make infra` name them.
 
 There is no separate migration step. Migrations are embedded in the backend binary, and a standalone `/app/migrate` binary ships in the image as well.
 
@@ -261,13 +256,33 @@ BOX_GOOGLE_CLIENT_SECRET=
 BOX_OUTLOOK_CLIENT_ID=
 BOX_OUTLOOK_CLIENT_SECRET=
 
-# ── Platform email (login codes, resets, digests) ─────────────────
+# ── Platform email (resets, invitations, digests) ─────────────────
+# log writes messages to the backend logs and delivers nothing. Switch to
+# smtp before anyone else relies on this instance.
+MAIL_TRANSPORT=smtp
 SMTP_HOST=smtp.example.com
-SMTP_PORT=587
 SMTP_USERNAME=
 SMTP_PASSWORD=
+SMTP_SECURITY=starttls               # starttls (587) | tls (465) | none (25)
 EMAIL_NAME=Warmbly
 EMAIL_ADDRESS=noreply@example.com
+
+# ── Auth ──────────────────────────────────────────────────────────
+DEPLOYMENT_MODE=self_hosted
+# AUTH_LOGIN_CODE=off                # always | new_device | off
+# DISABLE_REGISTRATION=invite_only   # true | false | invite_only
+# TRUSTED_PROXIES=10.0.0.0/8         # required when a reverse proxy is in front
+
+# First owner, read only while the users table is empty. Omit and the backend
+# prints a single-use setup link to its logs.
+# WARMBLY_BOOTSTRAP_EMAIL=you@example.com
+# WARMBLY_BOOTSTRAP_PASSWORD_HASH=
+
+# ── Optional: single sign-on ──────────────────────────────────────
+# OIDC_ISSUER_URL=https://id.example.com/application/o/warmbly/
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_DEFAULT_ORG=<organization uuid>
 
 # ── Optional: AI assistant ────────────────────────────────────────
 # AI_PROVIDER=openai
@@ -344,16 +359,69 @@ Every origin that talks to the API has to appear in `CORS_ALLOW_ORIGINS`. Anythi
 
 Make sure the proxy serves the websocket host over HTTP/1.1. The upgrade handshake cannot be expressed in HTTP/2, so a proxy that forces h2 to the client on that hostname breaks realtime while leaving everything else working.
 
-## Notification email
+## Platform email
 
-The platform's own mail (login codes, confirmations, resets, digests) goes out over SMTP. Compose points it at the bundled Mailpit. Switch to a real relay before you rely on the install:
+The platform's own mail is registration codes, password resets, team invitations, notification digests, and login codes where those are enabled. It is separate from campaign mail, which goes out through the mailboxes you connect.
+
+`MAIL_TRANSPORT` selects how it is sent.
+
+| Transport | What it does |
+|-----------|--------------|
+| `log` | Writes every message to the backend logs and delivers nothing. The default, so a fresh install works before you have a relay |
+| `smtp` | A real submission relay |
+| `ses` | AWS SES; needs AWS credentials and a verified sending identity |
+
+The default is deliberate. Nothing about signing in requires mail on a self-hosted install, so an unconfigured relay costs you password resets and invitations, not access. Read a code out of the logs with:
 
 ```bash
-SMTP_HOST=smtp.example.com        # unset falls back to AWS SES, which needs AWS credentials
-SMTP_PORT=587
+docker compose -p warmbly logs backend | grep -B2 -A12 "MAIL_TRANSPORT=log"
+```
+
+### Using a real relay
+
+```bash
+MAIL_TRANSPORT=smtp
+SMTP_HOST=smtp.example.com
+SMTP_USERNAME=apikey
+SMTP_PASSWORD=...
 EMAIL_NAME=Warmbly
 EMAIL_ADDRESS=noreply@example.com
 ```
+
+`SMTP_SECURITY` picks the transport security, and the port follows from it:
+
+| `SMTP_SECURITY` | Port | When |
+|-----------------|------|------|
+| `starttls` | 587 | The default, and what almost every provider wants |
+| `tls` | 465 | Implicit TLS |
+| `none` | 25 | Cleartext. Only legitimate for a sink or a relay on the same host |
+
+Set either the security mode or the port and the other follows, so `SMTP_PORT=465` alone is enough.
+
+Credentials are never sent over an unencrypted connection. If the relay does not offer STARTTLS and you have set a username, the send fails rather than transmitting the password in the clear. `SMTP_AUTH` defaults to `auto`, which picks the strongest mechanism the relay advertises; set it explicitly to `plain`, `login` or `cram-md5` if you need to pin one. `SMTP_TLS_INSECURE_SKIP_VERIFY=true` exists for an internal relay with a private CA and should not be used with a public provider.
+
+### Checking it works
+
+The backend dials the relay once at boot and logs the result, so a broken configuration shows up in `docker compose logs backend` rather than as a failed password reset weeks later.
+
+The admin panel's **System Status** page has a Platform mail card with the current transport, a live connection check that shows the SMTP error verbatim, and a send-test button.
+
+### Deliverability
+
+Mail from a self-hosted instance is subject to the same rules as any other sender. Publish SPF and DKIM for the domain in `EMAIL_ADDRESS`, and use a domain you control: a `From` address on a domain with no records is the most common reason reset links land in spam.
+
+### Branding
+
+Transactional email carries Warmbly's name and legal footer by default. Override it with the `EMAIL_BRAND_*` variables, which is worth doing on an instance your own users receive mail from:
+
+```bash
+EMAIL_BRAND_NAME=Acme
+EMAIL_BRAND_LEGAL_ENTITY=Acme Ltd
+EMAIL_BRAND_WEBSITE_URL=https://acme.example.com
+EMAIL_BRAND_SUPPORT_EMAIL=support@acme.example.com
+```
+
+Every emailed link (password reset, invitation, the dashboard button in the welcome mail) is built from `APP_URL`. Set it, or those links point somewhere that is not your deployment.
 
 ## Connect mailboxes
 
@@ -459,6 +527,67 @@ APPLE_TEAM_ID=...
 APPLE_KEY_ID=...
 APPLE_KEY_SECRET=...
 ```
+
+## Authentication
+
+Self-hosted defaults differ from the hosted product, because a deployment you run yourself should not depend on infrastructure you have not set up. `DEPLOYMENT_MODE=self_hosted` picks them; each one is independently overridable.
+
+| Setting | Self-host default | What it does |
+|---------|-------------------|--------------|
+| `AUTH_LOGIN_CODE` | `off` | `always`, `new_device` or `off`. Whether a login also requires a code emailed to the account |
+| `REQUIRE_EMAIL_VERIFICATION` | `false` | Whether a signup must confirm an emailed code before the account exists |
+| `DISABLE_REGISTRATION` | `invite_only` | `true`, `false` or `invite_only`. Who may create an account |
+| `DISABLE_PASSWORD_LOGIN` | `false` | Turns off email and password entirely, for SSO-only deployments |
+| `AUTH_IP_RATE_LIMIT` | `60` | Unauthenticated auth requests allowed per source IP per 15 minutes |
+
+### Why the login code is off by default
+
+Emailing a code on every sign-in makes the mail relay a single point of failure for all authentication, and it is not a second factor: NIST SP 800-63B states that email is not to be used for out-of-band authentication, and OWASP ASVS says the same. Codes remain in use for the things email is appropriate for, which are verifying an address at signup and recovering an account.
+
+Set `AUTH_LOGIN_CODE=new_device` to require one only from a device that has not signed in before, or `always` for the hosted behavior. TOTP and passkeys are both stronger and both available.
+
+### Stronger factors
+
+TOTP applies to every sign-in path, including Google, Apple and single sign-on. A passkey does not additionally prompt for TOTP: a user-verified passkey is already a possession factor bound to this origin.
+
+Passkeys need a secure context, so they are only available when `APP_URL` is HTTPS or a `localhost` address. A LAN IP over plain HTTP cannot be a WebAuthn relying-party ID; the backend detects this, logs it at boot, and the login screen hides the option instead of failing in the browser. Changing `APP_URL` after passkeys are enrolled invalidates all of them.
+
+### Behind a reverse proxy
+
+Set `TRUSTED_PROXIES` to the CIDRs your proxy connects from:
+
+```bash
+TRUSTED_PROXIES=10.0.0.0/8,172.16.0.0/12
+```
+
+Empty means no proxy header is trusted, which is correct for a directly exposed backend. Without this a client can set `X-Forwarded-For` to anything, which forges the address used for rate limits, session records, audit entries, and API-key IP restrictions.
+
+## Single sign-on
+
+Generic OpenID Connect works with Authentik, Keycloak, Zitadel, Pocket ID, Dex, and anything else that publishes a discovery document. It is in the standard build, not a paid tier.
+
+For a self-hosted deployment it is also the sign-in path with no dependency on outbound mail at all, which makes it the recommended posture when you have no relay.
+
+```bash
+OIDC_ISSUER_URL=https://id.example.com/application/o/warmbly/
+OIDC_CLIENT_ID=...
+OIDC_CLIENT_SECRET=...
+OIDC_REDIRECT_URL=https://api.example.com/api/v1/auth/oidc/callback
+OIDC_ALLOWED_DOMAINS=example.com
+OIDC_DEFAULT_ORG=<organization uuid>
+```
+
+Register `OIDC_REDIRECT_URL` as the redirect URI at your provider. It defaults to `API_PUBLIC_URL` plus `/api/v1/auth/oidc/callback`, and providers match it by exact string, so it has to be identical on both sides.
+
+Discovery runs at boot. An unreachable or misconfigured issuer disables SSO with a logged reason rather than shipping a button that always fails.
+
+Three things worth knowing:
+
+- **Set `OIDC_DEFAULT_ORG`.** Warmbly is multi-tenant, and a new user normally gets their own organization. Without this, a twenty-person identity provider produces twenty single-member organizations that share nothing.
+- **Accounts are bound to the provider's subject claim**, not to the email address, and an unverified address is refused. Matching on email alone would let anyone who can register an arbitrary address at your provider claim an existing Warmbly account.
+- **Only RS256 ID tokens are accepted**, which every mainstream provider issues by default.
+
+Pair it with `DISABLE_PASSWORD_LOGIN=true` for an SSO-only deployment.
 
 ## Provider switches
 
@@ -663,12 +792,12 @@ The compose file is a template, not a requirement. The Dockerfiles in `deploy/do
 
 | Symptom | Cause and fix |
 |---------|---------------|
-| No login code arrives | On a default install codes go to Mailpit, not your inbox. Open `http://localhost:18025`. Set `SMTP_HOST` to a real relay to change that |
+| No login code arrives | Self-host does not send one by default (`AUTH_LOGIN_CODE=off`). Registration and reset codes go wherever `MAIL_TRANSPORT` points; on a default install that is the backend logs. Set `MAIL_TRANSPORT=smtp` and the `SMTP_` variables for real delivery |
 | "Too many attempts" on login or signup | Auth emails are capped at 5 per address per 30 minutes. Wait it out, or clear the counter with `docker compose -p warmbly exec redis redis-cli FLUSHDB` |
 | Backend exits at boot | Read the first log lines. Usual causes: cloud provider defaults outside compose, a malformed `CREDENTIALS_ENCRYPTION_KEY` (it needs exactly 64 hex characters), or `APP_ENV=prod` without `SENTRY_DSN` or the GeoIP file |
 | Dashboard loads but every request fails | Check `http://localhost:5173/config.js` returns the right `API_URL`. It is generated at container start from `WARMBLY_API_URL` |
 | "No mailbox workers are available" when connecting a mailbox | No worker is active with a heartbeat inside the last 10 minutes. Check `make status` shows `worker` running and `make logs worker` is clean. Placement deliberately ignores workers that stopped reporting, so a worker that was removed cannot silently swallow mailboxes |
-| Connecting a mailbox is rejected on the port | SMTP must be `587` or `465`. The bundled Mailpit listens on `1025` and offers no STARTTLS, so it catches platform email but cannot be used as a test mailbox |
+| Connecting a mailbox is rejected on the port | SMTP must be `587` or `465`. The Mailpit sink used by `make sandbox` listens on `1025` and offers no STARTTLS, so it cannot be used as a test mailbox |
 | Workers or tracking get 401s | `INTERNAL_API_TOKEN` must match on the backend, the workers (as `ENCRYPTED_KEYS_WORKER_TOKEN`), and tracking. Unset fails closed |
 | No realtime updates | `AUTH_SECRET` must equal realtime's `JWT_SECRET`, and `PUBSUB_ENABLED` must agree across backend, consumer, and realtime. Compose wires both |
 | Seeding fails with `no migration found for version N` | The seed image is older than your schema. Re-run with `--build` |
@@ -682,7 +811,10 @@ Still stuck? `make logs` follows everything, and `make logs backend` follows one
 ## Quick reference
 
 ```bash
-make up          # build and start the whole platform in Docker
+make up          # build and start the platform, then print the claim link
+make claim       # print the claim link again
+make seed-demo   # load the showcase workspace
+
 make status      # docker compose ps
 make logs        # follow logs (make logs backend for one service)
 make stop        # stop everything, keep data
@@ -690,7 +822,7 @@ make down        # stop and remove containers, keep data
 make reset       # tear down including volumes (destroys data)
 
 make gen-key     # print a fresh KMS_LOCAL_MASTER_KEY
-make grant-admin EMAIL=you@example.com   # bootstrap the first platform admin
+make grant-admin EMAIL=you@example.com   # promote an existing account to platform admin
 
 make dev         # local development stack instead (native Go, hot reload)
 make sandbox     # live end-to-end demo environment

--- a/docs/content/docs/development/local-development.mdx
+++ b/docs/content/docs/development/local-development.mdx
@@ -32,9 +32,13 @@ and admin panel together in your terminal.
 
 Open `http://localhost:5173` and log in with `dev@warmbly.com` / `password123`.
 
-Warmbly emails a 6-digit code on every login, and local mail goes to Mailpit
-rather than a real inbox. Open `http://localhost:18025`, read the newest "Your
-Login Code" message, and paste the code into the dashboard.
+The native dev stack keeps the emailed login code on (`AUTH_LOGIN_CODE=always`)
+so the flow stays exercised, and local mail goes to Mailpit rather than a real
+inbox. Open `http://localhost:18025`, read the newest "Your Login Code"
+message, and paste the code into the dashboard.
+
+A self-hosted install behaves differently: there the code is off by default, so
+signing in never depends on mail. See [self-hosting](/development/deployment-guide/#authentication).
 
 Ctrl-C stops the app services; the Docker infra stays up, so the next `make dev`
 skips straight to starting the app. The Go services run natively with `go run`,
@@ -239,7 +243,9 @@ make backend AI_PROVIDER=openai AI_KEY=sk-...
 
 ## Mailpit
 
-All outbound mail is captured by Mailpit. The backend uses plain SMTP (`mailpit:1025`) in dev rather than SES, so no AWS credentials are needed. Mailpit accepts SMTP AUTH with any credentials (no TLS required), so worker sends from sandbox mailboxes are captured too.
+All outbound mail is captured by Mailpit. The dev targets set `MAIL_TRANSPORT=smtp` with `SMTP_SECURITY=none`, because a sink offers no STARTTLS and the platform transport refuses to send credentials over an unencrypted connection. Mailpit accepts SMTP AUTH with any credentials, so worker sends from sandbox mailboxes are captured too.
+
+Mailpit sits in the `sandbox` compose profile, so the self-host `make up` never starts it. `make dev`, `make infra` and `make sandbox` name it explicitly, which starts it regardless of the profile.
 
 - Web UI: `http://localhost:18025`
 - SMTP from inside docker: `mailpit:1025`

--- a/internal/api/handler/admin_mail.go
+++ b/internal/api/handler/admin_mail.go
@@ -1,0 +1,83 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// AdminMailStatus reports the platform mail transport and dials it.
+//
+// Every mature self-hosted product ships this (Mattermost's Test Connection,
+// Gitea's mailer summary, Vaultwarden's /admin/test/smtp, Zulip's
+// send_test_email) because a broken relay is not a degraded feature here, it
+// is a lockout: login codes, password resets and invitations all go through it.
+func (h *Handler) AdminMailStatus(c *gin.Context) {
+	transport := h.MailTransportRef
+	if transport == nil {
+		c.JSON(http.StatusOK, gin.H{
+			"transport": "unconfigured",
+			"delivers":  false,
+			"healthy":   false,
+			"detail":    "No platform mail transport is configured.",
+		})
+		return
+	}
+
+	resp := gin.H{
+		"transport": transport.Kind,
+		"delivers":  transport.Delivers,
+		"detail":    transport.Description,
+	}
+
+	if err := transport.Preflight(c.Request.Context()); err != nil {
+		resp["healthy"] = false
+		// The dialogue-level error is the whole value of this endpoint: which
+		// step failed, and what the relay said.
+		resp["error"] = err.Error()
+	} else {
+		resp["healthy"] = true
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+type platformTestEmailRequest struct {
+	To string `json:"to" binding:"required"`
+}
+
+// AdminSendTestEmail sends a real message through the platform transport.
+func (h *Handler) AdminSendTestEmail(c *gin.Context) {
+	var req platformTestEmailRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	transport := h.MailTransportRef
+	if transport == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "No platform mail transport is configured."))
+		return
+	}
+
+	const subject = "Warmbly test email"
+	body := `<p>This is a test message from your Warmbly deployment.</p>` +
+		`<p>If you are reading it in your inbox, login codes, password resets and team invitations will reach your users.</p>` +
+		`<p>Transport: ` + transport.Description + `</p>`
+
+	if err := transport.Send(c.Request.Context(), []string{req.To}, nil, nil, subject, body); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"sent":      false,
+			"transport": transport.Kind,
+			"error":     err.Error(),
+		})
+		return
+	}
+
+	sent := gin.H{"sent": true, "transport": transport.Kind}
+	if !transport.Delivers {
+		sent["note"] = "MAIL_TRANSPORT=log, so the message was written to the backend logs instead of being delivered."
+	}
+	c.JSON(http.StatusOK, sent)
+}

--- a/internal/api/handler/auth.go
+++ b/internal/api/handler/auth.go
@@ -25,7 +25,7 @@ func (h *Handler) LoginStart(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), authRequestTimeout)
 	defer cancel()
 
-	resp, err := h.AuthService.LoginStart(ctx, &data, c.ClientIP())
+	resp, err := h.AuthService.LoginStart(ctx, &data, c.ClientIP(), c.Request.UserAgent())
 	if err != nil {
 		errx.Handle(c, err)
 		return

--- a/internal/api/handler/auth_config.go
+++ b/internal/api/handler/auth_config.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/config"
+)
+
+// DeploymentAuthConfig is what the login screen needs to render truthfully.
+//
+// Without it the frontends guess: the Turnstile widget mounted even when
+// captcha was off server-side, social buttons rendered with no client
+// configured, and nothing told a self-hoster their login code was going to a
+// log file. Everything here is public, non-secret configuration.
+type DeploymentAuthConfig struct {
+	// Captcha reports whether a Turnstile token is actually verified. When
+	// false the client must not mount the widget: a self-hosted or air-gapped
+	// install cannot reach challenges.cloudflare.com.
+	Captcha bool `json:"captcha"`
+
+	// PasswordLogin is false when the deployment authenticates only through
+	// OIDC or passkeys.
+	PasswordLogin bool `json:"password_login"`
+
+	// LoginCode is always, new_device or off. The client uses it to decide
+	// whether to expect a code step, and to explain the flow up front.
+	LoginCode string `json:"login_code"`
+
+	// Registration is false, invite_only or true, already resolved through the
+	// first-launch exemption, so a brand new instance reports open signups.
+	Registration string `json:"registration"`
+
+	// EmailVerification reports whether a signup must confirm an emailed code.
+	EmailVerification bool `json:"email_verification"`
+
+	// MailDelivers is false when the platform mail transport does not put mail
+	// on the wire (MAIL_TRANSPORT=log). The login screen tells the operator
+	// where to find codes instead of leaving them waiting for an email.
+	MailDelivers bool `json:"mail_delivers"`
+
+	// Passkeys reports whether WebAuthn can work here at all. It needs a
+	// secure context, so a plain-http LAN origin disables it rather than
+	// failing in the browser with an opaque error.
+	Passkeys bool `json:"passkeys"`
+
+	Providers []string `json:"providers"`
+
+	// SelfHosted lets the UI drop hosted-only affordances (billing prompts,
+	// referral fields) that make no sense on someone's own server.
+	SelfHosted bool `json:"self_hosted"`
+
+	// SetupRequired is true while the instance has no accounts at all. The
+	// login screen redirects to the setup page rather than showing a form
+	// nobody can yet use.
+	SetupRequired bool `json:"setup_required"`
+}
+
+// AuthConfig serves GET /v1/auth/config. Public and unauthenticated by design:
+// it is the first request the login screen makes.
+func (h *Handler) AuthConfig(c *gin.Context) {
+	policy := h.AuthService.Policy()
+
+	providers := []string{}
+	if h.ExternalAuthProviders.GoogleIOSClientID != "" || h.GoogleWebSignIn {
+		providers = append(providers, "google")
+	}
+	if h.ExternalAuthProviders.AppleBundleID != "" || h.AppleWebSignIn {
+		providers = append(providers, "apple")
+	}
+	if h.OIDCEnabled {
+		providers = append(providers, "oidc")
+	}
+
+	c.JSON(http.StatusOK, DeploymentAuthConfig{
+		Captcha:           config.CaptchaProvider() != "none",
+		PasswordLogin:     !policy.DisablePasswordLogin,
+		LoginCode:         policy.LoginCode,
+		Registration:      h.AuthService.RegistrationMode(c.Request.Context()),
+		EmailVerification: policy.RequireEmailVerification,
+		MailDelivers:      h.MailDelivers,
+		Passkeys:          h.PasskeysUsable,
+		Providers:         providers,
+		SelfHosted:        config.SelfHosted(),
+		SetupRequired:     h.BootstrapService != nil && h.BootstrapService.Required(c.Request.Context()),
+	})
+}

--- a/internal/api/handler/auth_oidc.go
+++ b/internal/api/handler/auth_oidc.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// OIDCBegin starts a generic OpenID Connect authorization.
+//
+// It returns the URL rather than issuing a 302 so the dashboard, which is a
+// single-page app on a different origin from the API, can navigate to it
+// itself. The state, nonce and PKCE verifier are stored server-side and never
+// leave the backend.
+func (h *Handler) OIDCBegin(c *gin.Context) {
+	redirect, err := h.AuthService.OIDCBegin(c.Request.Context())
+	if err != nil {
+		errx.Handle(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, redirect)
+}
+
+// OIDCCallback is where the provider sends the browser back.
+//
+// It answers with a redirect, not JSON: a person is looking at this response.
+// The session itself is held server-side behind a single-use handoff code that
+// the dashboard immediately exchanges, so no token ever appears in a URL,
+// browser history, Referer header or proxy log.
+func (h *Handler) OIDCCallback(c *gin.Context) {
+	base := config.AppBaseURL()
+
+	// A provider-side refusal arrives as ?error=, not as a failed exchange.
+	if e := c.Query("error"); e != "" {
+		c.Redirect(http.StatusFound, base+"/auth/login?sso_error="+url.QueryEscape(e))
+		return
+	}
+
+	handoff, err := h.AuthService.OIDCCallback(
+		c.Request.Context(),
+		c.Query("code"),
+		c.Query("state"),
+		c.ClientIP(),
+		c.Request.UserAgent(),
+	)
+	if err != nil {
+		c.Redirect(http.StatusFound, base+"/auth/login?sso_error="+url.QueryEscape(err.Message))
+		return
+	}
+
+	c.Redirect(http.StatusFound, base+"/auth/sso?code="+url.QueryEscape(handoff))
+}
+
+type oidcExchangeRequest struct {
+	Code string `json:"code"`
+}
+
+// OIDCExchange swaps the handoff code for the session. Single use.
+func (h *Handler) OIDCExchange(c *gin.Context) {
+	var req oidcExchangeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	result, err := h.AuthService.OIDCExchange(c.Request.Context(), req.Code)
+	if err != nil {
+		errx.Handle(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}

--- a/internal/api/handler/auth_setup.go
+++ b/internal/api/handler/auth_setup.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/app/token"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+type setupClaimRequest struct {
+	Token     string `json:"token"`
+	Email     string `json:"email"`
+	Password  string `json:"password"`
+	FirstName string `json:"first_name"`
+	LastName  string `json:"last_name"`
+}
+
+// SetupClaim exchanges the one-time link printed at first boot for the owner
+// account, and signs them straight in.
+//
+// Public by necessity: there is no account to authenticate as yet. The token is
+// the protection, and it is consumed atomically, refused once any user exists,
+// and covered by the same per-IP limiter as the rest of the auth group.
+func (h *Handler) SetupClaim(c *gin.Context) {
+	if h.BootstrapService == nil {
+		errx.Handle(c, errx.New(errx.NotFound, "Setup is not available on this deployment."))
+		return
+	}
+
+	var req setupClaimRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.Handle(c, errx.ErrInvalid)
+		return
+	}
+
+	u, xerr := h.BootstrapService.Claim(
+		c.Request.Context(),
+		req.Token,
+		req.Email,
+		req.Password,
+		req.FirstName,
+		req.LastName,
+	)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+
+	// Hand back a session rather than bouncing them to the login screen. They
+	// just proved ownership of the instance; asking them to type the password
+	// again immediately is friction with no security value.
+	session, terr := h.TokenService.GenerateSession(
+		c.Request.Context(),
+		u.ID,
+		u.Email,
+		c.ClientIP(),
+		c.Request.UserAgent(),
+		token.AuthProviderEmail,
+	)
+	if terr != nil {
+		errx.Handle(c, terr)
+		return
+	}
+
+	c.JSON(http.StatusOK, session)
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/audit"
 	"github.com/warmbly/warmbly/internal/app/auth"
 	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/app/bootstrap"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/compose"
 	"github.com/warmbly/warmbly/internal/app/contact"
@@ -73,12 +74,26 @@ type Handler struct {
 
 	// Native-app social sign-in discovery (GET /auth/providers).
 	ExternalAuthProviders models.ExternalAuthProviders
-	UserService           user.UserService
-	EmailService          email.EmailService
-	CampaignService       campaign.CampaignService
-	ContactService        contact.ContactService
-	SequenceService       sequence.SequenceService
-	UniboxService         unibox.UniboxService
+
+	// Deployment facts served by GET /auth/config so the login screen renders
+	// what this backend can actually do instead of guessing.
+	GoogleWebSignIn bool
+	AppleWebSignIn  bool
+	OIDCEnabled     bool
+	MailDelivers    bool
+	PasskeysUsable  bool
+	MailTransport   string
+	// MailTransportRef backs the admin mail diagnostics, which need Preflight
+	// and so cannot go through the EmailNotificationService interface.
+	MailTransportRef *notify.Transport
+	// BootstrapService backs the first-run setup page.
+	BootstrapService *bootstrap.Service
+	UserService      user.UserService
+	EmailService     email.EmailService
+	CampaignService  campaign.CampaignService
+	ContactService   contact.ContactService
+	SequenceService  sequence.SequenceService
+	UniboxService    unibox.UniboxService
 
 	FolderService   group.GroupService
 	TagService      group.GroupService

--- a/internal/api/handler/organization.go
+++ b/internal/api/handler/organization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/notify/templates"
@@ -224,11 +225,17 @@ func (h *Handler) InviteMember(c *gin.Context) {
 
 	// Send invitation email
 	if h.EmailNotificationService != nil {
-		subject := fmt.Sprintf("You've been invited to join %s on Warmbly", orgName)
-		acceptURL := fmt.Sprintf("%s/invite?token=%s", templates.AppURL, inv.Token)
+		subject := fmt.Sprintf("You've been invited to join %s on %s", orgName, templates.CompanyName)
+		acceptURL := config.GetInviteURL(inv.Token)
 		// GenerateInvitationHTML reports its own render errors to Sentry.
 		if body, gerr := templates.GenerateInvitationHTML(inviterName, orgName, acceptURL); gerr == nil {
-			go h.EmailNotificationService.Send(c.Request.Context(), []string{req.Email}, nil, nil, subject, body)
+			// Detached from the request context: the handler returns before the
+			// send completes, and a cancelled context aborted the send mid-dial.
+			sendCtx, cancel := context.WithTimeout(context.WithoutCancel(c.Request.Context()), 45*time.Second)
+			go func() {
+				defer cancel()
+				_ = h.EmailNotificationService.Send(sendCtx, []string{req.Email}, nil, nil, subject, body)
+			}()
 		}
 	}
 

--- a/internal/api/middleware/handler.go
+++ b/internal/api/middleware/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/organization"
 	"github.com/warmbly/warmbly/internal/app/ratelimit"
 	"github.com/warmbly/warmbly/internal/app/token"
+	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 )
 
 type Handler struct {
@@ -18,4 +19,8 @@ type Handler struct {
 	// OAuthService validates OAuth 2.1 bearer access tokens (nil-safe: when
 	// unset, only JWT + API-key auth are accepted).
 	OAuthService *oauth.Service
+	// Cache backs the pre-login per-IP limiter, which cannot use
+	// RateLimitService because that one is keyed on a user id that does not
+	// exist yet.
+	Cache *cache.Cache
 }

--- a/internal/api/middleware/ratelimit_ip.go
+++ b/internal/api/middleware/ratelimit_ip.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// authIPWindow and authIPLimit bound unauthenticated auth traffic from one
+	// source. The limit is generous enough for a shared office NAT retyping a
+	// password, and far below what credential stuffing needs.
+	authIPWindow       = 15 * time.Minute
+	authIPDefaultLimit = 60
+)
+
+// AuthIPRateLimitMiddleware throttles the public /auth group per source IP.
+//
+// This is the only limiter those routes have. RateLimitMiddleware keys on the
+// authenticated user id and calls c.Next() when there is none, so before this
+// existed every pre-login endpoint was unbounded: password guessing was free,
+// and each guess cost a 64 MiB Argon2 hash, which is a memory-exhaustion lever
+// on the small VPS most self-hosters run.
+//
+// Fails open on a cache error, deliberately: a Redis blip must not lock every
+// user out of their own instance.
+func (h *Handler) AuthIPRateLimitMiddleware() gin.HandlerFunc {
+	limit := authIPDefaultLimit
+	if v := os.Getenv("AUTH_IP_RATE_LIMIT"); v != "" {
+		if parsed, err := strconv.Atoi(v); err == nil && parsed > 0 {
+			limit = parsed
+		}
+	}
+
+	return func(c *gin.Context) {
+		if h.Cache == nil {
+			c.Next()
+			return
+		}
+		// Reads are cheap and the login screen makes one on every load.
+		if c.Request.Method == http.MethodGet {
+			c.Next()
+			return
+		}
+
+		ip := c.ClientIP()
+		if ip == "" {
+			c.Next()
+			return
+		}
+
+		key := "auth_ip:" + ip
+		n, err := h.Cache.Incr(c.Request.Context(), key).Result()
+		if err != nil {
+			c.Next()
+			return
+		}
+		if n == 1 {
+			_ = h.Cache.Expire(c.Request.Context(), key, authIPWindow).Err()
+		}
+
+		if n > int64(limit) {
+			c.Header("Retry-After", fmt.Sprintf("%d", int(authIPWindow.Seconds())))
+			c.JSON(http.StatusTooManyRequests, gin.H{
+				"error":   "rate_limit_exceeded",
+				"message": "Too many authentication attempts from this address. Try again later.",
+				"code":    "rate_limit_exceeded",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"log"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -11,6 +14,17 @@ import (
 	"github.com/warmbly/warmbly/internal/api/middleware"
 	"github.com/warmbly/warmbly/internal/models"
 )
+
+// splitCSV parses a comma-separated env list, dropping empty entries.
+func splitCSV(value string) []string {
+	out := make([]string, 0, 4)
+	for _, part := range strings.Split(value, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
 
 func Run(
 	h *handler.Handler,
@@ -22,6 +36,20 @@ func Run(
 	gin.SetMode(ginMode)
 
 	r := gin.Default()
+
+	// Gin trusts every proxy by default, which makes X-Forwarded-For (and so
+	// c.ClientIP()) attacker-controlled: forged values reach the captcha
+	// verifier, session records, audit rows, and the API-key IP allowlist.
+	// Default to trusting nothing and honor the header only for the CIDRs an
+	// operator names in TRUSTED_PROXIES.
+	if proxies := splitCSV(os.Getenv("TRUSTED_PROXIES")); len(proxies) > 0 {
+		if err := r.SetTrustedProxies(proxies); err != nil {
+			log.Fatalf("invalid TRUSTED_PROXIES: %v", err)
+		}
+	} else {
+		_ = r.SetTrustedProxies(nil)
+	}
+
 	r.Use(middleware.RequestIDMiddleware())
 	r.Use(middleware.APIVersionMiddleware(middleware.APIVersion))
 
@@ -184,7 +212,21 @@ func Run(
 	v1.GET("/invitations/lookup", h.PreviewInvitation)
 
 	auth := v1.Group("/auth")
+	// Every unauthenticated auth route shares one per-IP budget. Nothing
+	// throttled these before: RateLimitMiddleware is keyed on the user id and
+	// short-circuits when there is none, so password guessing was unbounded and
+	// each guess cost a 64 MiB Argon2 hash.
+	auth.Use(m.AuthIPRateLimitMiddleware())
 	{
+		// Public deployment capabilities. Deliberately outside the rate limiter
+		// below is not an option (it is a GET the login screen makes first), so
+		// it shares the budget with a generous allowance.
+		auth.GET("/config", h.AuthConfig)
+
+		// First-run claim. Public because there is no account to authenticate
+		// as yet; the one-time token is the protection.
+		auth.POST("/setup", h.SetupClaim)
+
 		auth.POST("/login", h.LoginStart)
 		auth.POST("/login/confirm", h.LoginConfirm)
 		auth.POST("/register", h.RegistrationStart)
@@ -208,6 +250,13 @@ func Run(
 		auth.GET("/providers", h.AuthProviders)
 		auth.POST("/apple", h.AppleTokenLogin)
 		auth.POST("/google", h.GoogleTokenLogin)
+
+		// Generic OpenID Connect. The only sign-in path with no dependency on
+		// outbound mail, which is what makes it the one that matters for a
+		// deployment with no relay.
+		auth.POST("/oidc/begin", h.OIDCBegin)
+		auth.GET("/oidc/callback", h.OIDCCallback)
+		auth.POST("/oidc/exchange", h.OIDCExchange)
 
 		// 2FA login challenge (PUBLIC): exchanges a single-use pending token +
 		// TOTP/recovery code for a real session. Rate-limited in the service
@@ -1032,6 +1081,12 @@ func Run(
 	adminRoutes.Use(m.AuthMiddleware(), m.AdminMiddleware())
 	{
 		// Settings → Storage backends (pluggable infrastructure registry)
+		// Platform mail diagnostics. A broken relay locks everyone out, so the
+		// operator needs to see the SMTP dialogue from inside the panel rather
+		// than inferring it from a 500 on the login screen.
+		adminRoutes.GET("/mail/status", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminMailStatus)
+		adminRoutes.POST("/mail/test", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminSendTestEmail)
+
 		adminRoutes.GET("/settings/backends", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminListStorageBackends)
 		adminRoutes.GET("/settings/backends/active/:kind", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminGetActiveStorageBackend)
 		adminRoutes.POST("/settings/backends/:id/activate", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminActivateStorageBackend)

--- a/internal/app/auth/cache.go
+++ b/internal/app/auth/cache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -14,8 +15,17 @@ import (
 	"github.com/warmbly/warmbly/internal/pkg/crypt"
 )
 
-func getEmailVerificationKey(email string) string {
-	return "email_verification:" + crypt.SHA256(email)
+// Login and registration keep separate send budgets. They used to share one
+// key, which let anyone lock a known user out of login for the whole window by
+// POSTing /auth/register with that user's address.
+func getEmailVerificationKey(flow, email string) string {
+	return "email_verification:" + flow + ":" + crypt.SHA256(email)
+}
+
+// getKnownDeviceKey remembers a device that has already completed a full login,
+// so AUTH_LOGIN_CODE=new_device only challenges genuinely new ones.
+func getKnownDeviceKey(userID uuid.UUID, fingerprint string) string {
+	return "known_device:" + userID.String() + ":" + fingerprint
 }
 
 func getPasswordResetLimitKey(email string) string {
@@ -102,8 +112,8 @@ func (s *authService) getRegistrationSession(ctx context.Context, sessionID uuid
 	return &session, nil
 }
 
-func (s *authService) canSendEmail(ctx context.Context, email string) *errx.Error {
-	key := getEmailVerificationKey(email)
+func (s *authService) canSendEmail(ctx context.Context, flow, email string) *errx.Error {
+	key := getEmailVerificationKey(flow, email)
 
 	count, err := s.cache.Incr(ctx, key).Result()
 	if err != nil {
@@ -148,8 +158,12 @@ func (s *authService) passwordResetLimit(ctx context.Context, email string) *err
 	return nil
 }
 
+// saveResetPasswordSession binds the emailed reset JWT to a server-side nonce.
+// The TTL is PasswordResetTTL, the same lifetime the JWT carries and the same
+// one the email quotes: it used to be SessionTTL (10 minutes) against a 1-hour
+// token and a mail that promised 4 hours.
 func (s *authService) saveResetPasswordSession(ctx context.Context, sessionID uuid.UUID, nonce string) *errx.Error {
-	if err := s.cache.SetEx(ctx, getResetPasswordSessionKey(sessionID), nonce, SessionTTL).Err(); err != nil {
+	if err := s.cache.SetEx(ctx, getResetPasswordSessionKey(sessionID), nonce, PasswordResetTTL).Err(); err != nil {
 		sentry.CaptureException(err)
 		return errx.InternalError()
 	}
@@ -160,11 +174,47 @@ func (s *authService) saveResetPasswordSession(ctx context.Context, sessionID uu
 func (s *authService) getResetPasswordSession(ctx context.Context, sessionID uuid.UUID) (string, *errx.Error) {
 	val, err := s.cache.Get(ctx, getResetPasswordSessionKey(sessionID)).Result()
 	if err != nil {
+		// An expired or already-used link is ordinary, not an internal fault.
+		if errors.Is(err, redis.Nil) {
+			return "", errx.ErrToken
+		}
 		sentry.CaptureException(err)
 		return "", errx.InternalError()
 	}
 
 	return val, nil
+}
+
+// rememberDevice marks this device as having completed a full login, so
+// AUTH_LOGIN_CODE=new_device stops challenging it.
+func (s *authService) rememberDevice(ctx context.Context, userID uuid.UUID, userAgent string) {
+	fp := deviceFingerprint(userAgent)
+	if fp == "" {
+		return
+	}
+	_ = s.cache.SetEx(ctx, getKnownDeviceKey(userID, fp), "1", KnownDeviceTTL).Err()
+}
+
+// isKnownDevice reports whether this device has completed a login inside the
+// retention window.
+func (s *authService) isKnownDevice(ctx context.Context, userID uuid.UUID, userAgent string) bool {
+	fp := deviceFingerprint(userAgent)
+	if fp == "" {
+		return false
+	}
+	n, err := s.cache.Exists(ctx, getKnownDeviceKey(userID, fp)).Result()
+	return err == nil && n > 0
+}
+
+// deviceFingerprint is deliberately weak: a user agent is trivially spoofable,
+// so this is a convenience signal for skipping a code on a device the user has
+// already used, never an authentication factor. An empty agent yields no
+// fingerprint, which fails closed into "new device".
+func deviceFingerprint(userAgent string) string {
+	if strings.TrimSpace(userAgent) == "" {
+		return ""
+	}
+	return crypt.SHA256(userAgent)
 }
 
 func (s *authService) deletePasswordResetSession(ctx context.Context, sessionID uuid.UUID) *errx.Error {

--- a/internal/app/auth/config.go
+++ b/internal/app/auth/config.go
@@ -14,4 +14,15 @@ const (
 
 	PasswordResetLimit    = 2
 	PasswordResetLimitTTL = 4 * time.Hour
+
+	// KnownDeviceTTL is how long a device stays exempt from the login code
+	// under AUTH_LOGIN_CODE=new_device.
+	KnownDeviceTTL = 90 * 24 * time.Hour
+)
+
+// Email send-budget flows. Separate keys so registration traffic cannot exhaust
+// a user's login budget.
+const (
+	emailFlowLogin        = "login"
+	emailFlowRegistration = "registration"
 )

--- a/internal/app/auth/external_apple.go
+++ b/internal/app/auth/external_apple.go
@@ -11,7 +11,7 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-func (s *authService) AppleAuth(ctx context.Context, code, ipaddr, userAgent string) (*models.Token, *errx.Error) {
+func (s *authService) AppleAuth(ctx context.Context, code, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
 	atoken, err := s.externalAuth.AppleAuth.ValidateCode(code)
 	if err != nil {
 		if errors.Is(err, apple.ErrorResponseInvalidGrant) {
@@ -35,10 +35,6 @@ func (s *authService) AppleAuth(ctx context.Context, code, ipaddr, userAgent str
 		return nil, xerr
 	}
 
-	session, xerr := s.tokenService.GenerateSession(ctx, udb.ID, "", ipaddr, userAgent, token.AuthProviderApple)
-	if xerr != nil {
-		return nil, xerr
-	}
-
-	return session, nil
+	// Ban enforcement and the 2FA gate, which this path skipped entirely.
+	return s.finishLoginAs(ctx, udb.ID, ipaddr, userAgent, token.AuthProviderApple)
 }

--- a/internal/app/auth/external_google.go
+++ b/internal/app/auth/external_google.go
@@ -8,7 +8,7 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-func (s *authService) GoogleAuth(ctx context.Context, code, ipaddr, userAgent string) (*models.Token, *errx.Error) {
+func (s *authService) GoogleAuth(ctx context.Context, code, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
 	atoken, err := s.externalAuth.GoogleAuth.Exchange(ctx, code)
 	if err != nil {
 		return nil, errx.ErrExternalCode
@@ -28,10 +28,7 @@ func (s *authService) GoogleAuth(ctx context.Context, code, ipaddr, userAgent st
 		return nil, xerr
 	}
 
-	session, xerr := s.tokenService.GenerateSession(ctx, udb.ID, "", ipaddr, userAgent, token.AuthProviderGoogle)
-	if xerr != nil {
-		return nil, xerr
-	}
-
-	return session, nil
+	// Ban enforcement and the 2FA gate, which this path skipped entirely: a
+	// user who enrolled TOTP could sign in without it by choosing Google.
+	return s.finishLoginAs(ctx, udb.ID, ipaddr, userAgent, token.AuthProviderGoogle)
 }

--- a/internal/app/auth/external_idtoken.go
+++ b/internal/app/auth/external_idtoken.go
@@ -6,6 +6,7 @@ import (
 	"net/mail"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/token"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
@@ -29,12 +30,12 @@ func (s *authService) WireExternalIDTokens(apple, google IDTokenVerifier) {
 // AppleIDTokenAuth signs a user in with a native Sign in with Apple identity
 // token. Apple only shares the user's name with the app (never in the token),
 // so the client forwards it for first-sign-in profile prefill.
-func (s *authService) AppleIDTokenAuth(ctx context.Context, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.Token, *errx.Error) {
+func (s *authService) AppleIDTokenAuth(ctx context.Context, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
 	return s.externalIDTokenAuth(ctx, s.appleIDTokens, token.AuthProviderApple, rawToken, firstName, lastName, ipaddr, userAgent)
 }
 
 // GoogleIDTokenAuth signs a user in with a native Google Sign-In ID token.
-func (s *authService) GoogleIDTokenAuth(ctx context.Context, rawToken, ipaddr, userAgent string) (*models.Token, *errx.Error) {
+func (s *authService) GoogleIDTokenAuth(ctx context.Context, rawToken, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
 	return s.externalIDTokenAuth(ctx, s.googleIDTokens, token.AuthProviderGoogle, rawToken, "", "", ipaddr, userAgent)
 }
 
@@ -43,7 +44,7 @@ func (s *authService) GoogleIDTokenAuth(ctx context.Context, rawToken, ipaddr, u
 // provider-verified identity is already strong auth, so there is no email OTP
 // or captcha step; first sign-in provisions the org and free trial exactly
 // like password registration does.
-func (s *authService) externalIDTokenAuth(ctx context.Context, verifier IDTokenVerifier, provider, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.Token, *errx.Error) {
+func (s *authService) externalIDTokenAuth(ctx context.Context, verifier IDTokenVerifier, provider, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
 	if verifier == nil {
 		return nil, errx.ErrExternalProvider
 	}
@@ -67,32 +68,76 @@ func (s *authService) externalIDTokenAuth(ctx context.Context, verifier IDTokenV
 		return nil, errx.ErrEmail
 	}
 
+	userID, rerr := s.resolveFederatedUser(ctx, provider, claims.Issuer, claims.Subject, email, firstName, lastName)
+	if rerr != nil {
+		return nil, rerr
+	}
+
+	// Ban check and the 2FA gate both live in finishLoginAs, so social
+	// sign-in enforces exactly what password login does.
+	return s.finishLoginAs(ctx, userID, ipaddr, userAgent, provider)
+}
+
+// resolveFederatedUser maps a verified external identity to a local account.
+//
+// The lookup order is what keeps this safe. The (issuer, subject) pair is the
+// only provider-controlled stable identifier, so it is checked first. Falling
+// back to the email address is allowed exactly once, to link a pre-existing
+// local account, and only when that account has no other identity from this
+// issuer already: a second subject claiming an address that is already
+// federated is an impersonation attempt, not a re-login.
+func (s *authService) resolveFederatedUser(ctx context.Context, provider, issuer, subject string, email *mail.Address, firstName, lastName string) (uuid.UUID, *errx.Error) {
+	if s.identities != nil && issuer != "" && subject != "" {
+		existing, ierr := s.identities.FindUserByIdentity(ctx, issuer, subject)
+		if ierr != nil {
+			sentry.CaptureException(ierr)
+			return uuid.Nil, errx.InternalError()
+		}
+		if existing != uuid.Nil {
+			_ = s.identities.TouchLogin(ctx, issuer, subject)
+			return existing, nil
+		}
+	}
+
 	u, uerr := s.userRepository.GetUserByEmail(ctx, email.Address)
 	if uerr != nil && !errors.Is(uerr, errx.ErrUser) {
 		sentry.CaptureException(uerr)
-		return nil, errx.InternalError()
+		return uuid.Nil, errx.InternalError()
 	}
 
 	if u == nil {
-		u, uerr = s.createExternalUser(ctx, email, firstName, lastName)
-		if uerr != nil {
-			sentry.CaptureException(uerr)
-			return nil, errx.InternalError()
+		var cerr error
+		u, cerr = s.createExternalUser(ctx, email, firstName, lastName)
+		if cerr != nil {
+			sentry.CaptureException(cerr)
+			return uuid.Nil, errx.InternalError()
+		}
+	} else if s.identities != nil && issuer != "" {
+		linked, herr := s.identities.HasIdentityForIssuer(ctx, u.ID, issuer)
+		if herr != nil {
+			sentry.CaptureException(herr)
+			return uuid.Nil, errx.InternalError()
+		}
+		if linked {
+			return uuid.Nil, errx.New(errx.Forbidden, "this account is already linked to a different identity from that provider")
 		}
 	}
 
-	// Ban-scope enforcement — parity with password and passkey login.
-	if scope, scopeErr := s.userRepository.GetBanState(ctx, u.ID); scopeErr == nil {
-		if models.BanScope(scope).Has(models.BanScopeLogin) {
-			return nil, errx.New(errx.Forbidden, "this account has been suspended")
+	if s.identities != nil && issuer != "" && subject != "" {
+		if lerr := s.identities.Link(ctx, u.ID, models.UserIdentity{
+			Provider: provider,
+			Issuer:   issuer,
+			Subject:  subject,
+			Email:    email.Address,
+		}); lerr != nil {
+			// A unique-index violation means another account already owns this
+			// identity. Refuse rather than sign anyone in.
+			sentry.CaptureException(lerr)
+			return uuid.Nil, errx.New(errx.Forbidden, "that identity is already linked to another account")
 		}
 	}
 
-	session, xerr := s.tokenService.GenerateSession(ctx, u.ID, "", ipaddr, userAgent, provider)
-	if xerr != nil {
-		return nil, xerr
-	}
-	return session, nil
+	return u.ID, nil
 }
 
 // createExternalUser provisions a first-time social sign-in: a passwordless

--- a/internal/app/auth/login.go
+++ b/internal/app/auth/login.go
@@ -7,6 +7,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/token"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/notify/templates"
@@ -14,7 +15,11 @@ import (
 	"github.com/warmbly/warmbly/internal/pkg/crypt"
 )
 
-func (s *authService) LoginStart(ctx context.Context, data *AuthData, ipaddr string) (*models.AuthSession, *errx.Error) {
+func (s *authService) LoginStart(ctx context.Context, data *AuthData, ipaddr, userAgent string) (*models.AuthSession, *errx.Error) {
+	if s.policy.DisablePasswordLogin {
+		return nil, errx.New(errx.Forbidden, "password sign-in is disabled on this deployment")
+	}
+
 	if xerr := s.captcha.Verify(ctx, data.Turnstile, ipaddr); xerr != nil {
 		sentry.CaptureException(xerr)
 		return nil, xerr
@@ -25,7 +30,25 @@ func (s *authService) LoginStart(ctx context.Context, data *AuthData, ipaddr str
 		return nil, err
 	}
 
-	if err := s.canSendEmail(ctx, data.Email); err != nil {
+	// The emailed code is a step in the login, not a second factor: NIST
+	// SP 800-63B and OWASP ASVS both decline to count email as one. When it is
+	// off, or the device is already known, the login completes here and never
+	// touches the mail transport.
+	if !s.loginCodeRequired(ctx, uid, userAgent) {
+		result, ferr := s.finishLogin(ctx, uid, ipaddr, userAgent)
+		if ferr != nil {
+			return nil, ferr
+		}
+		return &models.AuthSession{
+			CodeRequired:  false,
+			Token:         result.Token,
+			TwoFARequired: result.TwoFARequired,
+			PendingToken:  result.PendingToken,
+			ExpiresIn:     result.ExpiresIn,
+		}, nil
+	}
+
+	if err := s.canSendEmail(ctx, emailFlowLogin, data.Email); err != nil {
 		return nil, err
 	}
 
@@ -53,7 +76,7 @@ func (s *authService) LoginStart(ctx context.Context, data *AuthData, ipaddr str
 
 	if xerr := s.sendAuthEmail(ctx, data.Email, "Your Login Code", text); xerr != nil {
 		sentry.CaptureException(xerr)
-		return nil, errx.InternalError()
+		return nil, errx.ErrMailUndeliverable
 	}
 
 	codeHash, xerr := argon2.Hash(code)
@@ -78,8 +101,25 @@ func (s *authService) LoginStart(ctx context.Context, data *AuthData, ipaddr str
 	}
 
 	return &models.AuthSession{
-		Session: sessionToken,
+		Session:      sessionToken,
+		CodeRequired: true,
 	}, nil
+}
+
+// loginCodeRequired applies AUTH_LOGIN_CODE. A transport that cannot deliver
+// never demands a code, because there would be no way to complete the login.
+func (s *authService) loginCodeRequired(ctx context.Context, userID uuid.UUID, userAgent string) bool {
+	if !s.mailDelivers {
+		return false
+	}
+	switch s.policy.LoginCode {
+	case config.LoginCodeOff:
+		return false
+	case config.LoginCodeNewDevice:
+		return !s.isKnownDevice(ctx, userID, userAgent)
+	default:
+		return true
+	}
 }
 
 func (s *authService) LoginConfirm(ctx context.Context, data *ConfirmData, session, ipaddr string, userAgent string) (*models.LoginResult, *errx.Error) {
@@ -114,37 +154,55 @@ func (s *authService) LoginConfirm(ctx context.Context, data *ConfirmData, sessi
 		return nil, errx.ErrCode
 	}
 
+	// Consume the session on success so it cannot be re-confirmed to mint fresh
+	// 2FA pending tokens, which would reset the per-pending attempt counter.
+	// One email confirmation means exactly one challenge.
+	_ = s.cache.Del(ctx, getLoginSessionKey(atoken.SessionID)).Err()
+
+	return s.finishLogin(ctx, atoken.UserID, ipaddr, userAgent)
+}
+
+func (s *authService) finishLogin(ctx context.Context, userID uuid.UUID, ipaddr, userAgent string) (*models.LoginResult, *errx.Error) {
+	return s.finishLoginAs(ctx, userID, ipaddr, userAgent, token.AuthProviderEmail)
+}
+
+// finishLoginAs is everything that happens once a caller has proved they own
+// the account: ban enforcement, the 2FA gate, and session issuance.
+//
+// Every login path goes through it. Previously only the password path checked
+// 2FA, so a user who enrolled TOTP could still be signed in without it through
+// Apple, Google or a passkey, and the browser OAuth paths skipped the ban check
+// as well.
+func (s *authService) finishLoginAs(ctx context.Context, userID uuid.UUID, ipaddr, userAgent, provider string) (*models.LoginResult, *errx.Error) {
 	// Ban-scope enforcement (migration 000045). The runtime treats
 	// BanScopeLogin as "this account cannot authenticate" — the row's
 	// banned_at is set in tandem so legacy callers still see the user
 	// as banned, but the bit makes the rule auditable.
-	if scope, scopeErr := s.userRepository.GetBanState(ctx, atoken.UserID); scopeErr == nil {
+	if scope, scopeErr := s.userRepository.GetBanState(ctx, userID); scopeErr == nil {
 		if models.BanScope(scope).Has(models.BanScopeLogin) {
 			return nil, errx.New(errx.Forbidden, "this account has been suspended")
 		}
 	}
 
-	// 2FA gate: after the email-code + ban check, if the user has TOTP enabled,
-	// issue a single-use pending challenge instead of a full session. The FE
-	// distinguishes on two_fa_required and POSTs /auth/2fa/verify next.
+	// 2FA gate: if the user has TOTP enabled, issue a single-use pending
+	// challenge instead of a full session. The FE distinguishes on
+	// two_fa_required and POSTs /auth/2fa/verify next.
 	if s.twofa != nil {
-		if enabled, _ := s.twofa.IsEnabled(ctx, atoken.UserID); enabled {
-			pendTok, expiresIn, perr := s.twofa.CreatePendingChallenge(ctx, atoken.UserID)
+		if enabled, _ := s.twofa.IsEnabled(ctx, userID); enabled {
+			pendTok, expiresIn, perr := s.twofa.CreatePendingChallenge(ctx, userID)
 			if perr != nil {
 				return nil, perr
 			}
-			// Consume the email login session so it can't be re-confirmed to mint
-			// fresh pending tokens (which would reset the per-pending 2FA attempt
-			// counter). One email confirmation => exactly one 2FA challenge.
-			_ = s.cache.Del(ctx, getLoginSessionKey(atoken.SessionID)).Err()
 			return &models.LoginResult{TwoFARequired: true, PendingToken: pendTok, ExpiresIn: expiresIn}, nil
 		}
 	}
 
-	newToken, err := s.tokenService.GenerateSession(ctx, atoken.UserID, "", ipaddr, userAgent, token.AuthProviderEmail)
+	newToken, err := s.tokenService.GenerateSession(ctx, userID, "", ipaddr, userAgent, provider)
 	if err != nil {
 		return nil, err
 	}
+
+	s.rememberDevice(ctx, userID, userAgent)
 
 	return &models.LoginResult{Token: newToken}, nil
 }

--- a/internal/app/auth/oidc.go
+++ b/internal/app/auth/oidc.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/mail"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/warmbly/warmbly/internal/app/token"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/idtoken"
+)
+
+// oidcStateTTL bounds how long an in-flight authorization may take. Short
+// enough that a leaked state is useless, long enough for a real person to type
+// a password and approve an MFA prompt at their IdP.
+const oidcStateTTL = 10 * time.Minute
+
+// OIDCProvider is the generic OpenID Connect client. Satisfied by
+// *oidcauth.Service; an interface here so the auth package does not import it
+// and tests can stub it.
+type OIDCProvider interface {
+	AuthCodeURL(state, nonce, verifier string) string
+	Exchange(ctx context.Context, code, verifier, expectedNonce string) (*idtoken.Claims, error)
+	Issuer() string
+	ProviderName() string
+	DefaultOrgID() string
+}
+
+// OIDCRedirect is what the client sends the browser to.
+type OIDCRedirect struct {
+	URL string `json:"url"`
+}
+
+// oidcFlow is the server-side half of one authorization request. Keeping the
+// verifier and nonce here, keyed by state, is what makes them single-use: RFC
+// 9700 requires PKCE and a one-time state, and an ID token nonce only proves
+// anything if the value it is compared against was never reused.
+type oidcFlow struct {
+	Verifier string `json:"verifier"`
+	Nonce    string `json:"nonce"`
+}
+
+func oidcStateKey(state string) string { return "oidc_state:" + state }
+
+// oidcHandoffTTL is how long the dashboard has to exchange the handoff code for
+// the real session. Seconds, not minutes: the redirect and the exchange happen
+// back to back.
+const oidcHandoffTTL = 60 * time.Second
+
+func oidcHandoffKey(code string) string { return "oidc_handoff:" + code }
+
+// mintHandoff stores a completed login behind a single-use code.
+//
+// The provider redirects a browser to the callback, so that response cannot be
+// JSON: it has to be a redirect the user can follow. Putting tokens in the URL
+// would leak them into history, Referer and any proxy log, so the redirect
+// carries an opaque code and the dashboard exchanges it over POST.
+func (s *authService) mintHandoff(ctx context.Context, result *models.LoginResult) (string, *errx.Error) {
+	code, err := randomHex(32)
+	if err != nil {
+		sentry.CaptureException(err)
+		return "", errx.InternalError()
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		sentry.CaptureException(err)
+		return "", errx.InternalError()
+	}
+	if err := s.cache.SetEx(ctx, oidcHandoffKey(code), payload, oidcHandoffTTL).Err(); err != nil {
+		sentry.CaptureException(err)
+		return "", errx.InternalError()
+	}
+	return code, nil
+}
+
+// OIDCExchange swaps a handoff code for the session it stands for. Single use:
+// the code is deleted as it is read.
+func (s *authService) OIDCExchange(ctx context.Context, code string) (*models.LoginResult, *errx.Error) {
+	if code == "" {
+		return nil, errx.ErrToken
+	}
+	raw, err := s.cache.GetDel(ctx, oidcHandoffKey(code)).Bytes()
+	if err != nil || len(raw) == 0 {
+		return nil, errx.ErrToken
+	}
+	var result models.LoginResult
+	if err := json.Unmarshal(raw, &result); err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	return &result, nil
+}
+
+// OIDCBegin starts an authorization request.
+func (s *authService) OIDCBegin(ctx context.Context) (*OIDCRedirect, *errx.Error) {
+	if s.oidc == nil {
+		return nil, errx.ErrExternalProvider
+	}
+
+	state, err := randomHex(32)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	nonce, err := randomHex(32)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	verifier, err := randomHex(32)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+
+	payload, err := json.Marshal(oidcFlow{Verifier: verifier, Nonce: nonce})
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	if err := s.cache.SetEx(ctx, oidcStateKey(state), payload, oidcStateTTL).Err(); err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+
+	return &OIDCRedirect{URL: s.oidc.AuthCodeURL(state, nonce, verifier)}, nil
+}
+
+// OIDCCallback completes the authorization and returns a single-use handoff
+// code the dashboard exchanges for the session.
+func (s *authService) OIDCCallback(ctx context.Context, code, state, ipaddr, userAgent string) (string, *errx.Error) {
+	if s.oidc == nil {
+		return "", errx.ErrExternalProvider
+	}
+	if code == "" || state == "" {
+		return "", errx.ErrExternalCode
+	}
+
+	// Consume the state before doing anything with it. A replayed callback
+	// finds nothing and is rejected, which is the whole point of one-time
+	// state.
+	raw, cerr := s.cache.GetDel(ctx, oidcStateKey(state)).Bytes()
+	if cerr != nil || len(raw) == 0 {
+		return "", errx.ErrExternalCode
+	}
+
+	var flow oidcFlow
+	if err := json.Unmarshal(raw, &flow); err != nil {
+		sentry.CaptureException(err)
+		return "", errx.InternalError()
+	}
+
+	claims, err := s.oidc.Exchange(ctx, code, flow.Verifier, flow.Nonce)
+	if err != nil {
+		// Provider-side failures are user-visible configuration problems more
+		// often than attacks, so they are worth reporting rather than burying.
+		sentry.CaptureException(err)
+		return "", errx.ErrExternalCode
+	}
+
+	email, perr := mail.ParseAddress(claims.Email)
+	if perr != nil {
+		return "", errx.ErrExternalEmail
+	}
+
+	userID, rerr := s.resolveFederatedUser(
+		ctx,
+		models.IdentityProviderOIDC,
+		claims.Issuer,
+		claims.Subject,
+		email,
+		claims.GivenName,
+		claims.FamilyName,
+	)
+	if rerr != nil {
+		return "", rerr
+	}
+
+	result, lerr := s.finishLoginAs(ctx, userID, ipaddr, userAgent, token.AuthProviderEmail)
+	if lerr != nil {
+		return "", lerr
+	}
+	return s.mintHandoff(ctx, result)
+}
+
+func randomHex(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/internal/app/auth/provision.go
+++ b/internal/app/auth/provision.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"context"
+	"net/mail"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// createAccount provisions a user, their organization and their trial. Both
+// registration paths share it: the emailed-code confirm, and the direct create
+// used when email verification is off.
+func (s *authService) createAccount(ctx context.Context, address, passwordHash, referralCode string) *errx.Error {
+	email, perr := mail.ParseAddress(address)
+	if perr != nil {
+		return errx.ErrEmail
+	}
+
+	u, xerr := s.userRepository.CreateUser(ctx, email, passwordHash)
+	if xerr != nil {
+		sentry.CaptureException(xerr)
+		return errx.InternalError()
+	}
+
+	if err := s.userService.SaveUser(ctx, u); err != nil {
+		return err
+	}
+
+	// Auto-create organization for new user
+	var org *models.Organization
+	if s.organizationService != nil {
+		orgName := u.FirstName + "'s Organization"
+		if u.FirstName == "" {
+			orgName = "My Organization"
+		}
+		var orgErr *errx.Error
+		org, orgErr = s.organizationService.Create(ctx, u.ID, orgName)
+		if orgErr != nil {
+			sentry.CaptureException(orgErr)
+			// Don't fail registration if org creation fails
+		}
+	}
+
+	// Start 2-week free trial for new user (linked to organization)
+	if s.trialService != nil && org != nil {
+		if err := s.trialService.StartFreeTrialWithOrg(ctx, u.ID, org.ID); err != nil {
+			sentry.CaptureException(err)
+			// Don't fail registration if trial creation fails
+		}
+	}
+
+	// Attribute the signup to a referrer if a referral code rode along.
+	// Best-effort: a bad or self-referral code never fails registration.
+	if s.referral != nil && org != nil && referralCode != "" {
+		if xerr := s.referral.AttributeSignup(ctx, referralCode, org.ID, u.ID); xerr != nil {
+			sentry.CaptureException(xerr)
+		}
+	}
+
+	return nil
+}
+
+// signupAllowed enforces DISABLE_REGISTRATION.
+//
+// The first-launch exemption is what makes invite_only safe as a default: an
+// instance with no users yet always accepts the first signup, so there is no
+// chicken-and-egg where the lockdown blocks the account that would issue the
+// invitations. Plausible's MaybeDisableRegistration plug works the same way.
+func (s *authService) signupAllowed(ctx context.Context) *errx.Error {
+	if s.policy.PublicSignupsAllowed() {
+		return nil
+	}
+
+	empty, err := s.userRepository.IsEmpty(ctx)
+	if err != nil {
+		sentry.CaptureException(err)
+		return errx.InternalError()
+	}
+	if empty {
+		return nil
+	}
+
+	return errx.ErrRegistrationClosed
+}
+
+// RegistrationMode reports the effective mode for the /auth/config endpoint,
+// resolving the first-launch exemption so the login screen can show a signup
+// form on a brand new instance.
+func (s *authService) RegistrationMode(ctx context.Context) string {
+	if s.policy.PublicSignupsAllowed() {
+		return config.RegistrationOpen
+	}
+	if empty, err := s.userRepository.IsEmpty(ctx); err == nil && empty {
+		return config.RegistrationOpen
+	}
+	return s.policy.Registration
+}

--- a/internal/app/auth/registration.go
+++ b/internal/app/auth/registration.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"net/mail"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -15,6 +14,14 @@ import (
 )
 
 func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipaddr string) (*models.AuthSession, *errx.Error) {
+	if s.policy.DisablePasswordLogin {
+		return nil, errx.New(errx.Forbidden, "password sign-up is disabled on this deployment")
+	}
+
+	if err := s.signupAllowed(ctx); err != nil {
+		return nil, err
+	}
+
 	if xerr := s.captcha.Verify(ctx, data.Turnstile, ipaddr); xerr != nil {
 		sentry.CaptureException(xerr)
 		return nil, xerr
@@ -24,14 +31,24 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 		return nil, errx.ErrPassword
 	}
 
-	if err := s.canSendEmail(ctx, data.Email); err != nil {
-		return nil, err
-	}
-
 	passwordHash, xerr := argon2.Hash(data.Password)
 	if xerr != nil {
 		sentry.CaptureException(xerr)
 		return nil, errx.InternalError()
+	}
+
+	// With verification off, or with a transport that cannot deliver, there is
+	// nothing to confirm: create the account now rather than issuing a code
+	// nobody can receive. Every product surveyed defaults self-host to this.
+	if !s.policy.RequireEmailVerification || !s.mailDelivers {
+		if err := s.createAccount(ctx, data.Email, passwordHash, data.ReferralCode); err != nil {
+			return nil, err
+		}
+		return &models.AuthSession{CodeRequired: false}, nil
+	}
+
+	if err := s.canSendEmail(ctx, emailFlowRegistration, data.Email); err != nil {
+		return nil, err
 	}
 
 	issuedAt := time.Now()
@@ -57,7 +74,7 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 
 	if xerr := s.sendAuthEmail(ctx, data.Email, "Your Verification Code", text); xerr != nil {
 		sentry.CaptureException(xerr)
-		return nil, errx.InternalError()
+		return nil, errx.ErrMailUndeliverable
 	}
 
 	codeHash, xerr := argon2.Hash(code)
@@ -84,7 +101,8 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 	}
 
 	return &models.AuthSession{
-		Session: sessionToken,
+		Session:      sessionToken,
+		CodeRequired: true,
 	}, nil
 }
 
@@ -120,51 +138,5 @@ func (s *authService) RegistrationConfirm(ctx context.Context, data *ConfirmData
 		return errx.ErrCode
 	}
 
-	email, xerr := mail.ParseAddress(token.Email)
-	if xerr != nil {
-		return errx.ErrEmail
-	}
-
-	u, xerr := s.userRepository.CreateUser(ctx, email, sess.PasswordHash)
-	if xerr != nil {
-		sentry.CaptureException(xerr)
-		return errx.InternalError()
-	}
-
-	if err := s.userService.SaveUser(ctx, u); err != nil {
-		return err
-	}
-
-	// Auto-create organization for new user
-	var org *models.Organization
-	if s.organizationService != nil {
-		orgName := u.FirstName + "'s Organization"
-		if u.FirstName == "" {
-			orgName = "My Organization"
-		}
-		var orgErr *errx.Error
-		org, orgErr = s.organizationService.Create(ctx, u.ID, orgName)
-		if orgErr != nil {
-			sentry.CaptureException(orgErr)
-			// Don't fail registration if org creation fails
-		}
-	}
-
-	// Start 2-week free trial for new user (linked to organization)
-	if s.trialService != nil && org != nil {
-		if err := s.trialService.StartFreeTrialWithOrg(ctx, u.ID, org.ID); err != nil {
-			sentry.CaptureException(err)
-			// Don't fail registration if trial creation fails
-		}
-	}
-
-	// Attribute the signup to a referrer if a referral code rode along.
-	// Best-effort: a bad or self-referral code never fails registration.
-	if s.referral != nil && org != nil && sess.ReferralCode != "" {
-		if xerr := s.referral.AttributeSignup(ctx, sess.ReferralCode, org.ID, u.ID); xerr != nil {
-			sentry.CaptureException(xerr)
-		}
-	}
-
-	return nil
+	return s.createAccount(ctx, token.Email, sess.PasswordHash, sess.ReferralCode)
 }

--- a/internal/app/auth/reset_password.go
+++ b/internal/app/auth/reset_password.go
@@ -2,12 +2,10 @@ package auth
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/notify/templates"
@@ -21,21 +19,23 @@ func (s *authService) ResetPasswordStart(ctx context.Context, data *ResetPasswor
 		return err
 	}
 
-	user, err := s.userRepository.GetUserByEmail(ctx, data.Email)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return errx.ErrUser
-		}
-		return errx.InternalError()
+	// Spend the budget before the lookup, and key it on the submitted address,
+	// so an unknown address costs the attacker the same as a known one.
+	if err := s.passwordResetLimit(ctx, data.Email); err != nil {
+		return err
+	}
+
+	user, uerr := s.userRepository.GetUserByEmail(ctx, data.Email)
+	if uerr != nil {
+		// Unknown address answers 200 like every other. Returning ErrUser here
+		// was an enumeration oracle, and because *errx.Error has no Unwrap the
+		// errors.Is check never matched, so it answered 500 instead.
+		return nil
 	}
 
 	u, xerr := s.userService.GetUser(ctx, user.ID)
 	if xerr != nil {
-		return xerr
-	}
-
-	if err := s.passwordResetLimit(ctx, u.Email); err != nil {
-		return err
+		return nil
 	}
 
 	sessionID := uuid.New()
@@ -68,7 +68,7 @@ func (s *authService) ResetPasswordStart(ctx context.Context, data *ResetPasswor
 
 	if err := s.sendAuthEmail(ctx, u.Email, "Password Reset Confirmation", text); err != nil {
 		sentry.CaptureException(err)
-		return errx.InternalError()
+		return errx.ErrMailUndeliverable
 	}
 
 	return nil

--- a/internal/app/auth/service.go
+++ b/internal/app/auth/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/token"
 	"github.com/warmbly/warmbly/internal/app/trial"
 	"github.com/warmbly/warmbly/internal/app/user"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/models"
@@ -33,7 +34,7 @@ type ReferralAttributor interface {
 }
 
 type AuthService interface {
-	LoginStart(ctx context.Context, data *AuthData, ipaddr string) (*models.AuthSession, *errx.Error)
+	LoginStart(ctx context.Context, data *AuthData, ipaddr, userAgent string) (*models.AuthSession, *errx.Error)
 	LoginConfirm(ctx context.Context, data *ConfirmData, session, ipaddr, userAgent string) (*models.LoginResult, *errx.Error)
 	// WireTwoFA attaches the 2FA challenger (post-construction; nil = 2FA off).
 	WireTwoFA(t TwoFAChallenger)
@@ -47,8 +48,8 @@ type AuthService interface {
 	// Native-app social sign-in: the client authenticates with the provider on
 	// device and exchanges the resulting ID token for a session. First sign-in
 	// provisions the account (org + trial) like password registration.
-	AppleIDTokenAuth(ctx context.Context, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.Token, *errx.Error)
-	GoogleIDTokenAuth(ctx context.Context, rawToken, ipaddr, userAgent string) (*models.Token, *errx.Error)
+	AppleIDTokenAuth(ctx context.Context, rawToken, firstName, lastName, ipaddr, userAgent string) (*models.LoginResult, *errx.Error)
+	GoogleIDTokenAuth(ctx context.Context, rawToken, ipaddr, userAgent string) (*models.LoginResult, *errx.Error)
 	// WireExternalIDTokens attaches the ID-token verifiers (post-construction;
 	// a nil verifier disables that provider).
 	WireExternalIDTokens(apple, google IDTokenVerifier)
@@ -59,6 +60,30 @@ type AuthService interface {
 	// ChangePassword updates a logged-in user's password after verifying the
 	// current one.
 	ChangePassword(ctx context.Context, userID, currentSessionID uuid.UUID, data *ChangePassword) *errx.Error
+
+	// Policy is the resolved per-deployment auth behavior, exposed so the
+	// public /auth/config endpoint can report it to the login screen.
+	Policy() *config.AuthPolicy
+
+	// RegistrationMode is Policy().Registration with the first-launch
+	// exemption applied, so a brand new instance advertises open signups.
+	RegistrationMode(ctx context.Context) string
+
+	// WireDeployment attaches the deployment-level facts auth decisions depend
+	// on: the resolved policy and whether the mail transport actually delivers.
+	WireDeployment(policy *config.AuthPolicy, mailDelivers bool)
+
+	// WireIdentities attaches the federated-identity store, so external
+	// sign-in resolves accounts by (issuer, subject) instead of email.
+	WireIdentities(r repository.IdentityRepository)
+
+	// Generic OIDC. WireOIDC attaches the provider (nil = OIDC disabled).
+	WireOIDC(p OIDCProvider)
+	OIDCBegin(ctx context.Context) (*OIDCRedirect, *errx.Error)
+	// OIDCCallback returns a single-use handoff code, not a session: the
+	// provider redirects a browser here, so the response must be a redirect.
+	OIDCCallback(ctx context.Context, code, state, ipaddr, userAgent string) (string, *errx.Error)
+	OIDCExchange(ctx context.Context, code string) (*models.LoginResult, *errx.Error)
 }
 
 type authService struct {
@@ -76,9 +101,34 @@ type authService struct {
 	googleIDTokens           IDTokenVerifier
 	twofa                    TwoFAChallenger
 	referral                 ReferralAttributor
+	// identities binds federated logins to (issuer, subject). Nil-safe: an
+	// unwired repository falls back to the historic email-only matching, which
+	// is only safe for Apple and Google.
+	identities repository.IdentityRepository
+	// oidc is the generic OpenID Connect provider, nil unless configured.
+	oidc OIDCProvider
+
+	// policy and mailDelivers govern whether an emailed code gates a login and
+	// whether public signups are open. Defaults are set in NewService so a
+	// caller that never wires them still behaves like the historic flow.
+	policy       *config.AuthPolicy
+	mailDelivers bool
 }
 
 func (s *authService) WireTwoFA(t TwoFAChallenger) { s.twofa = t }
+
+func (s *authService) WireDeployment(policy *config.AuthPolicy, mailDelivers bool) {
+	if policy != nil {
+		s.policy = policy
+	}
+	s.mailDelivers = mailDelivers
+}
+
+func (s *authService) Policy() *config.AuthPolicy { return s.policy }
+
+func (s *authService) WireIdentities(r repository.IdentityRepository) { s.identities = r }
+
+func (s *authService) WireOIDC(p OIDCProvider) { s.oidc = p }
 
 func (s *authService) WireReferral(r ReferralAttributor) { s.referral = r }
 
@@ -105,5 +155,10 @@ func NewService(
 		organizationService:      organizationService,
 		userRepository:           userRepository,
 		userService:              userService,
+		// Overwritten by WireDeployment during boot. The default assumes a
+		// delivering transport so an unwired service keeps the historic
+		// always-email-a-code behavior rather than silently relaxing it.
+		policy:       config.LoadAuthPolicy(true),
+		mailDelivers: true,
 	}
 }

--- a/internal/app/bootstrap/bootstrap.go
+++ b/internal/app/bootstrap/bootstrap.go
@@ -1,0 +1,279 @@
+// Package bootstrap provisions the first owner of a fresh install.
+//
+// Without it the only documented path was: register through the public form,
+// read the emailed code out of a mail catcher, then run a psql UPDATE from the
+// host. That is three manual steps, it depends on working mail, and the window
+// between "instance is reachable" and "an admin exists" is claimable by anyone
+// who finds the URL first, which is a recurring CVE class in self-hosted
+// software.
+//
+// Two mechanisms, both standard in the field:
+//
+//   - WARMBLY_BOOTSTRAP_EMAIL plus WARMBLY_BOOTSTRAP_PASSWORD_HASH, read only
+//     while the users table is empty (authentik, n8n and NocoDB all do this).
+//   - Otherwise a single-use setup token printed once to the logs, which is
+//     Zulip's realm-creation link, invalidated the moment it is used.
+package bootstrap
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net/mail"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/warmbly/warmbly/internal/app/organization"
+	"github.com/warmbly/warmbly/internal/app/trial"
+	"github.com/warmbly/warmbly/internal/app/user"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/infrastructure/cache"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/argon2"
+	"github.com/warmbly/warmbly/internal/pkg/crypt"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// SetupTokenTTL bounds the window in which the printed token can be claimed.
+const SetupTokenTTL = 24 * time.Hour
+
+const setupTokenKey = "bootstrap:setup_token"
+
+type Service struct {
+	users     repository.UserRepository
+	userSvc   user.UserService
+	orgSvc    organization.OrganizationService
+	trialSvc  trial.TrialService
+	adminRepo repository.AdminRepository
+	cache     *cache.Cache
+}
+
+func NewService(
+	users repository.UserRepository,
+	userSvc user.UserService,
+	orgSvc organization.OrganizationService,
+	trialSvc trial.TrialService,
+	adminRepo repository.AdminRepository,
+	cache *cache.Cache,
+) *Service {
+	return &Service{
+		users:     users,
+		userSvc:   userSvc,
+		orgSvc:    orgSvc,
+		trialSvc:  trialSvc,
+		adminRepo: adminRepo,
+		cache:     cache,
+	}
+}
+
+// Run is called once at boot, after migrations. It is a no-op on an instance
+// that already has users, so it is safe on every restart.
+func (s *Service) Run(ctx context.Context) error {
+	empty, err := s.users.IsEmpty(ctx)
+	if err != nil {
+		return fmt.Errorf("bootstrap: checking for existing users: %w", err)
+	}
+	if !empty {
+		return nil
+	}
+
+	email := strings.TrimSpace(os.Getenv("WARMBLY_BOOTSTRAP_EMAIL"))
+	if email != "" {
+		return s.createOwner(ctx, email)
+	}
+
+	return s.printSetupToken(ctx)
+}
+
+func (s *Service) createOwner(ctx context.Context, address string) error {
+	parsed, err := mail.ParseAddress(address)
+	if err != nil {
+		return fmt.Errorf("bootstrap: WARMBLY_BOOTSTRAP_EMAIL is not a valid address: %w", err)
+	}
+
+	hash := strings.TrimSpace(os.Getenv("WARMBLY_BOOTSTRAP_PASSWORD_HASH"))
+	if hash == "" {
+		// A plaintext password is accepted as a convenience, with the same
+		// warning authentik gives: environment variables leak through process
+		// listings, orchestrator APIs and crash dumps.
+		plain := os.Getenv("WARMBLY_BOOTSTRAP_PASSWORD")
+		if plain == "" {
+			return fmt.Errorf("bootstrap: WARMBLY_BOOTSTRAP_EMAIL is set but neither WARMBLY_BOOTSTRAP_PASSWORD_HASH nor WARMBLY_BOOTSTRAP_PASSWORD is")
+		}
+		log.Printf("Warning: WARMBLY_BOOTSTRAP_PASSWORD is a plaintext password in an environment variable. Prefer WARMBLY_BOOTSTRAP_PASSWORD_HASH.")
+		hashed, herr := argon2.Hash(plain)
+		if herr != nil {
+			return fmt.Errorf("bootstrap: hashing the password: %w", herr)
+		}
+		hash = hashed
+	}
+
+	u, uerr := s.users.CreateUser(ctx, parsed, hash)
+	if uerr != nil {
+		return fmt.Errorf("bootstrap: creating the owner: %w", uerr)
+	}
+	if err := s.userSvc.SaveUser(ctx, u); err != nil {
+		return fmt.Errorf("bootstrap: saving the owner: %w", err)
+	}
+
+	orgName := strings.TrimSpace(os.Getenv("WARMBLY_BOOTSTRAP_ORG"))
+	if orgName == "" {
+		orgName = defaultOrgName(u.FirstName)
+	}
+	org, orgErr := s.orgSvc.Create(ctx, u.ID, orgName)
+	if orgErr != nil {
+		return fmt.Errorf("bootstrap: creating the organization: %w", orgErr)
+	}
+	if s.trialSvc != nil {
+		_ = s.trialSvc.StartFreeTrialWithOrg(ctx, u.ID, org.ID)
+	}
+
+	// The bootstrap account is the platform operator, so it gets full admin.
+	// This is the only path that grants admin without an existing admin.
+	if err := s.adminRepo.GrantBootstrapAdmin(ctx, u.ID, uint32(models.AllAdminPermissions)); err != nil {
+		return fmt.Errorf("bootstrap: granting admin: %w", err)
+	}
+
+	log.Printf("Bootstrap: created owner %s with full admin permissions and organization %q.", parsed.Address, orgName)
+	return nil
+}
+
+// printSetupToken mints a single-use claim token for the first account and
+// prints it once. Only its hash is stored, so reading the database does not
+// yield a usable token, and claiming it deletes the key.
+func (s *Service) printSetupToken(ctx context.Context) error {
+	if s.cache == nil {
+		return nil
+	}
+
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return err
+	}
+	token := hex.EncodeToString(buf)
+
+	if err := s.cache.SetEx(ctx, setupTokenKey, hashToken(token), SetupTokenTTL).Err(); err != nil {
+		return fmt.Errorf("bootstrap: storing the setup token: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/setup?token=%s", config.AppBaseURL(), token)
+	log.Printf("\n"+
+		"┌──────────────────────────────────────────────────────────────────────\n"+
+		"│ No accounts exist yet. Claim this instance with the link below.\n"+
+		"│\n"+
+		"│   %s\n"+
+		"│\n"+
+		"│ Single use, valid for %s. It is printed only once, and only its hash\n"+
+		"│ is stored. Set WARMBLY_BOOTSTRAP_EMAIL and\n"+
+		"│ WARMBLY_BOOTSTRAP_PASSWORD_HASH to provision the owner without it.\n"+
+		"└──────────────────────────────────────────────────────────────────────\n",
+		url, SetupTokenTTL)
+
+	return nil
+}
+
+// Required reports whether this instance still needs to be claimed. Drives the
+// setup page and the `setup_required` flag on GET /auth/config.
+func (s *Service) Required(ctx context.Context) bool {
+	empty, err := s.users.IsEmpty(ctx)
+	return err == nil && empty
+}
+
+// Claim exchanges the printed setup token for the owner account.
+//
+// The token is consumed before the account is created, not after: two requests
+// racing with the same token must not both succeed, and Redis GETDEL is the
+// atomic step that decides which one wins.
+func (s *Service) Claim(ctx context.Context, token, address, password, firstName, lastName string) (*models.User, *errx.Error) {
+	if s.cache == nil || token == "" {
+		return nil, errx.ErrToken
+	}
+
+	parsed, perr := mail.ParseAddress(address)
+	if perr != nil {
+		return nil, errx.ErrEmail
+	}
+	if !crypt.ValidatePassword(password) {
+		return nil, errx.ErrPassword
+	}
+
+	// Refuse on an instance that already has accounts, even with a valid
+	// token: a stale link out of an old log must never mint a second owner.
+	empty, eerr := s.users.IsEmpty(ctx)
+	if eerr != nil {
+		sentry.CaptureException(eerr)
+		return nil, errx.InternalError()
+	}
+	if !empty {
+		return nil, errx.New(errx.Forbidden, "this instance has already been set up")
+	}
+
+	stored, gerr := s.cache.GetDel(ctx, setupTokenKey).Result()
+	if gerr != nil || stored == "" || stored != hashToken(token) {
+		// Put a valid-but-losing token back only when the value did not match,
+		// so a typo does not burn the real one.
+		if gerr == nil && stored != "" && stored != hashToken(token) {
+			_ = s.cache.SetEx(ctx, setupTokenKey, stored, SetupTokenTTL).Err()
+		}
+		return nil, errx.ErrToken
+	}
+
+	hash, herr := argon2.Hash(password)
+	if herr != nil {
+		sentry.CaptureException(herr)
+		return nil, errx.InternalError()
+	}
+
+	u, uerr := s.users.CreateUser(ctx, parsed, hash)
+	if uerr != nil {
+		sentry.CaptureException(uerr)
+		return nil, errx.InternalError()
+	}
+	if firstName != "" {
+		if err := s.users.UpdateProfile(ctx, u.ID, firstName, lastName); err == nil {
+			u.FirstName, u.LastName = firstName, lastName
+		}
+	}
+	if err := s.userSvc.SaveUser(ctx, u); err != nil {
+		return nil, err
+	}
+
+	orgName := strings.TrimSpace(os.Getenv("WARMBLY_BOOTSTRAP_ORG"))
+	if orgName == "" {
+		orgName = defaultOrgName(u.FirstName)
+	}
+	org, orgErr := s.orgSvc.Create(ctx, u.ID, orgName)
+	if orgErr != nil {
+		sentry.CaptureException(orgErr)
+		return nil, errx.InternalError()
+	}
+	if s.trialSvc != nil {
+		_ = s.trialSvc.StartFreeTrialWithOrg(ctx, u.ID, org.ID)
+	}
+
+	if err := s.adminRepo.GrantBootstrapAdmin(ctx, u.ID, uint32(models.AllAdminPermissions)); err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+
+	log.Printf("Setup: %s claimed this instance and is now its owner and platform admin.", parsed.Address)
+	return u, nil
+}
+
+func defaultOrgName(firstName string) string {
+	if firstName == "" {
+		return "My Organization"
+	}
+	return firstName + "'s Organization"
+}
+
+func hashToken(token string) string {
+	// argon2 is overkill for a 256-bit random token, so the shared SHA-256
+	// helper is the right cost here.
+	return crypt.SHA256(token)
+}

--- a/internal/app/contact/handler.go
+++ b/internal/app/contact/handler.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/utils/paging"
@@ -13,8 +14,13 @@ import (
 )
 
 func (s *contactService) Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error) {
-	// Enforce contact limit if subscription repos are available
-	if s.subRepo != nil && s.planRepo != nil {
+	// Enforce contact limit if subscription repos are available.
+	//
+	// This path reads the plan directly instead of going through the feature
+	// gate, so it never saw the self-host short-circuit: every self-hosted org
+	// was capped at the seeded Free Trial plan's 100 contacts even though
+	// BILLING_PROVIDER=none unlocks every other limit.
+	if !config.SelfHosted() && s.subRepo != nil && s.planRepo != nil {
 		uid, parseErr := uuid.Parse(userID)
 		if parseErr == nil {
 			sub, err := s.subRepo.GetByUserID(ctx, uid)

--- a/internal/app/oidcauth/oidcauth.go
+++ b/internal/app/oidcauth/oidcauth.go
@@ -1,0 +1,235 @@
+// Package oidcauth is generic OpenID Connect login for self-hosted
+// deployments.
+//
+// It matters more than convenience here: it is the only sign-in path that does
+// not depend on outbound mail, so it is what makes a deployment with no relay
+// fully usable. Sign in with Google and Apple do not fill this gap, because
+// both require registering an OAuth app per deployment, which nobody does for
+// a homelab. What self-hosters actually run is Authentik, Keycloak, Zitadel or
+// Pocket ID, and all of them speak plain OIDC.
+//
+// Built on discovery plus the existing JWKS verifier in internal/pkg/idtoken
+// and the PKCE helpers in golang.org/x/oauth2, so it adds no dependency.
+// RS256 only, which every mainstream provider issues by default.
+package oidcauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/pkg/idtoken"
+	"golang.org/x/oauth2"
+)
+
+// Config is the operator-facing configuration, using the variable names that
+// recur across Outline, Documenso, n8n, Gitea, Immich and Zulip.
+type Config struct {
+	IssuerURL    string
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+	Scopes       []string
+
+	// AllowedDomains restricts sign-in to these email domains. Empty allows
+	// any address the provider vouches for.
+	AllowedDomains []string
+
+	// DefaultOrgID makes every JIT-provisioned user join one existing
+	// organization. Without it a corporate IdP produces one single-member org
+	// per employee, because the signup path creates an org per new user.
+	DefaultOrgID string
+
+	// ProviderName is the label the login button shows.
+	ProviderName string
+}
+
+// discovery is the subset of the provider metadata document we use.
+type discovery struct {
+	Issuer                string   `json:"issuer"`
+	AuthorizationEndpoint string   `json:"authorization_endpoint"`
+	TokenEndpoint         string   `json:"token_endpoint"`
+	JWKSURI               string   `json:"jwks_uri"`
+	IDTokenSigningAlgs    []string `json:"id_token_signing_alg_values_supported"`
+}
+
+type Service struct {
+	cfg      Config
+	oauth    *oauth2.Config
+	verifier *idtoken.Verifier
+	issuer   string
+}
+
+// New performs discovery against the issuer and returns a ready service.
+// A provider that is unreachable at boot is a configuration error worth
+// failing on: a login button that always errors is worse than no button.
+func New(ctx context.Context, cfg Config) (*Service, error) {
+	if cfg.IssuerURL == "" || cfg.ClientID == "" {
+		return nil, errors.New("oidcauth: OIDC_ISSUER_URL and OIDC_CLIENT_ID are required")
+	}
+	if cfg.RedirectURL == "" {
+		return nil, errors.New("oidcauth: OIDC_REDIRECT_URL is required")
+	}
+
+	doc, err := discover(ctx, cfg.IssuerURL)
+	if err != nil {
+		return nil, err
+	}
+
+	// RFC 8414 requires the issuer in the document to match the one requested;
+	// a mismatch is an issuer-substitution attempt or a misconfigured proxy.
+	if doc.Issuer != strings.TrimRight(cfg.IssuerURL, "/") && doc.Issuer != cfg.IssuerURL {
+		return nil, fmt.Errorf("oidcauth: discovery issuer %q does not match OIDC_ISSUER_URL %q", doc.Issuer, cfg.IssuerURL)
+	}
+	if len(doc.IDTokenSigningAlgs) > 0 && !contains(doc.IDTokenSigningAlgs, "RS256") {
+		return nil, fmt.Errorf("oidcauth: provider signs ID tokens with %v; only RS256 is supported", doc.IDTokenSigningAlgs)
+	}
+
+	scopes := cfg.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email"}
+	}
+
+	return &Service{
+		cfg: cfg,
+		oauth: &oauth2.Config{
+			ClientID:     cfg.ClientID,
+			ClientSecret: cfg.ClientSecret,
+			RedirectURL:  cfg.RedirectURL,
+			Scopes:       scopes,
+			Endpoint: oauth2.Endpoint{
+				AuthURL:  doc.AuthorizationEndpoint,
+				TokenURL: doc.TokenEndpoint,
+			},
+		},
+		verifier: idtoken.NewVerifier(doc.JWKSURI, []string{doc.Issuer}, []string{cfg.ClientID}),
+		issuer:   doc.Issuer,
+	}, nil
+}
+
+func discover(ctx context.Context, issuer string) (*discovery, error) {
+	url := strings.TrimRight(issuer, "/") + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidcauth: discovery request to %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("oidcauth: discovery at %s returned %d", url, resp.StatusCode)
+	}
+
+	var doc discovery
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("oidcauth: decoding discovery document: %w", err)
+	}
+	if doc.AuthorizationEndpoint == "" || doc.TokenEndpoint == "" || doc.JWKSURI == "" {
+		return nil, errors.New("oidcauth: discovery document is missing required endpoints")
+	}
+	return &doc, nil
+}
+
+// Issuer is the verified issuer identifier, used as part of the identity key.
+func (s *Service) Issuer() string { return s.issuer }
+
+// ProviderName is the label for the login button.
+func (s *Service) ProviderName() string {
+	if s.cfg.ProviderName != "" {
+		return s.cfg.ProviderName
+	}
+	return "Single sign-on"
+}
+
+// DefaultOrgID is the organization JIT-provisioned users join.
+func (s *Service) DefaultOrgID() string { return s.cfg.DefaultOrgID }
+
+// AuthCodeURL builds the authorization request. RFC 9700 makes PKCE mandatory
+// for every client type including confidential ones, and requires state to be
+// one-time and bound to the user agent. The caller stores verifier, state and
+// nonce server-side and hands them back to Exchange.
+func (s *Service) AuthCodeURL(state, nonce, verifier string) string {
+	return s.oauth.AuthCodeURL(
+		state,
+		oauth2.AccessTypeOffline,
+		oauth2.S256ChallengeOption(verifier),
+		oauth2.SetAuthURLParam("nonce", nonce),
+	)
+}
+
+// Exchange trades the authorization code for a verified identity.
+//
+// The nonce comparison is done here and is not optional: verifying an ID token
+// proves the provider issued it, not that it was issued for this login attempt.
+func (s *Service) Exchange(ctx context.Context, code, verifier, expectedNonce string) (*idtoken.Claims, error) {
+	tok, err := s.oauth.Exchange(ctx, code, oauth2.VerifierOption(verifier))
+	if err != nil {
+		return nil, fmt.Errorf("oidcauth: code exchange: %w", err)
+	}
+
+	rawID, ok := tok.Extra("id_token").(string)
+	if !ok || rawID == "" {
+		return nil, errors.New("oidcauth: token response carried no id_token")
+	}
+
+	claims, err := s.verifier.Verify(ctx, rawID)
+	if err != nil {
+		return nil, fmt.Errorf("oidcauth: verifying id_token: %w", err)
+	}
+
+	if expectedNonce == "" || claims.Nonce != expectedNonce {
+		return nil, errors.New("oidcauth: id_token nonce does not match this authorization request")
+	}
+	if claims.Subject == "" {
+		return nil, errors.New("oidcauth: id_token carried no subject")
+	}
+	if claims.Email == "" {
+		return nil, errors.New("oidcauth: id_token carried no email claim; add the email scope")
+	}
+	// Fail closed on an unverified address: an issuer where anyone can
+	// self-register an arbitrary email is exactly how federated login turns
+	// into account takeover.
+	if !claims.EmailVerified {
+		return nil, errors.New("oidcauth: the provider did not report this email address as verified")
+	}
+	if err := s.domainAllowed(claims.Email); err != nil {
+		return nil, err
+	}
+
+	return claims, nil
+}
+
+func (s *Service) domainAllowed(email string) error {
+	if len(s.cfg.AllowedDomains) == 0 {
+		return nil
+	}
+	at := strings.LastIndex(email, "@")
+	if at < 0 {
+		return errors.New("oidcauth: malformed email claim")
+	}
+	domain := strings.ToLower(email[at+1:])
+	for _, allowed := range s.cfg.AllowedDomains {
+		if strings.EqualFold(strings.TrimSpace(allowed), domain) {
+			return nil
+		}
+	}
+	return fmt.Errorf("oidcauth: %s is not in OIDC_ALLOWED_DOMAINS", domain)
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/passkey/login.go
+++ b/internal/app/passkey/login.go
@@ -79,6 +79,12 @@ func (s *service) FinishLogin(ctx context.Context, session string, credential []
 		}
 	}
 
+	// No TOTP step, deliberately. A user-verified passkey is a possession
+	// factor bound to this origin and already satisfies multi-factor on its
+	// own, so demanding a second one adds friction without adding security.
+	// Social sign-in is the opposite case and does run the 2FA gate
+	// (auth.finishLoginAs), because there the second factor is the identity
+	// provider's business, not something this deployment can observe.
 	tok, xerr := s.token.GenerateSession(ctx, user.ID, user.Email, ipaddr, userAgent, token.AuthProviderWebAuthn)
 	if xerr != nil {
 		return nil, xerr

--- a/internal/config/config_authpolicy.go
+++ b/internal/config/config_authpolicy.go
@@ -1,0 +1,104 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+// Login-code modes. Emailing a code on every login makes the mail relay a
+// single point of failure for all authentication, and NIST SP 800-63B and OWASP
+// ASVS both decline to count email as a second factor. The code stays valuable
+// for address validation and recovery, so the setting governs the login step
+// only.
+const (
+	LoginCodeAlways    = "always"
+	LoginCodeNewDevice = "new_device"
+	LoginCodeOff       = "off"
+)
+
+// Registration modes, using Plausible's vocabulary. Tri-state rather than a
+// boolean because "closed to the public but invitations still work" is the
+// state most operators actually want.
+const (
+	RegistrationOpen       = "false"
+	RegistrationInviteOnly = "invite_only"
+	RegistrationClosed     = "true"
+)
+
+// AuthPolicy is the per-deployment auth behavior that self-host and cloud need
+// to differ on. Every value is independently overridable; DEPLOYMENT_MODE only
+// picks the defaults.
+type AuthPolicy struct {
+	// LoginCode is one of the LoginCode* constants.
+	LoginCode string
+	// RequireEmailVerification gates whether registration must complete an
+	// emailed code before the account exists.
+	RequireEmailVerification bool
+	// Registration is one of the Registration* constants.
+	Registration string
+	// DisablePasswordLogin turns off email+password entirely, for deployments
+	// that authenticate through OIDC only.
+	DisablePasswordLogin bool
+}
+
+// LoadAuthPolicy resolves the policy from the environment. mailDelivers is
+// whether the configured transport actually puts mail on the wire: when it does
+// not, an emailed login code cannot be a hard requirement, because there would
+// be no way to complete a login at all.
+func LoadAuthPolicy(mailDelivers bool) *AuthPolicy {
+	selfHost := SelfHosted()
+
+	loginCode := strings.ToLower(strings.TrimSpace(os.Getenv("AUTH_LOGIN_CODE")))
+	switch loginCode {
+	case LoginCodeAlways, LoginCodeNewDevice, LoginCodeOff:
+	default:
+		if selfHost {
+			loginCode = LoginCodeOff
+		} else {
+			loginCode = LoginCodeNewDevice
+		}
+	}
+	// A transport that does not deliver cannot gate logins, whatever the
+	// operator asked for. Codes still reach them through the log transport, so
+	// this only removes the hard dependency, not the audit trail.
+	if !mailDelivers && loginCode == LoginCodeAlways {
+		loginCode = LoginCodeNewDevice
+	}
+
+	requireVerification := !selfHost
+	if v := os.Getenv("REQUIRE_EMAIL_VERIFICATION"); v != "" {
+		requireVerification = isTrue(v)
+	}
+
+	registration := strings.ToLower(strings.TrimSpace(os.Getenv("DISABLE_REGISTRATION")))
+	switch registration {
+	case RegistrationOpen, RegistrationInviteOnly, RegistrationClosed:
+	default:
+		if selfHost {
+			registration = RegistrationInviteOnly
+		} else {
+			registration = RegistrationOpen
+		}
+	}
+
+	return &AuthPolicy{
+		LoginCode:                loginCode,
+		RequireEmailVerification: requireVerification,
+		Registration:             registration,
+		DisablePasswordLogin:     isTrue(os.Getenv("DISABLE_PASSWORD_LOGIN")),
+	}
+}
+
+// PublicSignupsAllowed reports whether an uninvited stranger may create an
+// account. The first-launch exemption is applied by the caller, which knows
+// whether any user exists yet.
+func (p *AuthPolicy) PublicSignupsAllowed() bool {
+	return p.Registration == RegistrationOpen
+}
+
+// InvitesAllowed reports whether an existing member may still invite people.
+// Only the fully closed mode stops that; invite_only exists precisely to keep
+// it working.
+func (p *AuthPolicy) InvitesAllowed() bool {
+	return p.Registration != RegistrationClosed
+}

--- a/internal/config/config_smtp.go
+++ b/internal/config/config_smtp.go
@@ -3,11 +3,45 @@ package config
 import (
 	"context"
 	"os"
+	"strings"
+)
+
+// SMTP security modes. The enum is explicit rather than a bare "secure" boolean
+// because that boolean means implicit TLS in some products and STARTTLS in
+// others, and operators get it wrong in both directions.
+const (
+	SMTPSecurityStartTLS = "starttls" // submission on 587, upgrade in-band
+	SMTPSecurityTLS      = "tls"      // implicit TLS on 465
+	SMTPSecurityNone     = "none"     // cleartext; only legitimate for a local sink
+)
+
+// SMTP auth mechanisms. "auto" picks the strongest mechanism the server
+// advertises, which is what an operator copying credentials out of a provider
+// dashboard expects.
+const (
+	SMTPAuthAuto    = "auto"
+	SMTPAuthPlain   = "plain"
+	SMTPAuthLogin   = "login"
+	SMTPAuthCRAMMD5 = "cram-md5"
+	SMTPAuthNone    = "none"
 )
 
 type SMTPConfig struct {
-	Host string
-	Port string
+	Host     string
+	Port     string
+	Username string
+	Password string
+	// Security is one of the SMTPSecurity* constants.
+	Security string
+	// Auth is one of the SMTPAuth* constants.
+	Auth string
+	// EHLOName is the name announced to the relay. Defaults to the sender
+	// domain, because net/smtp otherwise announces "localhost" and relays
+	// score that as suspicious.
+	EHLOName string
+	// InsecureSkipVerify disables certificate verification. Only for a relay
+	// with a private CA; never for a public provider.
+	InsecureSkipVerify bool
 }
 
 func (c *Config) LoadSMTPConfig(ctx context.Context) *SMTPConfig {
@@ -16,13 +50,55 @@ func (c *Config) LoadSMTPConfig(ctx context.Context) *SMTPConfig {
 		return nil
 	}
 
-	port := os.Getenv("SMTP_PORT")
+	security := strings.ToLower(strings.TrimSpace(os.Getenv("SMTP_SECURITY")))
+	port := strings.TrimSpace(os.Getenv("SMTP_PORT"))
+
+	// Security and port each infer the other so an operator can set either one
+	// alone and get the conventional pairing. Explicit values always win.
+	if security == "" {
+		switch port {
+		case "465":
+			security = SMTPSecurityTLS
+		// 1025 and 11025 are the Mailpit and MailHog defaults; a sink offers
+		// no STARTTLS, so inferring starttls there would fail every send.
+		case "25", "1025", "11025", "2525":
+			security = SMTPSecurityNone
+		default:
+			security = SMTPSecurityStartTLS
+		}
+	}
 	if port == "" {
-		port = "1025"
+		switch security {
+		case SMTPSecurityTLS:
+			port = "465"
+		case SMTPSecurityNone:
+			port = "25"
+		default:
+			port = "587"
+		}
+	}
+
+	auth := strings.ToLower(strings.TrimSpace(os.Getenv("SMTP_AUTH")))
+	if auth == "" {
+		auth = SMTPAuthAuto
 	}
 
 	return &SMTPConfig{
-		Host: host,
-		Port: port,
+		Host:               host,
+		Port:               port,
+		Username:           os.Getenv("SMTP_USERNAME"),
+		Password:           os.Getenv("SMTP_PASSWORD"),
+		Security:           security,
+		Auth:               auth,
+		EHLOName:           os.Getenv("SMTP_EHLO_NAME"),
+		InsecureSkipVerify: isTrue(os.Getenv("SMTP_TLS_INSECURE_SKIP_VERIFY")),
 	}
+}
+
+func isTrue(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }

--- a/internal/config/endpoints.go
+++ b/internal/config/endpoints.go
@@ -1,5 +1,34 @@
 package config
 
+import (
+	"net/url"
+	"os"
+	"strings"
+)
+
+// AppBaseURL is the dashboard origin every emailed link is built from.
+//
+// This used to be a hardcoded https://app.warmbly.com, which meant a
+// self-hosted deployment mailed its users a reset link pointing at someone
+// else's dashboard, carrying a live reset token signed with the self-host's own
+// AUTH_SECRET. APP_URL is the documented variable; FRONTEND_BASE_URL is the
+// older name and stays supported so existing deployments keep working.
+func AppBaseURL() string {
+	for _, key := range []string{"APP_URL", "FRONTEND_BASE_URL"} {
+		if v := strings.TrimRight(strings.TrimSpace(os.Getenv(key)), "/"); v != "" {
+			return v
+		}
+	}
+	return "https://app.warmbly.com"
+}
+
 func GetPasswordResetURL(sessionToken string) string {
-	return "https://app.warmbly.com/auth/reset-password/confirm?session=" + sessionToken
+	return AppBaseURL() + "/auth/reset-password/confirm?session=" + url.QueryEscape(sessionToken)
+}
+
+// GetInviteURL is the team-invitation accept link. Same reasoning as the reset
+// URL: the dashboard's own copy-link button already used the browser origin, so
+// only the emailed variant was broken on self-host.
+func GetInviteURL(token string) string {
+	return AppBaseURL() + "/invite?token=" + url.QueryEscape(token)
 }

--- a/internal/config/providers.go
+++ b/internal/config/providers.go
@@ -1,6 +1,9 @@
 package config
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // Provider selection helpers. These centralize the env-var switches and their
 // defaults so the service mains (and the AWS-config gate below) agree on which
@@ -28,6 +31,40 @@ func TasksProvider() string { return providerOr("TASKS_PROVIDER", "local") }
 // BillingProvider returns the selected billing backend ("none" | "stripe").
 // Default none — self-host boots without Stripe and unlocks all features.
 func BillingProvider() string { return providerOr("BILLING_PROVIDER", "none") }
+
+// Mail transports for platform email (login codes, resets, invites, digests).
+const (
+	MailTransportSMTP = "smtp"
+	MailTransportLog  = "log"
+	MailTransportSES  = "ses"
+)
+
+// MailTransport returns the selected platform-mail transport. Explicit
+// MAIL_TRANSPORT wins; otherwise SMTP_HOST selects smtp and an unset one falls
+// back to ses, which is what hosted deployments have always used. Self-host
+// compose sets log explicitly so a fresh install can log in with no relay.
+func MailTransport() string {
+	if v := os.Getenv("MAIL_TRANSPORT"); v != "" {
+		return strings.ToLower(strings.TrimSpace(v))
+	}
+	if os.Getenv("SMTP_HOST") != "" {
+		return MailTransportSMTP
+	}
+	return MailTransportSES
+}
+
+// SelfHosted reports whether this deployment is a self-host install.
+// DEPLOYMENT_MODE is the explicit switch; BILLING_PROVIDER=none is the historic
+// signal and stays the fallback so existing installs keep their behavior.
+func SelfHosted() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("DEPLOYMENT_MODE"))) {
+	case "self_hosted", "selfhosted", "self-hosted":
+		return true
+	case "cloud", "hosted":
+		return false
+	}
+	return BillingProvider() == "none"
+}
 
 // CaptchaProvider returns the selected captcha backend ("turnstile" | "none").
 // Explicit CAPTCHA_PROVIDER wins; otherwise it's "turnstile" only when a

--- a/internal/errx/common.go
+++ b/internal/errx/common.go
@@ -36,6 +36,16 @@ var (
 	ErrCode        = New(BadRequest, "Invalid or expired verification code.")
 	ErrAuthLimit   = New(BadRequest, "Too many attempts, please try again later.")
 
+	// ErrMailUndeliverable separates "we could not send you the email" from
+	// every other internal fault. It used to be a bare 500, which on a
+	// self-hosted install with no working relay is the single least helpful
+	// thing to show someone who cannot log in.
+	ErrMailUndeliverable = New(Internal, "We couldn't send the email. If you administer this server, check the mail transport configuration.")
+
+	// ErrRegistrationClosed is returned when public signups are off. The
+	// operator sets DISABLE_REGISTRATION.
+	ErrRegistrationClosed = New(Forbidden, "This server is not accepting new accounts. Ask an administrator for an invitation.")
+
 	ErrExternalCode     = New(BadRequest, "Invalid or expired code, please try again.")
 	ErrExternalEmail    = New(BadRequest, "Invalid or unverified email address.")
 	ErrExternalProvider = New(BadRequest, "This sign-in method isn't available on this server.")

--- a/internal/infrastructure/db/migrations/000082_user_identities.down.sql
+++ b/internal/infrastructure/db/migrations/000082_user_identities.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS user_identities_user_id_idx;
+DROP INDEX IF EXISTS user_identities_issuer_subject_idx;
+DROP TABLE IF EXISTS user_identities;

--- a/internal/infrastructure/db/migrations/000082_user_identities.up.sql
+++ b/internal/infrastructure/db/migrations/000082_user_identities.up.sql
@@ -1,0 +1,38 @@
+-- Federated identities, keyed on (provider, issuer, subject).
+--
+-- External sign-in previously resolved the account by email alone. That is
+-- defensible for Apple and Google, which control their own email namespace,
+-- but it becomes an account-takeover primitive the moment an operator points
+-- a generic OIDC issuer at a provider where anyone can self-register an
+-- arbitrary address: sign up there as someone@company.com and you are them
+-- here. Coder shipped that exact bug (CVE-2026-55076).
+--
+-- The subject claim is the only stable, provider-controlled identifier, so it
+-- is what the account is bound to. Email is a fallback used once, to link a
+-- pre-existing local account, and only when the provider says the address is
+-- verified and no other identity from that issuer already claims that user.
+
+CREATE TABLE IF NOT EXISTS user_identities (
+    id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id      uuid NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+
+    -- provider is the mechanism ('oidc', 'google', 'apple'), issuer is the
+    -- verified iss claim, subject is the sub claim.
+    provider     text NOT NULL,
+    issuer       text NOT NULL,
+    subject      text NOT NULL,
+
+    email        text,
+    created_at   timestamptz NOT NULL DEFAULT NOW(),
+    last_login_at timestamptz,
+
+    CONSTRAINT user_identities_provider_check CHECK (provider IN ('oidc', 'google', 'apple'))
+);
+
+-- One account per (issuer, subject). The unique index is the actual security
+-- control: it makes it impossible for two users to claim the same identity.
+CREATE UNIQUE INDEX IF NOT EXISTS user_identities_issuer_subject_idx
+    ON user_identities (issuer, subject);
+
+CREATE INDEX IF NOT EXISTS user_identities_user_id_idx
+    ON user_identities (user_id);

--- a/internal/models/identity_link.go
+++ b/internal/models/identity_link.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// Federated identity providers.
+const (
+	IdentityProviderOIDC   = "oidc"
+	IdentityProviderGoogle = "google"
+	IdentityProviderApple  = "apple"
+)
+
+// UserIdentity binds a local account to an external identity. The account is
+// resolved by (Issuer, Subject), never by Email alone: an operator-configured
+// issuer may let anyone register an arbitrary address.
+type UserIdentity struct {
+	Provider    string     `json:"provider"`
+	Issuer      string     `json:"issuer"`
+	Subject     string     `json:"subject"`
+	Email       string     `json:"email,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+	LastLoginAt *time.Time `json:"last_login_at,omitempty"`
+}

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -61,8 +61,22 @@ type Session struct {
 	AccessNonce     string    `json:"access_nonce"`
 }
 
+// AuthSession is what LoginStart and RegistrationStart return.
+//
+// Session plus CodeRequired=true is the original two-step flow: a code was
+// emailed and the caller POSTs it to the matching /confirm endpoint. When the
+// deployment has AUTH_LOGIN_CODE off, or the device is already known, no code
+// is sent and the remaining fields carry the completed login instead. The extra
+// fields are additive, so a client that only reads `session` still works.
 type AuthSession struct {
-	Session string `json:"session"`
+	Session string `json:"session,omitempty"`
+
+	CodeRequired bool `json:"code_required"`
+
+	Token         *Token `json:"token,omitempty"`
+	TwoFARequired bool   `json:"two_fa_required,omitempty"`
+	PendingToken  string `json:"pending_token,omitempty"`
+	ExpiresIn     int    `json:"expires_in,omitempty"`
 }
 
 type LoginSession struct {

--- a/internal/notify/factory.go
+++ b/internal/notify/factory.go
@@ -1,0 +1,103 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/config"
+)
+
+// Transport is a constructed platform-mail sender plus enough metadata for the
+// boot preflight, the admin diagnostics endpoint, and the login screen to tell
+// the operator what is actually happening to their mail.
+type Transport struct {
+	EmailNotificationService
+
+	// Kind is one of the config.MailTransport* constants.
+	Kind string
+	// Description is a one-line human summary, e.g. "smtp starttls
+	// smtp.example.com:587 (authenticated)".
+	Description string
+	// Delivers reports whether this transport actually puts mail on the wire.
+	// False for the log transport, which is the signal every caller uses to
+	// decide whether email-dependent flows can be relied on.
+	Delivers bool
+
+	smtp *config.SMTPConfig
+}
+
+// NewTransport builds the platform mail sender selected by MAIL_TRANSPORT.
+func NewTransport(ctx context.Context, cfg *config.Config, name, address string) (*Transport, error) {
+	kind := config.MailTransport()
+
+	switch kind {
+	case config.MailTransportLog:
+		return &Transport{
+			EmailNotificationService: NewLogEmailNotificationService(name, address),
+			Kind:                     kind,
+			Description:              "log (messages are written to stdout, not delivered)",
+			Delivers:                 false,
+		}, nil
+
+	case config.MailTransportSMTP:
+		smtpCfg := cfg.LoadSMTPConfig(ctx)
+		if smtpCfg == nil {
+			return nil, fmt.Errorf("MAIL_TRANSPORT=smtp requires SMTP_HOST")
+		}
+		auth := "no auth"
+		if smtpCfg.Username != "" {
+			auth = "authenticated as " + smtpCfg.Username
+		}
+		return &Transport{
+			EmailNotificationService: NewSMTPEmailNotificationService(name, address, smtpCfg),
+			Kind:                     kind,
+			Description: fmt.Sprintf("smtp %s %s (%s)",
+				smtpCfg.Security, net.JoinHostPort(smtpCfg.Host, smtpCfg.Port), auth),
+			Delivers: true,
+			smtp:     smtpCfg,
+		}, nil
+
+	case config.MailTransportSES:
+		ses, err := NewEmailNotficiationService(ctx, name, address)
+		if err != nil {
+			return nil, err
+		}
+		return &Transport{
+			EmailNotificationService: ses,
+			Kind:                     kind,
+			Description:              "ses (AWS credentials and a verified identity required)",
+			Delivers:                 true,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("unknown MAIL_TRANSPORT %q (want smtp, log or ses)", kind)
+}
+
+// Preflight checks the transport without sending a message. It dials and
+// authenticates the SMTP relay, which is the failure every self-hoster hits and
+// the one that previously only surfaced as a 500 on the login screen.
+func (t *Transport) Preflight(ctx context.Context) error {
+	if t.Kind != config.MailTransportSMTP || t.smtp == nil {
+		return nil
+	}
+	svc, ok := t.EmailNotificationService.(*smtpEmailNotificationService)
+	if !ok {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	client, err := svc.dial(ctx)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	if err := svc.authenticate(client); err != nil {
+		return err
+	}
+	return client.Quit()
+}

--- a/internal/notify/log.go
+++ b/internal/notify/log.go
@@ -1,0 +1,55 @@
+package notify
+
+import (
+	"context"
+	"log"
+	"strings"
+)
+
+// logEmailNotificationService writes messages to stdout instead of delivering
+// them. It exists so a fresh install can complete first login before any relay
+// is configured: the login code is in the container logs rather than lost in a
+// sink the operator may not know is there.
+//
+// Gitea calls the same idea PROTOCOL=dummy and Zulip uses a file-based backend.
+// The banner is deliberately loud because this transport must never be mistaken
+// for working mail.
+type logEmailNotificationService struct {
+	Name    string
+	Address string
+}
+
+func NewLogEmailNotificationService(name, address string) EmailNotificationService {
+	return &logEmailNotificationService{Name: name, Address: address}
+}
+
+func (s *logEmailNotificationService) Send(ctx context.Context, to, cc, bcc []string, subject, message string) error {
+	return s.write(to, cc, bcc, "", subject, message)
+}
+
+func (s *logEmailNotificationService) SendOutreach(ctx context.Context, to []string, replyTo, subject, message string) error {
+	return s.write(to, nil, nil, replyTo, subject, message)
+}
+
+func (s *logEmailNotificationService) write(to, cc, bcc []string, replyTo, subject, html string) error {
+	recipients := append(append(append([]string{}, to...), cc...), bcc...)
+
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString("┌──────────────────────────────────────────────────────────────────────\n")
+	b.WriteString("│ MAIL_TRANSPORT=log — this message was NOT delivered\n")
+	b.WriteString("│ To:      " + strings.Join(recipients, ", ") + "\n")
+	b.WriteString("│ From:    " + formatAddress(s.Name, s.Address) + "\n")
+	if replyTo != "" {
+		b.WriteString("│ Reply-To: " + replyTo + "\n")
+	}
+	b.WriteString("│ Subject: " + subject + "\n")
+	b.WriteString("├──────────────────────────────────────────────────────────────────────\n")
+	for _, line := range strings.Split(htmlToPlainText(html), "\n") {
+		b.WriteString("│ " + line + "\n")
+	}
+	b.WriteString("└──────────────────────────────────────────────────────────────────────\n")
+
+	log.Print(b.String())
+	return nil
+}

--- a/internal/notify/message.go
+++ b/internal/notify/message.go
@@ -1,0 +1,155 @@
+package notify
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"mime"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// buildMessage renders a complete RFC 5322 message. The SES path builds its own
+// envelope, so this is the SMTP and log transports' shared formatter.
+//
+// It exists mostly for three things the old header string did not do: a Date
+// and Message-ID header (mailbox providers penalize messages missing either),
+// RFC 2047 encoding of non-ASCII display names and subjects, and a plain-text
+// alternative alongside the HTML.
+func buildMessage(fromName, fromAddress string, to, cc []string, replyTo, subject, html string) ([]byte, error) {
+	if err := rejectHeaderInjection(subject, replyTo, fromName, fromAddress); err != nil {
+		return nil, err
+	}
+	for _, addr := range append(append([]string{}, to...), cc...) {
+		if err := rejectHeaderInjection(addr); err != nil {
+			return nil, err
+		}
+	}
+
+	boundary, err := randomToken(16)
+	if err != nil {
+		return nil, err
+	}
+	messageID, err := newMessageID(fromAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	var b strings.Builder
+	writeHeader(&b, "From", formatAddress(fromName, fromAddress))
+	writeHeader(&b, "To", strings.Join(to, ", "))
+	if len(cc) > 0 {
+		writeHeader(&b, "Cc", strings.Join(cc, ", "))
+	}
+	if replyTo != "" {
+		writeHeader(&b, "Reply-To", replyTo)
+	}
+	writeHeader(&b, "Subject", mime.QEncoding.Encode("UTF-8", subject))
+	writeHeader(&b, "Date", time.Now().Format(time.RFC1123Z))
+	writeHeader(&b, "Message-ID", messageID)
+	writeHeader(&b, "MIME-Version", "1.0")
+	writeHeader(&b, "Content-Type", fmt.Sprintf("multipart/alternative; boundary=%q", boundary))
+	b.WriteString("\r\n")
+
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/plain; charset=\"UTF-8\"\r\n\r\n")
+	b.WriteString(normalizeCRLF(htmlToPlainText(html)))
+	b.WriteString("\r\n\r\n")
+
+	b.WriteString("--" + boundary + "\r\n")
+	b.WriteString("Content-Type: text/html; charset=\"UTF-8\"\r\n\r\n")
+	b.WriteString(normalizeCRLF(html))
+	b.WriteString("\r\n\r\n")
+
+	b.WriteString("--" + boundary + "--\r\n")
+
+	return []byte(b.String()), nil
+}
+
+func writeHeader(b *strings.Builder, name, value string) {
+	b.WriteString(name)
+	b.WriteString(": ")
+	b.WriteString(value)
+	b.WriteString("\r\n")
+}
+
+func formatAddress(name, address string) string {
+	if name == "" {
+		return address
+	}
+	return fmt.Sprintf("%s <%s>", mime.QEncoding.Encode("UTF-8", name), address)
+}
+
+// rejectHeaderInjection refuses values carrying a bare CR or LF. Subjects and
+// display names reach here from user-controlled data (organization names, admin
+// outreach), and a newline there splices arbitrary headers into the message.
+func rejectHeaderInjection(values ...string) error {
+	for _, v := range values {
+		if strings.ContainsAny(v, "\r\n") {
+			return errors.New("notify: header value contains a line break")
+		}
+	}
+	return nil
+}
+
+func newMessageID(fromAddress string) (string, error) {
+	token, err := randomToken(16)
+	if err != nil {
+		return "", err
+	}
+	domain := "localhost"
+	if at := strings.LastIndex(fromAddress, "@"); at >= 0 && at+1 < len(fromAddress) {
+		domain = fromAddress[at+1:]
+	}
+	return fmt.Sprintf("<%s@%s>", token, domain), nil
+}
+
+func randomToken(n int) (string, error) {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// normalizeCRLF converts bare LF to CRLF as SMTP requires, without doubling the
+// CR in text that already uses CRLF.
+func normalizeCRLF(s string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(s, "\r\n", "\n"), "\n", "\r\n")
+}
+
+var (
+	blockElements  = regexp.MustCompile(`(?i)</(p|div|tr|h[1-6]|li|table|blockquote)>|<br\s*/?>`)
+	anchorTag      = regexp.MustCompile(`(?is)<a\b[^>]*href=["']([^"']+)["'][^>]*>(.*?)</a>`)
+	dropElements   = regexp.MustCompile(`(?is)<(script|style|head)\b.*?</(script|style|head)>`)
+	anyTag         = regexp.MustCompile(`(?s)<[^>]*>`)
+	blankLineRun   = regexp.MustCompile(`\n{3,}`)
+	trailingSpaces = regexp.MustCompile(`[ \t]+\n`)
+)
+
+// htmlToPlainText produces the text/plain alternative. It keeps link targets
+// inline, because the auth mails whose text part matters most are the ones
+// carrying a reset or invite URL.
+func htmlToPlainText(html string) string {
+	s := dropElements.ReplaceAllString(html, "")
+	s = anchorTag.ReplaceAllString(s, "$2 <$1>")
+	s = blockElements.ReplaceAllString(s, "\n")
+	s = anyTag.ReplaceAllString(s, "")
+
+	replacer := strings.NewReplacer(
+		"&nbsp;", " ",
+		"&amp;", "&",
+		"&lt;", "<",
+		"&gt;", ">",
+		"&quot;", `"`,
+		"&#39;", "'",
+		"\r", "",
+	)
+	s = replacer.Replace(s)
+
+	s = trailingSpaces.ReplaceAllString(s, "\n")
+	s = blankLineRun.ReplaceAllString(s, "\n\n")
+	return strings.TrimSpace(s)
+}

--- a/internal/notify/smtp.go
+++ b/internal/notify/smtp.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -11,114 +12,85 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/warmbly/warmbly/internal/config"
 )
 
-const smtpSendTimeout = 10 * time.Second
+const smtpSendTimeout = 30 * time.Second
+
+// ErrSMTPCleartextAuth is returned rather than sending credentials over an
+// unencrypted link. Go's own PlainAuth refuses the same thing, but silently
+// enough that operators read it as a credentials problem.
+var ErrSMTPCleartextAuth = errors.New("smtp: refusing to send credentials over an unencrypted connection (set SMTP_SECURITY=starttls or tls)")
 
 type smtpEmailNotificationService struct {
 	Name    string
 	Address string
-	Host    string
-	Port    string
+	cfg     *config.SMTPConfig
 }
 
-func NewSMTPEmailNotificationService(name, address, host, port string) EmailNotificationService {
+func NewSMTPEmailNotificationService(name, address string, cfg *config.SMTPConfig) EmailNotificationService {
 	return &smtpEmailNotificationService{
 		Name:    name,
 		Address: address,
-		Host:    host,
-		Port:    port,
+		cfg:     cfg,
 	}
 }
 
 func (s *smtpEmailNotificationService) Send(ctx context.Context, to, cc, bcc []string, subject, message string) error {
-	from := fmt.Sprintf("%s <%s>", s.Name, s.Address)
-	addr := net.JoinHostPort(s.Host, s.Port)
-
-	allRecipients := make([]string, 0, len(to)+len(cc)+len(bcc))
-	allRecipients = append(allRecipients, to...)
-	allRecipients = append(allRecipients, cc...)
-	allRecipients = append(allRecipients, bcc...)
-
-	headers := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=\"UTF-8\"\r\n\r\n",
-		from,
-		strings.Join(to, ", "),
-		subject,
-	)
-
-	msg := []byte(headers + message)
-
-	if err := sendSMTP(ctx, addr, s.Host, s.Address, allRecipients, msg); err != nil {
-		sentry.CaptureException(err)
-		return err
-	}
-
-	return nil
+	return s.send(ctx, to, cc, bcc, "", subject, message)
 }
 
-// SendOutreach is Send with an explicit Reply-To. The SMTP transport
-// doesn't have a structured envelope for this so we forge the header
-// directly into the message.
+// SendOutreach is Send with an explicit Reply-To so a noreply From can still
+// funnel replies into a real inbox.
 func (s *smtpEmailNotificationService) SendOutreach(ctx context.Context, to []string, replyTo, subject, message string) error {
-	from := fmt.Sprintf("%s <%s>", s.Name, s.Address)
-	addr := net.JoinHostPort(s.Host, s.Port)
+	return s.send(ctx, to, nil, nil, replyTo, subject, message)
+}
 
-	headers := "From: " + from + "\r\n" +
-		"To: " + strings.Join(to, ", ") + "\r\n" +
-		"Subject: " + subject + "\r\n"
-	if replyTo != "" {
-		headers += "Reply-To: " + replyTo + "\r\n"
+func (s *smtpEmailNotificationService) send(ctx context.Context, to, cc, bcc []string, replyTo, subject, message string) error {
+	recipients := make([]string, 0, len(to)+len(cc)+len(bcc))
+	recipients = append(recipients, to...)
+	recipients = append(recipients, cc...)
+	recipients = append(recipients, bcc...)
+
+	msg, err := buildMessage(s.Name, s.Address, to, cc, replyTo, subject, message)
+	if err != nil {
+		return err
 	}
-	headers += "MIME-Version: 1.0\r\n" +
-		"Content-Type: text/html; charset=\"UTF-8\"\r\n\r\n"
 
-	msg := []byte(headers + message)
-	if err := sendSMTP(ctx, addr, s.Host, s.Address, to, msg); err != nil {
+	if err := s.deliver(ctx, recipients, msg); err != nil {
 		sentry.CaptureException(err)
 		return err
 	}
 	return nil
 }
 
-func sendSMTP(ctx context.Context, addr, host, from string, recipients []string, msg []byte) error {
+func (s *smtpEmailNotificationService) deliver(ctx context.Context, recipients []string, msg []byte) error {
 	if len(recipients) == 0 {
 		return errors.New("smtp send requires at least one recipient")
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, smtpSendTimeout)
-	defer cancel()
-
-	dialer := net.Dialer{Timeout: smtpSendTimeout}
-	conn, err := dialer.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	if deadline, ok := ctx.Deadline(); ok {
-		if err := conn.SetDeadline(deadline); err != nil {
-			return err
-		}
-	}
-
-	client, err := smtp.NewClient(conn, host)
+	client, err := s.dial(ctx)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 
-	if err := client.Mail(from); err != nil {
+	if err := s.authenticate(client); err != nil {
 		return err
+	}
+
+	if err := client.Mail(s.Address); err != nil {
+		return fmt.Errorf("smtp MAIL FROM: %w", err)
 	}
 	for _, recipient := range recipients {
 		if err := client.Rcpt(recipient); err != nil {
-			return err
+			return fmt.Errorf("smtp RCPT TO: %w", err)
 		}
 	}
 
 	writer, err := client.Data()
 	if err != nil {
-		return err
+		return fmt.Errorf("smtp DATA: %w", err)
 	}
 	if _, err := writer.Write(msg); err != nil {
 		_ = writer.Close()
@@ -132,4 +104,179 @@ func sendSMTP(ctx context.Context, addr, host, from string, recipients []string,
 		return err
 	}
 	return nil
+}
+
+// dial returns a connected client with TLS already established according to
+// the configured security mode.
+func (s *smtpEmailNotificationService) dial(ctx context.Context) (*smtp.Client, error) {
+	addr := net.JoinHostPort(s.cfg.Host, s.cfg.Port)
+
+	ctx, cancel := context.WithTimeout(ctx, smtpSendTimeout)
+	defer cancel()
+
+	tlsConf := &tls.Config{
+		ServerName:         s.cfg.Host,
+		InsecureSkipVerify: s.cfg.InsecureSkipVerify, //nolint:gosec // operator opt-in for a private-CA relay
+		MinVersion:         tls.VersionTLS12,
+	}
+
+	var conn net.Conn
+	var err error
+	if s.cfg.Security == config.SMTPSecurityTLS {
+		dialer := &tls.Dialer{NetDialer: &net.Dialer{Timeout: smtpSendTimeout}, Config: tlsConf}
+		conn, err = dialer.DialContext(ctx, "tcp", addr)
+	} else {
+		dialer := &net.Dialer{Timeout: smtpSendTimeout}
+		conn, err = dialer.DialContext(ctx, "tcp", addr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("smtp dial %s: %w", addr, err)
+	}
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+
+	client, err := smtp.NewClient(conn, s.cfg.Host)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("smtp greeting: %w", err)
+	}
+
+	if name := s.ehloName(); name != "" {
+		if err := client.Hello(name); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("smtp EHLO: %w", err)
+		}
+	}
+
+	if s.cfg.Security == config.SMTPSecurityStartTLS {
+		ok, _ := client.Extension("STARTTLS")
+		if !ok {
+			_ = client.Close()
+			return nil, fmt.Errorf("smtp: %s does not offer STARTTLS (set SMTP_SECURITY=tls for port 465, or none for a local sink)", addr)
+		}
+		if err := client.StartTLS(tlsConf); err != nil {
+			_ = client.Close()
+			return nil, fmt.Errorf("smtp STARTTLS: %w", err)
+		}
+	}
+
+	return client, nil
+}
+
+func (s *smtpEmailNotificationService) authenticate(client *smtp.Client) error {
+	if s.cfg.Auth == config.SMTPAuthNone || s.cfg.Username == "" {
+		return nil
+	}
+
+	// Credentials only travel over an encrypted link. Loopback is exempt so a
+	// sidecar relay on the same host still works.
+	if _, isTLS := client.TLSConnectionState(); !isTLS && !isLoopback(s.cfg.Host) {
+		return ErrSMTPCleartextAuth
+	}
+
+	auth, err := s.authMechanism(client)
+	if err != nil {
+		return err
+	}
+	if auth == nil {
+		return nil
+	}
+	if err := client.Auth(auth); err != nil {
+		return fmt.Errorf("smtp AUTH: %w", err)
+	}
+	return nil
+}
+
+func (s *smtpEmailNotificationService) authMechanism(client *smtp.Client) (smtp.Auth, error) {
+	switch s.cfg.Auth {
+	case config.SMTPAuthPlain:
+		return smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host), nil
+	case config.SMTPAuthLogin:
+		return newLoginAuth(s.cfg.Username, s.cfg.Password, s.cfg.Host), nil
+	case config.SMTPAuthCRAMMD5:
+		return smtp.CRAMMD5Auth(s.cfg.Username, s.cfg.Password), nil
+	}
+
+	// auto: pick from what the server advertises. LOGIN is listed before PLAIN
+	// because the relays that only speak one of them (Exchange Online and most
+	// appliances) speak LOGIN.
+	ok, ext := client.Extension("AUTH")
+	if !ok {
+		return nil, fmt.Errorf("smtp: %s advertises no AUTH extension but SMTP_USERNAME is set", s.cfg.Host)
+	}
+	mechs := strings.ToUpper(ext)
+	switch {
+	case strings.Contains(mechs, "CRAM-MD5"):
+		return smtp.CRAMMD5Auth(s.cfg.Username, s.cfg.Password), nil
+	case strings.Contains(mechs, "LOGIN"):
+		return newLoginAuth(s.cfg.Username, s.cfg.Password, s.cfg.Host), nil
+	case strings.Contains(mechs, "PLAIN"):
+		return smtp.PlainAuth("", s.cfg.Username, s.cfg.Password, s.cfg.Host), nil
+	default:
+		return nil, fmt.Errorf("smtp: no supported AUTH mechanism in %q", ext)
+	}
+}
+
+func (s *smtpEmailNotificationService) ehloName() string {
+	if s.cfg.EHLOName != "" {
+		return s.cfg.EHLOName
+	}
+	// Announce the sender domain rather than net/smtp's "localhost", which
+	// relays treat as a spam signal.
+	if at := strings.LastIndex(s.Address, "@"); at >= 0 && at+1 < len(s.Address) {
+		return s.Address[at+1:]
+	}
+	return ""
+}
+
+func isLoopback(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}
+
+// loginAuth implements the non-standard but widely required AUTH LOGIN
+// mechanism, which net/smtp does not ship. Exchange Online and many appliance
+// relays advertise it exclusively.
+type loginAuth struct {
+	username string
+	password string
+	host     string
+}
+
+func newLoginAuth(username, password, host string) smtp.Auth {
+	return &loginAuth{username: username, password: password, host: host}
+}
+
+func (a *loginAuth) Start(server *smtp.ServerInfo) (string, []byte, error) {
+	if !server.TLS && !isLoopback(server.Name) {
+		return "", nil, ErrSMTPCleartextAuth
+	}
+	return "LOGIN", nil, nil
+}
+
+func (a *loginAuth) Next(fromServer []byte, more bool) ([]byte, error) {
+	if !more {
+		return nil, nil
+	}
+	// Servers vary in how they word the prompts, so match on the decoded
+	// challenge rather than expecting an exact string.
+	switch strings.ToLower(string(fromServer)) {
+	case "username:", "user name":
+		return []byte(a.username), nil
+	case "password:":
+		return []byte(a.password), nil
+	}
+	if strings.Contains(strings.ToLower(string(fromServer)), "user") {
+		return []byte(a.username), nil
+	}
+	if strings.Contains(strings.ToLower(string(fromServer)), "pass") {
+		return []byte(a.password), nil
+	}
+	return nil, fmt.Errorf("smtp: unexpected LOGIN challenge %q", string(fromServer))
 }

--- a/internal/notify/templates/base.go
+++ b/internal/notify/templates/base.go
@@ -3,25 +3,56 @@ package templates
 import (
 	"bytes"
 	"html/template"
+	"os"
+	"strings"
 
 	"github.com/getsentry/sentry-go"
 )
 
 // ─── Centralized Business Details ────────────────────────────────
-// Update these constants to change the branding and legal info
-// across all email templates.
-const (
-	CompanyName    = "Warmbly"
-	LegalEntity    = "Mindroot Ltd"
-	CompanyNumber  = "00000000"
-	PlaceOfReg     = "England and Wales"
-	RegisteredAddr = "1 Example Street, London, W1A 1AA"
-	WebsiteURL     = "https://warmbly.com"
-	AppURL         = "https://app.warmbly.com"
-	SupportEmail   = "team@warmbly.com"
-	TermsURL       = "https://warmbly.com/terms"
-	PrivacyURL     = "https://warmbly.com/privacy"
+// Branding and legal info for every email template. These are variables, not
+// constants, because a self-hosted install must not send mail attributed to
+// Mindroot Ltd with links to someone else's dashboard: AppURL derives from
+// APP_URL and the rest are overridable with EMAIL_BRAND_*.
+var (
+	CompanyName    = brandEnv("EMAIL_BRAND_NAME", "Warmbly")
+	LegalEntity    = brandEnv("EMAIL_BRAND_LEGAL_ENTITY", "Mindroot Ltd")
+	CompanyNumber  = brandEnv("EMAIL_BRAND_COMPANY_NUMBER", "00000000")
+	PlaceOfReg     = brandEnv("EMAIL_BRAND_PLACE_OF_REG", "England and Wales")
+	RegisteredAddr = brandEnv("EMAIL_BRAND_ADDRESS", "1 Example Street, London, W1A 1AA")
+	WebsiteURL     = brandEnv("EMAIL_BRAND_WEBSITE_URL", "https://warmbly.com")
+	AppURL         = appURL()
+	SupportEmail   = brandEnv("EMAIL_BRAND_SUPPORT_EMAIL", "team@warmbly.com")
+	TermsURL       = brandEnv("EMAIL_BRAND_TERMS_URL", "https://warmbly.com/terms")
+	PrivacyURL     = brandEnv("EMAIL_BRAND_PRIVACY_URL", "https://warmbly.com/privacy")
 )
+
+func brandEnv(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+// appURL is the dashboard base every emailed link is built from. Reading it
+// here rather than hardcoding it is what makes password reset and team invites
+// work on a self-hosted install.
+func appURL() string {
+	for _, key := range []string{"APP_URL", "FRONTEND_BASE_URL"} {
+		if v := strings.TrimRight(strings.TrimSpace(os.Getenv(key)), "/"); v != "" {
+			return v
+		}
+	}
+	return "https://app.warmbly.com"
+}
+
+// WebsiteLabel is the display text for the footer website link, derived from
+// WebsiteURL so a rebranded install does not render "warmbly.com" pointing
+// somewhere else.
+func WebsiteLabel() string {
+	label := strings.TrimPrefix(strings.TrimPrefix(WebsiteURL, "https://"), "http://")
+	return strings.TrimSuffix(label, "/")
+}
 
 type baseData struct {
 	Subject        string
@@ -32,6 +63,7 @@ type baseData struct {
 	PlaceOfReg     string
 	RegisteredAddr string
 	WebsiteURL     string
+	WebsiteLabel   string
 	TermsURL       string
 	PrivacyURL     string
 }
@@ -48,6 +80,7 @@ func renderEmail(subject, content string) (string, error) {
 		PlaceOfReg:     PlaceOfReg,
 		RegisteredAddr: RegisteredAddr,
 		WebsiteURL:     WebsiteURL,
+		WebsiteLabel:   WebsiteLabel(),
 		TermsURL:       TermsURL,
 		PrivacyURL:     PrivacyURL,
 	}
@@ -118,7 +151,7 @@ const baseHTML = `<!DOCTYPE html>
 <span style="color:#cbd5e1;">&nbsp;·&nbsp;</span>
 <a href="{{.TermsURL}}" style="color:#64748b;text-decoration:none;">Terms</a>
 <span style="color:#cbd5e1;">&nbsp;·&nbsp;</span>
-<a href="{{.WebsiteURL}}" style="color:#64748b;text-decoration:none;">warmbly.com</a>
+<a href="{{.WebsiteURL}}" style="color:#64748b;text-decoration:none;">{{.WebsiteLabel}}</a>
 </td>
 </tr>
 <tr>

--- a/internal/notify/templates/welcome.go
+++ b/internal/notify/templates/welcome.go
@@ -40,7 +40,7 @@ Your account is ready. From here you can connect mailboxes, warm them up, and st
 <table cellpadding="0" cellspacing="0" border="0" align="center" role="presentation" style="margin:0 0 24px;">
 <tr>
 <td align="center" style="border-radius:6px;background:#0f172a;">
-<a href="https://app.warmbly.com/" target="_blank" style="display:inline-block;padding:10px 22px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:0.01em;">Open the dashboard</a>
+<a href="{{.AppURL}}/" target="_blank" style="display:inline-block;padding:10px 22px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;font-weight:600;color:#ffffff;text-decoration:none;letter-spacing:0.01em;">Open the dashboard</a>
 </td>
 </tr>
 </table>
@@ -58,13 +58,16 @@ var welcomeTmpl = template.Must(template.New("welcome_content").Parse(welcomeCon
 // base shell so styling stays consistent with the rest of the
 // transactional mail.
 func GenerateWelcomeHTML(firstName string) (string, error) {
-	data := struct{ FirstName string }{FirstName: firstName}
+	data := struct {
+		FirstName string
+		AppURL    string
+	}{FirstName: firstName, AppURL: AppURL}
 	var buf bytes.Buffer
 	if err := welcomeTmpl.Execute(&buf, data); err != nil {
 		sentry.CaptureException(err)
 		return "", err
 	}
-	return renderEmail("Welcome to Warmbly", buf.String())
+	return renderEmail("Welcome to "+CompanyName, buf.String())
 }
 
 // WelcomeTemplate / WelcomeHTMLTMPL retained as deprecated exports so

--- a/internal/observability/sentry.go
+++ b/internal/observability/sentry.go
@@ -19,13 +19,16 @@ func InitSentry(ctx context.Context, cfg *config.Config, service string) error {
 		ServerName:     service,
 	}
 
-	if cfg.Env == "prod" {
-		sentryDsn, err := cfg.LoadSentryDSNBackend(ctx)
-		if err != nil {
-			return err
-		}
+	// A DSN is used when one is configured, in any environment. Error reporting
+	// is the operator's choice, not a requirement of the software: demanding a
+	// Sentry account to run APP_ENV=prod made a self-hosted deployment fail to
+	// boot over a service it never asked for.
+	if sentryDsn, err := cfg.LoadSentryDSNBackend(ctx); err == nil && sentryDsn != "" {
 		options.Dsn = sentryDsn
 	} else {
+		if cfg.Env == "prod" {
+			log.Printf("Sentry is not configured (no SENTRY_DSN); errors are logged locally only.")
+		}
 		options.BeforeSend = func(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
 			log.Printf("[sentry-local][%s][%s] %s", service, event.Level, summarizeSentryEvent(event))
 			return event

--- a/internal/pkg/idtoken/idtoken.go
+++ b/internal/pkg/idtoken/idtoken.go
@@ -31,6 +31,15 @@ type Claims struct {
 	EmailVerified bool
 	GivenName     string
 	FamilyName    string
+	// Issuer is carried through so a generic OIDC caller can key the account
+	// on (issuer, subject) rather than on the email address alone.
+	Issuer string
+	// Nonce binds the token to one authorization request. This package does
+	// not compare it: only the caller knows which nonce it minted, so the
+	// caller must check it and reject a mismatch.
+	Nonce string
+	// Groups carries the group or role claim when the provider sends one.
+	Groups []string
 }
 
 // Verifier validates RS256 ID tokens for one provider: signature via the
@@ -110,6 +119,7 @@ func (v *Verifier) Verify(ctx context.Context, raw string) (*Claims, error) {
 	email, _ := mc["email"].(string)
 	given, _ := mc["given_name"].(string)
 	family, _ := mc["family_name"].(string)
+	nonce, _ := mc["nonce"].(string)
 
 	return &Claims{
 		Subject:       sub,
@@ -117,7 +127,31 @@ func (v *Verifier) Verify(ctx context.Context, raw string) (*Claims, error) {
 		EmailVerified: boolClaim(mc["email_verified"]),
 		GivenName:     given,
 		FamilyName:    family,
+		Issuer:        iss,
+		Nonce:         nonce,
+		Groups:        stringsClaim(mc["groups"]),
 	}, nil
+}
+
+// stringsClaim reads a claim that providers send as either a single string or
+// an array of them.
+func stringsClaim(v any) []string {
+	switch value := v.(type) {
+	case string:
+		if value == "" {
+			return nil
+		}
+		return []string{value}
+	case []any:
+		out := make([]string, 0, len(value))
+		for _, entry := range value {
+			if s, ok := entry.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
 }
 
 // audienceAllowed accepts the JWT aud claim as either a string or an array.

--- a/internal/repository/pg_admin.go
+++ b/internal/repository/pg_admin.go
@@ -17,6 +17,10 @@ import (
 
 // AdminRepository defines the interface for admin data access
 type AdminRepository interface {
+	// GrantBootstrapAdmin grants admin permissions to the first owner of a
+	// fresh install, where there is no existing admin to attribute the grant to.
+	GrantBootstrapAdmin(ctx context.Context, userID uuid.UUID, permissions uint32) error
+
 	// User Management
 	SearchUsers(ctx context.Context, search *models.AdminUserSearch) (*models.AdminUsersResult, error)
 	GetUserDetail(ctx context.Context, userID uuid.UUID) (*models.AdminUserDetail, error)
@@ -428,6 +432,23 @@ func (r *adminRepository) GetUserPreview(ctx context.Context, userID uuid.UUID) 
 	preview.RateLimits, _ = r.GetUserRateLimits(ctx, userID)
 
 	return preview, nil
+}
+
+// GrantBootstrapAdmin grants admin permissions with no granter. It exists for
+// the first owner of a fresh install, where by definition no admin exists to
+// do the granting, and admin_granted_by has a foreign key to users so it must
+// be NULL rather than a zero UUID.
+func (r *adminRepository) GrantBootstrapAdmin(ctx context.Context, userID uuid.UUID, permissions uint32) error {
+	const query = `
+		UPDATE users SET
+			admin_permissions = $2,
+			admin_granted_at = NOW(),
+			admin_granted_by = NULL,
+			updated_at = NOW()
+		WHERE id = $1
+	`
+	_, err := r.db.Exec(ctx, query, userID, permissions)
+	return err
 }
 
 // UpdateUserAdminPermissions updates a user's admin permissions

--- a/internal/repository/pg_identity.go
+++ b/internal/repository/pg_identity.go
@@ -1,0 +1,107 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// IdentityRepository stores the (provider, issuer, subject) bindings that
+// federated sign-in resolves accounts by. Matching on the subject rather than
+// the email is what stops a self-registration IdP from being able to claim an
+// existing account.
+type IdentityRepository interface {
+	// FindUserByIdentity returns the user bound to this issuer and subject, or
+	// uuid.Nil when the identity is unknown.
+	FindUserByIdentity(ctx context.Context, issuer, subject string) (uuid.UUID, error)
+
+	// Link binds an identity to a user. The unique index on (issuer, subject)
+	// makes a second claim on the same identity fail rather than overwrite.
+	Link(ctx context.Context, userID uuid.UUID, identity models.UserIdentity) error
+
+	// HasIdentityForIssuer reports whether the user already has a different
+	// subject from this issuer. Used to refuse the email fallback for a user
+	// who is already federated: a second subject claiming the same address is
+	// an impersonation attempt, not a re-login.
+	HasIdentityForIssuer(ctx context.Context, userID uuid.UUID, issuer string) (bool, error)
+
+	// TouchLogin records a successful federated sign-in.
+	TouchLogin(ctx context.Context, issuer, subject string) error
+
+	// ListForUser returns every identity linked to a user, for the account
+	// security screen.
+	ListForUser(ctx context.Context, userID uuid.UUID) ([]models.UserIdentity, error)
+}
+
+type identityRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewIdentityRepository(db *pgxpool.Pool) IdentityRepository {
+	return &identityRepository{db: db}
+}
+
+func (r *identityRepository) FindUserByIdentity(ctx context.Context, issuer, subject string) (uuid.UUID, error) {
+	const q = `SELECT user_id FROM user_identities WHERE issuer = $1 AND subject = $2`
+	var id uuid.UUID
+	err := r.db.QueryRow(ctx, q, issuer, subject).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, nil
+	}
+	return id, err
+}
+
+func (r *identityRepository) Link(ctx context.Context, userID uuid.UUID, identity models.UserIdentity) error {
+	const q = `
+		INSERT INTO user_identities (user_id, provider, issuer, subject, email, last_login_at)
+		VALUES ($1, $2, $3, $4, $5, NOW())
+		ON CONFLICT (issuer, subject) DO UPDATE
+			SET last_login_at = NOW(), email = EXCLUDED.email
+			WHERE user_identities.user_id = EXCLUDED.user_id
+	`
+	_, err := r.db.Exec(ctx, q, userID, identity.Provider, identity.Issuer, identity.Subject, identity.Email)
+	return err
+}
+
+func (r *identityRepository) HasIdentityForIssuer(ctx context.Context, userID uuid.UUID, issuer string) (bool, error) {
+	const q = `SELECT EXISTS (SELECT 1 FROM user_identities WHERE user_id = $1 AND issuer = $2)`
+	var exists bool
+	err := r.db.QueryRow(ctx, q, userID, issuer).Scan(&exists)
+	return exists, err
+}
+
+func (r *identityRepository) TouchLogin(ctx context.Context, issuer, subject string) error {
+	const q = `UPDATE user_identities SET last_login_at = NOW() WHERE issuer = $1 AND subject = $2`
+	_, err := r.db.Exec(ctx, q, issuer, subject)
+	return err
+}
+
+func (r *identityRepository) ListForUser(ctx context.Context, userID uuid.UUID) ([]models.UserIdentity, error) {
+	const q = `
+		SELECT provider, issuer, subject, COALESCE(email, ''), created_at, last_login_at
+		FROM user_identities WHERE user_id = $1 ORDER BY created_at
+	`
+	rows, err := r.db.Query(ctx, q, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []models.UserIdentity{}
+	for rows.Next() {
+		var identity models.UserIdentity
+		var lastLogin *time.Time
+		if err := rows.Scan(&identity.Provider, &identity.Issuer, &identity.Subject,
+			&identity.Email, &identity.CreatedAt, &lastLogin); err != nil {
+			return nil, err
+		}
+		identity.LastLoginAt = lastLogin
+		out = append(out, identity)
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/pg_user.go
+++ b/internal/repository/pg_user.go
@@ -34,6 +34,11 @@ type UserRepository interface {
 	// fetching the full user row (hot path: every instant send).
 	GetUndoSendSeconds(ctx context.Context, userID uuid.UUID) (int, error)
 	SetUndoSendSeconds(ctx context.Context, userID uuid.UUID, seconds int) error
+
+	// IsEmpty reports whether the instance has no users at all. Drives the
+	// first-launch exemption for DISABLE_REGISTRATION and the bootstrap owner,
+	// both of which must only apply to a brand new install.
+	IsEmpty(ctx context.Context) (bool, error)
 }
 
 type userRepository struct {
@@ -189,6 +194,15 @@ func (r *userRepository) GetBanState(ctx context.Context, userID uuid.UUID) (uin
 	var scope uint32
 	err := r.DB.QueryRow(ctx, q, userID).Scan(&scope)
 	return scope, err
+}
+
+func (r *userRepository) IsEmpty(ctx context.Context) (bool, error) {
+	// EXISTS rather than COUNT: this runs on every signup attempt once the
+	// lockdown is on, and it only ever needs the first row.
+	const q = `SELECT NOT EXISTS (SELECT 1 FROM users LIMIT 1)`
+	var empty bool
+	err := r.DB.QueryRow(ctx, q).Scan(&empty)
+	return empty, err
 }
 
 func (r *userRepository) GetUndoSendSeconds(ctx context.Context, userID uuid.UUID) (int, error) {

--- a/ios/Warmbly/Core/Models/CoreModels.swift
+++ b/ios/Warmbly/Core/Models/CoreModels.swift
@@ -50,8 +50,31 @@ struct LoginResult: Codable, Sendable {
     }
 }
 
+/// `POST /auth/login` and `/auth/register`.
+///
+/// `session` plus `codeRequired == true` is the two-step flow: a code was
+/// emailed and the caller confirms it. When the deployment has the login code
+/// off, or email verification off, nothing is sent and the remaining fields
+/// carry the outcome instead, so `session` is optional.
 struct AuthSession: Codable, Sendable {
-    var session: String
+    var session: String?
+    var codeRequired: Bool?
+    var token: AuthToken?
+    var twoFARequired: Bool?
+    var pendingToken: String?
+    var expiresIn: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case session
+        case codeRequired = "code_required"
+        case token
+        case twoFARequired = "two_fa_required"
+        case pendingToken = "pending_token"
+        case expiresIn = "expires_in"
+    }
+
+    /// Older backends omit the field entirely; they always sent a code.
+    var needsCode: Bool { codeRequired ?? true }
 }
 
 /// `GET /auth/providers`: which native social sign-in options this host

--- a/ios/Warmbly/Core/Session/SessionStore.swift
+++ b/ios/Warmbly/Core/Session/SessionStore.swift
@@ -14,6 +14,10 @@ enum SessionPhase: Equatable {
 enum LoginOutcome {
     case loggedIn
     case needsTwoFA(pendingToken: String)
+    /// A code was emailed and must be confirmed with `confirmLogin`. Not every
+    /// deployment sends one: self-hosted installs default to signing in without
+    /// it, so a login can resolve on the first call.
+    case needsCode(session: String)
 }
 
 /// Owns the auth lifecycle and the active-organization context.
@@ -173,14 +177,33 @@ final class SessionStore {
 
     // MARK: - Login flow
 
-    func startLogin(email: String, password: String) async throws -> String {
+    func startLogin(email: String, password: String) async throws -> LoginOutcome {
         let body = [
             "email": email,
             "password": password,
             "turnstile": AppConfig.turnstileToken,
         ]
-        let session: AuthSession = try await api.post("auth/login", body: body, authorized: false)
-        return session.session
+        let result: AuthSession = try await api.post("auth/login", body: body, authorized: false)
+        return try await resolve(result)
+    }
+
+    /// Maps a start-of-login response onto an outcome, completing the sign-in
+    /// when the backend already resolved it.
+    private func resolve(_ result: AuthSession) async throws -> LoginOutcome {
+        if result.needsCode {
+            guard let session = result.session else {
+                throw APIError.decoding(URLError(.cannotParseResponse))
+            }
+            return .needsCode(session: session)
+        }
+        if result.twoFARequired == true, let pending = result.pendingToken {
+            return .needsTwoFA(pendingToken: pending)
+        }
+        guard let token = result.token else {
+            throw APIError.decoding(URLError(.cannotParseResponse))
+        }
+        try await completeLogin(with: token)
+        return .loggedIn
     }
 
     func confirmLogin(session: String, code: String) async throws -> LoginOutcome {
@@ -222,29 +245,44 @@ final class SessionStore {
 
     /// Apple shares the user's name only with the app, never inside the
     /// identity token, so it rides along for first-sign-in profile prefill.
-    func signInWithApple(identityToken: String, firstName: String?, lastName: String?) async throws {
+    func signInWithApple(identityToken: String, firstName: String?, lastName: String?) async throws -> LoginOutcome {
         var body = ["identity_token": identityToken]
         if let firstName, !firstName.isEmpty { body["first_name"] = firstName }
         if let lastName, !lastName.isEmpty { body["last_name"] = lastName }
-        let token: AuthToken = try await api.post("auth/apple", body: body, authorized: false)
-        try await completeLogin(with: token)
+        let result: LoginResult = try await api.post("auth/apple", body: body, authorized: false)
+        return try await resolve(social: result)
     }
 
-    func signInWithGoogle(idToken: String) async throws {
-        let token: AuthToken = try await api.post("auth/google", body: ["id_token": idToken], authorized: false)
+    func signInWithGoogle(idToken: String) async throws -> LoginOutcome {
+        let result: LoginResult = try await api.post("auth/google", body: ["id_token": idToken], authorized: false)
+        return try await resolve(social: result)
+    }
+
+    /// Social sign-in runs the same 2FA gate as password login, so it can
+    /// return a challenge instead of a token.
+    private func resolve(social result: LoginResult) async throws -> LoginOutcome {
+        if result.twoFARequired == true, let pending = result.pendingToken {
+            return .needsTwoFA(pendingToken: pending)
+        }
+        guard let token = result.token else {
+            throw APIError.decoding(URLError(.cannotParseResponse))
+        }
         try await completeLogin(with: token)
+        return .loggedIn
     }
 
     // MARK: - Registration
 
-    func startRegister(email: String, password: String) async throws -> String {
+    /// Returns the session to confirm, or nil when the deployment has email
+    /// verification off and the account already exists.
+    func startRegister(email: String, password: String) async throws -> String? {
         let body = [
             "email": email,
             "password": password,
             "turnstile": AppConfig.turnstileToken,
         ]
-        let session: AuthSession = try await api.post("auth/register", body: body, authorized: false)
-        return session.session
+        let result: AuthSession = try await api.post("auth/register", body: body, authorized: false)
+        return result.needsCode ? result.session : nil
     }
 
     /// Registration confirm returns 204 (no tokens); chain into the login flow after.

--- a/ios/Warmbly/Features/Auth/AuthFlowView.swift
+++ b/ios/Warmbly/Features/Auth/AuthFlowView.swift
@@ -468,9 +468,15 @@ struct AuthFlowView: View {
             // stay right above the keyboard.
             if focusedField != .email {
                 VStack(spacing: 12) {
-                    SocialSignInRow(providers: providers, busy: $busy) { message in
-                        showError(message)
-                    }
+                    SocialSignInRow(
+                        providers: providers,
+                        busy: $busy,
+                        onError: { message in showError(message) },
+                        onTwoFA: { pendingToken in
+                            code = ""
+                            go(to: .twoFA(pendingToken: pendingToken))
+                        }
+                    )
 
                     HStack(spacing: 12) {
                         Rectangle().fill(Color(.separator).opacity(0.45)).frame(height: 1)
@@ -727,19 +733,50 @@ struct AuthFlowView: View {
     private func submitCredentials() async {
         guard !busy, password.count >= (mode == .signIn ? 1 : 8) else { return }
         await run {
-            let session: String
             switch mode {
             case .signIn:
-                session = try await env.session.startLogin(email: email, password: password)
                 registerFlow = false
+                // A deployment can sign someone in without emailing a code, so
+                // the first call may already be the whole login.
+                let outcome = try await env.session.startLogin(email: email, password: password)
+                switch outcome {
+                case .loggedIn:
+                    return
+                case let .needsTwoFA(pendingToken):
+                    code = ""
+                    go(to: .twoFA(pendingToken: pendingToken))
+                    return
+                case let .needsCode(session):
+                    code = ""
+                    infoMessage = nil
+                    resendRemaining = 60
+                    go(to: .verify(session: session))
+                }
             case .signUp:
-                session = try await env.session.startRegister(email: email, password: password)
                 registerFlow = true
+                // With email verification off the account already exists, so
+                // fall straight through to signing in.
+                guard let session = try await env.session.startRegister(email: email, password: password) else {
+                    registerFlow = false
+                    let outcome = try await env.session.startLogin(email: email, password: password)
+                    switch outcome {
+                    case .loggedIn:
+                        return
+                    case let .needsTwoFA(pendingToken):
+                        code = ""
+                        go(to: .twoFA(pendingToken: pendingToken))
+                    case let .needsCode(loginSession):
+                        code = ""
+                        resendRemaining = 60
+                        go(to: .verify(session: loginSession))
+                    }
+                    return
+                }
+                code = ""
+                infoMessage = nil
+                resendRemaining = 60
+                go(to: .verify(session: session))
             }
-            code = ""
-            infoMessage = nil
-            resendRemaining = 60
-            go(to: .verify(session: session))
         }
     }
 
@@ -749,14 +786,21 @@ struct AuthFlowView: View {
             if registerFlow {
                 try await env.session.confirmRegister(session: session, code: submitted)
                 // Registration returns no tokens; chain into login with the same credentials.
-                let loginSession = try await env.session.startLogin(email: email, password: password)
+                let outcome = try await env.session.startLogin(email: email, password: password)
                 registerFlow = false
                 code = ""
                 resendRemaining = 60
-                withAnimation(.easeOut(duration: 0.2)) {
-                    infoMessage = "Account created. We emailed you a sign-in code."
+                switch outcome {
+                case .loggedIn:
+                    return
+                case let .needsTwoFA(pendingToken):
+                    go(to: .twoFA(pendingToken: pendingToken))
+                case let .needsCode(loginSession):
+                    withAnimation(.easeOut(duration: 0.2)) {
+                        infoMessage = "Account created. We emailed you a sign-in code."
+                    }
+                    go(to: .verify(session: loginSession))
                 }
-                go(to: .verify(session: loginSession))
             } else {
                 let outcome = try await env.session.confirmLogin(session: session, code: submitted)
                 if case let .needsTwoFA(pendingToken) = outcome {
@@ -771,12 +815,18 @@ struct AuthFlowView: View {
     private func resendCode() async {
         guard case .verify = step else { return }
         await run {
-            let session: String
+            let session: String?
             if registerFlow {
                 session = try await env.session.startRegister(email: email, password: password)
             } else {
-                session = try await env.session.startLogin(email: email, password: password)
+                if case let .needsCode(loginSession) = try await env.session.startLogin(email: email, password: password) {
+                    session = loginSession
+                } else {
+                    // The retry resolved the login outright; nothing to resend.
+                    return
+                }
             }
+            guard let session else { return }
             code = ""
             resendRemaining = 60
             step = .verify(session: session)

--- a/ios/Warmbly/Features/Auth/SocialSignIn.swift
+++ b/ios/Warmbly/Features/Auth/SocialSignIn.swift
@@ -13,6 +13,9 @@ struct SocialSignInRow: View {
     let providers: AuthProvidersInfo?
     @Binding var busy: Bool
     let onError: (String) -> Void
+    /// Social sign-in runs the same 2FA gate as password login, so it can end
+    /// in a challenge rather than a session.
+    var onTwoFA: (String) -> Void = { _ in }
 
     @State private var googleFlow = GoogleSignInFlow()
 
@@ -75,7 +78,8 @@ struct SocialSignInRow: View {
             Task {
                 defer { busy = false }
                 do {
-                    try await env.session.signInWithApple(identityToken: identityToken, firstName: first, lastName: last)
+                    let outcome = try await env.session.signInWithApple(identityToken: identityToken, firstName: first, lastName: last)
+                    if case let .needsTwoFA(pendingToken) = outcome { onTwoFA(pendingToken) }
                 } catch {
                     onError((error as? APIError)?.errorDescription ?? error.localizedDescription)
                 }
@@ -93,7 +97,8 @@ struct SocialSignInRow: View {
             defer { busy = false }
             do {
                 let idToken = try await googleFlow.signIn(clientID: clientID)
-                try await env.session.signInWithGoogle(idToken: idToken)
+                let outcome = try await env.session.signInWithGoogle(idToken: idToken)
+                if case let .needsTwoFA(pendingToken) = outcome { onTwoFA(pendingToken) }
             } catch GoogleSignInFlow.Failure.cancelled {
                 // User closed the sheet; stay quiet.
             } catch {

--- a/web/src/app/auth/hooks/useLoginConfirmForm.ts
+++ b/web/src/app/auth/hooks/useLoginConfirmForm.ts
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import useLoginConfirm from "@/lib/api/hooks/auth/useLoginConfirm";
 import { saveTokens } from "@/lib/auth";
@@ -10,13 +10,17 @@ import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 
 export function useLoginConfirmForm() {
-    const params = useParams();
+    // Query params, not path params: the login page navigates to
+    // /auth/login/confirm?session=...&to=..., and the route declares no
+    // path segments, so useParams() always returned empty and every
+    // confirmation posted a blank session.
+    const [params] = useSearchParams();
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const loginConfirm = useLoginConfirm();
 
-    const mail = params["to"] ?? "";
-    const session = params["session"] ?? "";
+    const mail = params.get("to") ?? "";
+    const session = params.get("session") ?? "";
     const [otp, setOtp] = useState<string[]>(Array(6).fill(""));
     const [captcha, setCaptcha] = useState(false);
     const [pending, setPending] = useState(false);

--- a/web/src/app/auth/hooks/useLoginForm.ts
+++ b/web/src/app/auth/hooks/useLoginForm.ts
@@ -1,17 +1,17 @@
 import type React from "react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import useLogin from "@/lib/api/hooks/auth/useLogin";
 import toast from "react-hot-toast";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 
 export function useLoginForm() {
-    const params = useParams();
+    const [params] = useSearchParams();
     const navigate = useNavigate();
     const login = useLogin();
 
-    const actionType = params["action"] ?? "";
+    const actionType = params.get("action") ?? "";
     const [mail, setMail] = useState("");
     const [password, setPassword] = useState("");
     const [captcha, setCaptcha] = useState(false);

--- a/web/src/app/auth/hooks/useRegisterConfirmForm.ts
+++ b/web/src/app/auth/hooks/useRegisterConfirmForm.ts
@@ -1,18 +1,19 @@
 import type React from "react";
 import { useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import useRegisterConfirm from "@/lib/api/hooks/auth/useRegisterConfirm";
 import toast from "react-hot-toast";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 
 export function useRegisterConfirmForm() {
-    const params = useParams();
+    // Query params, not path params. See useLoginConfirmForm.
+    const [params] = useSearchParams();
     const navigate = useNavigate();
     const registerConfirm = useRegisterConfirm();
 
-    const mail = params["to"] ?? "";
-    const session = params["session"] ?? "";
+    const mail = params.get("to") ?? "";
+    const session = params.get("session") ?? "";
     const [otp, setOtp] = useState<string[]>(Array(6).fill(""));
     const [captcha, setCaptcha] = useState(false);
     const [pending, setPending] = useState(false);

--- a/web/src/app/auth/hooks/useResetPasswordConfirmForm.ts
+++ b/web/src/app/auth/hooks/useResetPasswordConfirmForm.ts
@@ -1,21 +1,25 @@
 import type React from "react";
 import { useState, useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import useResetPasswordConfirm from "@/lib/api/hooks/auth/useResetPasswordConfirm";
 import { usePasswordStrength } from "@/hooks/usePasswordStrength";
-import { is64ByteHex } from "@/lib/token";
 import toast from "react-hot-toast";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 
 export function useResetPasswordConfirmForm() {
-    const params = useParams();
+    // The emailed link is /auth/reset-password/confirm?session=<jwt>. This
+    // read a path param named "token" against a route with no path
+    // segments, and then validated it as 128 hex characters, which a JWT
+    // can never be, so the page always rendered "Link expired" and never
+    // called the API.
+    const [params] = useSearchParams();
     const navigate = useNavigate();
     const resetConfirm = useResetPasswordConfirm();
     const { evaluate } = usePasswordStrength();
 
-    const token = params["token"] ?? "";
-    const isValidToken = is64ByteHex(token);
+    const session = params.get("session") ?? "";
+    const isValidToken = session.length > 0;
     const [password, setPassword] = useState("");
     const [password2, setPassword2] = useState("");
     const [captcha, setCaptcha] = useState(false);
@@ -33,7 +37,7 @@ export function useResetPasswordConfirmForm() {
         setPending(true);
         try {
             await toast.promise(
-                resetConfirm.mutateAsync({ token, password, turnstile: turnstileToken }),
+                resetConfirm.mutateAsync({ session, password, turnstile: turnstileToken }),
                 { loading: "Loading...", success: "Password successfully changed", error: (err: AppError) => buildError(err) }
             );
             navigate("/auth/login?action=1");

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -22,6 +22,9 @@ import useRegisterConfirm from "@/lib/api/hooks/auth/useRegisterConfirm";
 import { saveTokens } from "@/lib/auth";
 import getUser from "@/lib/api/client/auth/getUser";
 import { WEBSITE_URL, TURNSTILE_KEY } from "@/lib/information";
+import useAuthConfig from "@/lib/api/hooks/auth/useAuthConfig";
+import type Session from "@/lib/api/models/auth/Session";
+import beginOIDC from "@/lib/api/client/auth/beginOIDC";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import * as Sentry from "@sentry/react";
@@ -153,9 +156,27 @@ export default function LoginPage() {
     const navigate = useNavigate();
     const location = useLocation();
     const queryClient = useQueryClient();
-    const defaultDevBypassToken = "warmbly-local-turnstile-bypass";
+    // What this backend actually supports. Gating on import.meta.env.DEV meant
+    // the widget mounted in every container build regardless of
+    // CAPTCHA_PROVIDER, so login silently required reaching
+    // challenges.cloudflare.com even on an air-gapped install.
+    const { config: authConfig, ready: authConfigReady } = useAuthConfig();
+
+    // A brand new instance has no account to sign in as. Send them to the
+    // claim link rather than showing a form that cannot succeed.
+    useEffect(() => {
+        if (authConfigReady && authConfig.setup_required) navigate("/setup", { replace: true });
+    }, [authConfigReady, authConfig.setup_required, navigate]);
+
+    // The SSO callback redirects here with a reason when the provider or the
+    // exchange refused, so the failure is visible instead of silent.
+    useEffect(() => {
+        const reason = new URLSearchParams(location.search).get("sso_error");
+        if (reason) toast.error(reason);
+    }, [location.search]);
+    const captchaRequired = authConfig.captcha;
     const turnstileBypassToken = import.meta.env.DEV
-        ? (import.meta.env.VITE_TURNSTILE_BYPASS_TOKEN?.trim() || defaultDevBypassToken)
+        ? (import.meta.env.VITE_TURNSTILE_BYPASS_TOKEN?.trim() || "")
         : "";
 
     /* State */
@@ -330,6 +351,15 @@ export default function LoginPage() {
 
     /* Captcha helper — invisible Turnstile with loading + timeout */
     const withCaptcha = useCallback((fn: (token: string) => Promise<void>) => {
+        // No captcha configured server-side means no token to obtain. Waiting
+        // on a widget that will never load is how this used to hang for ten
+        // seconds and then fail with "Verification timed out". The widget above
+        // stays mounted until the config resolves, so this only skips it once
+        // we know the backend does not verify a token.
+        if (authConfigReady && !captchaRequired) {
+            void fn("");
+            return;
+        }
         if (turnstileBypassToken) {
             void fn(turnstileBypassToken);
             return;
@@ -363,7 +393,7 @@ export default function LoginPage() {
             // Invisible Turnstile requires explicit execution per action.
             turnstileRef.current?.execute();
         }
-    }, [turnstileBypassToken]);
+    }, [turnstileBypassToken, captchaRequired, authConfigReady]);
 
     const onTurnstileVerify = (token: string, bound?: BoundTurnstileObject) => {
         if (bound) turnstileRef.current = bound;
@@ -395,6 +425,38 @@ export default function LoginPage() {
         turnstileRef.current?.reset();
     };
 
+    /* Completes a login that needed no emailed code, honoring the 2FA gate. */
+    const finishDirectLogin = useCallback(async (res: Session): Promise<boolean> => {
+        if (res.two_fa_required) {
+            if (!res.pending_token) {
+                toast.error("Something went wrong, please try again.");
+                return false;
+            }
+            setPendingToken(res.pending_token);
+            goTo("2fa");
+            return true;
+        }
+        if (!res.token?.access_token) {
+            toast.error("Something went wrong, please try again.");
+            return false;
+        }
+        toast.success("Welcome back!");
+        try { sessionStorage.setItem(SUGGEST_PASSKEY_FLAG, "1"); } catch { /* storage unavailable */ }
+        await completeSession(res.token);
+        return true;
+    }, [completeSession]);
+
+    /* Single sign-on. The backend mints state, nonce and the PKCE verifier and
+       stores them server-side, so the client only needs the URL. */
+    const handleSSO = useCallback(async () => {
+        try {
+            const { url } = await beginOIDC();
+            window.location.href = url;
+        } catch (e) {
+            toast.error(buildError(e as AppError));
+        }
+    }, []);
+
     /* ── Step 1: Email ─────────────────────── */
     const handleEmailContinue = (data: z.infer<typeof emailSchema>) => {
         setEmail(data.email);
@@ -407,8 +469,15 @@ export default function LoginPage() {
         withCaptcha(async (token) => {
             try {
                 const res = await loginMutation.mutateAsync({ email, password: data.password, turnstile: token });
+                // A deployment with the login code turned off, or a device this
+                // account has used before, completes here: there is nothing to
+                // confirm and nothing was emailed.
+                if (!res.code_required) {
+                    if (await finishDirectLogin(res)) return;
+                    return;
+                }
                 toast.success("Verification code sent!");
-                setSession(res.session);
+                setSession(res.session ?? "");
                 goTo("verify");
             } catch (e) {
                 toast.error(buildError(e as AppError));
@@ -422,8 +491,16 @@ export default function LoginPage() {
         withCaptcha(async (token) => {
             try {
                 const res = await registerMutation.mutateAsync({ email, password: data.password, turnstile: token });
+                // Email verification off means the account already exists, so
+                // send them to sign in rather than to a code they never got.
+                if (!res.code_required) {
+                    toast.success("Account created. Sign in to continue.");
+                    handleModeChange("signin");
+                    goTo("signin");
+                    return;
+                }
                 toast.success("Verification code sent!");
-                setSession(res.session);
+                setSession(res.session ?? "");
                 goTo("verify");
             } catch (e) {
                 toast.error(buildError(e as AppError));
@@ -493,7 +570,7 @@ export default function LoginPage() {
                 const mutation = mode === "signin" ? loginMutation : registerMutation;
                 const res = await mutation.mutateAsync({ email, password, turnstile: token });
                 toast.success("Code resent!");
-                setSession(res.session);
+                setSession(res.session ?? "");
             } catch (e) {
                 toast.error(buildError(e as AppError));
             }
@@ -523,6 +600,8 @@ export default function LoginPage() {
                         <SignInStep
                             email={email}
                             pending={pending}
+                            ssoEnabled={authConfig.providers.includes("oidc")}
+                            onSSO={handleSSO}
                             onBack={() => goTo("email", -1)}
                             onSubmit={handleSignIn}
                         />
@@ -541,6 +620,7 @@ export default function LoginPage() {
                 {step === "verify" && (
                     <MotionWrap key="verify" direction={direction}>
                         <VerifyStep
+                            mailDelivers={authConfig.mail_delivers}
                             email={email}
                             pending={pending}
                             onBack={() => goTo(mode === "signin" ? "signin" : "signup", -1)}
@@ -564,7 +644,7 @@ export default function LoginPage() {
                 )}
             </AnimatePresence>
 
-            {!turnstileBypassToken && (
+            {(!authConfigReady || captchaRequired) && !turnstileBypassToken && (
                 <Turnstile
                     sitekey={TURNSTILE_KEY}
                     execution="execute"
@@ -802,11 +882,15 @@ function EmailStep({
 function SignInStep({
     email,
     pending,
+    ssoEnabled,
+    onSSO,
     onBack,
     onSubmit,
 }: {
     email: string;
     pending: boolean;
+    ssoEnabled: boolean;
+    onSSO: () => void;
     onBack: () => void;
     onSubmit: (data: z.infer<typeof signInSchema>) => void;
 }) {
@@ -845,6 +929,24 @@ function SignInStep({
                     <AuthButton loading={pending}>Sign in</AuthButton>
                 </div>
             </form>
+
+            {ssoEnabled && (
+                <>
+                    <div className="flex items-center gap-3 my-4">
+                        <div className="h-px flex-1 bg-slate-200" />
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400">or</span>
+                        <div className="h-px flex-1 bg-slate-200" />
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onSSO}
+                        disabled={pending}
+                        className="w-full h-10 rounded-md border border-slate-200 text-[13px] font-medium text-slate-700 hover:bg-slate-50 focus:border-sky-400 focus:ring-2 focus:ring-sky-100 transition-colors disabled:opacity-50"
+                    >
+                        Continue with single sign-on
+                    </button>
+                </>
+            )}
         </div>
     );
 }
@@ -952,12 +1054,14 @@ function SignUpStep({
 function VerifyStep({
     email,
     pending,
+    mailDelivers,
     onBack,
     onSubmit,
     onResend,
 }: {
     email: string;
     pending: boolean;
+    mailDelivers: boolean;
     onBack: () => void;
     onSubmit: (code: string) => void;
     onResend: () => void;
@@ -983,6 +1087,11 @@ function VerifyStep({
                 <p className="text-sm text-slate-400 mt-1.5">
                     We sent a 6-digit code to <span className="text-slate-600 font-medium break-all">{email}</span>
                 </p>
+                {!mailDelivers && (
+                    <p className="mt-3 mx-auto max-w-sm rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[12.5px] leading-relaxed text-amber-800">
+                        This server has no mail transport configured, so the code was written to the backend logs instead of being sent. Run <span className="font-mono">docker compose logs backend</span> to read it.
+                    </p>
+                )}
             </div>
 
             <div className="space-y-5">

--- a/web/src/app/auth/sso/page.tsx
+++ b/web/src/app/auth/sso/page.tsx
@@ -1,0 +1,81 @@
+// SSO landing (/auth/sso?code=...).
+//
+// The identity provider redirects the browser to the backend callback, which
+// completes the exchange server-side and sends the user here with a single-use
+// code. This page trades that code for the session and drops the user into the
+// dashboard, so a token never appears in a URL or in history.
+
+import { useEffect, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2Icon, AlertCircleIcon } from "lucide-react";
+
+import exchangeSSO from "@/lib/api/client/auth/exchangeSSO";
+import getUser from "@/lib/api/client/auth/getUser";
+import { saveTokens } from "@/lib/auth";
+import buildError from "@/lib/helper/buildError";
+import type { AppError } from "@/lib/api/client/normalizeError";
+
+export default function SSOCallbackPage() {
+    const [params] = useSearchParams();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const [error, setError] = useState("");
+    // The code is single use, so React 18's double-invoked effect in dev would
+    // burn it on the first run and fail on the second.
+    const started = useRef(false);
+
+    useEffect(() => {
+        if (started.current) return;
+        started.current = true;
+
+        const code = params.get("code");
+        if (!code) {
+            setError("This sign-in link is missing its code.");
+            return;
+        }
+
+        (async () => {
+            try {
+                const session = await exchangeSSO(code);
+                saveTokens(session as unknown as Record<string, unknown>);
+                queryClient.clear();
+                try {
+                    await queryClient.fetchQuery({ queryKey: ["auth", "me"], queryFn: getUser });
+                } catch {
+                    // UserProvider retries and redirects on a genuine failure.
+                }
+                navigate("/app/emails", { replace: true });
+            } catch (err) {
+                setError(buildError(err as AppError));
+            }
+        })();
+    }, [params, navigate, queryClient]);
+
+    return (
+        <div className="min-h-screen grid place-items-center bg-slate-50 px-4">
+            <div className="w-full max-w-sm bg-white rounded-xl border border-slate-200 p-6 shadow-sm text-center">
+                {error ? (
+                    <>
+                        <div className="mx-auto w-12 h-12 rounded-xl bg-red-50 grid place-items-center mb-4">
+                            <AlertCircleIcon className="w-6 h-6 text-red-500" />
+                        </div>
+                        <h1 className="text-[18px] font-semibold text-slate-900">Sign-in failed</h1>
+                        <p className="text-sm text-slate-500 mt-2">{error}</p>
+                        <button
+                            onClick={() => navigate("/auth/login", { replace: true })}
+                            className="mt-5 w-full h-10 rounded-md bg-slate-900 text-white text-[13px] font-medium hover:bg-slate-800 transition-colors"
+                        >
+                            Back to sign in
+                        </button>
+                    </>
+                ) : (
+                    <>
+                        <Loader2Icon className="w-5 h-5 animate-spin text-slate-400 mx-auto" />
+                        <p className="text-sm text-slate-500 mt-3">Signing you in…</p>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/web/src/app/setup/page.tsx
+++ b/web/src/app/setup/page.tsx
@@ -1,0 +1,210 @@
+// First-run setup (/setup?token=...).
+//
+// The backend prints this link once when it boots against an empty database.
+// Whoever opens it becomes the owner and platform admin of the instance, so it
+// replaces the old routine of registering through the public form, digging a
+// code out of a mail catcher, and then running a psql UPDATE from the host.
+//
+// The token is the capability. It is single use, expires, and the backend
+// refuses the exchange outright once any account exists, so a stale link out of
+// an old log cannot mint a second owner.
+
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2Icon, ShieldCheckIcon, AlertCircleIcon } from "lucide-react";
+import toast from "react-hot-toast";
+
+import claimSetup from "@/lib/api/client/auth/claimSetup";
+import getUser from "@/lib/api/client/auth/getUser";
+import useAuthConfig from "@/lib/api/hooks/auth/useAuthConfig";
+import { usePasswordStrength } from "@/hooks/usePasswordStrength";
+import { saveTokens } from "@/lib/auth";
+import buildError from "@/lib/helper/buildError";
+import type { AppError } from "@/lib/api/client/normalizeError";
+
+export default function SetupPage() {
+    const [params] = useSearchParams();
+    const navigate = useNavigate();
+    const queryClient = useQueryClient();
+    const { config, ready } = useAuthConfig();
+    const { evaluate } = usePasswordStrength();
+
+    const token = params.get("token") ?? "";
+    const [email, setEmail] = useState("");
+    const [firstName, setFirstName] = useState("");
+    const [password, setPassword] = useState("");
+    const [confirm, setConfirm] = useState("");
+    const [pending, setPending] = useState(false);
+
+    async function onSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (pending) return;
+
+        if (password.length < 8) {
+            toast.error("Password must be at least 8 characters long.");
+            return;
+        }
+        if (password !== confirm) {
+            toast.error("Passwords don't match.");
+            return;
+        }
+        const strength = await evaluate(password);
+        if (strength.score < 2) {
+            toast.error(strength.warning || "Please choose a stronger password.");
+            return;
+        }
+
+        setPending(true);
+        try {
+            const session = await claimSetup({
+                token,
+                email,
+                password,
+                first_name: firstName || undefined,
+            });
+            saveTokens(session as unknown as Record<string, unknown>);
+            // Prime the profile with the new token before entering the gated
+            // shell, so it never mounts without an identity.
+            queryClient.clear();
+            try {
+                await queryClient.fetchQuery({ queryKey: ["auth", "me"], queryFn: getUser });
+            } catch {
+                // UserProvider retries and redirects on a genuine failure.
+            }
+            toast.success("This instance is yours.");
+            navigate("/app/emails");
+        } catch (err) {
+            toast.error(buildError(err as AppError));
+        } finally {
+            setPending(false);
+        }
+    }
+
+    if (!ready) {
+        return (
+            <div className="min-h-screen grid place-items-center">
+                <Loader2Icon className="w-5 h-5 animate-spin text-slate-400" />
+            </div>
+        );
+    }
+
+    // Already claimed, or someone found the URL without a link.
+    if (!config.setup_required || !token) {
+        return (
+            <Shell>
+                <div className="mx-auto w-12 h-12 rounded-xl bg-slate-100 grid place-items-center mb-4">
+                    <AlertCircleIcon className="w-6 h-6 text-slate-400" />
+                </div>
+                <h1 className="text-[22px] font-bold text-slate-900 tracking-tight text-center">
+                    {config.setup_required ? "This link is incomplete" : "Already set up"}
+                </h1>
+                <p className="text-sm text-slate-500 mt-2 text-center">
+                    {config.setup_required
+                        ? "Open the full link from the backend logs, or run make claim to print it again."
+                        : "This instance already has an account. Sign in instead."}
+                </p>
+                <button
+                    onClick={() => navigate("/auth/login")}
+                    className="mt-6 w-full h-10 rounded-md bg-slate-900 text-white text-[13px] font-medium hover:bg-slate-800 transition-colors"
+                >
+                    Go to sign in
+                </button>
+            </Shell>
+        );
+    }
+
+    return (
+        <Shell>
+            <div className="mx-auto w-12 h-12 rounded-xl bg-sky-50 grid place-items-center mb-4">
+                <ShieldCheckIcon className="w-6 h-6 text-sky-500" />
+            </div>
+            <h1 className="text-[22px] font-bold text-slate-900 tracking-tight text-center">
+                Claim this instance
+            </h1>
+            <p className="text-sm text-slate-500 mt-2 text-center">
+                This creates the owner account and makes it a platform admin. It can only be done once.
+            </p>
+
+            <form onSubmit={onSubmit} className="mt-6 space-y-4">
+                <Field label="Your name">
+                    <input
+                        type="text"
+                        value={firstName}
+                        onChange={(e) => setFirstName(e.target.value)}
+                        autoComplete="given-name"
+                        placeholder="Alex"
+                        className={inputClass}
+                    />
+                </Field>
+
+                <Field label="Email">
+                    <input
+                        type="email"
+                        required
+                        autoFocus
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        autoComplete="email"
+                        placeholder="you@example.com"
+                        className={inputClass}
+                    />
+                </Field>
+
+                <Field label="Password">
+                    <input
+                        type="password"
+                        required
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        autoComplete="new-password"
+                        placeholder="At least 8 characters"
+                        className={inputClass}
+                    />
+                </Field>
+
+                <Field label="Confirm password">
+                    <input
+                        type="password"
+                        required
+                        value={confirm}
+                        onChange={(e) => setConfirm(e.target.value)}
+                        autoComplete="new-password"
+                        className={inputClass}
+                    />
+                </Field>
+
+                <button
+                    type="submit"
+                    disabled={pending}
+                    className="w-full h-10 rounded-md bg-slate-900 text-white text-[13px] font-medium hover:bg-slate-800 transition-colors disabled:opacity-60 inline-flex items-center justify-center gap-2"
+                >
+                    {pending && <Loader2Icon className="w-4 h-4 animate-spin" />}
+                    {pending ? "Setting up…" : "Create owner account"}
+                </button>
+            </form>
+        </Shell>
+    );
+}
+
+const inputClass =
+    "w-full h-10 px-3 rounded-md border border-slate-200 text-[13px] text-slate-900 placeholder:text-slate-400 focus:border-sky-400 focus:ring-2 focus:ring-sky-100 outline-none transition-colors";
+
+function Shell({ children }: { children: React.ReactNode }) {
+    return (
+        <div className="min-h-screen grid place-items-center bg-slate-50 px-4">
+            <div className="w-full max-w-sm bg-white rounded-xl border border-slate-200 p-6 shadow-sm">
+                {children}
+            </div>
+        </div>
+    );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div>
+            <label className="block text-sm font-medium text-slate-600 mb-1 pl-0.5">{label}</label>
+            {children}
+        </div>
+    );
+}

--- a/web/src/lib/api/client/auth/beginOIDC.ts
+++ b/web/src/lib/api/client/auth/beginOIDC.ts
@@ -1,0 +1,13 @@
+import Request from "../Request";
+
+/**
+ * Starts a generic OpenID Connect sign-in. The backend returns the
+ * authorization URL rather than redirecting, because the dashboard is a
+ * single-page app on a different origin from the API.
+ */
+export default async function beginOIDC(): Promise<{ url: string }> {
+    return await Request<{ url: string }>({
+        method: "POST",
+        url: "/auth/oidc/begin",
+    });
+}

--- a/web/src/lib/api/client/auth/claimSetup.ts
+++ b/web/src/lib/api/client/auth/claimSetup.ts
@@ -1,0 +1,25 @@
+import type Token from "../../models/auth/Token";
+import Request from "../Request";
+
+export interface ClaimSetupInput {
+    token: string;
+    email: string;
+    password: string;
+    first_name?: string;
+    last_name?: string;
+}
+
+/**
+ * Exchanges the one-time link printed at first boot for the owner account.
+ *
+ * Returns a session directly: whoever holds the token has already proved they
+ * control the server, so sending them back to a login form adds friction and
+ * no security.
+ */
+export default async function claimSetup(data: ClaimSetupInput): Promise<Token> {
+    return await Request<Token>({
+        method: "POST",
+        url: "/auth/setup",
+        data,
+    });
+}

--- a/web/src/lib/api/client/auth/exchangeSSO.ts
+++ b/web/src/lib/api/client/auth/exchangeSSO.ts
@@ -1,0 +1,16 @@
+import type Token from "../../models/auth/Token";
+import Request from "../Request";
+
+/**
+ * Swaps the single-use code from an SSO redirect for the real session.
+ *
+ * The backend holds the session and hands back only an opaque code, so no token
+ * ever lands in a URL, browser history or proxy log.
+ */
+export default async function exchangeSSO(code: string): Promise<Token> {
+    return await Request<Token>({
+        method: "POST",
+        url: "/auth/oidc/exchange",
+        data: { code },
+    });
+}

--- a/web/src/lib/api/client/auth/getAuthConfig.ts
+++ b/web/src/lib/api/client/auth/getAuthConfig.ts
@@ -1,0 +1,9 @@
+import type AuthConfig from "../../models/auth/AuthConfig";
+import Request from "../Request";
+
+export default async function getAuthConfig(): Promise<AuthConfig> {
+    return await Request<AuthConfig>({
+        method: "GET",
+        url: "/auth/config",
+    });
+}

--- a/web/src/lib/api/hooks/auth/useAuthConfig.ts
+++ b/web/src/lib/api/hooks/auth/useAuthConfig.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import getAuthConfig from "../../client/auth/getAuthConfig";
+import type AuthConfig from "../../models/auth/AuthConfig";
+
+/**
+ * Deployment auth capabilities. Fetched once and cached for the session: it is
+ * boot-time backend configuration, so it cannot change while the login screen
+ * is open.
+ *
+ * The fallback matters as much as the fetch. If the endpoint is unreachable
+ * (an older backend, or a proxy problem) the login screen must still render,
+ * so it falls back to the hosted defaults.
+ */
+export const AUTH_CONFIG_FALLBACK: AuthConfig = {
+    captcha: true,
+    password_login: true,
+    login_code: "always",
+    registration: "false",
+    email_verification: true,
+    mail_delivers: true,
+    passkeys: true,
+    providers: [],
+    self_hosted: false,
+    setup_required: false,
+};
+
+export default function useAuthConfig() {
+    const query = useQuery({
+        queryKey: ["auth", "config"],
+        queryFn: getAuthConfig,
+        staleTime: Infinity,
+        gcTime: Infinity,
+        retry: 1,
+    });
+
+    return {
+        ...query,
+        config: query.data ?? AUTH_CONFIG_FALLBACK,
+        // Callers must not render the captcha widget or provider buttons until
+        // the real answer arrives, or the widget mounts and then unmounts.
+        ready: !query.isLoading,
+    };
+}

--- a/web/src/lib/api/models/auth/AuthConfig.ts
+++ b/web/src/lib/api/models/auth/AuthConfig.ts
@@ -1,0 +1,21 @@
+/**
+ * What this deployment's auth can actually do, served by GET /auth/config.
+ *
+ * The login screen used to guess: it mounted the Turnstile widget in every
+ * production build even when captcha was off server-side, rendered social
+ * buttons for providers the backend had no client for, and gave a self-hoster
+ * no hint that their login code had gone to a log file.
+ */
+export default interface AuthConfig {
+    captcha: boolean;
+    password_login: boolean;
+    login_code: "always" | "new_device" | "off";
+    registration: "true" | "false" | "invite_only";
+    email_verification: boolean;
+    mail_delivers: boolean;
+    passkeys: boolean;
+    providers: string[];
+    self_hosted: boolean;
+    /** True while the instance has no accounts and must be claimed. */
+    setup_required: boolean;
+}

--- a/web/src/lib/api/models/auth/ResetPasswordConfirm.ts
+++ b/web/src/lib/api/models/auth/ResetPasswordConfirm.ts
@@ -1,5 +1,7 @@
 export default interface ResetPasswordConfirm {
-    token: string;
+    // The backend binds this as `session`; it used to be sent as `token`,
+    // which never matched.
+    session: string;
     password: string;
     turnstile: string;
 }

--- a/web/src/lib/api/models/auth/Session.ts
+++ b/web/src/lib/api/models/auth/Session.ts
@@ -1,3 +1,18 @@
+import type Token from "./Token";
+
+/**
+ * What POST /auth/login and /auth/register return.
+ *
+ * `session` plus `code_required: true` is the two-step flow: a code was emailed
+ * and the caller confirms it. When the deployment has AUTH_LOGIN_CODE off, or
+ * the device is already known, no code is sent and the login is already
+ * complete, so the remaining fields carry the result instead.
+ */
 export default interface Session {
-    session: string;
+    session?: string;
+    code_required: boolean;
+    token?: Token;
+    two_fa_required?: boolean;
+    pending_token?: string;
+    expires_in?: number;
 }

--- a/web/src/lib/token.ts
+++ b/web/src/lib/token.ts
@@ -1,3 +1,0 @@
-export function is64ByteHex(input: string): boolean {
-  return /^[a-fA-F0-9]{128}$/.test(input);
-}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -78,6 +78,8 @@ import OnboardingLayout from './app/onboarding/layout';
 import OnboardingPage from './app/onboarding/page';
 import SelectOrgPage from './app/select-org/page';
 import InviteAcceptPage from './app/invite/page';
+import SetupPage from './app/setup/page';
+import SSOCallbackPage from './app/auth/sso/page';
 
 // React-Query defaults tuned for a dashboard. The library's
 // out-of-the-box behaviour treats every query as immediately stale
@@ -152,6 +154,11 @@ const router = createBrowserRouter([
             ]
           },
           {
+            // Landing for the single-use code an SSO redirect carries.
+            path: "sso",
+            element: <SSOCallbackPage />,
+          },
+          {
             path: "reset-password",
             element: <ResetPasswordLayout />,
             children: [
@@ -184,6 +191,11 @@ const router = createBrowserRouter([
       {
         path: "invite",
         element: <InviteAcceptPage />,
+      },
+      {
+        // First-run claim link printed by the backend on an empty database.
+        path: "setup",
+        element: <SetupPage />,
       },
       {
         path: "oauth",


### PR DESCRIPTION
Self-hosted auth: real SMTP transport, OIDC with PKCE, identity binding on (issuer, subject), bootstrap owner claim, per-IP auth limiter, and boot refusal on default secrets.

Migration `000082_user_identities` adds a `UNIQUE INDEX` on `(issuer, subject)` as the database-level control against two users claiming one identity, plus `ON DELETE CASCADE` from `users`. Down migration is a correct inverse. `000082` is the next free number, no collision.

## Review findings that should be resolved before merge

Reviewed across 8 dimensions with an adversarial verification pass. 71 findings confirmed, 9 refuted. The ones that matter:

**Blocking**

1. **OIDC `state` is not bound to the browser.** `OIDCBegin` (`internal/app/auth/oidc.go:100-131`) stores `{verifier, nonce}` in Redis keyed by `state` alone and returns the full authorize URL as JSON from an unauthenticated `POST`. `OIDCCallback` is a `GET` that accepts any `(code, state)` pair from any browser. `GetDel` gives single-use, not user-agent binding, which is the distinction RFC 9700 4.3.1 draws. An attacker can mint a flow, authenticate as themselves, and hand the victim a callback URL that logs the victim into the attacker's tenant. The doc comments at `oidc.go:39-46` and `oidcauth.go:156-159` claim this binding exists.

2. **SSO is unusable for any TOTP-enrolled user, and logs them out.** `finishLoginAs` correctly returns `two_fa_required` with a nil token, but `web/src/app/auth/sso/page.tsx:41` calls `saveTokens(session)` unconditionally. `web/src/lib/auth.ts:29-41` removes every key whose value is `undefined`, so the existing session is wiped and no new one is set. Escalates to a full lockout under the `DISABLE_PASSWORD_LOGIN=true` posture the deployment guide recommends.

3. **`session` became `omitempty` while the login-code default changed**, which breaks already-shipped iOS builds (`internal/models/token.go:65`, `internal/config/config_authpolicy.go:58`, `ios/Warmbly/Core/Models/CoreModels.swift:59`).

4. **Federated JIT provisioning bypasses `DISABLE_REGISTRATION`** (`internal/app/auth/external_idtoken.go:108-113`). An instance with registration closed still creates accounts for anyone the IdP will authenticate.

**Should fix**

5. `OIDC_DEFAULT_ORG` is read into config, exposed on the service and declared on the interface, but never used. The deployment guide actively recommends setting it (`deployment-guide.mdx:586`); doing so has no effect and every SSO user still gets a single-member org.
6. The default-secret boot refusal never fires on `make up`, because `APP_ENV` defaults to `dev` (`cmd/backend/boot.go:47,57-60` vs `docker-compose.yml:43`).
7. A stranger can `POST /auth/register` on a fresh instance and permanently burn the bootstrap setup claim (`internal/app/auth/provision.go:72-90`, `internal/app/bootstrap/bootstrap.go:207-214`). A wrong-token attempt also refreshes the setup token TTL.
8. `identityRepository.Link` swallows a cross-user conflict via `ON CONFLICT`, so the documented "refuse rather than sign anyone in" path is unreachable (`internal/repository/pg_identity.go:60-68`).
9. IPv6 limiter keys on the full /128, so a /64 bypasses it. `INCR` and `EXPIRE` are not atomic, so a dropped `EXPIRE` permanently 429s an IP (`internal/api/middleware/ratelimit_ip.go:50-64`).
10. Docs say `MAIL_TRANSPORT` defaults to `log`; the code defaults to `ses` (`deployment-guide.mdx:370`). `POST /auth/oidc/exchange` and the changed `/auth/login` response shape are undocumented, and `docs/public/openapi.json` was not regenerated.

**Explicitly refuted, no action needed**

- Email-fallback linking does require a verified email: `external_idtoken.go:56` and `oidcauth.go:201` both gate on `EmailVerified`.

**Pre-existing, not from this branch, but worth knowing**

- `middleware.Handler{}` at `cmd/backend/main.go:1637` omits `RateLimitService`, and `middleware/ratelimit.go:17` fails open on nil. Every `m.RateLimitMiddleware(...)` is a no-op today, on `main` as well.

## Local gates

`gofmt -l cmd internal` clean. `pnpm typecheck` passes in `web/` and `admin/`. `pnpm types:check` passes in `docs/`. `golangci-lint` not run locally.
