### PR TITLE
docs: warmblyctl reference, and a shorter self-hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,49 +120,40 @@ git clone https://github.com/warmbly/warmbly && cd warmbly
 make up
 ```
 
-That is the whole install. `make up` waits for the backend and prints a
-one-time link that claims the instance and makes you its admin. Open it, pick a
-password, and you are in.
+That is the whole install. `make up` waits for the backend and prints a one-time
+link that claims the instance and makes you its admin. Open it, pick a password,
+and you are in. You need Docker with Compose v2 and about 10 GB of free disk; the
+first run builds the images once, which takes roughly 6 minutes.
 
-You need Docker with Compose v2 and about 10 GB of free disk; the first run
-builds the images once, which takes roughly 6 minutes.
+Nothing else is required: no SMTP relay, no captcha keys, no cloud account, no
+`.env` to hand-write, and no separate command to grant yourself admin. To change
+something, `cp .env.example .env` and edit it. The [template](./.env.example)
+boots as-is and carries the commands that generate your own secrets; set those
+and `APP_ENV=prod` before anyone else can reach the instance.
 
-Nothing else is required. No SMTP relay, no captcha keys, no cloud account, no
-`.env` to hand-write, and no separate command to grant yourself admin. When you
-are ready to change something, `cp .env.example .env` and edit it: the
-[template](./.env.example) boots as-is, and every variable in it is documented
-in the
-[configuration reference](https://docs.warmbly.com/development/configuration/).
-Generate your own secrets and set `APP_ENV=prod` before anyone else can reach
-the instance; the file has the commands. To skip the claim link entirely, set
-`WARMBLY_BOOTSTRAP_EMAIL` and `WARMBLY_BOOTSTRAP_PASSWORD_HASH` before the first
-start and the owner account exists when it comes up.
+| If | Then |
+|----|------|
+| The claim link is gone | It is single use and lasts 24 hours. `make claim` prints a fresh one |
+| No link was printed at all | The database already has accounts, so the instance is claimed. `make cli ARGS="user create --email you@example.com --admin"` adds you, prompting for a password to set |
+| You would rather skip the link | Set `WARMBLY_BOOTSTRAP_EMAIL` and `WARMBLY_BOOTSTRAP_PASSWORD_HASH` before the first start and the owner exists when it comes up |
+| Something is wrong | `make doctor` prints the instance state and every failing check |
 
-Three things that catch people, all covered in
-[first run](https://docs.warmbly.com/development/first-run/):
-
-- **The link is gone.** It is single use and lasts 24 hours. Print another with
-  `docker compose -p warmbly exec backend warmblyctl setup-link`, or `make claim`.
-- **No link was printed at all.** The database already has accounts, so the
-  instance is already claimed. Add yourself with
-  `docker compose -p warmbly exec backend warmblyctl user create --email you@example.com --admin`.
-- **`make dev` and `make up` share one database.** Seeding in one claims the
-  other. That is the usual reason there was no link.
+Those all run [`warmblyctl`](https://docs.warmbly.com/development/warmblyctl/),
+the operator CLI baked into the backend image. It talks to the database directly,
+so it works when signing in does not.
 
 > [!NOTE]
-> Signing in never depends on outbound mail. Under Docker Compose, platform email
-> defaults to `MAIL_TRANSPORT=log`, so password resets and invitations are
-> written to the backend logs until you point `SMTP_*` at a real relay. Team
-> invitations still work without one: invite the person under **Settings >
-> Members**, then copy the invite link from their row under **Pending
-> invitations** and send it yourself. See
+> Signing in never depends on outbound mail. Platform email defaults to
+> `MAIL_TRANSPORT=log` under Compose, so password resets and invitations go to the
+> backend logs until you point `SMTP_*` at a relay. Invitations still work without
+> one: invite the person under **Settings > Members**, then copy the link from
+> their row and send it yourself. See
 > [accounts and access](https://docs.warmbly.com/development/accounts-and-access/).
 
 **➡️ Follow the [step-by-step self-hosting guide](https://docs.warmbly.com/development/deployment-guide/)**
-for the full walkthrough: setting your own secrets, verifying the stack is
-healthy, configuring mail and single sign-on, exposing it on your network or
-behind HTTPS, connecting Gmail and Microsoft mailboxes, scaling workers,
-backups, and a troubleshooting table for the errors people actually hit.
+for the full walkthrough: your own secrets, verifying the stack is healthy, mail
+and single sign-on, HTTPS, connecting Gmail and Microsoft mailboxes, scaling
+workers, backups, and a troubleshooting table.
 
 Every external dependency is picked by an environment variable, so you swap in a
 cloud service only if you want one:
@@ -187,6 +178,7 @@ The full docs live at **[docs.warmbly.com](https://docs.warmbly.com)**.
 | [Self-hosting guide](https://docs.warmbly.com/development/deployment-guide/) | Step-by-step install, then production, backups, and scaling the worker fleet |
 | [First run](https://docs.warmbly.com/development/first-run/) | Claiming the instance, reissuing the setup link, and what to do when accounts already exist |
 | [Accounts and access](https://docs.warmbly.com/development/accounts-and-access/) | Registration modes, inviting people with or without a mail relay, SSO, and recovering access |
+| [`warmblyctl`](https://docs.warmbly.com/development/warmblyctl/) | The operator CLI: creating accounts, setting passwords, granting admin, and instance status |
 | [Configuration reference](https://docs.warmbly.com/development/configuration/) | Every environment variable, its default, and whether changing it needs a restart |
 | [Instance health](https://docs.warmbly.com/development/instance-health/) | The checks the admin panel runs against your deployment, and `make doctor` |
 | [Troubleshooting](https://docs.warmbly.com/development/troubleshooting/) | The errors self-hosters actually hit, and the command that fixes each one |

--- a/docs/content/docs/development/accounts-and-access.mdx
+++ b/docs/content/docs/development/accounts-and-access.mdx
@@ -263,7 +263,7 @@ kubectl exec -it deploy/warmbly-backend -- warmblyctl status
 warmblyctl status                                          # bare binary
 ```
 
-The rest of this section shows the compose form. Substitute the prefix you need.
+The rest of this section shows the compose form. Substitute the prefix you need. Every flag each command takes is on the [warmblyctl reference](/development/warmblyctl/).
 
 ### See where you stand
 
@@ -348,6 +348,7 @@ Understand what that means on an instance reachable from the internet: every vis
 ## See also
 
 - [First run](/development/first-run/) for claiming a fresh instance
+- [warmblyctl](/development/warmblyctl/) for every command and flag named here
 - [Configuration reference](/development/configuration/) for every variable named here
 - [Team and roles](/guides/team-roles/) for what each workspace role grants
 - [Troubleshooting](/development/troubleshooting/) for the errors self-hosters actually hit

--- a/docs/content/docs/development/first-run.mdx
+++ b/docs/content/docs/development/first-run.mdx
@@ -78,7 +78,7 @@ Both pin the same compose project (`-p warmbly`), the same `warmbly_postgres_dat
   Why:                      https://docs.warmbly.com/development/first-run/
 ```
 
-That command creates the account, an organization and a trial, and grants every platform admin bit. It prompts for a password on a terminal and refuses on a non-TTY rather than creating a passwordless account, so pass `--password-stdin` from a script.
+That command creates the account, an organization and a trial, and grants every platform admin bit. The password is the one you type: it prompts for it twice on a terminal, and refuses on a non-TTY rather than creating a passwordless account, so pass `--password-stdin` from a script. Then sign in at `APP_URL` with that password. See [user create](/development/warmblyctl/#user-create).
 
 If one of the existing accounts is yours and you only lost the password, use `warmblyctl user reset-password` instead. Every recovery command is listed under [recovering access](/development/accounts-and-access/#recovering-access).
 
@@ -146,7 +146,7 @@ Instance
   App URL           http://localhost:5173 (APP_URL)
 
 Platform admins
-  you@example.com (super, mask 4294967295)
+  you@example.com (super, mask 4194303)
 
 Checks
   ...one line per finding, grouped by severity...
@@ -213,6 +213,7 @@ For a demo where mail actually flows end to end, with sends, replies, opens and 
 ## See also
 
 - [Accounts and access](/development/accounts-and-access/) for registration modes, invitations and recovery
+- [warmblyctl](/development/warmblyctl/) for every command and flag on this page
 - [Configuration reference](/development/configuration/) for every environment variable
 - [Instance health](/development/instance-health/) for the checks that run against a new install
 - [Self-hosting](/development/deployment-guide/) for the full deployment walkthrough

--- a/docs/content/docs/development/instance-health.mdx
+++ b/docs/content/docs/development/instance-health.mdx
@@ -40,6 +40,8 @@ kubectl exec -it deploy/warmbly-backend -- warmblyctl status
 warmblyctl status                                          # bare binary
 ```
 
+`status` is one of nine commands. The rest, including the ones that create an account and reset a password when nobody can sign in, are on the [warmblyctl reference](/development/warmblyctl/).
+
 ## Health endpoints
 
 There are two, and they answer different questions.
@@ -241,4 +243,5 @@ A reachable realtime service that still leaves the dashboard dead has a differen
 
 - [Configuration reference](/development/configuration/) for every variable named here, including the [realtime](/development/configuration/#realtime-service) and [tracking](/development/configuration/#tracking-service) variables no check reads
 - [Accounts and access](/development/accounts-and-access/) for the access checks
+- [warmblyctl](/development/warmblyctl/) for `status` and every other operator command
 - [Troubleshooting](/development/troubleshooting/) for symptoms that do not come from a check

--- a/docs/content/docs/development/meta.json
+++ b/docs/content/docs/development/meta.json
@@ -7,6 +7,7 @@
     "deployment-guide",
     "first-run",
     "accounts-and-access",
+    "warmblyctl",
     "configuration",
     "instance-health",
     "troubleshooting",

--- a/docs/content/docs/development/troubleshooting.mdx
+++ b/docs/content/docs/development/troubleshooting.mdx
@@ -114,5 +114,6 @@ Ask in [Discord](https://dc.warmbly.com) or open a [GitHub issue](https://github
 
 - [First run](/development/first-run/)
 - [Accounts and access](/development/accounts-and-access/)
+- [warmblyctl](/development/warmblyctl/)
 - [Configuration reference](/development/configuration/)
 - [Instance health](/development/instance-health/)

--- a/docs/content/docs/development/warmblyctl.mdx
+++ b/docs/content/docs/development/warmblyctl.mdx
@@ -1,0 +1,305 @@
+---
+title: warmblyctl
+description: The operator CLI for a Warmbly instance. Every command and flag, how to run it in each runtime, how passwords are set, and how to get back in when nobody can sign in.
+---
+
+`warmblyctl` is the operator CLI for a Warmbly instance. It answers two questions: what state is this install in, and how do I get back in. It reads and writes the database directly, so it keeps working when the sign-in page does not.
+
+Authorization is container or host access. That is the same trust model as Sentry's `createuser`, Gitea's `admin user create` and authentik's `ak changepassword`, and it is the right one when the identity system is the thing that is broken. The CLI has no HTTP surface and never will.
+
+## Running it
+
+The binary ships inside the backend image at `/usr/local/bin/warmblyctl`, so it is on the path in every runtime. Running it inside the backend is the documented path because the environment there is already correct.
+
+```bash
+docker compose -p warmbly exec backend warmblyctl status   # docker compose
+docker exec -it warmbly-backend warmblyctl status          # plain docker
+kubectl exec -it deploy/warmbly-backend -- warmblyctl status
+warmblyctl status                                          # bare binary
+```
+
+Every example on this page shows the compose form. Substitute the prefix you need.
+
+For a compose install, `make cli` is the same thing with less typing. Flags go through `ARGS`, because make reads a bare `--email` as one of its own options:
+
+```bash
+make cli status
+make cli setup-link
+make cli ARGS="user create --email you@example.com --admin"
+```
+
+### Terminals and pipes
+
+This is the one piece of shell mechanics the CLI cannot hide from you.
+
+`docker compose exec` allocates a TTY unless you pass `-T`. Commands that prompt need that TTY. Commands you pipe into need it gone.
+
+| You want to | Run |
+|---|---|
+| Be prompted for a password | `docker compose -p warmbly exec backend warmblyctl ...` |
+| Pipe a password in | `printf '%s' 'your-password' \| docker compose -p warmbly exec -T backend warmblyctl ... --password-stdin` |
+
+A command that would set a password refuses on a non-TTY unless you passed `--password-stdin`, rather than creating an account nobody can sign in to.
+
+### What it reads from the environment
+
+| Variable | Needed by | If it is missing |
+|---|---|---|
+| `PRIMARY_DB` | every command except `hash-password` | The command stops and tells you to run it inside the backend container |
+| `REDIS` | `setup-link` always, `reset-password` to mint a link | `setup-link` fails. Everything else degrades to a warning and continues |
+| `AUTH_SECRET` | `reset-password` when it mints a link | The link cannot be signed with the key the backend verifies, so it is refused |
+| `APP_URL` | every printed link and sign-in hint | Links are built against `https://app.warmbly.com`, which is the hosted service and not your instance |
+
+Inside the backend container all four are already set. Outside it, export them first, and match `AUTH_SECRET` to the backend's exactly.
+
+## The commands
+
+| Command | Does |
+|---|---|
+| [`status`](#status) | Prints the instance state, the platform admins, the health checks, and what to run next |
+| [`setup-link`](#setup-link) | Prints a fresh single-use link that claims an instance with no accounts |
+| [`user create`](#user-create) | Creates an account, an organization and a trial, optionally a platform admin |
+| [`user list`](#user-list) | Lists accounts, and answers whether any platform admin survives |
+| [`user reset-password`](#user-reset-password) | Prints a one-time reset link, or sets the password from stdin |
+| [`user grant-admin`](#user-grant-admin) | Gives an account a platform admin role |
+| [`user revoke-admin`](#user-revoke-admin) | Takes platform admin away from an account |
+| [`user disable-2fa`](#user-disable-2fa) | Clears an account's authenticator enrolment |
+| [`hash-password`](#hash-password) | Prints an argon2 hash for unattended provisioning |
+
+`warmblyctl --help` lists them, and `warmblyctl <command> --help` prints one command's flags with an example.
+
+## status
+
+```bash
+docker compose -p warmbly exec backend warmblyctl status
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--json` | off | Prints the state as JSON instead of prose, and always exits 0 |
+| `--quiet` | off | Prints only the checks, without the instance summary. Ignored with `--json` |
+
+It prints four blocks: the instance state, the platform admins, the health checks, and how to get in. A sample run is on [first run](/development/first-run/#checking-where-you-stand).
+
+The **How to get in** block changes with the state. An unclaimed instance is told to print a setup link; a claimed one is given the recovery commands; an instance with no platform admin is told to promote an account.
+
+The **Checks** block holds the same findings the admin panel's Setup and health page shows. Every one of them is documented on [instance health](/development/instance-health/).
+
+`make doctor` is `warmblyctl status` for a compose install.
+
+### Exit status and JSON
+
+`status` exits non-zero when any check is at error severity, which is what makes `make doctor` usable as the last line of a deploy script.
+
+`--json` is the exception: it always exits 0, because `make claim` uses it to decide whether the backend is answering at all. Read `.summary.error` for the verdict instead.
+
+| Key | Holds |
+|---|---|
+| `accounts`, `claimed`, `setup_required` | Account count, and whether a setup link can still be issued |
+| `admin_count`, `admins` | How many platform admins exist, and who they are |
+| `registration`, `registration_source` | The resolved registration mode, and whether it was set or defaulted |
+| `mail_transport`, `mail_delivers`, `mail_transport_source` | The transport, whether it puts mail on the wire, and where the setting came from |
+| `app_url`, `app_url_source` | The base URL every printed link is built from |
+| `next_steps` | The same commands the prose **How to get in** block prints |
+| `checks`, `summary` | The findings, and the error, warning and note counts |
+
+Those keys are a contract. They are only ever appended to, never renamed or dropped.
+
+## setup-link
+
+```bash
+docker compose -p warmbly exec backend warmblyctl setup-link
+```
+
+Prints a single-use link that claims an unclaimed instance. It expires in 24 hours, replaces any outstanding link, and only its hash is stored, so this is the only time it is printed.
+
+It refuses on an instance that already has accounts, by design: a second owner must never be mintable without an existing account. If you get that refusal, you want [`user create`](#user-create) instead.
+
+This is the one command that cannot degrade, because the token lives in Redis. With Redis down, create the owner directly instead.
+
+`make claim` wraps it for a compose install, and finds the link already in the logs before minting a new one.
+
+## user create
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user create --email you@example.com --admin
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--email` | required | The address of the account to create |
+| `--admin` | off | Grants every platform admin permission, the same as `--role super` |
+| `--org` | `<name>'s Organization` | Names the new organization |
+| `--no-org` | off | Creates the account with no organization and no trial |
+| `--password-stdin` | off | Reads the password from stdin instead of prompting |
+
+It creates the account, an organization and a free trial, and with `--admin` grants every platform admin bit. Use `--no-org` when the person will accept an invitation into a workspace that already exists.
+
+An address that already exists is an error, and the message points you at `reset-password`.
+
+### The password is the one you type
+
+There is no generated or default password. On a terminal the command prompts for it twice, with echo off:
+
+```
+Password for you@example.com:
+Repeat password for you@example.com:
+Created account you@example.com (id ...), organization "Your Organization" (id ...),
+a free trial, every platform admin permission (mask 4194303).
+
+Next
+  Sign in at http://localhost:5173 with the password you just set.
+```
+
+It must be between 8 and 128 characters, which is the same rule the dashboard enforces, so the scripted route is never weaker than the interactive one.
+
+From a script, pipe it in so it never reaches your shell history or `ps` output:
+
+```bash
+printf '%s' "$PASSWORD" | docker compose -p warmbly exec -T backend \
+  warmblyctl user create --email you@example.com --admin --password-stdin
+```
+
+### Signing in afterwards
+
+Open the URL the command printed, which is `APP_URL`, and sign in with the address and that password. On the default compose stack that is `http://localhost:5173`.
+
+Nothing else stands in the way on a stock self-hosted instance:
+
+- **No emailed login code.** `AUTH_LOGIN_CODE` defaults to off when self-hosted, and a transport that does not deliver can never gate a login whatever the setting says. See [login codes](/development/accounts-and-access/#login-codes)
+- **No email confirmation.** `REQUIRE_EMAIL_VERIFICATION` defaults to off when self-hosted, so the account is usable immediately
+- **No captcha** unless you set `TURNSTILE_SECRET`
+- **No invitation**, and no dependency on the registration mode. `invite_only` and `true` both govern the sign-up form, which this command does not use
+
+The dashboard and the admin panel are separate apps. `--admin` opens the panel on `ADMIN_URL`, port `5174` in the default stack, not `APP_URL`.
+
+## user list
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user list --admin
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--admin` | off | Lists only accounts holding platform admin permissions |
+| `--limit` | `50` | How many accounts to print, between 1 and 100 |
+
+Prints address, name, admin role and creation date, oldest first. `--admin` answers the narrow question of whether any admin account survives, and when none does it prints the two commands that fix that.
+
+## user reset-password
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user reset-password --email you@example.com
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--email` | required | The address of the account to reset |
+| `--password-stdin` | off | Reads the new password from stdin and sets it immediately |
+| `--ttl` | `1h` | How long the printed link stays valid, up to 24 hours |
+
+Without `--password-stdin` it prints a single-use reset URL and changes nothing yet. Open it in a browser and choose the new password there, which keeps it out of your shell history, your scrollback and the process list. It redeems through exactly the same path as the reset link the product emails, and opening it revokes every existing session for the account.
+
+`--ttl` is capped at 24 hours because a reset link is a bearer credential for the account.
+
+The automation path sets the password directly and revokes every existing session the same way:
+
+```bash
+printf '%s' "$PASSWORD" | docker compose -p warmbly exec -T backend \
+  warmblyctl user reset-password --email you@example.com --password-stdin
+```
+
+Reach for that form when Redis is down, since a link cannot be minted without it.
+
+## user grant-admin
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user grant-admin --email you@example.com --role super
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--email` | required | The address of the account to promote |
+| `--role` | required | One of `super`, `support`, `ops`, `analyst` |
+
+| Role | Grants |
+|---|---|
+| `super` | Every platform admin permission. This is the one that opens every admin screen |
+| `support` | Users, campaigns, organizations, the warmup pool, warmup bans, appeals, enterprise inquiries, audit logs |
+| `ops` | Workers and worker management, rate limits, analytics, organizations, audit logs |
+| `analyst` | Read only: users, campaigns, organizations, analytics, audit logs |
+
+The role replaces the account's existing mask rather than adding to it, and re-granting the role it already holds is reported as no change. The permissions are read from the session, so the account has to sign out and back in before the panel reflects the grant.
+
+The account must already exist. `make grant-admin EMAIL=... ROLE=...` wraps this for a compose install.
+
+## user revoke-admin
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user revoke-admin --email old@example.com
+```
+
+| Flag | Default | Does |
+|---|---|---|
+| `--email` | required | The address of the account to demote |
+| `--force` | off | Allows removing the last remaining platform admin |
+
+Removes every platform admin permission and leaves the account otherwise untouched.
+
+Revoking the only remaining admin is refused without `--force`, because it closes the admin panel for everyone and nothing inside the product can reopen it. Grant someone else first. `make revoke-admin EMAIL=...` wraps it.
+
+## user disable-2fa
+
+```bash
+docker compose -p warmbly exec backend warmblyctl user disable-2fa --email you@example.com
+```
+
+Clears the authenticator enrolment and the recovery codes, so a lost phone does not become a full password reset. The password still works, and the account can enroll a new authenticator from account security after signing in.
+
+## hash-password
+
+```bash
+warmblyctl hash-password
+printf '%s' 'your password' | warmblyctl hash-password
+```
+
+Prints an argon2 hash for `WARMBLY_BOOTSTRAP_PASSWORD_HASH`, which provisions the owner before the first start of an instance with no accounts. See [unattended provisioning](/development/first-run/#unattended-provisioning).
+
+It prompts when a terminal is attached and reads the pipe when one is not, so the same command works by hand and in a provisioning script. The hash alone goes to stdout, so it can be captured or piped; the explanation goes to stderr. This is the only command that does not need a database.
+
+<Callout type="warn" title="Quote the hash">
+An argon2 PHC string contains `$` characters. Docker Compose reads those as interpolation, so a bare hash in `.env` silently loses part of itself. Wrap it in single quotes there, and double every `$` if you paste it into `docker-compose.yml` directly.
+</Callout>
+
+## When Redis is down
+
+Account recovery must not depend on the cache, so most commands treat an unreachable Redis as a warning and carry on.
+
+| Command | Without Redis |
+|---|---|
+| `setup-link` | Fails. The token lives in Redis, so there is nowhere to put it |
+| `user reset-password` without `--password-stdin` | Fails. The link is bound to a nonce in Redis. The message points you at the `--password-stdin` form |
+| `user reset-password --password-stdin` | Works. The password changes, but existing sessions cannot be revoked |
+| `user create` | Works. The new account is not warmed into the cache, which is harmless |
+| `status` | Works, and reports `redis_unreachable` as a finding |
+| Everything else | Works |
+
+## Make targets
+
+Every one of these runs `warmblyctl` inside the backend container of a compose install.
+
+| Target | Runs |
+|---|---|
+| `make claim` | Finds or prints the first-run claim link, and says what to do instead when the instance is already claimed |
+| `make doctor` | `warmblyctl status`, non-zero on any error-severity check |
+| `make cli ARGS="..."` | Any command, with a TTY attached so prompts work |
+| `make grant-admin EMAIL=... ROLE=...` | `user grant-admin` |
+| `make revoke-admin EMAIL=...` | `user revoke-admin` |
+
+## See also
+
+- [First run](/development/first-run/) for claiming a fresh instance and provisioning the owner unattended
+- [Accounts and access](/development/accounts-and-access/) for registration modes, invitations, login codes and single sign-on
+- [Instance health](/development/instance-health/) for every check `status` can report
+- [Troubleshooting](/development/troubleshooting/) for symptoms and the command that fixes each one
+- [Configuration reference](/development/configuration/) for every variable named here


### PR DESCRIPTION
## Why

The README and the docs both tell a self-hoster to run:

```
docker compose -p warmbly exec backend warmblyctl user create --email you@example.com --admin
```

Neither says where the password comes from. There is no generated password: the command prompts for one. Nothing documented the prompt, the `-T` rule that decides whether the prompt can happen at all, or what to do next once the account exists. There was also no page listing the CLI's commands and flags, so the only complete reference was `--help` inside a container you may not be able to reach.

## What

**New page: `/development/warmblyctl/`** (`docs/content/docs/development/warmblyctl.mdx`), registered in the Development `meta.json` between accounts and access and the configuration reference. It covers:

- how to run it in each runtime, plus `make cli`
- the TTY rule: `docker compose exec` allocates a TTY unless `-T`, prompts need it, pipes need it gone
- the four environment variables each command reads, and what breaks without each
- all nine commands with every flag, defaults, and what each one prints
- **The password is the one you type**, and a **Signing in afterwards** section: no emailed login code (`AUTH_LOGIN_CODE` defaults to off self-hosted), no email confirmation, no captcha without `TURNSTILE_SECRET`, no dependency on the registration mode, and `--admin` opens `ADMIN_URL` not `APP_URL`
- the `status` JSON key contract and exit-code behaviour, the admin role table, per-command behaviour when Redis is down, and the `make` wrappers

**Cross-links** from the four pages that already print these commands: first run, accounts and access, instance health, troubleshooting.

**Fix:** the super-admin mask in the first-run sample output said `4294967295`. `AllAdminPermissions` is `(1 << 22) - 1`, so it is `4194303`.

**README:** the self-hosting section was too long. The three-bullet gotcha list is now a four-row table that also names `make doctor`, the duplicated `make dev` / `make up` shared-database warning is dropped (it is stated in a callout immediately above the section), and the prose is tightened. Every fact that was there is still there, and the docs table gains a `warmblyctl` row.

## Verification

`pnpm types:check` and `pnpm lint` pass in `docs/` (the two lint warnings are pre-existing, in `hooks/useKeyboardShortcuts.ts` and `postcss.config.mjs`). Docs-only change, no Go or frontend source touched. Every flag, default, constant and threshold on the new page was read out of `cmd/warmblyctl/`, `internal/config/config_authpolicy.go` and `internal/models/admin_permission.go` rather than from the existing docs.