### PR TITLE
fix: seed a reloaded Gmail mailbox from the saved history checkpoint, not the dead last_id column

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1085,6 +1085,9 @@ func main() {
 		emailService.WireThrottle(dailyThrottleService)
 		// Seed Graph delta cursors when the reconciler reloads mailboxes.
 		emailService.WireGraphDelta(repository.NewEmailGraphDeltaRepository(primaryDB))
+		// The Gmail equivalent: without it a reloaded mailbox re-bootstraps its
+		// history cursor and skips everything that arrived since the last sync.
+		emailService.WireEmailHistoryID(repository.NewEmailHistoryIDRepository(primaryDB))
 		analyticsRepository := repository.NewAnalyticsRepository(primaryDB)
 		emailAccountErrorRepository := repository.NewEmailAccountErrorRepository(primaryDB)
 		analyticsService = analytics.NewService(analyticsRepository, emailRepostory, campaignRepostory, emailAccountErrorRepository, warmupRepository)

--- a/internal/app/email/last_history_test.go
+++ b/internal/app/email/last_history_test.go
@@ -1,0 +1,67 @@
+package email
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+type stubHistoryRepo struct {
+	data *repository.EmailHistoryIDData
+	err  error
+}
+
+func (s *stubHistoryRepo) Put(ctx context.Context, userID, emailID uuid.UUID, historyID uint64) error {
+	return nil
+}
+
+func (s *stubHistoryRepo) Get(ctx context.Context, userID, emailID uuid.UUID) (*repository.EmailHistoryIDData, error) {
+	return s.data, s.err
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func TestLastHistoryForPrefersSavedCheckpoint(t *testing.T) {
+	s := &emailService{historyID: &stubHistoryRepo{data: &repository.EmailHistoryIDData{HistoryID: 65207}}}
+
+	// The legacy column is deliberately set to a different value: the
+	// checkpoint the consumer maintains is the one that must win.
+	got := s.lastHistoryFor(context.Background(), uuid.New(), uuid.New(), int64Ptr(1))
+	if got != 65207 {
+		t.Fatalf("got %d, want the saved checkpoint 65207", got)
+	}
+}
+
+// A zero cursor is what silently re-bootstraps the mailbox and skips mail, so
+// the fallbacks matter as much as the happy path.
+func TestLastHistoryForFallsBackToLegacyColumn(t *testing.T) {
+	tests := []struct {
+		name string
+		repo repository.EmailHistoryIDRepository
+	}{
+		{"no row yet", &stubHistoryRepo{}},
+		{"lookup failed", &stubHistoryRepo{err: errors.New("boom")}},
+		{"row with zero id", &stubHistoryRepo{data: &repository.EmailHistoryIDData{HistoryID: 0}}},
+		{"repository not wired", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &emailService{historyID: tt.repo}
+			if got := s.lastHistoryFor(context.Background(), uuid.New(), uuid.New(), int64Ptr(42)); got != 42 {
+				t.Errorf("got %d, want the legacy value 42", got)
+			}
+		})
+	}
+}
+
+func TestLastHistoryForZeroWhenNothingKnown(t *testing.T) {
+	s := &emailService{historyID: &stubHistoryRepo{}}
+
+	if got := s.lastHistoryFor(context.Background(), uuid.New(), uuid.New(), nil); got != 0 {
+		t.Fatalf("got %d, want 0 so the worker bootstraps a fresh baseline", got)
+	}
+}

--- a/internal/app/email/loader.go
+++ b/internal/app/email/loader.go
@@ -19,6 +19,13 @@ func (s *emailService) WireGraphDelta(repo repository.EmailGraphDeltaRepository)
 	s.graphDelta = repo
 }
 
+// WireEmailHistoryID attaches the Gmail history-cursor repository, the Google
+// counterpart of WireGraphDelta. Optional; when unset, a reloaded Gmail mailbox
+// falls back to the legacy email_accounts.last_id column.
+func (s *emailService) WireEmailHistoryID(repo repository.EmailHistoryIDRepository) {
+	s.historyID = repo
+}
+
 // reconcileRepublishInterval bounds how often the reconciler re-publishes a
 // given account. The immediate onboarding load and any reassignment still fire
 // right away (they call LoadAccountOntoWorker directly); this only throttles the
@@ -155,13 +162,9 @@ func (s *emailService) buildAddWorkerEmail(ctx context.Context, acc *models.Emai
 		if cerr != nil {
 			return nil, cerr
 		}
-		var lastHistory uint64
-		if acc.LastID != nil && *acc.LastID > 0 {
-			lastHistory = uint64(*acc.LastID)
-		}
 		out.Google = &models.AddWorkerEmailGoogleData{
 			Token:         oauthToken(creds),
-			LastHistoryID: lastHistory,
+			LastHistoryID: s.lastHistoryFor(ctx, userID, acc.ID, acc.LastID),
 		}
 	case models.InboxProviderOutlook:
 		creds, cerr := s.emailRepository.GetOAuthCredentials(ctx, acc.ID)
@@ -189,6 +192,29 @@ func (s *emailService) buildAddWorkerEmail(ctx context.Context, acc *models.Emai
 	}
 
 	return out, nil
+}
+
+// lastHistoryFor is the Gmail checkpoint a (re)loaded mailbox resumes from.
+//
+// The consumer writes every checkpoint to email_history_ids. This used to read
+// email_accounts.last_id instead, which nothing writes, so the column is always
+// NULL and every worker restart handed the mailbox a zero cursor. That silently
+// re-bootstraps to Gmail's current historyId and skips everything that arrived
+// since the last sync, unrecoverably: the history API only walks forward from
+// the id it is given.
+//
+// legacyLastID stays as a fallback for rows carrying a value from before the
+// checkpoint table existed.
+func (s *emailService) lastHistoryFor(ctx context.Context, userID, emailID uuid.UUID, legacyLastID *int64) uint64 {
+	if s.historyID != nil {
+		if saved, err := s.historyID.Get(ctx, userID, emailID); err == nil && saved != nil && saved.HistoryID > 0 {
+			return saved.HistoryID
+		}
+	}
+	if legacyLastID != nil && *legacyLastID > 0 {
+		return uint64(*legacyLastID)
+	}
+	return 0
 }
 
 func (s *emailService) deltaLinksFor(ctx context.Context, userID, emailID uuid.UUID) map[string]string {

--- a/internal/app/email/service.go
+++ b/internal/app/email/service.go
@@ -45,6 +45,10 @@ type EmailService interface {
 	// WireGraphDelta attaches the Graph delta-cursor repository so the worker
 	// reconciler can seed a mailbox's saved cursors when loading it.
 	WireGraphDelta(repo repository.EmailGraphDeltaRepository)
+	// WireEmailHistoryID attaches the Gmail history-cursor repository, the
+	// Google counterpart of WireGraphDelta, so a reloaded mailbox resumes from
+	// its saved checkpoint instead of re-bootstrapping.
+	WireEmailHistoryID(repo repository.EmailHistoryIDRepository)
 	// StartWorkerReconciler periodically ensures every active mailbox is
 	// assigned to a worker and loaded onto it (blocks until ctx is cancelled).
 	StartWorkerReconciler(ctx context.Context, interval time.Duration)
@@ -62,6 +66,7 @@ type emailService struct {
 	workerAssignment   worker.WorkerAssignmentService
 	throttle           dailythrottle.Service
 	graphDelta         repository.EmailGraphDeltaRepository
+	historyID          repository.EmailHistoryIDRepository
 	// webhookService is optional. When non-nil, account lifecycle events
 	// (email_account.connected, email_account.removed) are dispatched to
 	// subscribed customer webhooks.


### PR DESCRIPTION
Fixes #110.

## The bug

Two different stores, and they were never connected.

The consumer writes every Gmail checkpoint to **`email_history_ids`**. The loader seeded a reloaded mailbox from **`email_accounts.last_id`**:

```go
var lastHistory uint64
if acc.LastID != nil && *acc.LastID > 0 {
    lastHistory = uint64(*acc.LastID)
}
```

Nothing in the repository ever writes `last_id`. Confirmed by grep: every reference is a `SELECT`, there is no `INSERT` or `UPDATE` that touches it. The column is NULL forever.

So every worker restart, which is a routine event (deploy, crash, `docker compose up -d worker`, scaling), reloaded the mailbox with `LastHistoryID = 0`, which bootstraps straight to Gmail's *current* historyId. Anything that arrived between the last sync tick and the restart is skipped, and it is not recoverable: Gmail's history API only ever walks forward from the id you give it.

It fails invisibly. Sync looks correct in any test done in one sitting, because the worker never restarts mid-test. The damage lands on the *next* restart, hours or days later, with no error anywhere.

## The fix

Outlook already solved this. `WireGraphDelta` threads the Graph delta-cursor repository into `emailService` so `deltaLinksFor` can seed a reloaded Graph mailbox. Gmail simply never got the equivalent, so this mirrors it exactly:

- `historyID repository.EmailHistoryIDRepository` on `emailService`
- `WireEmailHistoryID` on the interface and implementation, documented as the Google counterpart
- `lastHistoryFor` alongside `deltaLinksFor`
- wired in `cmd/backend/main.go` on the line after `WireGraphDelta`

### Precedence

`lastHistoryFor` prefers the live checkpoint, then falls back to `last_id`, then zero:

| State | Result |
|---|---|
| checkpoint row exists | its `history_id` |
| no row / lookup failed / row is zero | `last_id` if positive |
| repository not wired | `last_id` if positive |
| nothing known | `0`, so the worker bootstraps a fresh baseline |

The `last_id` fallback is kept rather than deleted. The column is dead in current code but may carry a value on an older install, and preferring the checkpoint means it can only ever help.

A lookup failure falls back rather than propagating. A transient database error should not stop the mailbox loading, and the fallback path is the pre-existing behaviour.

## Tests

`last_history_test.go` covers the checkpoint winning over a conflicting legacy value, all four fallback routes (no row, error, zero row, unwired), and the genuinely-empty case returning zero.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/app/email/... ./cmd/backend/...` clean
- `go test ./internal/app/email/` passes

Depends on #109: without it no checkpoint is ever written, so there is nothing for this to read. The two together are what make Gmail sync survive a restart.
