### PR TITLE
docs: fix the documented block order of warmblyctl status

### DIFF
--- a/docs/content/docs/development/first-run.mdx
+++ b/docs/content/docs/development/first-run.mdx
@@ -134,7 +134,7 @@ Signing in never depends on mail. The emailed login code is off on a self-hosted
 docker compose -p warmbly exec backend warmblyctl status
 ```
 
-It prints four blocks: the instance state, the platform admins, the health checks, and what to run next. Roughly, on an instance that already has accounts:
+It prints four blocks: the instance state, the platform admins, what to run next, and the health checks. Roughly, on an instance that already has accounts:
 
 ```
 Instance
@@ -148,15 +148,15 @@ Instance
 Platform admins
   you@example.com (super, mask 4194303)
 
-Checks
-  ...one line per finding, grouped by severity...
-
 How to get in
   Sign in at http://localhost:5173
   Lost the password:       warmblyctl user reset-password --email you@example.com
   Lost the authenticator:  warmblyctl user disable-2fa --email you@example.com
   No account of your own:  warmblyctl user create --email you@example.com --admin
   Who is an admin:         warmblyctl user list --admin
+
+Checks
+  ...one line per finding, grouped by severity...
 ```
 
 The exact wording moves with the state: an unclaimed instance says so and tells you to print a setup link instead. `--json` prints the same facts as a machine-readable document, which is what `make claim` reads.

--- a/docs/content/docs/development/warmblyctl.mdx
+++ b/docs/content/docs/development/warmblyctl.mdx
@@ -79,7 +79,7 @@ docker compose -p warmbly exec backend warmblyctl status
 | `--json` | off | Prints the state as JSON instead of prose, and always exits 0 |
 | `--quiet` | off | Prints only the checks, without the instance summary. Ignored with `--json` |
 
-It prints four blocks: the instance state, the platform admins, the health checks, and how to get in. A sample run is on [first run](/development/first-run/#checking-where-you-stand).
+It prints four blocks in this order: the instance state, the platform admins, how to get in, and the checks. A sample run is on [first run](/development/first-run/#checking-where-you-stand).
 
 The **How to get in** block changes with the state. An unclaimed instance is told to print a setup link; a claimed one is given the recovery commands; an instance with no platform admin is told to promote an account.
 


### PR DESCRIPTION
Follow-up to #128, from actually running the command against a live instance rather than reading the source.

`runStatus` calls `printStatus`, which emits **Instance**, **Platform admins** and **How to get in**, and only then calls `printChecks`. So the real order is:

```
Instance
Platform admins
How to get in
Checks
```

Both pages said the checks came third. The first-run sample output also had **Checks** and **How to get in** transposed, which matters because an operator scanning for the recovery commands was being told to look past a findings list that is in fact printed after them.

Verified against the live stack:

```
$ warmblyctl status
Instance
  Accounts          80
  ...
Platform admins
  admin@warmbly.local (super, mask 4194303)

How to get in
  Sign in at http://localhost:5173
  ...

Checks
  4 errors, 0 warnings, 2 notes
```

That same run confirms the mask correction in #128 empirically: `4194303`, not the `4294967295` the docs carried before.

`pnpm types:check` and `pnpm lint` pass in `docs/` (the two warnings are pre-existing).