### PR TITLE
fix: make the Gmail history checkpoint persist, bootstrap, and advance

### DIFF
--- a/internal/app/worker/wmail/sync_google.go
+++ b/internal/app/worker/wmail/sync_google.go
@@ -8,15 +8,18 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// SyncGoogle walks Gmail's history from this mailbox's checkpoint and advances
+// it. Runs serially from StartSyncWorker, so LastHistoryID needs no locking.
 func (w *WMail) SyncGoogle(ctx context.Context) *errx.MailError {
 	newHistoryID, err := w.GoogleData.Client.FetchHistory(ctx, w.GoogleData.LastHistoryID)
 	if newHistoryID != 0 {
-		if err := w.NewHistoryID(newHistoryID); err != nil {
-			w.CaptureError(err)
-			return nil
+		// Advance the in-memory cursor before persisting. The next tick reads
+		// this field, so leaving it stale re-walks the window just processed,
+		// and leaving it at zero re-bootstraps past everything that arrived.
+		w.GoogleData.LastHistoryID = newHistoryID
+		if perr := w.NewHistoryID(newHistoryID); perr != nil {
+			w.CaptureError(perr)
 		}
-
-		return nil
 	}
 	if err != nil {
 		var errMail *errx.MailError
@@ -25,15 +28,19 @@ func (w *WMail) SyncGoogle(ctx context.Context) *errx.MailError {
 		}
 
 		w.CaptureError(err)
-
-		return nil
 	}
 
 	return nil
 }
 
+// NewHistoryID persists the mailbox's Gmail history checkpoint. UserID and
+// EmailID address the row: email_history_ids is keyed (user_id, email_id) with
+// a foreign key to users, so omitting them sends a zero UUID and the write is
+// rejected outright rather than landing on the wrong row.
 func (w *WMail) NewHistoryID(historyID uint64) error {
 	return w.onEvent(models.JobEventTypeHistoryIDUpdate, &models.JobEventHistoryIDUpdate{
+		UserID:    w.UserID,
+		EmailID:   w.ID,
 		HistoryID: historyID,
 	})
 }

--- a/internal/app/worker/wmail/sync_google_test.go
+++ b/internal/app/worker/wmail/sync_google_test.go
@@ -1,0 +1,49 @@
+package wmail
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// The checkpoint row is keyed (user_id, email_id) with a foreign key to users,
+// so an event carrying zero UUIDs is rejected by Postgres and the mailbox never
+// gets a checkpoint at all.
+func TestNewHistoryIDCarriesRowKey(t *testing.T) {
+	userID := uuid.New()
+	emailID := uuid.New()
+
+	var got *models.JobEventHistoryIDUpdate
+	w := &WMail{
+		UserID: userID,
+		ID:     emailID,
+		onEvent: func(jobType models.JobEventType, body any) error {
+			if jobType != models.JobEventTypeHistoryIDUpdate {
+				t.Errorf("published %v, want %v", jobType, models.JobEventTypeHistoryIDUpdate)
+			}
+			got = body.(*models.JobEventHistoryIDUpdate)
+			return nil
+		},
+	}
+
+	if err := w.NewHistoryID(65207); err != nil {
+		t.Fatalf("NewHistoryID: %v", err)
+	}
+
+	if got == nil {
+		t.Fatal("no event was published")
+	}
+	if got.UserID != userID {
+		t.Errorf("UserID = %v, want %v", got.UserID, userID)
+	}
+	if got.EmailID != emailID {
+		t.Errorf("EmailID = %v, want %v", got.EmailID, emailID)
+	}
+	if got.HistoryID != 65207 {
+		t.Errorf("HistoryID = %d, want 65207", got.HistoryID)
+	}
+	if got.UserID == uuid.Nil || got.EmailID == uuid.Nil {
+		t.Error("event carries a nil UUID, which violates the users foreign key")
+	}
+}

--- a/internal/client/goog/history.go
+++ b/internal/client/goog/history.go
@@ -6,7 +6,24 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+// FetchHistory walks Gmail's history from lastHistoryID and returns the new
+// checkpoint. A zero lastHistoryID means the mailbox has no baseline yet, which
+// history.list cannot serve: startHistoryId=0 is rejected with "Requested
+// entity was not found". Read the mailbox's current historyId instead and
+// return it as the baseline.
+//
+// The baseline is forward-looking only. Mail that arrived before the mailbox
+// was connected is not walked, because Gmail's history API is strictly
+// incremental from whatever id it is given.
 func (c *Client) FetchHistory(ctx context.Context, lastHistoryID uint64) (uint64, error) {
+	if lastHistoryID == 0 {
+		profile, err := c.srv.Users.GetProfile("me").Context(ctx).Do()
+		if err != nil {
+			return 0, HandleError(err)
+		}
+		return profile.HistoryId, nil
+	}
+
 	call := c.srv.Users.History.List("me").MaxResults(500).StartHistoryId(lastHistoryID) // It does not include the record that has that exact HistoryID
 
 	var newLastHistoryID uint64


### PR DESCRIPTION
Fixes #109.

## 1. The checkpoint could never be written

```go
func (w *WMail) NewHistoryID(historyID uint64) error {
	return w.onEvent(models.JobEventTypeHistoryIDUpdate, &models.JobEventHistoryIDUpdate{
		HistoryID: historyID,
	})
}
```

`models.JobEventHistoryIDUpdate` carries `UserID` and `EmailID` too, and the consumer uses both: `EmailHistoryIDRepository.Put(ctx, e.UserID, e.EmailID, e.HistoryID)`. The table is keyed `(user_id, email_id)` with `email_history_ids_user_id_fkey` referencing `users(id)`, so a zero UUID is rejected:

```
ERROR: insert or update on table "email_history_ids" violates foreign key constraint "email_history_ids_user_id_fkey" (SQLSTATE 23503)
```

No Gmail mailbox ever got a checkpoint row, so no reply, no label change and no inbound message ever reached Unibox.

`ImapGoogleSync` in the same package publishes the identical event and sets both fields correctly. It has no callers anywhere, which is presumably how the two drifted apart.

## 2. A fresh mailbox could never get a baseline

`FetchHistory` passed its argument straight to `StartHistoryId`, and on a mailbox with no checkpoint that argument is `0`. Gmail rejects `startHistoryId=0` with `Requested entity was not found`, so even with fix 1 there was nothing to walk *from*.

It now reads the mailbox's current `historyId` via `Users.GetProfile` and returns that as the baseline.

This baseline is forward-looking only, and the doc comment says so. Mail that arrived before the mailbox was connected is not backfilled, because Gmail's history API is strictly incremental from whatever id you hand it.

## 3. The in-memory cursor never advanced

This one is not in the issue but the first two fixes do not work without it.

`w.GoogleData.LastHistoryID` was written **only** at construction (`wmail.go:129`). `SyncGoogle` read it, fetched, published the new value, and never assigned it back. `StartSyncWorker` then ticks once a minute against the same field.

With fixes 1 and 2 alone, every tick would call `FetchHistory(0)`, re-bootstrap to Gmail's *current* historyId, and skip everything that arrived since the previous tick. The checkpoint row in Postgres would advance on every tick, looking healthy, while no message was ever processed.

`SyncGoogle` now assigns the new value before publishing. `StartSyncWorker` calls `syncOnce` serially in one goroutine, so this needs no locking, and the comment records that.

## 4. A swallowed error

The old control flow was:

```go
if newHistoryID != 0 {
    if err := w.NewHistoryID(newHistoryID); err != nil { ... }
    return nil     // <- returns before the err check below
}
if err != nil { ... }
```

A tick that processed part of a history page and *then* failed returned `nil`, discarding the `MailError` that would have marked the mailbox as needing auth attention. Both outcomes are now handled.

## Tests

`sync_google_test.go` asserts the published event carries the real user and email ids and a non-nil UUID, using the existing `onEvent` seam so no bus is needed.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/app/worker/... ./internal/client/goog/...` clean
- `go test ./internal/app/worker/... ./internal/client/goog/` passes

## Left alone

`ImapGoogleSync` is dead code (no callers in the repository) that duplicates this logic correctly. Removing it is not part of this fix, but it is a standing invitation for the two paths to drift again and is worth a follow-up.

#110 is the other half: this makes the checkpoint correct while the worker lives, and #110 is why a restart throws it away.
