### PR TITLE
fix: thread Unibox replies for both the sender and the recipient

### DIFF
--- a/docs/content/docs/guides/unibox.mdx
+++ b/docs/content/docs/guides/unibox.mdx
@@ -26,6 +26,8 @@ Search (press `/`) searches within your current scope. The filters icon narrows 
 
 Each row is a conversation, not a message, with a badge showing how many messages are inside. Opening it shows every message in order with participants and the owning mailbox. Replies and new inbound mail land in the same thread. Rows group under `Today`, `Yesterday`, `This week`, and `Earlier` headers.
 
+Threading applies on both sides. A reply you send carries the provider's thread id, which nests it in your own mailbox, and an `In-Reply-To` header naming the last message in the conversation, which is what nests it for the recipient. Their mail client only ever sees the header: a thread id means nothing outside the mailbox that issued it.
+
 <Callout type="info" title="Keyboard navigation">
 `j` / `k` move between rows, `Enter` opens, `Esc` closes, `/` focuses search, `c` labels. A cheat sheet sits at the bottom of the list.
 </Callout>

--- a/internal/api/handler/unibox.go
+++ b/internal/api/handler/unibox.go
@@ -444,6 +444,17 @@ func (h *Handler) UniboxReply(c *gin.Context) {
 		return
 	}
 
+	// The composer only knows the provider thread id, but a thread id is
+	// meaningless outside the sending mailbox: the recipient's client threads
+	// on In-Reply-To/References. Resolve the parent Message-ID here so a reply
+	// nests for them too, without needing a client change.
+	inReplyTo := req.InReplyTo
+	if len(inReplyTo) == 0 && req.ThreadID != "" {
+		if parentMessageID, xerr := h.UniboxService.LatestMessageIDInThread(c.Request.Context(), *orgID, req.ThreadID); xerr == nil && parentMessageID != "" {
+			inReplyTo = []string{parentMessageID}
+		}
+	}
+
 	sendReq := &emailsend.SendEmailRequest{
 		To:          req.To,
 		CC:          req.CC,
@@ -451,7 +462,7 @@ func (h *Handler) UniboxReply(c *gin.Context) {
 		Subject:     req.Subject,
 		BodyHTML:    req.BodyHTML,
 		BodyPlain:   req.BodyPlain,
-		InReplyTo:   req.InReplyTo,
+		InReplyTo:   inReplyTo,
 		ThreadID:    req.ThreadID,
 		SendMode:    req.SendMode,
 		ScheduledAt: req.ScheduledAt,

--- a/internal/app/unibox/service.go
+++ b/internal/app/unibox/service.go
@@ -34,6 +34,10 @@ type UniboxService interface {
 		orgID, emailID uuid.UUID,
 		threadID, limit, cursor string,
 	) (*models.MailSearchResult, *errx.Error)
+	// LatestMessageIDInThread is the RFC Message-ID a reply into this thread
+	// should name in its In-Reply-To header. Returns "" when the thread is
+	// unknown or holds no message id, which callers treat as "no backfill".
+	LatestMessageIDInThread(ctx context.Context, orgID uuid.UUID, threadID string) (string, *errx.Error)
 	GetUnseenCount(
 		ctx context.Context,
 		orgID uuid.UUID,

--- a/internal/app/unibox/thread.go
+++ b/internal/app/unibox/thread.go
@@ -38,3 +38,18 @@ func (s *uniboxService) GetByThread(
 
 	return resp, nil
 }
+
+// LatestMessageIDInThread resolves the parent Message-ID for a reply that only
+// knows its provider thread id.
+func (s *uniboxService) LatestMessageIDInThread(
+	ctx context.Context,
+	orgID uuid.UUID,
+	threadID string,
+) (string, *errx.Error) {
+	messageID, err := s.uniboxRepository.LatestMessageIDInThread(ctx, orgID, threadID)
+	if err != nil {
+		sentry.CaptureException(err)
+		return "", errx.InternalError()
+	}
+	return messageID, nil
+}

--- a/internal/app/worker/wmail/parent_reference_test.go
+++ b/internal/app/worker/wmail/parent_reference_test.go
@@ -1,0 +1,88 @@
+package wmail
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestParentReference(t *testing.T) {
+	tests := []struct {
+		name          string
+		req           *SendRequest
+		wantNil       bool
+		wantMessageID string
+		wantThreadID  string
+	}{
+		{
+			// The dashboard reply case. The composer knows the thread and
+			// nothing else, and requiring InReplyTo threw the thread away.
+			name:         "thread id only",
+			req:          &SendRequest{Parent: &models.EmailParent{ThreadID: "t-1"}},
+			wantThreadID: "t-1",
+		},
+		{
+			// The warmup reply case: an RFC Message-ID from the token flow and
+			// no provider thread record.
+			name:          "in-reply-to only",
+			req:           &SendRequest{InReplyTo: "<parent@example.com>"},
+			wantMessageID: "parent@example.com",
+		},
+		{
+			name: "both, parent wins for message id",
+			req: &SendRequest{
+				InReplyTo: "<header@example.com>",
+				Parent:    &models.EmailParent{MessageID: "parent@example.com", ThreadID: "t-1"},
+			},
+			wantMessageID: "parent@example.com",
+			wantThreadID:  "t-1",
+		},
+		{
+			// A parent carrying only a thread still picks the header up, so
+			// both the sender's and the recipient's clients can thread it.
+			name: "parent thread plus header message id",
+			req: &SendRequest{
+				InReplyTo: "<header@example.com>",
+				Parent:    &models.EmailParent{ThreadID: "t-1"},
+			},
+			wantMessageID: "header@example.com",
+			wantThreadID:  "t-1",
+		},
+		{
+			name:    "nothing to thread onto",
+			req:     &SendRequest{},
+			wantNil: true,
+		},
+		{
+			name:    "empty parent is not a parent",
+			req:     &SendRequest{Parent: &models.EmailParent{}},
+			wantNil: true,
+		},
+		{
+			name:    "nil request",
+			req:     nil,
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parentReference(tt.req)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("got %+v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want a parent reference")
+			}
+			if got.MessageID != tt.wantMessageID {
+				t.Errorf("MessageID = %q, want %q", got.MessageID, tt.wantMessageID)
+			}
+			if got.ThreadID != tt.wantThreadID {
+				t.Errorf("ThreadID = %q, want %q", got.ThreadID, tt.wantThreadID)
+			}
+		})
+	}
+}

--- a/internal/app/worker/wmail/send.go
+++ b/internal/app/worker/wmail/send.go
@@ -15,6 +15,33 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// parentReference resolves what a reply should be threaded onto, from whichever
+// of the two independent handles the request carries.
+//
+// They are genuinely independent. ThreadID is the provider's own conversation
+// id and is what makes the message appear in the thread in the SENDER's
+// mailbox; it is meaningless to anyone else. MessageID becomes the RFC
+// In-Reply-To/References headers, which is the only thing the RECIPIENT's mail
+// client can thread on. A dashboard reply starts with only a ThreadID and a
+// warmup reply with only a Message-ID, so requiring both threads neither.
+func parentReference(req *SendRequest) *models.EmailMessageData {
+	if req == nil {
+		return nil
+	}
+	var messageID, threadID string
+	if req.Parent != nil {
+		messageID = req.Parent.MessageID
+		threadID = req.Parent.ThreadID
+	}
+	if messageID == "" && req.InReplyTo != "" {
+		messageID = strings.Trim(req.InReplyTo, "<>")
+	}
+	if messageID == "" && threadID == "" {
+		return nil
+	}
+	return &models.EmailMessageData{MessageID: messageID, ThreadID: threadID}
+}
+
 // Attachment is a fully-resolved attachment ready to be MIME-encoded: the
 // worker has already fetched Data from object storage.
 type Attachment struct {
@@ -144,19 +171,12 @@ func (w *WMail) sendViaGmail(ctx context.Context, req *SendRequest, bodyHTML str
 		return result
 	}
 
-	// Build parent reference for replies. Warmup replies often only have the
-	// RFC Message-ID from the token flow, not a local provider thread record.
-	var parent *models.EmailMessageData
-	if req.InReplyTo != "" && req.Parent != nil {
-		parent = &models.EmailMessageData{
-			MessageID: req.Parent.MessageID,
-			ThreadID:  req.Parent.ThreadID,
-		}
-	} else if req.InReplyTo != "" {
-		parent = &models.EmailMessageData{
-			MessageID: strings.Trim(req.InReplyTo, "<>"),
-		}
-	}
+	// Build parent reference for replies. Gating this on InReplyTo dropped a
+	// perfectly good ThreadID whenever the header was absent, which is every
+	// dashboard reply, so the provider started a new conversation instead.
+	// Warmup replies are the mirror case: an RFC Message-ID from the token flow
+	// and no local thread record.
+	parent := parentReference(req)
 
 	// Build custom headers (warmup token + RFC 8058 one-click unsubscribe).
 	customHeaders := buildSendHeaders(req)
@@ -220,19 +240,12 @@ func (w *WMail) sendViaGraph(ctx context.Context, req *SendRequest, bodyHTML str
 		return result
 	}
 
-	// Build parent reference for replies. Warmup replies often only have the RFC
-	// Message-ID from the token flow, not a local provider thread record.
-	var parent *models.EmailMessageData
-	if req.InReplyTo != "" && req.Parent != nil {
-		parent = &models.EmailMessageData{
-			MessageID: req.Parent.MessageID,
-			ThreadID:  req.Parent.ThreadID,
-		}
-	} else if req.InReplyTo != "" {
-		parent = &models.EmailMessageData{
-			MessageID: strings.Trim(req.InReplyTo, "<>"),
-		}
-	}
+	// Build parent reference for replies. Gating this on InReplyTo dropped a
+	// perfectly good ThreadID whenever the header was absent, which is every
+	// dashboard reply, so the provider started a new conversation instead.
+	// Warmup replies are the mirror case: an RFC Message-ID from the token flow
+	// and no local thread record.
+	parent := parentReference(req)
 
 	// Warmup token + RFC 8058 one-click unsubscribe headers; RAW MIME carries
 	// them verbatim (the JSON message shape cannot).

--- a/internal/events/publisher.go
+++ b/internal/events/publisher.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -52,6 +53,7 @@ type SendEmailParams struct {
 	CC             []string
 	BCC            []string
 	InReplyTo      string
+	ThreadID       string
 	Subject        string
 	MessageID      string
 	BodyPlain      string
@@ -109,6 +111,18 @@ func (p *publisher) PublishSendEmail(ctx context.Context, workerID uuid.UUID, pa
 		subject = encSubject
 	}
 
+	// Parent is what makes a reply land inside its conversation. ThreadID is
+	// the provider-side handle (Gmail appends to a thread only when it is set);
+	// MessageID is the RFC Message-ID the recipient's own client threads on.
+	// Both fields already exist on the event, so this adds no schema change.
+	var parent *models.EmailParent
+	if params.ThreadID != "" || params.InReplyTo != "" {
+		parent = &models.EmailParent{
+			ThreadID:  params.ThreadID,
+			MessageID: strings.Trim(params.InReplyTo, "<>"),
+		}
+	}
+
 	// Create SendEmail message for worker
 	sendEmail := &models.SendEmail{
 		TaskID:         params.TaskID,
@@ -121,6 +135,7 @@ func (p *publisher) PublishSendEmail(ctx context.Context, workerID uuid.UUID, pa
 		BodyS3Key:      s3Key,
 		MessageID:      params.MessageID,
 		InReplyTo:      params.InReplyTo,
+		Parent:         parent,
 		IsWarmup:       params.IsWarmup,
 		TrackingInfo:   params.TrackingInfo,
 		WarmupToken:    params.WarmupToken,

--- a/internal/repository/pg_unibox.go
+++ b/internal/repository/pg_unibox.go
@@ -64,6 +64,10 @@ type UniboxRepository interface {
 	// step that knows the contact but not the thread can still label it.
 	AddThreadLabels(ctx context.Context, userID uuid.UUID, threadID string, categoryIDs []uuid.UUID) error
 	LatestThreadIDForContact(ctx context.Context, userID uuid.UUID, email string) (string, error)
+	// LatestMessageIDInThread returns the newest RFC Message-ID in a thread, so
+	// a reply that arrives with only a provider thread id can still carry the
+	// In-Reply-To header the recipient's mail client threads on.
+	LatestMessageIDInThread(ctx context.Context, orgID uuid.UUID, threadID string) (string, error)
 }
 
 type uniboxRepository struct {
@@ -820,6 +824,37 @@ func (r *uniboxRepository) LatestThreadIDForContact(ctx context.Context, userID 
 			return "", err
 		}
 		return threadID, nil
+	}
+	return "", rows.Err()
+}
+
+// LatestMessageIDInThread returns the newest non-empty RFC Message-ID in the
+// thread. Scoped through email_accounts so one organization cannot read another
+// organization's conversation, matching every other org-scoped unibox read.
+func (r *uniboxRepository) LatestMessageIDInThread(ctx context.Context, orgID uuid.UUID, threadID string) (string, error) {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return "", nil
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT message_id
+		FROM unibox_emails
+		WHERE thread_id = $2
+		  AND message_id <> ''
+		  AND email_id IN (SELECT id FROM email_accounts WHERE organization_id = $1)
+		ORDER BY internal_date DESC
+		LIMIT 1
+	`, orgID, threadID)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		var messageID string
+		if err := rows.Scan(&messageID); err != nil {
+			return "", err
+		}
+		return messageID, nil
 	}
 	return "", rows.Err()
 }

--- a/internal/tasks/email_sender.go
+++ b/internal/tasks/email_sender.go
@@ -13,15 +13,19 @@ import (
 
 // EmailMessage represents an email to be sent
 type EmailMessage struct {
-	From           string
-	To             []string
-	CC             []string
-	BCC            []string
-	Subject        string
-	BodyHTML       string
-	BodyPlain      string
-	InReplyTo      string
-	MessageID      string
+	From      string
+	To        []string
+	CC        []string
+	BCC       []string
+	Subject   string
+	BodyHTML  string
+	BodyPlain string
+	InReplyTo string
+	MessageID string
+	// ThreadID is the provider-side conversation handle. Gmail only appends to
+	// an existing thread when it is set on the outbound message; a matching
+	// Subject and In-Reply-To are not enough.
+	ThreadID       string
 	IsWarmup       bool
 	Tracking       *models.TrackingInfo
 	WarmupToken    string
@@ -79,6 +83,7 @@ func (s *emailSender) Send(ctx context.Context, taskID uuid.UUID, msg EmailMessa
 		CC:             msg.CC,
 		BCC:            msg.BCC,
 		InReplyTo:      msg.InReplyTo,
+		ThreadID:       msg.ThreadID,
 		Subject:        msg.Subject,
 		MessageID:      msg.MessageID,
 		BodyPlain:      msg.BodyPlain,

--- a/internal/tasks/user_email_task.go
+++ b/internal/tasks/user_email_task.go
@@ -149,6 +149,13 @@ func (s *tasksService) HandleUserEmailTask(task *proto.ProcessTask) *errx.Error 
 		inReplyTo = emailTask.InReplyTo[0]
 	}
 
+	// The composer's thread is persisted on the task row; without carrying it
+	// through, every dashboard reply starts a new conversation.
+	var threadID string
+	if emailTask.ThreadID != nil {
+		threadID = *emailTask.ThreadID
+	}
+
 	// STEP 9: Build EmailMessage and send via worker
 	emailMsg := EmailMessage{
 		From:      account.Email,
@@ -160,6 +167,7 @@ func (s *tasksService) HandleUserEmailTask(task *proto.ProcessTask) *errx.Error 
 		BodyPlain: bodyPlain,
 		InReplyTo: inReplyTo,
 		MessageID: messageID,
+		ThreadID:  threadID,
 		IsWarmup:  false,
 		Tracking:  nil,
 	}


### PR DESCRIPTION
Fixes #111.

Two independent breaks, stacked. A dashboard reply sent fine, the task completed, nothing errored, and it arrived in the recipient's inbox as a brand-new top-level email.

## 11a: the thread id never left the backend

`UniboxReply` persisted `thread_id` to `email_tasks` correctly. The task processor then dropped it, because `EmailMessage` **had no `ThreadID` field**: the column was read out of the database and thrown away.

Even after adding it, a second gate blocked it. The worker only consulted `req.Parent` when `req.InReplyTo` was *also* set:

```go
if req.InReplyTo != "" && req.Parent != nil { ... }
else if req.InReplyTo != "" { ... }
```

A dashboard reply never sets that header (see 11b), so neither branch fired and `parent` stayed `nil` with a perfectly valid `ThreadID` sitting in `req.Parent`.

## 11b: no RFC header, so the recipient could not thread it either

Fixing 11a alone only threads the message inside the **sender's own** mailbox. A `threadId` is a provider-side handle and means nothing outside the account that issued it. The recipient is a different mailbox entirely, and their client threads purely on `In-Reply-To`/`References` matching a Message-ID it has already seen.

The composer sends only `thread_id`, because the frontend `UniboxEmail` model does not expose the parent's RFC Message-ID to build one from.

## The fix

**Thread the id through.** `ThreadID` added to `EmailMessage` and `SendEmailParams`, read from `emailTask.ThreadID`, and used to populate `models.SendEmail.Parent`.

No schema change was needed: `Parent *EmailParent` already existed on `models.SendEmail` with an avro tag, and `internal/app/worker/event_send_email.go:79` already forwarded it. Nothing had ever set it.

**Ungate the parent.** Both send paths now call one `parentReference` helper. The two handles are resolved independently, which is the actual insight the old code missed:

| Handle | Threads it for | Present on |
|---|---|---|
| `ThreadID` | the sender's own mailbox | dashboard replies |
| `MessageID` → `In-Reply-To`/`References` | the recipient's client | warmup replies |

Requiring both threaded neither. Warmup replies keep working through the `InReplyTo` fallback, which is now explicit rather than incidental.

**Backfill the header server-side.** `UniboxReply` resolves the newest Message-ID in the thread when the request carries a `thread_id` but no `in_reply_to`, via a new `LatestMessageIDInThread` query scoped through `email_accounts` by `organization_id`, matching every other org-scoped unibox read. Doing it on the server means no client change is required and every existing caller of the endpoint benefits.

## Tests

`parent_reference_test.go` covers thread-id-only (the dashboard case), in-reply-to-only (the warmup case), both, a parent carrying only a thread picking the header up, and the three empty cases.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/...` clean
- `go test ./internal/...` passes
- `pnpm types:check` in `docs/` passes

## Docs

The Unibox guide's Threading section claimed replies land in the same thread, which was not true outbound. It now states what actually happens and why the header is the part that matters to the recipient.

## Follow-up worth doing

`ReplyComposer.tsx` could pass the parent's Message-ID directly once `UniboxEmail` exposes `message_id`. The server-side backfill covers the normal case, but a client-supplied value would be more precise for forwarded or merged threads where "newest message in the thread" is not necessarily the one being replied to.

Note also that a message which was already sent unthreaded cannot be retroactively repaired: it never carried the header. This fixes conversations from the next reply onward.
