### PR TITLE
fix: let a mailbox have no timezone instead of silently defaulting it into UTC

### DIFF
--- a/docs/content/docs/api/reference/mailboxes.mdx
+++ b/docs/content/docs/api/reference/mailboxes.mdx
@@ -147,6 +147,7 @@ Auth: **Scope** `WRITE_EMAILS` · **Org permission** `manage_emails`
 | `campaign_limit` | integer | no | Daily cold-campaign cap for this mailbox (validated up to `100`). |
 | `min_wait_time` | integer | no | Minimum seconds between sends. |
 | `reply_to` | string | no | Reply-to address. |
+| `timezone` | string | no | The mailbox's own IANA zone, such as `America/Denver`. Its sending behaviour and business-hours window are evaluated in this zone. Send an empty string to clear it, which leaves only the campaign's own window applying. |
 | `warmup` | boolean | no | Enable or disable warmup. |
 | `warmup_base` | integer | no | Warmup starting volume per day. |
 | `warmup_max` | integer | no | Warmup daily ceiling. |

--- a/docs/content/docs/guides/sending-behavior.mdx
+++ b/docs/content/docs/guides/sending-behavior.mdx
@@ -29,6 +29,8 @@ It is off by default. A mailbox that has not opted in keeps its fixed daily cap 
 
 Every time is local to the mailbox's own timezone, which you set on the mailbox itself.
 
+A new mailbox has no timezone set, and that is a valid state rather than a gap: with none set, only the campaign's own sending window applies. Set one when the mailbox belongs to somebody in a particular place, and both calendars then have to agree before a send goes out.
+
 ## The daily plan
 
 The roll happens once per mailbox per local day, and the result is stored. That matters: the scheduler recomputes a mailbox's next slot many times a day, and a fresh random workday on every calculation would mean the mailbox never actually keeps to one.

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -259,6 +259,12 @@ func (s *campaignService) enqueueCampaignWakeup(ctx context.Context, campaignID 
 	// the defer time rather than failing the campaign start.
 	if err != nil && !errors.Is(err, scheduler.ErrCampaignDeferred) {
 		switch {
+		// Checked before ErrNoEmailAccounts, which it wraps.
+		case errors.Is(err, scheduler.ErrNoEligibleMailbox):
+			_ = s.campaignRepository.UpdateStatusWithLock(ctx, campaignID, "paused_no_accounts")
+			return errx.New(errx.BadRequest,
+				"this campaign's mailboxes are all outside their sending window or over their daily limit right now; "+
+					"check each mailbox's timezone, sending behaviour and daily cap")
 		case errors.Is(err, scheduler.ErrNoEmailAccounts):
 			_ = s.campaignRepository.UpdateStatusWithLock(ctx, campaignID, "paused_no_accounts")
 			return errx.New(errx.BadRequest, "no active email accounts found for campaign's email tags")

--- a/internal/errx/common.go
+++ b/internal/errx/common.go
@@ -119,6 +119,7 @@ var (
 	ErrEmailSignatureHTML        = New(BadRequest, "HTML email signature is too long.")
 	ErrEmailMinWaitTime          = New(BadRequest, "Minimum time gap between emails must be between 0 and 86400 minutes.")
 	ErrEmailCampaignLimit        = New(BadRequest, "Campaign limit must be between 0 and 100.")
+	ErrEmailTimezone             = New(BadRequest, "Invalid timezone. Use an IANA name such as Europe/London or America/Denver, or leave it empty to follow the campaign.")
 	ErrEmailWarmupBase           = New(BadRequest, "Warmup base must be between 0 and 100.")
 	ErrEmailWarmupMax            = New(BadRequest, "Warmup max amount must be between 0 and 100.")
 	ErrEmailWarmupIncrease       = New(BadRequest, "Warmup increase amount must be between 0 and 100.")

--- a/internal/infrastructure/db/migrations/000084_email_account_timezone_unset.down.sql
+++ b/internal/infrastructure/db/migrations/000084_email_account_timezone_unset.down.sql
@@ -1,0 +1,4 @@
+-- Restore the previous default. The backfill is not reversed: an empty
+-- timezone and 'UTC' are indistinguishable once merged, and rewriting every
+-- empty row back to 'UTC' would clobber mailboxes deliberately left unset.
+ALTER TABLE email_accounts ALTER COLUMN timezone SET DEFAULT 'UTC';

--- a/internal/infrastructure/db/migrations/000084_email_account_timezone_unset.up.sql
+++ b/internal/infrastructure/db/migrations/000084_email_account_timezone_unset.up.sql
@@ -1,0 +1,22 @@
+-- Make "no timezone chosen" representable on a mailbox.
+--
+-- The campaign scheduler already gates its mailbox business-hours check on
+-- `acct.Timezone != ""`, so an empty timezone was always meant to mean "not
+-- configured, do not apply a second window on top of the campaign's own". The
+-- column default defeated that: it was 'UTC', which the scheduler cannot tell
+-- apart from a deliberate choice of UTC.
+--
+-- The effect was that a freshly connected mailbox looked like it had been
+-- placed in UTC on purpose, so it was compared against the campaign timezone
+-- (default 'Europe/London') and dropped whenever the current UTC hour was
+-- outside 08:00-20:00. With one mailbox that empties the candidate pool and the
+-- campaign refuses to start.
+ALTER TABLE email_accounts ALTER COLUMN timezone SET DEFAULT '';
+
+-- Existing rows holding 'UTC' are the old default, not a choice: until this
+-- migration there was no API field, dashboard control or onboarding path that
+-- could set email_accounts.timezone at all. The only writer was this default
+-- and the seed fixtures, which set explicit non-UTC zones.
+--
+-- Rows deliberately set to UTC from here on are preserved: this runs once.
+UPDATE email_accounts SET timezone = '' WHERE timezone = 'UTC';

--- a/internal/models/email.go
+++ b/internal/models/email.go
@@ -191,6 +191,11 @@ type UpdateEmail struct {
 	WarmupEndTime   *string `json:"warmup_end_time"`
 	WarmupDays      *int    `json:"warmup_days"`
 
+	// Timezone is the mailbox's own IANA zone, which its sending behaviour and
+	// business-hours window are evaluated in. Empty means not configured, so
+	// only the campaign's window applies.
+	Timezone *string `json:"timezone"`
+
 	Tags []string `json:"tags"`
 }
 

--- a/internal/repository/pg_email.go
+++ b/internal/repository/pg_email.go
@@ -674,6 +674,15 @@ func (r *emailRepository) Update(ctx context.Context, userID, emailAccountID str
 		args = append(args, *udata.SignatureSync)
 		argPos++
 	}
+	if udata.Timezone != nil {
+		tz := strings.TrimSpace(*udata.Timezone)
+		if verr := validate.EmailTimezone(tz); verr != nil {
+			return nil, verr
+		}
+		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", "timezone", argPos))
+		args = append(args, tz)
+		argPos++
+	}
 	if udata.SignatureCode != nil {
 		setClauses = append(setClauses, fmt.Sprintf("%s = $%d", "signature_code", argPos))
 		args = append(args, *udata.SignatureCode)

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -463,7 +463,8 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 				// Deferral, not a send (see above).
 				return s.deferToNextDay(campaign), nil, accounts[0].ID, ErrCampaignDeferred
 			}
-			return time.Time{}, nil, uuid.Nil, ErrNoEmailAccounts
+			// The pool was not empty, every mailbox in it was gated out.
+			return time.Time{}, nil, uuid.Nil, ErrNoEligibleMailbox
 		}
 	}
 

--- a/internal/scheduler/errors.go
+++ b/internal/scheduler/errors.go
@@ -1,6 +1,9 @@
 package scheduler
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrWarmupNotEnabled is returned when warmup is not enabled for an account
@@ -17,6 +20,17 @@ var (
 
 	// ErrNoEmailAccounts is returned when no email accounts are available for sending
 	ErrNoEmailAccounts = errors.New("no email accounts available for this campaign")
+
+	// ErrNoEligibleMailbox is the narrower case: the campaign HAS mailboxes,
+	// but every one was gated out for both today and tomorrow (daily cap
+	// reached, warmup health, or outside its own sending window). Reporting
+	// that as ErrNoEmailAccounts sent people looking at their tag configuration
+	// for a problem that was never there.
+	//
+	// It wraps ErrNoEmailAccounts so existing callers that pause the campaign
+	// on errors.Is(err, ErrNoEmailAccounts) keep behaving exactly as before.
+	ErrNoEligibleMailbox = fmt.Errorf(
+		"%w: every mailbox is outside its sending window or over its daily budget", ErrNoEmailAccounts)
 
 	// ErrDailyLimitReached is returned when the daily limit has been reached
 	ErrDailyLimitReached = errors.New("daily email limit reached")

--- a/internal/scheduler/no_eligible_mailbox_test.go
+++ b/internal/scheduler/no_eligible_mailbox_test.go
@@ -1,0 +1,20 @@
+package scheduler
+
+import (
+	"errors"
+	"testing"
+)
+
+// ErrNoEligibleMailbox has to stay assignable to ErrNoEmailAccounts: three
+// callers (the campaign handler, the campaign task and the reconciler) pause a
+// campaign on errors.Is(err, ErrNoEmailAccounts), and narrowing the error must
+// not silently change that behaviour.
+func TestNoEligibleMailboxWrapsNoEmailAccounts(t *testing.T) {
+	if !errors.Is(ErrNoEligibleMailbox, ErrNoEmailAccounts) {
+		t.Fatal("ErrNoEligibleMailbox no longer matches ErrNoEmailAccounts; existing pause behaviour would regress")
+	}
+	// The reverse must not hold, or the handler cannot tell them apart.
+	if errors.Is(ErrNoEmailAccounts, ErrNoEligibleMailbox) {
+		t.Fatal("ErrNoEmailAccounts matches ErrNoEligibleMailbox, so the two cases are indistinguishable")
+	}
+}

--- a/internal/utils/validate/email.go
+++ b/internal/utils/validate/email.go
@@ -4,6 +4,7 @@ import (
 	"net/mail"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/warmbly/warmbly/internal/errx"
 )
@@ -65,5 +66,22 @@ func ValidateTrackingDomain(domain string) *errx.Error {
 		return errx.ErrEmailTrackingDomain
 	}
 
+	return nil
+}
+
+// EmailTimezone accepts an IANA zone name the runtime can actually load, or the
+// empty string meaning "not configured". A zone that does not resolve would be
+// silently coerced to UTC by the scheduler, which is how a mailbox ends up
+// sending at the wrong local hour with nothing to point at.
+func EmailTimezone(tz string) *errx.Error {
+	if tz == "" {
+		return nil
+	}
+	if len(tz) > 64 {
+		return errx.ErrEmailTimezone
+	}
+	if _, err := time.LoadLocation(tz); err != nil {
+		return errx.ErrEmailTimezone
+	}
 	return nil
 }

--- a/internal/utils/validate/email_timezone_test.go
+++ b/internal/utils/validate/email_timezone_test.go
@@ -1,0 +1,32 @@
+package validate
+
+import "testing"
+
+func TestEmailTimezone(t *testing.T) {
+	valid := []string{
+		"",    // not configured: the campaign's own window is the only one
+		"UTC", // still a legitimate deliberate choice
+		"Europe/London",
+		"America/Denver",
+		"Asia/Tokyo",
+	}
+	for _, tz := range valid {
+		if err := EmailTimezone(tz); err != nil {
+			t.Errorf("EmailTimezone(%q) rejected a valid zone: %v", tz, err)
+		}
+	}
+
+	// The scheduler coerces an unloadable zone to UTC, so an invalid value
+	// would otherwise be accepted and then silently ignored.
+	invalid := []string{
+		"Europe/Nowhere",
+		"GMT+1",
+		"not a timezone",
+		"America/Denver; DROP TABLE email_accounts",
+	}
+	for _, tz := range invalid {
+		if err := EmailTimezone(tz); err == nil {
+			t.Errorf("EmailTimezone(%q) accepted an unloadable zone", tz)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #103.

## The bug

Two `DEFAULT` literals in the same baseline migration disagree:

- `email_accounts.timezone` defaults to `'UTC'`
- `campaigns.timezone` defaults to `'Europe/London'`

Nothing in the Gmail/Outlook OAuth flow or the SMTP/IMAP form ever sets the mailbox one, so a brand-new mailbox is always `'UTC'`. The scheduler then reads that as a deliberate placement:

```go
} else if acct.Timezone != "" && acct.Timezone != campaign.Timezone {
    acctHour := candidateTime.In(loadLocation(acct.Timezone)).Hour()
    if acctHour < 8 || acctHour >= 20 {
        continue // outside account's business hours
    }
}
```

The zones differ, so the 8am–8pm gate applies in UTC. Outside 08:00–20:00 UTC the mailbox is dropped, and with one connected mailbox that empties the pool.

The `else if` reaches this because sending-behaviour profiles are `enabled boolean NOT NULL DEFAULT false` (migration 000081), so a new mailbox has no profile and takes the legacy branch.

## The insight

**The code was already right.** That `acct.Timezone != ""` guard says an empty timezone means "not configured, do not apply a second window on top of the campaign's own". The column default defeated it: `'UTC'` is indistinguishable from someone deliberately choosing UTC.

So the fix is to make "unset" representable rather than to add new logic.

### Migration 000084

```sql
ALTER TABLE email_accounts ALTER COLUMN timezone SET DEFAULT '';
UPDATE email_accounts SET timezone = '' WHERE timezone = 'UTC';
```

The backfill is safe because **until this PR there was no way to set that column**: no `UpdateEmail` field, no dashboard control, no onboarding path. The only writers were this default and the seed fixtures, which set explicit non-UTC zones. Every `'UTC'` row in a real install is therefore the old default, not a choice. It runs once, so deliberate UTC from here on is preserved.

Validated against the running dev database inside a rolled-back transaction:

```
column_default: 'UTC'::text   ->  ''::text
UPDATE 49
 timezone   | count            timezone   | count
------------+-------          ------------+-------
 Asia/Tokyo |     5     ->                |    49
 UTC        |    49            Asia/Tokyo |     5      <- deliberate zones preserved
```

## Second bug found while fixing this

`UpdateEmail` has **no `Timezone` field**, so the timezone could not be changed through the API or dashboard at all. Meanwhile `SendingBehaviorTab.tsx` tells the user:

> "Change the timezone on the mailbox to move the whole schedule."

That instruction was impossible to follow, and it left the entire sending-behaviour feature stuck in one zone despite migration 000081 being designed around "a London mailbox and a Denver mailbox on the same worker each keep their own 9-to-5".

Added as an additive field with `validate.EmailTimezone`, which requires a zone `time.LoadLocation` can actually resolve. Without that check an invalid zone is silently coerced to UTC by `loadLocation`, which is how a mailbox ends up sending at the wrong local hour with nothing to point at.

## Third: the misleading error

A campaign whose mailboxes were all gated out reported:

> `400 no active email accounts found for campaign's email tags`

which sends people to inspect tag configuration that was never the problem. `ErrNoEligibleMailbox` now covers "the pool was not empty, every mailbox in it was gated out" and the handler names the real cause.

It is defined as `fmt.Errorf("%w: ...", ErrNoEmailAccounts)`, so it **wraps** the original. Three callers pause a campaign on `errors.Is(err, ErrNoEmailAccounts)` (`campaign/handlers.go`, `tasks/campaign_task.go`, `tasks/campaign_reconciler.go`) and all keep working unchanged; only the message narrows. A test pins both directions of that relationship.

## Verification

- `gofmt -l cmd internal` clean
- `golangci-lint run ./internal/...` clean
- `go test ./internal/...` passes
- migration executed against the live schema and rolled back, as above
- `pnpm types:check` in `docs/` passes

## Docs

`api/reference/mailboxes.mdx` documents the new `timezone` field on `PATCH /emails/:id`, and `guides/sending-behavior.mdx` explains that an unset timezone is a valid state rather than a gap.
