### PR TITLE
fix: build OAuth redirect_uri from API_PUBLIC_URL instead of the bind address

### DIFF
--- a/cmd/backend/boot.go
+++ b/cmd/backend/boot.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"net/url"
 	"os"
 	"sort"
@@ -97,6 +98,49 @@ func oidcRedirectURL() string {
 	}
 	// The route is registered on /v1, not /api/v1: there is no /api prefix.
 	return base + "/v1/auth/oidc/callback"
+}
+
+// oauthPublicBaseURL is the base every mailbox-connect redirect_uri is built
+// from. It has to be the address the provider will send a browser back to,
+// which is API_PUBLIC_URL, the same value oidcRedirectURL derives from and the
+// one .env.example already documents as `<API_PUBLIC_URL>/addresses/...`.
+//
+// It is emphatically NOT API_HOST: that is the listener's bind address, which
+// stays 0.0.0.0:8080 in a container. Sent as a redirect_uri it is not even an
+// absolute URI, so the provider rejects the request outright.
+func oauthPublicBaseURL(bindAddr string) string {
+	if v := strings.TrimRight(strings.TrimSpace(os.Getenv("API_PUBLIC_URL")), "/"); v != "" {
+		return v
+	}
+	return browsableBaseFromBindAddr(bindAddr)
+}
+
+// browsableBaseFromBindAddr turns a listener address into a URL a browser on
+// the same host can actually open, so a stock local install that never set
+// API_PUBLIC_URL still produces an absolute redirect_uri.
+func browsableBaseFromBindAddr(addr string) string {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return ""
+	}
+	// Already a URL (someone put a real base in API_HOST): keep it as-is.
+	if strings.Contains(addr, "://") {
+		return strings.TrimRight(addr, "/")
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		host, port = addr, ""
+	}
+	// A wildcard bind is reachable from the host itself as localhost.
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		host = "localhost"
+	}
+	if port == "" {
+		return "http://" + host
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // splitList parses a comma-separated env list.

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1065,7 +1065,10 @@ func main() {
 
 		eventsPublisher := events.NewPublisher(bus, s3, codecImpl, cipherService)
 
-		oauth2Cfg := config.LoadOauth2(apiCfg.Hostname)
+		// apiCfg.Hostname is the bind address, not a reachable base. Building
+		// the mailbox-connect redirect_uri from it sends the provider
+		// "0.0.0.0:8080/addresses/google/callback".
+		oauth2Cfg := config.LoadOauth2(oauthPublicBaseURL(apiCfg.Hostname))
 		emailService = email.NewServiceWithWorker(
 			emailRepostory,
 			cipherService,

--- a/cmd/backend/oauth_base_url_test.go
+++ b/cmd/backend/oauth_base_url_test.go
@@ -1,0 +1,48 @@
+package main
+
+import "testing"
+
+func TestOAuthPublicBaseURLPrefersAPIPublicURL(t *testing.T) {
+	t.Setenv("API_PUBLIC_URL", "https://api.example.com/")
+
+	if got := oauthPublicBaseURL("0.0.0.0:8080"); got != "https://api.example.com" {
+		t.Fatalf("got %q, want the trailing slash trimmed public URL", got)
+	}
+}
+
+// A stock local install sets no API_PUBLIC_URL. The redirect_uri still has to
+// be an absolute URL a browser can open, which "0.0.0.0:8080" is not.
+func TestOAuthPublicBaseURLFallsBackToBrowsableAddress(t *testing.T) {
+	t.Setenv("API_PUBLIC_URL", "")
+
+	tests := []struct {
+		bind string
+		want string
+	}{
+		{"0.0.0.0:8080", "http://localhost:8080"},
+		{"[::]:8080", "http://localhost:8080"},
+		{":8080", "http://localhost:8080"},
+		{"127.0.0.1:8080", "http://127.0.0.1:8080"},
+		{"api.internal:9000", "http://api.internal:9000"},
+		// Someone who already put a real base in API_HOST keeps it.
+		{"https://api.example.com/", "https://api.example.com"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if got := oauthPublicBaseURL(tt.bind); got != tt.want {
+			t.Errorf("oauthPublicBaseURL(%q) = %q, want %q", tt.bind, got, tt.want)
+		}
+	}
+}
+
+// The callback routes are registered at the root, not under /v1, so the base
+// must be joined with no API prefix.
+func TestOAuthPublicBaseURLBuildsRegisteredCallbackPath(t *testing.T) {
+	t.Setenv("API_PUBLIC_URL", "https://api.example.com")
+
+	got := oauthPublicBaseURL("0.0.0.0:8080") + "/addresses/google/callback"
+	if want := "https://api.example.com/addresses/google/callback"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -459,6 +459,8 @@ https://api.example.com/addresses/google/callback
 ```
 
 On a stock local install that is `http://localhost:8080/addresses/google/callback`.
+
+The base Warmbly actually sends is `API_PUBLIC_URL`, so it has to match what you register here. Behind a reverse proxy that means the public API host, not the address the container binds to. Leave `API_PUBLIC_URL` unset and the base falls back to `http://localhost:8080`, which is right for a local install and wrong for every proxied one.
 </Step>
 
 <Step>


### PR DESCRIPTION
Fixes #101.

## The bug

`API_HOST` was doing two incompatible jobs. It is the Gin listener's bind address, so it must stay `0.0.0.0:8080` inside a container, and it was also the base every OAuth `redirect_uri` was built from:

```go
oauth2Cfg := config.LoadOauth2(apiCfg.Hostname)   // cmd/backend/main.go:1068
```

`internal/config/inbox.go:20` then does `RedirectURL: baseURL + "/addresses/google/callback"`, so every self-hosted mailbox connect sent Google:

```
redirect_uri=0.0.0.0%3A8080%2Faddresses%2Fgoogle%2Fcallback
```

That is not a `redirect_uri_mismatch`. It has no scheme, so it is not an absolute URI at all, which is why Google rejects it with `Error 400: invalid_request` before the account picker even renders.

`API_HOST` defaults to `0.0.0.0:8080` (`internal/config/config_api.go:22`) and is bound at `main.go:1486`, so there is no value that satisfies both jobs.

## The fix

`API_PUBLIC_URL` already exists, is already documented, and is already the convention for this: `oidcRedirectURL()` in `cmd/backend/boot.go` derives from it, `docker-compose.yml:299` sets it, and `.env.example:415` literally documents the redirect as `<API_PUBLIC_URL>/addresses/google/callback`. The code just never used it.

`oauthPublicBaseURL` sits next to `oidcRedirectURL` and reads the same variable.

### The fallback matters

Rather than falling through to the bind address unchanged, an unset `API_PUBLIC_URL` derives a base a browser can actually open:

| `API_HOST` | base used |
|---|---|
| `0.0.0.0:8080` | `http://localhost:8080` |
| `[::]:8080`, `:8080` | `http://localhost:8080` |
| `127.0.0.1:8080` | `http://127.0.0.1:8080` |
| `https://api.example.com/` | `https://api.example.com` (already a URL, passed through) |

This matters for local development specifically: `make backend` sets `API_HOST=0.0.0.0:8080` and no `API_PUBLIC_URL`, so without the mapping a native dev stack stays broken. With it, a stock local install produces exactly `http://localhost:8080/addresses/google/callback`, which is the URL the deployment guide already tells operators to register.

## Scope

This is the mailbox-connect flow (`BOX_GOOGLE_*` / `BOX_OUTLOOK_*`). Only `InboxAuthorization` is consumed from the returned config; the sibling `GoogleAuthorization` field is constructed and never read anywhere (sign-in with Google goes through `POST /v1/auth/google` as an ID-token exchange, not a redirect), so it is dead but harmless. Left alone here rather than widening this change.

Callback routes are registered at the root (`internal/api/routes.go:92-93`), with no `/v1` or `/api/v1` prefix, so the base is joined directly. A test pins that, since getting the prefix wrong is exactly what broke OIDC login in 734cb5f.

## Tests

`cmd/backend/oauth_base_url_test.go` covers the precedence, every wildcard bind form, the already-a-URL passthrough, the empty case, and the assembled callback path.

## Docs

The guide already showed the right URL but never said which variable produces it. Added a note under the redirect-URI step naming `API_PUBLIC_URL` and calling out that the fallback is correct locally and wrong behind a proxy.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./cmd/backend/...` clean
- `go test ./cmd/backend/` passes
- `pnpm types:check` in `docs/` passes

Note that this is necessary but not sufficient to connect a mailbox on a split-domain deployment: #102 is the next failure, and #105 is what stops the connected mailbox from ever loading onto a worker.
