### PR TITLE
fix: make the tracking dedupe insert match the table's actual primary key

### DIFF
--- a/internal/repository/pg_tracking_dedupe.go
+++ b/internal/repository/pg_tracking_dedupe.go
@@ -23,7 +23,11 @@ func NewTrackingDedupeRepository(db *pgxpool.Pool) TrackingDedupeRepository {
 	return &trackingDedupeRepository{db: db}
 }
 
-// IsProcessed checks if a tracking event has already been processed
+// IsProcessed checks if a tracking event has already been processed.
+//
+// url_hash is NOT NULL and defaults to the empty string, which is exactly what
+// an open event carries, so this compares the column directly. Wrapping it in
+// COALESCE only hid that and made the primary key unusable for the lookup.
 func (r *trackingDedupeRepository) IsProcessed(ctx context.Context, taskID uuid.UUID, eventType, urlHash string) (bool, error) {
 	query := `
 		SELECT EXISTS(
@@ -31,7 +35,7 @@ func (r *trackingDedupeRepository) IsProcessed(ctx context.Context, taskID uuid.
 			FROM tracking_events_processed
 			WHERE task_id = $1
 			  AND event_type = $2
-			  AND COALESCE(url_hash, '') = COALESCE($3, '')
+			  AND url_hash = $3
 		)
 	`
 
@@ -40,12 +44,19 @@ func (r *trackingDedupeRepository) IsProcessed(ctx context.Context, taskID uuid.
 	return exists, err
 }
 
-// MarkProcessed marks a tracking event as processed
+// MarkProcessed marks a tracking event as processed.
+//
+// The conflict target must name the primary key's plain columns
+// (task_id, event_type, url_hash). Targeting an expression instead requires a
+// matching expression index, and there is none, so Postgres rejected every
+// insert with SQLSTATE 42P10 whether or not the row was a duplicate. NULLIF was
+// the second half of the same mistake: it turned an open event's empty url_hash
+// into NULL, which the NOT NULL column would have refused anyway.
 func (r *trackingDedupeRepository) MarkProcessed(ctx context.Context, taskID uuid.UUID, eventType, urlHash string) error {
 	query := `
 		INSERT INTO tracking_events_processed (task_id, event_type, url_hash, processed_at)
-		VALUES ($1, $2, NULLIF($3, ''), NOW())
-		ON CONFLICT (task_id, event_type, COALESCE(url_hash, ''))
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (task_id, event_type, url_hash)
 		DO NOTHING
 	`
 


### PR DESCRIPTION
Fixes #113.

## The bug

```sql
INSERT INTO tracking_events_processed (task_id, event_type, url_hash, processed_at)
VALUES ($1, $2, NULLIF($3, ''), NOW())
ON CONFLICT (task_id, event_type, COALESCE(url_hash, ''))
DO NOTHING
```

Two independent faults in one statement:

1. **The conflict target is an expression.** The primary key is on the three plain columns `(task_id, event_type, url_hash)`. `ON CONFLICT` on an expression requires a matching expression index, and there is none, so Postgres rejected **every** insert with `42P10` regardless of whether the row was a duplicate.
2. **`NULLIF` writes NULL into a NOT NULL column.** `url_hash` is `character varying(16) NOT NULL DEFAULT ''`, and an open event legitimately carries the empty string. Even with the conflict target fixed, this would have been refused.

The failure is caught with `log.Warn`, and the `opened_at`/`clicked_at` write happens earlier in `HandleTrackingEvent`, so opens and clicks recorded correctly and only a warning in the consumer's logs pointed at it.

The consequence is the missing second line of defence. `IsProcessed` had nothing to check against, because nothing was ever inserted. JetStream is at-least-once and the consumer runs `MaxDeliver: 10`, so a redelivery is not hypothetical, and the Rust service's in-memory cache resets on every `tracking` restart.

## Verified against the real schema

Reproduced and fixed against the running dev Postgres rather than by reading:

```
$ \d tracking_events_processed
 url_hash | character varying(16) | not null | ''::character varying
Indexes:
    "tracking_events_processed_pkey" PRIMARY KEY, btree (task_id, event_type, url_hash)

### old query
ERROR:  there is no unique or exclusion constraint matching the ON CONFLICT specification

### new query
INSERT 0 1     -- open, empty url_hash
INSERT 0 0     -- same open replayed, correctly swallowed
INSERT 0 1     -- click with a url hash
 open_is_processed
-------------------
 t
```

No migration is needed: the schema was always right, the query did not match it.

## Also in this change

`IsProcessed` compared `COALESCE(url_hash, '') = COALESCE($3, '')`. `url_hash` is NOT NULL and the Go parameter is a plain `string` that is never nil, so both COALESCEs were dead weight, and wrapping the column in a function made the primary key unusable for the lookup. It now compares the column directly.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/repository/...` clean
- both statements executed against the live schema, as above (test rows removed)

No docs change: this is internal consumer behaviour with no user-visible setting.
