### PR TITLE
fix: own /data/blobs in the images so the volume is writable by the non-root user

### DIFF
--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -40,6 +40,13 @@ RUN apk add --no-cache ca-certificates tzdata && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache librdkafka; fi && \
     adduser -D -u 1000 warmbly
 
+# BLOB_FS_ROOT's default mount point, owned by the user the process runs as.
+# Docker seeds a fresh named volume from the image, so the directory has to
+# exist here with the right owner; otherwise Docker creates the mount point
+# root-owned, the non-root process cannot write to it, and the first send fails
+# with "mkdir /data/blobs/emails: permission denied".
+RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
+
 COPY --from=builder /out/backend /app/backend
 COPY --from=builder /out/seed /app/seed
 COPY --from=builder /out/migrate /app/migrate

--- a/deploy/docker/consumer.Dockerfile
+++ b/deploy/docker/consumer.Dockerfile
@@ -29,6 +29,13 @@ RUN apk add --no-cache ca-certificates tzdata && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache librdkafka; fi && \
     adduser -D -u 1000 warmbly
 
+# BLOB_FS_ROOT's default mount point, owned by the user the process runs as.
+# Docker seeds a fresh named volume from the image, so the directory has to
+# exist here with the right owner; otherwise Docker creates the mount point
+# root-owned, the non-root process cannot write to it, and the first send fails
+# with "mkdir /data/blobs/emails: permission denied".
+RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
+
 COPY --from=builder /out/consumer /app/consumer
 
 USER warmbly

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -29,6 +29,12 @@ RUN apk add --no-cache ca-certificates tzdata && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache librdkafka; fi && \
     adduser -D -u 1000 warmbly
 
+# BLOB_FS_ROOT's default mount point, owned by the user the process runs as.
+# Docker seeds a fresh named volume from the image, so the directory has to
+# exist here with the right owner; otherwise Docker creates the mount point
+# root-owned and the worker cannot read the bodies it is asked to send.
+RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
+
 COPY --from=builder /out/worker /app/worker
 
 USER warmbly

--- a/docs/content/docs/development/troubleshooting.mdx
+++ b/docs/content/docs/development/troubleshooting.mdx
@@ -78,6 +78,7 @@ Newer builds return the invite-only refusal with its own machine code, `registra
 | Connecting a mailbox is rejected on the port | SMTP must be `587` or `465`. The Mailpit sink used by `make sandbox` listens on `1025` with no STARTTLS, so it cannot be used as a test mailbox |
 | A mailbox stalls after about an hour | The worker is missing `BOX_GOOGLE_*` or `BOX_OUTLOOK_*`. The backend starts the OAuth flow but each worker refreshes the token. Set them and restart the worker |
 | Scheduled sends never fire | Delayed sends run through the in-process Postgres task poller (`TASKS_PROVIDER=local`), so the backend must be running |
+| Every send dead-letters with `permission denied` on `/data/blobs` | The `blobs` volume was created before the images owned that path, so it is still `root:root` while the services run as uid 1000. Fix it once with `docker compose -p warmbly exec -u root backend chown -R warmbly:warmbly /data/blobs`. The `blob_fs_root` health check reports it, and volumes created from current images are already correct |
 | Opens and clicks never record | Check `TRACKING_DOMAIN` resolves and the tracking service answers on `/health`. If you overrode `KAFKA_TRACKING_TOPIC`, it has to be overridden for the Rust publisher and the Go subscriber together |
 | Seeding fails with `no migration found for version N` | The seed image is older than your schema. Re-run with `--build` |
 | Worker `install_state: error` | Test connection first (is the SSH key in `authorized_keys`?), then read `last_error` and Logs on the worker's detail page |


### PR DESCRIPTION
Fixes #104.

## The bug

`docker-compose.yml` mounts the `blobs` named volume at `/data/blobs` in `backend`, `consumer` and `worker`, and all three run as the Dockerfile's non-root `warmbly` user (uid 1000).

None of the three images contained `/data/blobs`. Docker seeds a fresh named volume from the image's content at the mount path, and when that path does not exist it creates the mount point `root:root`. uid 1000 then cannot write to it, and the first attempt to store an outbound body fails:

```
failed to publish send email event: failed to store email body: failed to upload email body to S3: mkdir /data/blobs/emails: permission denied
```

Confirmed live on the reporter's exact configuration:

```
$ docker exec warmbly-backend-1 sh -c 'id; ls -ldn /data/blobs; touch /data/blobs/.probe'
uid=1000(warmbly) gid=1000(warmbly)
drwxr-xr-x    1 0        0    /data/blobs
touch: /data/blobs/.probe: Permission denied
```

## The fix

Each runtime stage now creates the directory with the right owner, after `adduser` and before `USER warmbly`:

```dockerfile
RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
```

Verified with a minimal image against a fresh named volume, so the mechanism is proven rather than assumed:

```
===== BEFORE =====
drwxr-xr-x  1 0    0     /data/blobs
touch: /data/blobs/.probe: Permission denied
WRITE_FAILED
===== AFTER =====
drwxr-xr-x  1 1000 1000  /data/blobs
WRITE_OK
```

## Existing installs still need one command

Docker applies image ownership only when it **first creates** the volume. An install whose `blobs` volume already exists keeps the root-owned mount point after pulling these images, so the troubleshooting guide now carries the one-time fix:

```bash
docker compose -p warmbly exec -u root backend chown -R warmbly:warmbly /data/blobs
```

## One correction to the issue

The issue says "nothing about `make status` or the four documented health checks would ever surface this". That was true at `8f465fd` but is no longer: `734cb5f` added `checkBlobRootMissing` (`internal/app/instancecheck/checks_infra.go:101`), which does exactly the right thing, creating a temp file under `BLOB_FS_ROOT` and reporting **"Blob storage root is unusable ... is not writable"** at error severity. It appears on **Instance > Setup and health** and in `make doctor`.

So the detection already exists and no new check was added here. This change removes the cause, and the troubleshooting entry points at the existing check by name.

## Verification

- volume ownership before/after, as above
- `pnpm types:check` in `docs/` passes

No Go changed, so there is nothing for `gofmt` or `golangci-lint` to say about this one.
