### PR TITLE
fix: wire OnTokenRefresh for Gmail clients and stop stoken panicking on a nil callback

### DIFF
--- a/internal/app/worker/wmail/wmail.go
+++ b/internal/app/worker/wmail/wmail.go
@@ -125,6 +125,11 @@ func NewWMail(
 				OnMessageRemove: mail.onGoogleMessageRemove,
 				OnLabelAdd:      mail.onGoogleMessageLabelsAdded,
 				OnLabelRemove:   mail.onGoogleMessageLabelsRemoved,
+				// Without this a refreshed Gmail token is never persisted, so
+				// the mailbox stops working roughly an hour after connect.
+				OnTokenRefresh: func(_ context.Context, t *oauth2.Token) error {
+					return mail.onTokenUpdate(t)
+				},
 			},
 			LastHistoryID: data.Google.LastHistoryID,
 		}

--- a/internal/client/goog/goog.go
+++ b/internal/client/goog/goog.go
@@ -30,9 +30,14 @@ type Client struct {
 func (c *Client) Init(ctx context.Context, token *oauth2.Token, cfg oauth2.Config) *errx.MailError {
 	ts := cfg.TokenSource(ctx, token)
 	ts = oauth2.ReuseTokenSource(token, ts)
-	ts = stoken.New(ts, func(token *oauth2.Token) error {
-		return c.OnTokenRefresh(context.Background(), token)
-	})
+	// Only wrap when there is somewhere to persist to. stoken calls onUpdate on
+	// every Token(), which the oauth2 transport does per request, so wrapping
+	// with a nil OnTokenRefresh panics inside RoundTrip on the first API call.
+	if c.OnTokenRefresh != nil {
+		ts = stoken.New(ts, func(token *oauth2.Token) error {
+			return c.OnTokenRefresh(context.Background(), token)
+		})
+	}
 
 	httpClient := oauth2.NewClient(ctx, ts)
 	var err error

--- a/internal/client/msgraph/msgraph.go
+++ b/internal/client/msgraph/msgraph.go
@@ -66,9 +66,12 @@ type Client struct {
 func (c *Client) Init(ctx context.Context, token *oauth2.Token, cfg oauth2.Config) *errx.MailError {
 	ts := cfg.TokenSource(ctx, token)
 	ts = oauth2.ReuseTokenSource(token, ts)
-	ts = stoken.New(ts, func(t *oauth2.Token) error {
-		return c.OnTokenRefresh(context.Background(), t)
-	})
+	// Same guard as goog.Init: a nil OnTokenRefresh would panic per request.
+	if c.OnTokenRefresh != nil {
+		ts = stoken.New(ts, func(t *oauth2.Token) error {
+			return c.OnTokenRefresh(context.Background(), t)
+		})
+	}
 
 	c.hc = oauth2.NewClient(ctx, ts)
 	if c.DeltaLinks == nil {

--- a/internal/pkg/stoken/stoken.go
+++ b/internal/pkg/stoken/stoken.go
@@ -24,6 +24,11 @@ func (s *Token) Token() (*oauth2.Token, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Called from inside the oauth2 transport's RoundTrip, so a nil callback
+	// here takes down the caller's request rather than surfacing as an error.
+	if s.onUpdate == nil {
+		return t, nil
+	}
 
 	var lastErr error
 	for attempt := 1; attempt <= 3; attempt++ {

--- a/internal/pkg/stoken/stoken_test.go
+++ b/internal/pkg/stoken/stoken_test.go
@@ -1,0 +1,52 @@
+package stoken
+
+import (
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+type staticSource struct {
+	token *oauth2.Token
+}
+
+func (s *staticSource) Token() (*oauth2.Token, error) {
+	return s.token, nil
+}
+
+func TestTokenCallsOnUpdate(t *testing.T) {
+	src := &staticSource{token: &oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(time.Hour)}}
+
+	var got *oauth2.Token
+	ts := New(src, func(tok *oauth2.Token) error {
+		got = tok
+		return nil
+	})
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok.AccessToken != "a" {
+		t.Errorf("got access token %q, want %q", tok.AccessToken, "a")
+	}
+	if got == nil || got.AccessToken != "a" {
+		t.Error("onUpdate was not called with the refreshed token")
+	}
+}
+
+// The oauth2 transport calls Token() on every request, so a nil callback used
+// to panic inside RoundTrip on the first API call the client made.
+func TestTokenWithNilOnUpdateDoesNotPanic(t *testing.T) {
+	src := &staticSource{token: &oauth2.Token{AccessToken: "a", Expiry: time.Now().Add(time.Hour)}}
+	ts := New(src, nil)
+
+	tok, err := ts.Token()
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok.AccessToken != "a" {
+		t.Errorf("got access token %q, want %q", tok.AccessToken, "a")
+	}
+}


### PR DESCRIPTION
Fixes #106.

## The bug

`internal/app/worker/wmail/wmail.go` builds a `goog.Client` with every callback wired except one:

```go
Cache:           mail.Cache,
OnMessageAdd:    mail.onGoogleMessageAdd,
OnMessageRemove: mail.onGoogleMessageRemove,
OnLabelAdd:      mail.onGoogleMessageLabelsAdded,
OnLabelRemove:   mail.onGoogleMessageLabelsRemoved,
// no OnTokenRefresh
```

The `msgraph.Client` built ~20 lines below sets `OnTokenRefresh` correctly, so Outlook mailboxes were never affected.

`goog.Init` then wraps the token source unconditionally:

```go
ts = stoken.New(ts, func(token *oauth2.Token) error {
    return c.OnTokenRefresh(context.Background(), token)   // nil
})
```

and `stoken.Token()` calls `s.onUpdate(t)` on **every** call, not only on an actual refresh. The oauth2 transport calls `Token()` once per request, so this is a nil func value dereferenced inside `RoundTrip` on the first Gmail API call any mailbox ever makes. Every send and every sync tick for every Gmail mailbox panicked.

## The fix

Three layers, because the wiring omission was only possible in the first place due to the missing guard:

1. **`wmail.go`** wires `OnTokenRefresh` to `mail.onTokenUpdate`, matching the Outlook path. This is what actually makes Gmail work, and it also means a refreshed token is finally persisted rather than discarded.
2. **`goog.Init` and `msgraph.Init`** only install the `stoken` wrapper when `OnTokenRefresh` is non-nil. There is no reason to wrap a token source with a persist hook that has nowhere to persist to. Applied to both so they cannot drift again.
3. **`stoken.Token`** returns early on a nil `onUpdate`. This runs inside `RoundTrip`, where a panic takes down the caller's request instead of surfacing as an error, so a shared package should not assume its callback is set.

## Tests

`internal/pkg/stoken/stoken_test.go` covers the callback firing with the refreshed token, and the nil-callback path.

The nil test is a real regression test rather than a formality. Verified by stashing the fix:

```
$ git stash && go test ./internal/pkg/stoken/ -run TestTokenWithNilOnUpdate
--- FAIL: TestTokenWithNilOnUpdateDoesNotPanic
panic: runtime error: invalid memory address or nil pointer dereference
```

and it passes with the fix applied.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/pkg/stoken/... ./internal/client/... ./internal/app/worker/...` clean
- `go test ./internal/pkg/stoken/` passes

## Noted, not fixed here

`stoken.Token` retries a failed persist three times with `1<<attempt` second backoff, sleeping up to 14 seconds **inside `RoundTrip`**, which stalls the request that triggered it. That is a separate latent problem and did not seem right to change under a panic fix.

Ordering: this is what a Gmail mailbox hits after #105 lets its credentials load at all, and #107 is the next failure once the panic is gone.
