### PR TITLE
fix: accept the API origin in the OAuth callback listener and stop defaulting to a wildcard target

### DIFF
--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -102,7 +102,7 @@ Every emailed link (password reset, invitation, the first-run claim link) is bui
 | `FRONTEND_BASE_URL` | Alternative name for the same value, read when `APP_URL` is unset | unset | no |
 | `API_PUBLIC_URL` | The backend's public base. Frontends, blob URLs and the OIDC redirect derive from it | derived from `PUBLIC_HOST` under compose | yes |
 | `BACKEND_PUBLIC_URL` | The backend base used in generated worker configuration | falls back to `API_PUBLIC_URL` | yes |
-| `APP_ORIGIN` | The exact origin the mailbox OAuth callback page posts the authorization code back to. Unset means a wildcard target origin | derived under compose | yes |
+| `APP_ORIGIN` | The exact origin the mailbox OAuth callback page posts the authorization code back to. Only needed when the dashboard is served somewhere other than `APP_URL` | derived from `APP_URL` | yes |
 | `API_HOST` | The listen address | `0.0.0.0:8080` | yes |
 | `PUBLIC_HOST` | Compose only. A hostname or LAN IP that every other URL derives from | `localhost` | yes |
 | `CORS_ALLOW_ORIGINS` | Comma separated origins allowed to call the API. Anything not listed gets `403` on preflight | derived from `PUBLIC_HOST` under compose | yes |

--- a/docs/content/docs/development/instance-health.mdx
+++ b/docs/content/docs/development/instance-health.mdx
@@ -132,7 +132,7 @@ Discovery against the configured issuer failed at boot, so the single sign-on bu
 
 ### app_origin_wildcard
 
-`APP_ORIGIN` is unset, so the mailbox OAuth callback page posts the authorization code back to the dashboard with a wildcard target origin. Set `APP_ORIGIN` to your dashboard origin.
+Neither `APP_ORIGIN` nor a usable `APP_URL` is set, so the mailbox OAuth callback page posts the authorization code back to the dashboard with a wildcard target origin. Set `APP_URL` to your dashboard origin, or `APP_ORIGIN` if the dashboard is served somewhere else. Setting `APP_URL` alone clears this: the callback page derives its target from it.
 
 ### tracking_domain_unreachable
 

--- a/internal/api/handler/email_oauth_callback.go
+++ b/internal/api/handler/email_oauth_callback.go
@@ -3,9 +3,12 @@ package handler
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/config"
 )
 
 // callbackPage renders a tiny HTML page that hands the OAuth code + state
@@ -71,6 +74,23 @@ type callbackData struct {
 	AppOrigin string
 }
 
+// callbackTargetOrigin is the postMessage target the authorization code is
+// handed to. An empty value makes the bridge fall back to "*", which posts the
+// code to whatever origin the opener happens to have, so derive it from APP_URL
+// when APP_ORIGIN is unset rather than leaving a wildcard on a stock install.
+// APP_ORIGIN stays the explicit override for a dashboard served somewhere other
+// than APP_URL.
+func callbackTargetOrigin() string {
+	if v := strings.TrimSpace(os.Getenv("APP_ORIGIN")); v != "" {
+		return v
+	}
+	u, err := url.Parse(config.AppBaseURL())
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return ""
+	}
+	return u.Scheme + "://" + u.Host
+}
+
 func (h *Handler) EmailOAuthCallbackGmail(c *gin.Context) {
 	renderOAuthCallback(c, "gmail")
 }
@@ -90,7 +110,7 @@ func renderOAuthCallback(c *gin.Context, provider string) {
 		State:     state,
 		Error:     providerErr,
 		Status:    "Connecting your mailbox… this window will close.",
-		AppOrigin: os.Getenv("APP_ORIGIN"),
+		AppOrigin: callbackTargetOrigin(),
 	}
 	if providerErr != "" {
 		data.Status = "Connection cancelled."

--- a/internal/app/instancecheck/checks_urls.go
+++ b/internal/app/instancecheck/checks_urls.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+
+	"github.com/warmbly/warmbly/internal/config"
 )
 
 const (
@@ -175,9 +177,15 @@ func checkAppOriginWildcard(ctx context.Context, d Deps, in Input) *Finding {
 	if env("APP_ORIGIN") != "" {
 		return nil
 	}
-	return result(CategoryURLs, SeverityInfo, "APP_ORIGIN is not set",
-		"APP_ORIGIN is not set, so the mailbox OAuth callback page posts the authorization code back to the dashboard "+
-			"with a wildcard target origin. Set APP_ORIGIN to your dashboard origin.",
+	// APP_ORIGIN is only needed when APP_URL cannot supply the origin, since
+	// the callback page derives its postMessage target from APP_URL otherwise.
+	if u, err := url.Parse(config.AppBaseURL()); err == nil && u.Scheme != "" && u.Host != "" {
+		return nil
+	}
+	return result(CategoryURLs, SeverityInfo, "No OAuth callback target origin",
+		"Neither APP_ORIGIN nor a usable APP_URL is set, so the mailbox OAuth callback page posts the authorization "+
+			"code back to the dashboard with a wildcard target origin. Set APP_URL to your dashboard origin, "+
+			"or APP_ORIGIN if the dashboard is served somewhere else.",
 		docsAddresses)
 }
 

--- a/web/src/components/app/modals/AddEmailModal.tsx
+++ b/web/src/components/app/modals/AddEmailModal.tsx
@@ -35,7 +35,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Google, Outlook, Logo } from "@/components/svg";
 import { TextInput } from "@/components/ui/field";
 import { useUserProfile } from "@/hooks/context/user";
-import { APP_URL } from "@/lib/information";
+import { API_URL, APP_URL } from "@/lib/information";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import addEmail from "@/lib/api/client/app/emails/addEmail";
@@ -52,6 +52,34 @@ interface OAuthCallbackMessage {
     code: string;
     state: string;
     error: string;
+}
+
+// originOf normalises a configured base URL to a bare origin. APP_URL and
+// API_URL may carry a trailing slash or a path; event.origin never does.
+function originOf(value: string | undefined): string | null {
+    if (!value) return null;
+    try {
+        return new URL(value, window.location.href).origin;
+    } catch {
+        return null;
+    }
+}
+
+// The origins we accept an OAuth callback message from.
+//
+// The bridge page is served by the API, not the dashboard, so that the
+// redirect_uri registered with Google and Microsoft stays stable across
+// front-end changes. On a split-domain deployment (dashboard on one host, API
+// on another, which is what the self-hosting guide sets up) event.origin is
+// therefore API_URL's origin and never APP_URL's. Accepting only APP_URL
+// silently dropped every callback and left the modal waiting forever.
+//
+// This is a coarse gate: the real replay protection is the single-use state
+// match below, which the message still has to satisfy.
+function allowedCallbackOrigins(): string[] {
+    return [originOf(APP_URL), originOf(API_URL), window.location.origin].filter(
+        (o): o is string => Boolean(o),
+    );
 }
 
 function openCentered(url: string, name: string): Window | null {
@@ -94,13 +122,12 @@ export default function AddEmailModal() {
         }
     }, [user.addEmail]);
 
-    // Listen for the OAuth popup's postMessage. We only honour messages
-    // whose origin matches APP_URL and whose state matches the one we
-    // issued — protects against replay and stray posts.
+    // Listen for the OAuth popup's postMessage. We only honour messages from an
+    // origin we own and whose state matches the one we issued, which is what
+    // protects against replay and stray posts.
     React.useEffect(() => {
         function onMessage(event: MessageEvent) {
-            const expectedOrigin = APP_URL || window.location.origin;
-            if (event.origin && expectedOrigin && event.origin !== expectedOrigin && event.origin !== window.location.origin) {
+            if (event.origin && !allowedCallbackOrigins().includes(event.origin)) {
                 return;
             }
             const data = event.data as OAuthCallbackMessage | undefined;


### PR DESCRIPTION
Fixes #102.

## The bug

The connect-mailbox modal only ever accepted a callback message from `APP_URL`:

```ts
const expectedOrigin = APP_URL || window.location.origin;
if (event.origin && expectedOrigin && event.origin !== expectedOrigin && event.origin !== window.location.origin) {
    return;
}
```

But the bridge page that sends the message is served by the **backend** (`internal/api/handler/email_oauth_callback.go`), on purpose, and its own comment says why: keeping it on the API is what makes the registered `redirect_uri` stable across front-end changes. The popup is opened at `API_URL + "/emails/google/login"`, so `event.origin` is the API origin.

On any split-domain deployment, which is exactly the topology the self-hosting guide sets up, `event.origin` is `https://api.example.com` and `APP_URL` is `https://app.example.com`. They never match, so the message was discarded every time. The provider exchange had already succeeded and the callback had already returned `200`; the modal just sat on "Waiting for authorization…" forever.

## The fix

`allowedCallbackOrigins()` accepts the dashboard origin, the API origin, and the current window origin. Both configured values go through `new URL(...).origin`, which also fixes a latent problem in the old code: it compared `event.origin` (never has a trailing slash) against raw `APP_URL` (which may), so `APP_URL=https://app.example.com/` failed even on a single-domain install.

This stays a coarse gate on purpose. The actual replay protection is unchanged and still does the work: the message must carry `type: "email_oauth_callback"` and a `state` matching the single-use value this modal issued, which is cleared on first match.

## Second, related bug: the wildcard target origin

While tracing the message I found the other half. The bridge posts with:

```js
window.opener.postMessage(payload, origin || "*");
```

where `origin` is `os.Getenv("APP_ORIGIN")`. `APP_ORIGIN` **is not set anywhere in `docker-compose.yml`**, even though `configuration.mdx` claimed it was "derived under compose". So every stock install fell through to `"*"`, which posts the authorization code to whatever origin the opener happens to have.

`callbackTargetOrigin()` now derives the origin from `config.AppBaseURL()` (that is `APP_URL`, which compose *does* set) when `APP_ORIGIN` is unset. `APP_ORIGIN` remains the explicit override for a dashboard served somewhere other than `APP_URL`.

No install regresses: OAuth connect cannot currently complete at all, so there is no working configuration that this makes stricter.

## Health check and docs

`app_origin_wildcard` previously fired whenever `APP_ORIGIN` was unset, which will now be the normal, correct state. It only fires when neither `APP_ORIGIN` nor a usable `APP_URL` is available, and the message names the fix. `configuration.mdx` and `instance-health.mdx` updated to match.

## Verification

- `pnpm typecheck` in `web/` clean
- `pnpm lint` in `web/` reports nothing on the changed file (77 pre-existing warnings elsewhere, 0 errors)
- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/api/... ./internal/app/instancecheck/...` clean
- `pnpm types:check` in `docs/` passes

Stacks behind #101: the redirect_uri has to be right before the consent screen loads at all.
