### PR TITLE
feat: organization data export and import for moving a workspace between instances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,25 @@ Data modeling / representation:
 - prefer real typed columns / enums when the data is fixed-shape, queried or filtered in SQL, or benefits from FK integrity.
 - a `jsonb` column is the right call when the data is a free-form, evolving, read-then-execute blob that isn't filtered in SQL (e.g. the `sequences.conditions` branching tree and `sequences.action` node config) — keep it type-safe at the app boundary with a Go struct + validation on write, and a DB `CHECK` on any discriminator column.
 
+### Workspace data stays portable
+
+A customer can export their whole organization to an archive and import it on another instance (`internal/app/orgtransfer`, Settings > Data, `warmblyctl org export|import`). That only keeps working if every new piece of org-owned data is added to it deliberately. Data that isn't in the registry is silently absent from every archive, and nobody finds out until a migration lands on the other side missing a feature's data.
+
+So: **a migration that adds an organization-scoped table is not done until that table is in `internal/app/orgtransfer/spec.go`.** Add it to `Tables` with its data group and scope, or to `ExcludedTables` with the reason it must not travel. There is no third option; leaving it out is the bug.
+
+When you add one, work through:
+
+- **Scope.** The `WHERE` fragment selecting that table's rows for one organization, with `$1` as the org id. Use a subquery against a parent when the table has no `organization_id` of its own.
+- **Order.** `Tables` is applied top to bottom on import, so a table must sit below everything it references.
+- **Group.** Which `models.OrgDataGroup` it belongs to. If a NOT NULL foreign key crosses a group boundary, add the dependency to `Requires` in `models.OrgDataGroupCatalog` — otherwise a user who deselects the target group gets an import that aborts on a constraint. Nullable crossings need nothing; the importer blanks them.
+- **Secrets.** Any column holding ciphertext needs a `SecretColumn` with the right `KeyDomain`. Warmbly has two and they are not interchangeable: `KeyDomainInstance` is `CREDENTIALS_ENCRYPTION_KEY` (mailbox credentials, which the worker reads without an org context), `KeyDomainOrgDEK` is the per-organization DEK (everything else). Getting this wrong produces mailboxes that authenticate against nothing.
+- **Instance-local columns.** Anything naming a worker, a queue handle, a Stripe object, or a sync checkpoint belongs in `ResetOnImport`, or the whole table in `ImportSkip` when it only means something on the instance that wrote it.
+- **Blobs.** A column holding an object-storage key needs a `BlobColumn` so the bytes travel with the rows.
+
+Rows move as `jsonb` in both directions, so adding a *column* to an existing table needs no code change: the exporter emits it and the importer intersects against the destination catalog. Only new tables need registering.
+
+The same applies to the customer-facing side of a feature: if it stores org data, its docs page and `docs/content/docs/guides/workspace-export-import.mdx` should agree about whether that data moves.
+
 ### Verification: what to run, what to skip
 
 Keep the loop fast. The signals that matter are formatting, lint, and typecheck — not local builds or browser automation.

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/oauth"
 	"github.com/warmbly/warmbly/internal/app/oidcauth"
 	"github.com/warmbly/warmbly/internal/app/organization"
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
 	"github.com/warmbly/warmbly/internal/app/provisioning"
@@ -249,6 +250,9 @@ func main() {
 
 	// Danger zone (delayed deletions)
 	var dangerZoneService dangerzone.Service
+
+	// Workspace archives (export/import between instances)
+	var orgTransferService orgtransfer.Service
 
 	// Organization-wide audit trail
 	var auditService audit.AuditService
@@ -1396,6 +1400,25 @@ func main() {
 		dangerZoneScheduler := jobs.NewDangerZoneScheduler(dangerZoneJob, 1*time.Hour)
 		go dangerZoneScheduler.Start(ctx)
 
+		// Workspace archives: export a whole organization to a portable file
+		// and import one back, so a workspace can move between instances.
+		// It needs both key domains — the instance credential key for mailbox
+		// credentials and the org DEK for everything else — because neither is
+		// portable and both have to be re-keyed on the way through.
+		orgTransferService = orgtransfer.NewService(
+			repository.NewOrgTransferRepository(primaryDB),
+			cipherService,
+			credEncrypter,
+			s3,
+			orgtransfer.InstanceInfo{
+				PublicURL:  os.Getenv("APP_URL"),
+				AppVersion: os.Getenv("APP_VERSION"),
+			},
+		)
+		orgTransferJob := jobs.NewOrgTransferJob(orgTransferService)
+		orgTransferScheduler := jobs.NewOrgTransferScheduler(orgTransferJob, 1*time.Hour)
+		go orgTransferScheduler.Start(ctx)
+
 		// Prune audit entries past the retention window (90 days). Bounding the
 		// trail's age also bounds how long PII is retained. auditRepository is
 		// constructed earlier (before authService).
@@ -1684,7 +1707,8 @@ func main() {
 		ProvisioningPolicyRepo:   provisioningPolicyRepo,
 
 		// Danger zone
-		DangerZoneService: dangerZoneService,
+		DangerZoneService:  dangerZoneService,
+		OrgTransferService: orgTransferService,
 
 		// Admin System Status probes
 		SystemChecker: systemChecker,

--- a/cmd/warmblyctl/client.go
+++ b/cmd/warmblyctl/client.go
@@ -8,14 +8,23 @@ import (
 	"os"
 	"strings"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/organization"
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
 	"github.com/warmbly/warmbly/internal/app/token"
 	"github.com/warmbly/warmbly/internal/app/trial"
 	"github.com/warmbly/warmbly/internal/app/user"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/infrastructure/encryptedkeys"
+	"github.com/warmbly/warmbly/internal/infrastructure/kms"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -119,6 +128,96 @@ func (c *conn) trialService() trial.TrialService {
 
 func (c *conn) tokenService(secret string) token.TokenService {
 	return token.NewService(c.db, repository.NewTokenRepostory(c.db), c.cache, nil, secret)
+}
+
+// orgTransferService builds the workspace archive engine.
+//
+// This is the one command family that needs the crypto stack, because moving a
+// workspace means opening every sealed value on the way out and re-sealing it
+// on the way in. Both key domains are wired here: KMS (behind the per-org DEK)
+// and the instance credential key.
+//
+// Object storage is deliberately not wired. The CLI writes archives to a file
+// on the box it runs on, and attachment bytes are the only thing that needs a
+// blob store, which the export reports as absent rather than failing over.
+func (c *conn) orgTransferService(ctx context.Context) (orgtransfer.Service, error) {
+	// Redis only caches decrypted keys, so an outage costs a KMS round trip per
+	// organization rather than the command.
+	_ = c.openCache(ctx, false, "Sealed values will be unwrapped through KMS on every read, which is slower but correct.")
+
+	masterKey := "alias/master-key"
+	if cfg, err := config.NewConfig(ctx); err == nil && cfg.Env != "prod" {
+		masterKey += "-dev"
+	}
+
+	var awscfg aws.Config
+	if loaded, err := awsconfig.LoadDefaultConfig(ctx); err == nil {
+		awscfg = loaded
+	}
+
+	keyStore, err := kms.FromEnv(ctx, awscfg, masterKey)
+	if err != nil {
+		return nil, fmt.Errorf("this instance's KMS provider could not be opened, so sealed values cannot be read: %w", err)
+	}
+
+	encryptedKeys, err := encryptedkeys.FromEnv(encryptedkeys.Deps{DB: c.db}, "postgres")
+	if err != nil {
+		return nil, fmt.Errorf("the encrypted-key store could not be opened: %w", err)
+	}
+
+	// A missing CREDENTIALS_ENCRYPTION_KEY is not fatal: an export without
+	// credentials still works, and the engine reports the gap per mailbox.
+	credEncrypter, err := encrypt.FromEnv()
+	if err != nil {
+		return nil, fmt.Errorf("CREDENTIALS_ENCRYPTION_KEY is set but unusable: %w", err)
+	}
+	if credEncrypter == nil {
+		warn("CREDENTIALS_ENCRYPTION_KEY is not set, so mailbox credentials cannot be read or written by this command.")
+	}
+
+	return orgtransfer.NewService(
+		repository.NewOrgTransferRepository(c.db),
+		cipher.NewService(keyStore, c.cache, encryptedKeys),
+		credEncrypter,
+		nil,
+		orgtransfer.InstanceInfo{
+			PublicURL:  strings.TrimSpace(os.Getenv("APP_URL")),
+			AppVersion: strings.TrimSpace(os.Getenv("APP_VERSION")),
+		},
+	), nil
+}
+
+// resolveOrg accepts whatever an operator is most likely to have to hand: the
+// organization's id, its slug, or the email of the person who owns it.
+func (c *conn) resolveOrg(ctx context.Context, ref string) (uuid.UUID, string, error) {
+	ref = strings.TrimSpace(ref)
+
+	var id uuid.UUID
+	var name string
+	err := c.db.QueryRow(ctx, `
+		SELECT o.id, o.name
+		  FROM organizations o
+		  LEFT JOIN users u ON u.id = o.owner_user_id
+		 WHERE o.id::text = $1
+		    OR lower(o.slug) = lower($1)
+		    OR lower(u.email) = lower($1)
+		 ORDER BY o.created_at
+		 LIMIT 1
+	`, ref).Scan(&id, &name)
+	if err != nil {
+		return uuid.Nil, "", fmt.Errorf("no organization matches %q. Run `warmblyctl org list` to see what is on this instance.", ref)
+	}
+	return id, name, nil
+}
+
+// orgOwnerID returns the workspace owner, who inherits any imported row whose
+// original owner has no account on this instance.
+func (c *conn) orgOwnerID(ctx context.Context, orgID uuid.UUID) (uuid.UUID, error) {
+	var owner uuid.UUID
+	if err := c.db.QueryRow(ctx, `SELECT owner_user_id FROM organizations WHERE id = $1`, orgID).Scan(&owner); err != nil {
+		return uuid.Nil, fmt.Errorf("reading the organization's owner: %w", err)
+	}
+	return owner, nil
 }
 
 func dbEndpoint(ctx context.Context) (string, error) {

--- a/cmd/warmblyctl/main.go
+++ b/cmd/warmblyctl/main.go
@@ -61,6 +61,8 @@ func dispatch(ctx context.Context, args []string) error {
 		return runHashPassword(ctx, args[1:])
 	case "user":
 		return runUser(ctx, args[1:])
+	case "org":
+		return runOrg(ctx, args[1:])
 	}
 	return fmt.Errorf("unknown command %q. Run `warmblyctl --help` for the full list.", args[0])
 }
@@ -86,6 +88,9 @@ var commands = []command{
 	{"user revoke-admin", "Take platform admin away from an account", composeExec + "user revoke-admin --email old@example.com"},
 	{"user disable-2fa", "Clear an account's TOTP enrollment after a lost authenticator", composeExec + "user disable-2fa --email you@example.com"},
 	{"hash-password", "Print an argon2 hash for WARMBLY_BOOTSTRAP_PASSWORD_HASH", "printf '%s' 'your-password' | docker compose -p warmbly exec -T backend warmblyctl hash-password"},
+	{"org list", "List the workspaces on this instance with their id, owner, and size", composeExec + "org list"},
+	{"org export", "Write a whole workspace to a portable archive file", composeExec + "org export --org you@example.com --out /tmp/workspace.warmbly.zip"},
+	{"org import", "Apply an archive to a workspace on this instance", composeExec + "org import --org you@example.com --file /tmp/workspace.warmbly.zip"},
 }
 
 func usage(w *os.File) {
@@ -114,6 +119,12 @@ Environment:
   PRIMARY_DB   Postgres connection string. Every command except hash-password needs it.
   REDIS        Redis URL. setup-link needs it, and reset-password needs it to mint a link.
   APP_URL      Base URL every printed link is built from.
+
+  org export and org import additionally read the instance's crypto settings,
+  because a workspace's sealed values have to be opened on the way out and
+  re-sealed on the way in: KMS_PROVIDER (with KMS_LOCAL_MASTER_KEY or the AWS
+  settings) and CREDENTIALS_ENCRYPTION_KEY. Run them inside the backend
+  container, where those are already set.
 
 Exit status:
   status exits non-zero when a check is at error severity, so it works as a

--- a/cmd/warmblyctl/org.go
+++ b/cmd/warmblyctl/org.go
@@ -1,0 +1,495 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func runOrg(ctx context.Context, args []string) error {
+	if len(args) == 0 {
+		orgUsage(os.Stderr)
+		return errors.New("`org` needs a subcommand. Pick one from the list above.")
+	}
+
+	switch args[0] {
+	case "help", "-h", "--help":
+		orgUsage(os.Stdout)
+		return nil
+	case "list":
+		return runOrgList(ctx, args[1:])
+	case "export":
+		return runOrgExport(ctx, args[1:])
+	case "import":
+		return runOrgImport(ctx, args[1:])
+	}
+
+	orgUsage(os.Stderr)
+	return fmt.Errorf("unknown subcommand `org %s`. Pick one from the list above.", args[0])
+}
+
+func orgUsage(w *os.File) {
+	fmt.Fprint(w, "Move a workspace between instances.\n\nUsage:\n  warmblyctl org <subcommand> [flags]\n\nSubcommands:\n")
+	for _, c := range commands {
+		if !strings.HasPrefix(c.name, "org ") {
+			continue
+		}
+		fmt.Fprintf(w, "  %-16s %s\n", strings.TrimPrefix(c.name, "org "), c.summary)
+	}
+	fmt.Fprint(w, "\nExamples:\n")
+	for _, c := range commands {
+		if strings.HasPrefix(c.name, "org ") {
+			fmt.Fprintf(w, "  %s\n", c.example)
+		}
+	}
+	fmt.Fprint(w, `
+Data groups (--groups), comma separated. Omit to carry everything:
+`)
+	for _, g := range models.OrgDataGroupCatalog {
+		note := ""
+		if g.Required {
+			note = "  (always included)"
+		} else if g.Heavy {
+			note = "  (large)"
+		}
+		fmt.Fprintf(w, "  %-12s %s%s\n", g.Key, g.Label, note)
+	}
+	fmt.Fprint(w, `
+Credentials only travel when you pass --with-credentials, which seals them into
+the archive under a passphrase you supply. Import the archive with the same
+passphrase and mailboxes come up connected; without it they arrive needing a
+reconnect. The passphrase is never stored on either instance, so losing it means
+re-exporting.
+`)
+}
+
+// ---------- org list ----------
+
+func runOrgList(ctx context.Context, args []string) error {
+	fs := newFlagSet("org list")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := noExtraArgs(fs); err != nil {
+		return err
+	}
+
+	c, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.close()
+
+	rows, err := c.db.Query(ctx, `
+		SELECT o.id, o.name, u.email,
+		       (SELECT count(*) FROM organization_members m WHERE m.organization_id = o.id),
+		       (SELECT count(*) FROM email_accounts e WHERE e.organization_id = o.id),
+		       (SELECT count(*) FROM contacts ct WHERE ct.organization_id = o.id)
+		  FROM organizations o
+		  LEFT JOIN users u ON u.id = o.owner_user_id
+		 ORDER BY o.created_at
+	`)
+	if err != nil {
+		return fmt.Errorf("listing organizations: %w", err)
+	}
+	defer rows.Close()
+
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tNAME\tOWNER\tMEMBERS\tMAILBOXES\tCONTACTS")
+	var found int
+	for rows.Next() {
+		var id uuid.UUID
+		var name string
+		var owner *string
+		var members, mailboxes, contacts int64
+		if err := rows.Scan(&id, &name, &owner, &members, &mailboxes, &contacts); err != nil {
+			return err
+		}
+		ownerEmail := "(none)"
+		if owner != nil {
+			ownerEmail = *owner
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%d\t%d\n", id, name, ownerEmail, members, mailboxes, contacts)
+		found++
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+	if found == 0 {
+		fmt.Println("\nThis instance has no organizations yet.")
+	}
+	return nil
+}
+
+// ---------- org export ----------
+
+func runOrgExport(ctx context.Context, args []string) error {
+	fs := newFlagSet("org export")
+	orgRef := fs.String("org", "", "organization id, slug, or owner email (required)")
+	out := fs.String("out", "", "file to write the archive to (required; - writes to stdout)")
+	groupList := fs.String("groups", "", "comma-separated data groups to include (default: all)")
+	withCreds := fs.Bool("with-credentials", false, "seal mailbox and integration credentials into the archive")
+	passphraseStdin := fs.Bool("passphrase-stdin", false, "read the passphrase from stdin instead of prompting")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := noExtraArgs(fs); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*orgRef) == "" {
+		return errors.New("--org is required. Run `warmblyctl org list` to see what is on this instance.")
+	}
+	if strings.TrimSpace(*out) == "" {
+		return errors.New("--out is required, for example --out ./workspace.warmbly.zip")
+	}
+
+	groups, err := parseGroups(*groupList)
+	if err != nil {
+		return err
+	}
+
+	var passphrase string
+	if *withCreds {
+		passphrase, err = readPassphrase(ctx, *passphraseStdin, "Passphrase for the archive's credentials")
+		if err != nil {
+			return err
+		}
+		if err := orgtransfer.ValidatePassphrase(passphrase); err != nil {
+			return fmt.Errorf("%w. Nothing was written.", err)
+		}
+	}
+
+	c, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.close()
+
+	orgID, orgName, err := c.resolveOrg(ctx, *orgRef)
+	if err != nil {
+		return err
+	}
+
+	svc, err := c.orgTransferService(ctx)
+	if err != nil {
+		return err
+	}
+
+	// stdout is supported so the archive can be piped straight into ssh or a
+	// bucket without ever touching this box's disk.
+	var w *os.File
+	if *out == "-" {
+		w = os.Stdout
+	} else {
+		w, err = os.Create(*out)
+		if err != nil {
+			return fmt.Errorf("creating %s: %w", *out, err)
+		}
+		defer w.Close()
+	}
+
+	progress := newProgressPrinter(*out == "-")
+	manifest, err := svc.ExportTo(ctx, orgID, orgtransfer.ExportOptions{
+		Groups:     groups,
+		Passphrase: passphrase,
+	}, w, progress.report)
+	if err != nil {
+		return fmt.Errorf("exporting %s: %w", orgName, err)
+	}
+	progress.done()
+
+	if *out == "-" {
+		return nil
+	}
+
+	var total int64
+	for _, t := range manifest.Tables {
+		total += t.Rows
+	}
+	info, _ := w.Stat()
+
+	fmt.Printf("\nExported %s\n", orgName)
+	fmt.Printf("  File          %s", *out)
+	if info != nil {
+		fmt.Printf(" (%s)", humanBytes(info.Size()))
+	}
+	fmt.Println()
+	fmt.Printf("  Rows          %d across %d tables\n", total, len(manifest.Tables))
+	fmt.Printf("  Attachments   %d\n", len(manifest.Blobs))
+	fmt.Printf("  Members       %d\n", len(manifest.Members))
+	if manifest.Secrets != nil {
+		fmt.Printf("  Credentials   sealed with your passphrase\n")
+	} else {
+		fmt.Printf("  Credentials   not included; mailboxes will need reconnecting after import\n")
+	}
+
+	printSteps("Import it on the other instance with:", []string{
+		"warmblyctl org import --org <destination-org> --file " + *out +
+			map[bool]string{true: " --passphrase-stdin", false: ""}[manifest.Secrets != nil],
+	})
+	return nil
+}
+
+// ---------- org import ----------
+
+func runOrgImport(ctx context.Context, args []string) error {
+	fs := newFlagSet("org import")
+	orgRef := fs.String("org", "", "destination organization id, slug, or owner email (required)")
+	file := fs.String("file", "", "archive to import (required)")
+	groupList := fs.String("groups", "", "comma-separated data groups to apply (default: everything in the archive)")
+	overwrite := fs.Bool("overwrite", false, "replace rows that already exist here instead of keeping them")
+	passphraseStdin := fs.Bool("passphrase-stdin", false, "read the passphrase from stdin instead of prompting")
+	withCreds := fs.Bool("with-credentials", false, "unseal the archive's credentials (prompts for the export passphrase)")
+	dryRun := fs.Bool("dry-run", false, "report what would be applied and write nothing")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := noExtraArgs(fs); err != nil {
+		return err
+	}
+	if strings.TrimSpace(*orgRef) == "" {
+		return errors.New("--org is required. Run `warmblyctl org list` to see what is on this instance.")
+	}
+	if strings.TrimSpace(*file) == "" {
+		return errors.New("--file is required, for example --file ./workspace.warmbly.zip")
+	}
+
+	groups, err := parseGroups(*groupList)
+	if err != nil {
+		return err
+	}
+
+	f, err := os.Open(*file)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", *file, err)
+	}
+	defer f.Close()
+	stat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	archive := &fileArchive{f: f, size: stat.Size()}
+
+	var passphrase string
+	if *withCreds || *passphraseStdin {
+		passphrase, err = readPassphrase(ctx, *passphraseStdin, "Passphrase the archive was exported with")
+		if err != nil {
+			return err
+		}
+	}
+
+	c, err := connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer c.close()
+
+	orgID, orgName, err := c.resolveOrg(ctx, *orgRef)
+	if err != nil {
+		return err
+	}
+
+	svc, err := c.orgTransferService(ctx)
+	if err != nil {
+		return err
+	}
+
+	report, xerr := svc.Preflight(ctx, orgID, archive, passphrase)
+	if xerr != nil {
+		return errors.New(xerr.Message)
+	}
+
+	fmt.Printf("Archive\n")
+	fmt.Printf("  Workspace     %s\n", report.Archive.OrganizationName)
+	fmt.Printf("  Exported      %s from %s\n",
+		report.Archive.ExportedAt.Format("2006-01-02 15:04 MST"), orNone(report.Archive.SourceInstance))
+	fmt.Printf("  Rows          %d across %d tables\n", report.Archive.TotalRows(), len(report.Archive.RowCounts))
+	fmt.Printf("  Attachments   %d\n", report.Archive.BlobCount)
+	fmt.Printf("  Credentials   %s\n", credentialState(report))
+	fmt.Printf("\nDestination     %s\n", orgName)
+
+	if len(report.UnknownMembers) > 0 {
+		lines := make([]string, 0, len(report.UnknownMembers))
+		for _, m := range report.UnknownMembers {
+			lines = append(lines, m.Email)
+		}
+		sort.Strings(lines)
+		printSteps("These members have no account here, so their rows are reassigned to the workspace owner:", lines)
+	}
+	if len(report.Conflicts) > 0 {
+		lines := make([]string, 0, len(report.Conflicts))
+		for table, n := range report.Conflicts {
+			lines = append(lines, fmt.Sprintf("%-32s %d", table, n))
+		}
+		sort.Strings(lines)
+		verb := "kept as they are"
+		if *overwrite {
+			verb = "REPLACED, because --overwrite is set"
+		}
+		printSteps("Rows that already exist here will be "+verb+":", lines)
+	}
+	for _, w := range report.Warnings {
+		warn("%s", w)
+	}
+
+	if *dryRun {
+		fmt.Println("\nDry run: nothing was written.")
+		return nil
+	}
+
+	conflict := models.OrgImportConflictSkip
+	if *overwrite {
+		conflict = models.OrgImportConflictOverwrite
+	}
+
+	owner, err := c.orgOwnerID(ctx, orgID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println()
+	progress := newProgressPrinter(false)
+	result, err := svc.ImportFrom(ctx, orgID, archive, orgtransfer.ImportOptions{
+		Groups:      groups,
+		Conflict:    conflict,
+		Passphrase:  passphrase,
+		ActorUserID: owner,
+	}, progress.report)
+	if err != nil {
+		return fmt.Errorf("importing into %s: %w\nNothing was written: the import runs in one transaction.", orgName, err)
+	}
+	progress.done()
+
+	var applied int64
+	for _, n := range result.RowCounts {
+		applied += n
+	}
+	fmt.Printf("\nImported %d rows into %s\n", applied, orgName)
+	if result.SecretsApplied {
+		fmt.Println("  Credentials were unsealed and re-keyed for this instance.")
+	}
+	for _, w := range result.Warnings {
+		warn("%s", w)
+	}
+
+	printSteps("Next:", []string{
+		"Check the mailboxes in the dashboard; any that arrived without credentials show as needing a reconnect.",
+		"Workers are assigned by this instance, so a migrated mailbox is placed on its next scheduling pass.",
+	})
+	return nil
+}
+
+// ---------- helpers ----------
+
+// fileArchive adapts an open file to what the zip reader needs.
+type fileArchive struct {
+	f    *os.File
+	size int64
+}
+
+func (a *fileArchive) ReadAt(p []byte, off int64) (int, error) { return a.f.ReadAt(p, off) }
+func (a *fileArchive) Size() int64                             { return a.size }
+
+// parseGroups turns the --groups flag into a validated group list.
+func parseGroups(raw string) ([]models.OrgDataGroup, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	known := make(map[string]models.OrgDataGroup, len(models.AllOrgDataGroups))
+	for _, g := range models.AllOrgDataGroups {
+		known[string(g)] = g
+	}
+
+	var out []models.OrgDataGroup
+	for _, part := range strings.Split(raw, ",") {
+		name := strings.ToLower(strings.TrimSpace(part))
+		if name == "" {
+			continue
+		}
+		g, ok := known[name]
+		if !ok {
+			valid := make([]string, 0, len(models.AllOrgDataGroups))
+			for _, k := range models.AllOrgDataGroups {
+				valid = append(valid, string(k))
+			}
+			return nil, fmt.Errorf("unknown data group %q. Valid groups are: %s", name, strings.Join(valid, ", "))
+		}
+		out = append(out, g)
+	}
+	return out, nil
+}
+
+// readPassphrase prompts twice on a terminal, or reads stdin when told to. It
+// reuses the password prompt so the terminal rules are identical everywhere.
+func readPassphrase(ctx context.Context, fromStdin bool, what string) (string, error) {
+	return readPassword(ctx, fromStdin, what)
+}
+
+func credentialState(r *models.OrgImportPreflight) string {
+	switch {
+	case !r.Archive.HasSecrets:
+		return "not in this archive; mailboxes will need reconnecting"
+	case r.SecretsUnsealed:
+		return "sealed, and your passphrase opens them"
+	default:
+		return "sealed, but no passphrase was given; mailboxes will need reconnecting"
+	}
+}
+
+func orNone(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "an unnamed instance"
+	}
+	return s
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// progressPrinter keeps one line updated on stderr. It writes to stderr so
+// `--out -` can pipe the archive on stdout with the progress still visible.
+type progressPrinter struct {
+	quiet bool
+	last  string
+}
+
+func newProgressPrinter(quiet bool) *progressPrinter {
+	return &progressPrinter{quiet: quiet}
+}
+
+func (p *progressPrinter) report(percent int, stage string) {
+	if p.quiet || stage == p.last {
+		return
+	}
+	p.last = stage
+	fmt.Fprintf(os.Stderr, "\r\033[K  %3d%%  %s", percent, stage)
+}
+
+func (p *progressPrinter) done() {
+	if p.quiet || p.last == "" {
+		return
+	}
+	fmt.Fprint(os.Stderr, "\r\033[K")
+}

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -820,6 +820,13 @@ docker compose -p warmbly exec backend warmblyctl status
 docker compose -p warmbly exec backend warmblyctl setup-link
 docker compose -p warmbly exec backend warmblyctl user create --email you@example.com --admin
 docker compose -p warmbly exec backend warmblyctl user reset-password --email you@example.com
+docker compose -p warmbly exec backend warmblyctl org export --org you@example.com --out /tmp/workspace.warmbly.zip
 ```
+
+## Moving a workspace off this instance
+
+`warmblyctl org export` writes a whole workspace to one file, and `org import` reads it back on another instance. That is the supported route between a self-hosted install and the hosted service, in either direction, and between two self-hosted installs.
+
+Mailbox credentials are sealed under an instance-local key, so they only travel when you pass `--with-credentials` and a passphrase; without it, mailboxes arrive on the destination needing a reconnect. See [export and import](/guides/workspace-export-import/) for what an archive contains, and the [warmblyctl reference](/development/warmblyctl/#org-export) for every flag.
 
 See also: [configuration reference](/development/configuration/), [local development](/development/local-development/), [architecture](/development/architecture/), [event system](/development/events/).

--- a/docs/content/docs/development/warmblyctl.mdx
+++ b/docs/content/docs/development/warmblyctl.mdx
@@ -49,8 +49,10 @@ A command that would set a password refuses on a non-TTY unless you passed `--pa
 | `REDIS` | `setup-link` always, `reset-password` to mint a link | `setup-link` fails. Everything else degrades to a warning and continues |
 | `AUTH_SECRET` | `reset-password` when it mints a link | The link cannot be signed with the key the backend verifies, so it is refused |
 | `APP_URL` | every printed link and sign-in hint | Links are built against `https://app.warmbly.com`, which is the hosted service and not your instance |
+| `KMS_PROVIDER` and its key | `org export`, `org import` | The command stops: a workspace's sealed values cannot be opened, so an archive would be useless |
+| `CREDENTIALS_ENCRYPTION_KEY` | `org export`, `org import` | A warning, and mailbox credentials are neither read nor written. Everything else still moves |
 
-Inside the backend container all four are already set. Outside it, export them first, and match `AUTH_SECRET` to the backend's exactly.
+Inside the backend container all of these are already set. Outside it, export them first, and match `AUTH_SECRET` to the backend's exactly.
 
 ## The commands
 
@@ -65,6 +67,9 @@ Inside the backend container all four are already set. Outside it, export them f
 | [`user revoke-admin`](#user-revoke-admin) | Takes platform admin away from an account |
 | [`user disable-2fa`](#user-disable-2fa) | Clears an account's authenticator enrolment |
 | [`hash-password`](#hash-password) | Prints an argon2 hash for unattended provisioning |
+| [`org list`](#org-list) | Lists the workspaces on this instance with their id, owner, and size |
+| [`org export`](#org-export) | Writes a whole workspace to a portable archive file |
+| [`org import`](#org-import) | Applies an archive to a workspace on this instance |
 
 `warmblyctl --help` lists them, and `warmblyctl <command> --help` prints one command's flags with an example.
 
@@ -271,6 +276,70 @@ It prompts when a terminal is attached and reads the pipe when one is not, so th
 An argon2 PHC string contains `$` characters. Docker Compose reads those as interpolation, so a bare hash in `.env` silently loses part of itself. Wrap it in single quotes there, and double every `$` if you paste it into `docker-compose.yml` directly.
 </Callout>
 
+## org list
+
+```bash
+docker compose -p warmbly exec backend warmblyctl org list
+```
+
+Prints every workspace with its id, name, owner email, and member, mailbox and contact counts. It exists so the next two commands have something to name: `--org` accepts the id, the slug, or the owner's email, whichever you have to hand.
+
+## org export
+
+```bash
+docker compose -p warmbly exec backend warmblyctl org export \
+  --org you@example.com --out /tmp/workspace.warmbly.zip
+```
+
+Writes one workspace to a single archive file: the organization, its members and roles, mailboxes, campaigns, sequences, contacts, suppression, CRM, inbox history, and the send state that stops a migrated mailbox from sending twice its daily volume on the day it moves. It is the same archive the dashboard produces under **Settings > Data**, so either side of a migration can use either tool.
+
+| Flag | Does |
+|---|---|
+| `--org` | The workspace: its id, its slug, or the owner's email. Required |
+| `--out` | Where to write the archive. `-` writes to stdout, so it can be piped straight into `ssh` or a bucket. Required |
+| `--groups` | Comma-separated data groups to include. Omit for everything |
+| `--with-credentials` | Seals mailbox and integration credentials into the archive under a passphrase |
+| `--passphrase-stdin` | Reads the passphrase from stdin instead of prompting twice |
+
+`warmblyctl org export --help` prints the group list. `core` is always included; `inbox`, `sending`, `events` and `logs` are the ones that grow without limit, so dropping them is how you get a small archive that still rebuilds a working workspace.
+
+<Callout type="warn" title="An archive with credentials is the most sensitive file this product produces">
+It holds every mailbox password and refresh token in the workspace, protected only by the passphrase you type. Warmbly stores that passphrase nowhere, so losing it means exporting again, and anyone holding both the file and the passphrase can send mail as those mailboxes.
+</Callout>
+
+Without `--with-credentials` the credential fields travel empty and every mailbox arrives on the destination needing a reconnect. Everything else moves either way.
+
+Progress goes to stderr and the archive to the file, so `--out -` streams cleanly:
+
+```bash
+warmblyctl org export --org you@example.com --out - | ssh newhost 'cat > /tmp/workspace.zip'
+```
+
+## org import
+
+```bash
+docker compose -p warmbly exec backend warmblyctl org import \
+  --org you@example.com --file /tmp/workspace.warmbly.zip --dry-run
+```
+
+Applies an archive to a workspace on this instance. It always prints what the archive holds, which rows already exist here, and which members have no account, before writing anything.
+
+| Flag | Does |
+|---|---|
+| `--org` | The destination workspace: id, slug, or owner email. Required |
+| `--file` | The archive to read. Required |
+| `--groups` | Comma-separated data groups to apply. Omit for everything in the archive |
+| `--overwrite` | Replaces rows that already exist here instead of keeping them |
+| `--with-credentials` | Prompts for the export passphrase so credentials come across |
+| `--passphrase-stdin` | Reads that passphrase from stdin |
+| `--dry-run` | Prints the report and writes nothing |
+
+Run it with `--dry-run` first. The report is the same preflight the dashboard shows, and it costs nothing.
+
+The whole import runs in one transaction: if any part fails, nothing lands and the workspace is untouched. Members are matched to accounts on this instance by email address, and anyone without one has their rows reassigned to the workspace owner, named in the report before you commit. An archive carries no password material, so it can never create an account here.
+
+Billing history, plan overrides, worker placement, mailbox sync checkpoints and warmup pool membership are exported for the record but never applied: each belongs to the instance rather than to the workspace. [Export and import](/guides/workspace-export-import/) has the full table.
+
 ## When Redis is down
 
 Account recovery must not depend on the cache, so most commands treat an unreachable Redis as a warning and carry on.
@@ -282,6 +351,7 @@ Account recovery must not depend on the cache, so most commands treat an unreach
 | `user reset-password --password-stdin` | Works. The password changes, but existing sessions cannot be revoked |
 | `user create` | Works. The new account is not warmed into the cache, which is harmless |
 | `status` | Works, and reports `redis_unreachable` as a finding |
+| `org export` and `org import` | Work. Decrypted keys are not cached, so each workspace costs one extra KMS round trip |
 | Everything else | Works |
 
 ## Make targets
@@ -302,4 +372,5 @@ Every one of these runs `warmblyctl` inside the backend container of a compose i
 - [Accounts and access](/development/accounts-and-access/) for registration modes, invitations, login codes and single sign-on
 - [Instance health](/development/instance-health/) for every check `status` can report
 - [Troubleshooting](/development/troubleshooting/) for symptoms and the command that fixes each one
+- [Export and import](/guides/workspace-export-import/) for what an archive contains and what deliberately does not travel
 - [Configuration reference](/development/configuration/) for every variable named here

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -36,6 +36,7 @@
     "analytics",
     "notifications",
     "security",
+    "workspace-export-import",
     "team-roles",
     "collaboration",
     "referral-program"

--- a/docs/content/docs/guides/workspace-export-import.mdx
+++ b/docs/content/docs/guides/workspace-export-import.mdx
@@ -1,0 +1,109 @@
+---
+title: "Export and import"
+description: "Move a whole workspace between Warmbly instances, including mailboxes, campaigns, contacts, and inbox history."
+---
+
+A workspace archive is a single file holding everything one workspace owns. It exists so you can move between instances: a self-hosted install to the cloud, the cloud back to self-hosted, or one self-host to another.
+
+Everything here lives under **Settings > Data**, and is limited to the workspace owner. An export with credentials contains every mailbox password in the workspace, so it sits at the same level as deleting the workspace.
+
+## What an archive contains
+
+The data is split into groups. Every export includes **Workspace**; the rest are yours to choose.
+
+| Group | Contents |
+|-------|----------|
+| Workspace | The organization, members, roles, teams, mailboxes, API keys, webhooks, and settings. Always included |
+| Contacts | Contacts, categories, notes, activities, and the suppression list |
+| Campaigns | Campaigns, sequences, senders, attachments, and per-campaign settings |
+| CRM | Pipelines, deals, tasks, and meeting bookings |
+| Automations | Automations, connected integrations, and lead sync sources |
+| Assistant | Assistant sessions and messages, skills, MCP servers, and AI settings |
+| Warmup | Warmup participation, routing rules, statistics, and appeals |
+| Inbox | Unified inbox threads, message bodies, and mailbox sync state |
+| Send history | Queued and completed send tasks with their payloads |
+| Delivery events | Bounces, complaints, opens, clicks, and placement tests |
+| Logs | Audit log, campaign logs, and notifications |
+| Billing history | Subscription, credit ledger, and referral records |
+
+Inbox, send history, delivery events, and logs are the ones that grow without limit. Turn them off and you get a small archive that still rebuilds a working workspace; leave them on for a faithful copy.
+
+<Callout type="info" title="Suppression always travels with contacts">
+The suppression list is part of the Contacts group and is never optional within it. An import that dropped it would start mailing people who already opted out.
+</Callout>
+
+## Exporting
+
+Pick your groups, decide about credentials, and select **Start export**. The archive builds in the background, so you can leave the page; the **Archives** list shows live progress and a **Download** button when it lands.
+
+Archives are kept for 7 days and then deleted automatically. Each one is a full copy of the workspace, so they are not stored indefinitely. You can delete one yourself at any time, and export again whenever you need a fresh copy.
+
+### Credentials
+
+Mailbox passwords, OAuth tokens, and integration keys are encrypted with keys that belong to the instance they live on. Those keys mean nothing anywhere else, so credentials cannot simply be copied.
+
+Turn on **Include mailbox credentials** and Warmbly decrypts them, then re-seals them inside the archive with a key derived from a passphrase you choose. Import that archive with the same passphrase and the destination unseals them and re-encrypts them under its own keys. Mailboxes arrive connected and keep sending.
+
+<Callout type="warn" title="The passphrase is never stored">
+Warmbly does not keep it on either instance. If you lose it, the credentials inside that archive cannot be recovered and you have to export again. Use at least 12 characters and put it in a password manager before you close the page.
+</Callout>
+
+Leave the option off and the credential fields travel empty. Everything else imports normally, and each mailbox arrives marked for reconnection: open it on the destination and sign in again, exactly like connecting it the first time.
+
+## Importing
+
+Choose the archive file, enter its passphrase if it has one, and select **Check this archive**. Nothing is written yet. Warmbly reads the file and reports:
+
+- which workspace it came from, when, and how many rows it holds
+- whether your passphrase opens its credentials
+- how many rows already exist in the destination workspace
+- which members have no account on this instance
+- anything in the archive this instance is too old to understand
+
+Then pick the groups to apply, decide what happens to rows that already exist, and confirm.
+
+### Rows that already exist
+
+**Keep what is here** is the default: the archive only adds rows the destination does not already have. This is the right choice for an empty destination workspace, and the safe one for a workspace already in use.
+
+**Replace with the archive** overwrites matching rows with the archive's versions. Use it when you are re-running an import to pick up changes made on the source since the last one. It cannot be undone.
+
+### How people are matched
+
+Members are matched to destination accounts by email address, so the same person keeps their campaigns, contacts, and notes. An archive never carries password material and can never create an account.
+
+Anyone in the archive without an account on the destination has their rows reassigned to the person running the import, and the preflight report names them before you commit. Invite them afterwards and they get their access back through the normal member flow.
+
+### What deliberately does not import
+
+Some things belong to an instance rather than to a workspace, so they are not applied even when the archive contains them:
+
+| Not imported | Why |
+|--------------|-----|
+| Billing history | Subscription, credits, and referral balances belong to the platform that was paid. The destination issues its own |
+| Plan limit overrides | A capacity grant is a decision by one platform's operators, not a property the workspace carries |
+| Worker assignment | The destination places mailboxes on its own workers |
+| Mailbox sync checkpoints | Replaying a checkpoint would make the destination skip everything that arrived between export and import, so it re-syncs from scratch |
+| Warmup pool membership | Pools are shared across every workspace on an instance, so membership is re-earned rather than asserted by a file |
+| Scheduled deletions | A pending deletion from the source must never follow the workspace to its new home |
+
+An import runs as one transaction. If anything fails, nothing lands and the workspace is untouched.
+
+## After a move
+
+- **Reconnect any mailbox that needs it.** Mailboxes without credentials show as needing a reconnect in the mailbox list.
+- **Point your tracking domain at the new instance.** Click links already delivered keep resolving as long as the domain follows.
+- **Check campaign schedules.** Per-contact progress travels, so a running campaign resumes at the step it reached rather than restarting.
+- **Expect the daily send counters to be honoured.** Today's counts come across, so a mailbox cannot double its volume by being migrated mid-day.
+- **Re-authorize integrations** if you exported without credentials.
+
+<Callout type="info" title="Moving from a self-hosted instance">
+If you have shell access to the source, `warmblyctl org export` writes the same archive straight to a file without going through a browser, which is the easier route for a large workspace. See the [warmblyctl reference](/development/warmblyctl/).
+</Callout>
+
+## Limits
+
+- One export and one import can run per workspace at a time.
+- An uploaded archive can be up to 8 GB.
+- Archives expire 7 days after they finish.
+- An archive can be imported into any instance running the same or a newer release. A newer archive on an older instance is refused, with the version in the message.

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/notification"
 	"github.com/warmbly/warmbly/internal/app/oauth"
 	"github.com/warmbly/warmbly/internal/app/organization"
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
 	"github.com/warmbly/warmbly/internal/app/ratelimit"
@@ -279,6 +280,10 @@ type Handler struct {
 
 	// Danger zone (delayed deletions for orgs & user accounts)
 	DangerZoneService dangerzone.Service
+
+	// Workspace archives: export an organization to a portable file and import
+	// one back, for moving between instances. Nil disables the endpoints.
+	OrgTransferService orgtransfer.Service
 
 	// Infrastructure liveness probes for the admin System Status page.
 	// Wired in cmd/backend/main.go where the concrete clients live.

--- a/internal/api/handler/org_transfer.go
+++ b/internal/api/handler/org_transfer.go
@@ -1,0 +1,400 @@
+package handler
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Organization archives: export a whole workspace to a file, and import one
+// back. Owner-only, and JWT-only at the route.
+//
+// Owner-only is not conservatism for its own sake. An export with credentials
+// is the single most sensitive artifact this product can produce — every
+// mailbox password and OAuth refresh token in the workspace, in one file — and
+// an import rewrites the workspace wholesale. Both sit at the same level as
+// deleting the organization, so both are gated the same way.
+
+// orgOwnerContext resolves the caller's organization and confirms they own it,
+// answering the request itself when they do not.
+func (h *Handler) orgOwnerContext(c *gin.Context) (orgID, userID uuid.UUID, ok bool) {
+	uid, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return uuid.Nil, uuid.Nil, false
+	}
+	oid := middleware.GetOrganizationID(c)
+	if oid == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return uuid.Nil, uuid.Nil, false
+	}
+	if xerr := h.requireOrgOwner(c, *oid, uid); xerr != nil {
+		errx.JSON(c, errx.New(errx.Forbidden, "Only the workspace owner can export or import workspace data."))
+		return uuid.Nil, uuid.Nil, false
+	}
+	return *oid, uid, true
+}
+
+// GetOrgTransferGroups lists the data groups an archive can carry, so the
+// settings page renders the toggles from the server's own catalog rather than
+// a copy that drifts.
+//
+// GET /organization/current/transfer/groups
+func (h *Handler) GetOrgTransferGroups(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{
+		"groups":         models.OrgDataGroupCatalog,
+		"format_version": models.OrgTransferFormatVersion,
+		"min_passphrase": models.MinOrgExportPassphraseLength,
+		"retention_days": int(models.OrgExportRetention.Hours() / 24),
+	})
+}
+
+// ---------- export ----------
+
+// CreateOrgExport starts an archive build.
+//
+// POST /organization/current/export
+func (h *Handler) CreateOrgExport(c *gin.Context) {
+	orgID, userID, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "Workspace export is not available on this instance."))
+		return
+	}
+
+	var req models.CreateOrgExportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid request body"))
+		return
+	}
+
+	job, xerr := h.OrgTransferService.RequestExport(c.Request.Context(), orgID, &userID, &req)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+
+	h.auditOrg(c, models.AuditActionExport, models.AuditEntityOrgArchive, &job.ID, nil, map[string]string{
+		"include_secrets": fmt.Sprintf("%t", job.IncludeSecrets),
+		"groups":          fmt.Sprintf("%d", len(job.Groups)),
+	})
+	c.JSON(http.StatusAccepted, job)
+}
+
+// ListOrgExports returns recent archive builds.
+//
+// GET /organization/current/export
+func (h *Handler) ListOrgExports(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		c.JSON(http.StatusOK, gin.H{"data": []models.OrgExportJob{}})
+		return
+	}
+
+	jobs, xerr := h.OrgTransferService.ListExports(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": jobs})
+}
+
+// GetOrgExport returns one archive build, for progress polling.
+//
+// GET /organization/current/export/:id
+func (h *Handler) GetOrgExport(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	id, ok := parseUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.ErrNotFound)
+		return
+	}
+
+	job, xerr := h.OrgTransferService.GetExport(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, job)
+}
+
+// DownloadOrgExport streams a finished archive.
+//
+// GET /organization/current/export/:id/download
+func (h *Handler) DownloadOrgExport(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	id, ok := parseUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.ErrNotFound)
+		return
+	}
+
+	body, job, xerr := h.OrgTransferService.OpenExport(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	defer body.Close()
+
+	name := "workspace-" + job.ID.String()[:8] + ".warmbly.zip"
+	if org, err := h.OrgRepo.GetByID(c.Request.Context(), orgID); err == nil && org != nil {
+		name = orgtransfer.ArchiveFilename(org.Name, job.ID)
+	}
+
+	h.auditOrg(c, models.AuditActionExport, models.AuditEntityOrgArchive, &job.ID, nil, map[string]string{
+		"downloaded": "true",
+	})
+
+	c.Header("Content-Type", "application/zip")
+	c.Header("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, name))
+	c.Header("X-Content-Type-Options", "nosniff")
+	if job.ArchiveBytes != nil {
+		c.Header("Content-Length", fmt.Sprintf("%d", *job.ArchiveBytes))
+	}
+	if job.ArchiveSHA256 != nil {
+		c.Header("X-Archive-SHA256", *job.ArchiveSHA256)
+	}
+
+	if _, err := io.Copy(c.Writer, body); err != nil {
+		// The client hung up mid-download. Nothing useful left to say: the
+		// status line is already sent.
+		return
+	}
+}
+
+// DeleteOrgExport removes an archive and its stored object.
+//
+// DELETE /organization/current/export/:id
+func (h *Handler) DeleteOrgExport(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	id, ok := parseUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.ErrNotFound)
+		return
+	}
+
+	if xerr := h.OrgTransferService.DeleteExport(c.Request.Context(), orgID, id); xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	h.auditOrg(c, models.AuditActionDelete, models.AuditEntityOrgArchive, &id, nil, nil)
+	c.Status(http.StatusNoContent)
+}
+
+// ---------- import ----------
+
+// PreflightOrgImport reports what an uploaded archive would do, writing
+// nothing.
+//
+// POST /organization/current/import/preflight
+func (h *Handler) PreflightOrgImport(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "Workspace import is not available on this instance."))
+		return
+	}
+
+	spooled, xerr := spoolArchiveUpload(c)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	defer spooled.Close()
+
+	report, xerr := h.OrgTransferService.Preflight(
+		c.Request.Context(), orgID, spooled, c.Request.FormValue("passphrase"))
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, report)
+}
+
+// CreateOrgImport applies an uploaded archive to the current workspace.
+//
+// POST /organization/current/import
+func (h *Handler) CreateOrgImport(c *gin.Context) {
+	orgID, userID, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "Workspace import is not available on this instance."))
+		return
+	}
+
+	// The import keeps reading this file after the request returns, so
+	// ownership passes to the service on success and it closes it when the
+	// job ends. Every failure path before that hands it back here.
+	spooled, xerr := spoolArchiveUpload(c)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+
+	var req models.CreateOrgImportRequest
+	if opts := c.Request.FormValue("options"); opts != "" {
+		if err := jsonUnmarshalString(opts, &req); err != nil {
+			_ = spooled.Close()
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid 'options' JSON: "+err.Error()))
+			return
+		}
+	}
+	req.Passphrase = c.Request.FormValue("passphrase")
+
+	job, xerr := h.OrgTransferService.RequestImport(c.Request.Context(), orgID, &userID, spooled, &req)
+	if xerr != nil {
+		_ = spooled.Close()
+		errx.JSON(c, xerr)
+		return
+	}
+
+	h.auditOrg(c, models.AuditActionImport, models.AuditEntityOrgArchive, &job.ID, nil, map[string]string{
+		"conflict_strategy": string(job.ConflictStrategy),
+	})
+	c.JSON(http.StatusAccepted, job)
+}
+
+// ListOrgImports returns recent imports.
+//
+// GET /organization/current/import
+func (h *Handler) ListOrgImports(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		c.JSON(http.StatusOK, gin.H{"data": []models.OrgImportJob{}})
+		return
+	}
+
+	jobs, xerr := h.OrgTransferService.ListImports(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": jobs})
+}
+
+// GetOrgImport returns one import, for progress polling.
+//
+// GET /organization/current/import/:id
+func (h *Handler) GetOrgImport(c *gin.Context) {
+	orgID, _, ok := h.orgOwnerContext(c)
+	if !ok {
+		return
+	}
+	id, ok := parseUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if h.OrgTransferService == nil {
+		errx.JSON(c, errx.ErrNotFound)
+		return
+	}
+
+	job, xerr := h.OrgTransferService.GetImport(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, job)
+}
+
+// ---------- upload spooling ----------
+
+// spooledArchive is an uploaded archive on local disk. A zip needs random
+// access and a length, and a workspace archive is far too large to hold in
+// memory, so the upload lands in a temporary file first.
+//
+// It is an io.Closer so ownership can be handed to a background import: the
+// service closes it when the job ends, which is the only point at which the
+// bytes are certainly no longer needed.
+type spooledArchive struct {
+	f    *os.File
+	size int64
+}
+
+func (s *spooledArchive) ReadAt(p []byte, off int64) (int, error) { return s.f.ReadAt(p, off) }
+func (s *spooledArchive) Size() int64                             { return s.size }
+
+func (s *spooledArchive) Close() error {
+	err := s.f.Close()
+	_ = os.Remove(s.f.Name())
+	return err
+}
+
+// spoolArchiveUpload writes the multipart upload to a temporary file.
+func spoolArchiveUpload(c *gin.Context) (*spooledArchive, *errx.Error) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, models.MaxOrgArchiveUploadBytes)
+
+	file, _, err := c.Request.FormFile("file")
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "missing 'file' form field")
+	}
+	defer file.Close()
+
+	tmp, err := os.CreateTemp("", "warmbly-import-*.zip")
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	spooled := &spooledArchive{f: tmp}
+
+	size, err := io.Copy(tmp, file)
+	if err != nil {
+		_ = spooled.Close()
+		return nil, errx.New(errx.BadRequest, "the upload could not be read")
+	}
+	if size == 0 {
+		_ = spooled.Close()
+		return nil, errx.New(errx.BadRequest, "the uploaded file is empty")
+	}
+	spooled.size = size
+
+	return spooled, nil
+}
+
+// parseUUIDParam reads a UUID path parameter, answering 400 on a malformed one.
+func parseUUIDParam(c *gin.Context, name string) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param(name))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid "+name))
+		return uuid.Nil, false
+	}
+	return id, true
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -960,6 +960,22 @@ func Run(
 				org.POST("/avatar", m.RequireOrganization(), h.UploadOrganizationAvatar)
 				org.DELETE("/avatar", m.RequireOrganization(), h.DeleteOrganizationAvatar)
 
+				// Workspace archives: export the whole organization to a file
+				// and import one back, for moving between instances. Every
+				// route is owner-only (checked in the handler): an export with
+				// credentials is the most sensitive artifact this product
+				// produces, and an import rewrites the workspace.
+				org.GET("/current/transfer/groups", m.RequireOrganization(), h.GetOrgTransferGroups)
+				org.POST("/current/export", m.RequireOrganization(), h.CreateOrgExport)
+				org.GET("/current/export", m.RequireOrganization(), h.ListOrgExports)
+				org.GET("/current/export/:id", m.RequireOrganization(), h.GetOrgExport)
+				org.GET("/current/export/:id/download", m.RequireOrganization(), h.DownloadOrgExport)
+				org.DELETE("/current/export/:id", m.RequireOrganization(), h.DeleteOrgExport)
+				org.POST("/current/import/preflight", m.RequireOrganization(), h.PreflightOrgImport)
+				org.POST("/current/import", m.RequireOrganization(), h.CreateOrgImport)
+				org.GET("/current/import", m.RequireOrganization(), h.ListOrgImports)
+				org.GET("/current/import/:id", m.RequireOrganization(), h.GetOrgImport)
+
 				org.GET("/current/danger-zone", m.RequireOrganization(), h.GetOrganizationDangerZone)
 				org.POST("/current/danger-zone/delete", m.RequireOrganization(), h.ScheduleOrganizationDeletion)
 				org.DELETE("/current/danger-zone/delete", m.RequireOrganization(), h.CancelOrganizationDeletion)

--- a/internal/app/cipher/cache.go
+++ b/internal/app/cipher/cache.go
@@ -2,15 +2,24 @@ package cipher
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 )
+
+// errNoCache means this process was built without Redis. The DEK cache is an
+// optimisation, never a requirement, so a cacheless caller (warmblyctl, which
+// exists to work while things are down) falls through to KMS on every call.
+var errNoCache = errors.New("cipher: no cache configured")
 
 func getDecryptedKeyKey(orgID uuid.UUID) string {
 	return "decrypted_key:" + orgID.String()
 }
 
 func (s *cipherService) getDecryptedKey(ctx context.Context, orgID uuid.UUID) ([]byte, error) {
+	if s.cache == nil {
+		return nil, errNoCache
+	}
 	key := getDecryptedKeyKey(orgID)
 
 	deckey, err := s.cache.Get(ctx, key).Bytes()
@@ -22,6 +31,9 @@ func (s *cipherService) getDecryptedKey(ctx context.Context, orgID uuid.UUID) ([
 }
 
 func (s *cipherService) saveDecryptedKey(ctx context.Context, orgID uuid.UUID, decryptedKey []byte) error {
+	if s.cache == nil {
+		return nil
+	}
 	key := getDecryptedKeyKey(orgID)
 
 	if err := s.cache.SetNX(ctx, key, decryptedKey, DecryptedKeyTTL).Err(); err != nil {

--- a/internal/app/orgtransfer/export.go
+++ b/internal/app/orgtransfer/export.go
@@ -1,0 +1,438 @@
+package orgtransfer
+
+import (
+	"archive/zip"
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// ExportTo writes one organization's archive to w.
+//
+// The archive is a zip, so the manifest can be written last (after the row
+// counts are known) and still be the first thing an importer reads: zip has a
+// central directory, so entry order on disk is not read order.
+func (s *service) ExportTo(
+	ctx context.Context,
+	orgID uuid.UUID,
+	opts ExportOptions,
+	w io.Writer,
+	progress ProgressFunc,
+) (*Manifest, error) {
+	report := func(p int, stage string) {
+		if progress != nil {
+			progress(p, stage)
+		}
+	}
+	report(1, "reading workspace")
+
+	orgRaw, err := s.repo.OrganizationRow(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("read organization: %w", err)
+	}
+	if orgRaw == nil {
+		return nil, errors.New("organization not found")
+	}
+	var orgRow map[string]json.RawMessage
+	if err := json.Unmarshal(orgRaw, &orgRow); err != nil {
+		return nil, fmt.Errorf("decode organization: %w", err)
+	}
+
+	members, err := s.repo.ArchiveMembers(ctx, orgID)
+	if err != nil {
+		return nil, fmt.Errorf("read members: %w", err)
+	}
+
+	groups := NormalizeGroups(opts.Groups)
+	tables := GroupTables(groups)
+
+	manifest := &Manifest{
+		Kind:             ArchiveKind,
+		FormatVersion:    models.OrgTransferFormatVersion,
+		SourceInstance:   s.instance.PublicURL,
+		SourceAppVersion: s.instance.AppVersion,
+		ExportedAt:       time.Now().UTC(),
+		Organization:     toAnyMap(orgRow),
+		OrganizationID:   orgID,
+		OrganizationName: jsonString(orgRow["name"]),
+		Groups:           groups,
+		Members:          members,
+		Tables:           make([]ManifestTable, 0, len(tables)),
+	}
+
+	// Derive the archive key up front: a passphrase that fails validation
+	// should stop the export before it has read a single row.
+	var archiveKey []byte
+	if opts.Passphrase != "" {
+		hdr, key, err := NewSecretsHeader(opts.Passphrase)
+		if err != nil {
+			return nil, err
+		}
+		manifest.Secrets = hdr
+		archiveKey = key
+	}
+
+	// The org DEK is only needed when a selected table has DEK-sealed columns
+	// and we are actually carrying secrets.
+	var orgCipher *cipher.Cipher
+	if archiveKey != nil && s.cipher != nil && needsOrgDEK(tables) {
+		orgCipher, err = s.cipher.Cipher(ctx, orgID)
+		if err != nil {
+			return nil, fmt.Errorf("load organization key: %w", err)
+		}
+	}
+
+	zw := zip.NewWriter(w)
+	blobs := newBlobCollector()
+
+	// The org's own avatar is an object too, and the org row lives in the
+	// manifest rather than in a table, so it is collected here.
+	if url := jsonString(orgRow["avatar_url"]); url != "" {
+		blobs.addURL(url, "organizations", "avatar_url")
+	}
+
+	for i, t := range tables {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Table coverage is compiled in, but an instance mid-migration may not
+		// have it yet. Skipping beats failing the whole export.
+		cols, err := s.repo.TableColumns(ctx, t.Name)
+		if err != nil {
+			return nil, fmt.Errorf("inspect %s: %w", t.Name, err)
+		}
+		if len(cols) == 0 {
+			continue
+		}
+
+		report(5+(i*80)/len(tables), "exporting "+t.Name)
+
+		entry, err := zw.Create(dataPath(t.Name))
+		if err != nil {
+			return nil, err
+		}
+		buf := bufio.NewWriterSize(entry, 256*1024)
+
+		mt := ManifestTable{
+			Name:    t.Name,
+			Group:   t.Group,
+			Columns: columnNames(cols),
+		}
+		if archiveKey != nil {
+			for _, sc := range t.Secrets {
+				mt.SecretColumns = append(mt.SecretColumns, sc.Column)
+			}
+		}
+
+		// Rows only need decoding when something on them has to change. Most
+		// tables have neither secrets nor blobs, so they stream through
+		// untouched, which is what makes a million-row inbox export cheap.
+		passthrough := len(t.Secrets) == 0 && len(t.Blobs) == 0
+
+		err = s.repo.StreamScoped(ctx, t.Name, t.Scope, orgID, func(row []byte) error {
+			out := row
+			if !passthrough {
+				transformed, terr := s.exportRow(ctx, t, row, archiveKey, orgCipher, blobs)
+				if terr != nil {
+					return terr
+				}
+				out = transformed
+			}
+			if _, werr := buf.Write(out); werr != nil {
+				return werr
+			}
+			if werr := buf.WriteByte('\n'); werr != nil {
+				return werr
+			}
+			mt.Rows++
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := buf.Flush(); err != nil {
+			return nil, err
+		}
+		manifest.Tables = append(manifest.Tables, mt)
+	}
+
+	report(86, "collecting attachments")
+	if err := s.writeBlobs(ctx, zw, blobs, manifest); err != nil {
+		return nil, err
+	}
+
+	report(96, "writing manifest")
+	if err := writeJSONEntry(zw, manifestPath, manifest); err != nil {
+		return nil, err
+	}
+	if err := zw.Close(); err != nil {
+		return nil, err
+	}
+	report(100, "done")
+	return manifest, nil
+}
+
+// exportRow rewrites one row's secret and blob columns.
+func (s *service) exportRow(
+	ctx context.Context,
+	t *Table,
+	row []byte,
+	archiveKey []byte,
+	orgCipher *cipher.Cipher,
+	blobs *blobCollector,
+) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(row, &obj); err != nil {
+		return nil, fmt.Errorf("decode %s row: %w", t.Name, err)
+	}
+
+	for _, sc := range t.Secrets {
+		raw, ok := obj[sc.Column]
+		if !ok {
+			continue
+		}
+		stored := jsonString(raw)
+		if stored == "" {
+			continue
+		}
+		// A guarded column only holds ciphertext when its flag is set.
+		if sc.Guard != "" && !jsonBool(obj[sc.Guard]) {
+			continue
+		}
+
+		if archiveKey == nil {
+			// Not carrying secrets: blank the column rather than shipping
+			// ciphertext no destination could ever open.
+			blankSecret(obj, sc)
+			continue
+		}
+
+		plain, err := s.openSecret(ctx, sc, stored, orgCipher)
+		if err != nil {
+			// One unreadable credential must not sink the export. Blank it and
+			// let the mailbox arrive needing a reconnect.
+			blankSecret(obj, sc)
+			continue
+		}
+		sealed, err := SealValue(archiveKey, plain)
+		if err != nil {
+			return nil, err
+		}
+		enc, err := json.Marshal(sealed)
+		if err != nil {
+			return nil, err
+		}
+		obj[sc.Column] = enc
+	}
+
+	for _, bc := range t.Blobs {
+		v := jsonString(obj[bc.Column])
+		if v == "" {
+			continue
+		}
+		switch bc.Kind {
+		case BlobKindKey:
+			blobs.addKey(v, t.Name, bc.Column)
+		case BlobKindPublicURL:
+			blobs.addURL(v, t.Name, bc.Column)
+		}
+	}
+
+	return json.Marshal(obj)
+}
+
+// openSecret returns the plaintext behind one stored value, using whichever
+// key domain sealed it.
+func (s *service) openSecret(ctx context.Context, sc SecretColumn, stored string, orgCipher *cipher.Cipher) (string, error) {
+	switch sc.Domain {
+	case KeyDomainInstance:
+		if s.creds == nil {
+			return "", errors.New("credential key not configured")
+		}
+		return s.creds.Decrypt(stored)
+	case KeyDomainOrgDEK:
+		if orgCipher == nil {
+			return "", errors.New("organization key unavailable")
+		}
+		return orgCipher.Decrypt(ctx, stored)
+	}
+	return "", fmt.Errorf("column %s has no key domain", sc.Column)
+}
+
+// writeBlobs copies every collected object into the archive.
+func (s *service) writeBlobs(ctx context.Context, zw *zip.Writer, blobs *blobCollector, manifest *Manifest) error {
+	if s.blobs == nil || len(blobs.order) == 0 {
+		return nil
+	}
+	for i, key := range blobs.order {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		ref := blobs.refs[key]
+		body, err := s.blobs.Get(ctx, key)
+		if err != nil {
+			// A missing object is a gap in the archive, not a reason to lose
+			// the other ten thousand rows. The row keeps its key, and the
+			// import reports the object as absent.
+			continue
+		}
+
+		archivePath := blobArchivePath(i, key)
+		entry, cerr := zw.Create(archivePath)
+		if cerr != nil {
+			_ = body.Close()
+			return cerr
+		}
+		n, cerr := io.Copy(entry, body)
+		_ = body.Close()
+		if cerr != nil {
+			return cerr
+		}
+		manifest.Blobs = append(manifest.Blobs, ManifestBlob{
+			Key:    key,
+			Path:   archivePath,
+			Size:   n,
+			Table:  ref.table,
+			Column: ref.column,
+		})
+	}
+	return nil
+}
+
+// blobCollector dedupes object references across rows.
+type blobCollector struct {
+	order []string
+	refs  map[string]blobRef
+}
+
+type blobRef struct{ table, column string }
+
+func newBlobCollector() *blobCollector {
+	return &blobCollector{refs: map[string]blobRef{}}
+}
+
+func (b *blobCollector) addKey(key, table, column string) {
+	if key == "" {
+		return
+	}
+	if _, seen := b.refs[key]; seen {
+		return
+	}
+	b.refs[key] = blobRef{table, column}
+	b.order = append(b.order, key)
+}
+
+// addURL recovers an object key from a public URL. Both storage backends build
+// that URL differently, but the key always begins with a known prefix, so the
+// prefix is what we look for. A URL that matches nothing is left alone: the row
+// keeps its absolute URL and the image simply resolves against the old host.
+func (b *blobCollector) addURL(url, table, column string) {
+	for _, prefix := range publicKeyPrefixes {
+		if idx := strings.Index(url, prefix); idx >= 0 {
+			key := url[idx:]
+			if q := strings.IndexAny(key, "?#"); q >= 0 {
+				key = key[:q]
+			}
+			b.addKey(key, table, column)
+			return
+		}
+	}
+}
+
+// publicKeyPrefixes are the object-key prefixes reachable through a public URL.
+var publicKeyPrefixes = []string{"avatars/"}
+
+// ---------- small JSON helpers ----------
+
+func writeJSONEntry(zw *zip.Writer, name string, v any) error {
+	entry, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	enc := json.NewEncoder(entry)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// blankSecret empties a secret column, and clears its guard when it has one.
+// Leaving the guard set would leave the row claiming to hold ciphertext it no
+// longer has, which the reader would then try to decrypt.
+func blankSecret(obj map[string]json.RawMessage, sc SecretColumn) {
+	obj[sc.Column] = json.RawMessage(`""`)
+	if sc.Guard != "" {
+		obj[sc.Guard] = json.RawMessage(`false`)
+	}
+}
+
+// jsonString reads a JSON value as a string, returning "" for null, absent, or
+// a non-string value.
+func jsonString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+func jsonBool(raw json.RawMessage) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var b bool
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return false
+	}
+	return b
+}
+
+func toAnyMap(in map[string]json.RawMessage) map[string]any {
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		var decoded any
+		if err := json.Unmarshal(v, &decoded); err != nil {
+			continue
+		}
+		out[k] = decoded
+	}
+	return out
+}
+
+func columnNames(cols []repository.ColumnInfo) []string {
+	out := make([]string, len(cols))
+	for i, c := range cols {
+		out[i] = c.Name
+	}
+	return out
+}
+
+// needsOrgDEK reports whether any selected table has a DEK-sealed column.
+func needsOrgDEK(tables []*Table) bool {
+	for _, t := range tables {
+		for _, sc := range t.Secrets {
+			if sc.Domain == KeyDomainOrgDEK {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/app/orgtransfer/import.go
+++ b/internal/app/orgtransfer/import.go
@@ -1,0 +1,683 @@
+package orgtransfer
+
+import (
+	"archive/zip"
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+const (
+	// importBatchRows is how many rows go into one INSERT.
+	importBatchRows = 500
+	// importBatchBytes caps a batch by payload size, because one inbox row can
+	// carry a megabyte of message body and a fixed row count is no protection.
+	importBatchBytes = 8 << 20
+	// maxManifestBytes bounds the manifest read from an untrusted archive.
+	maxManifestBytes = 64 << 20
+)
+
+// ImportFrom applies an archive to a destination workspace.
+//
+// The whole thing runs in one transaction. An import is a rare, deliberate,
+// operator-driven event, and a half-applied workspace — campaigns without
+// their sequences, contacts without their suppression list — is far worse than
+// a long-running transaction. If anything fails, nothing lands.
+func (s *service) ImportFrom(
+	ctx context.Context,
+	orgID uuid.UUID,
+	archive ReaderAtSizer,
+	opts ImportOptions,
+	progress ProgressFunc,
+) (*ImportResult, error) {
+	report := func(p int, stage string) {
+		if progress != nil {
+			progress(p, stage)
+		}
+	}
+	report(1, "reading archive")
+
+	zr, err := zip.NewReader(archive, archive.Size())
+	if err != nil {
+		return nil, fmt.Errorf("archive is not a readable zip: %w", err)
+	}
+	entries := indexEntries(zr)
+
+	manifest, err := readManifest(entries)
+	if err != nil {
+		return nil, err
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, err
+	}
+
+	result := &ImportResult{RowCounts: map[string]int64{}}
+
+	archiveKey, err := s.resolveArchiveKey(manifest, opts.Passphrase)
+	if err != nil {
+		return nil, err
+	}
+	result.SecretsApplied = archiveKey != nil
+	switch {
+	case manifest.Secrets != nil && archiveKey == nil:
+		result.Warnings = append(result.Warnings,
+			"This archive carries sealed credentials but no passphrase was supplied, so mailboxes and integrations were imported without them and need reconnecting.")
+	case manifest.Secrets == nil:
+		result.Warnings = append(result.Warnings,
+			"This archive was exported without credentials, so mailboxes and integrations need reconnecting.")
+	}
+
+	// The destination's own DEK, for re-sealing everything the archive holds
+	// under the org key domain.
+	var orgCipher *cipher.Cipher
+	if archiveKey != nil && s.cipher != nil {
+		orgCipher, err = s.cipher.Cipher(ctx, orgID)
+		if err != nil {
+			return nil, fmt.Errorf("load destination organization key: %w", err)
+		}
+	}
+
+	report(4, "matching members")
+	userMap, unknown, err := s.buildUserMap(ctx, manifest, opts.ActorUserID)
+	if err != nil {
+		return nil, err
+	}
+	for _, u := range unknown {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(
+			"%s has no account on this instance; their rows were reassigned to you.", u.Email))
+	}
+
+	groups := NormalizeGroups(opts.Groups)
+	selected := map[models.OrgDataGroup]bool{}
+	for _, g := range groups {
+		selected[g] = true
+	}
+
+	tx, err := s.repo.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SET LOCAL statement_timeout = 0`); err != nil {
+		return nil, fmt.Errorf("lift statement timeout: %w", err)
+	}
+
+	report(6, "applying workspace settings")
+	if err := s.mergeOrganization(ctx, tx, orgID, manifest); err != nil {
+		return nil, err
+	}
+
+	byName := manifestTables(manifest)
+	applied := 0
+	for i := range Tables {
+		t := &Tables[i]
+		if t.ImportSkip || !selected[t.Group] {
+			continue
+		}
+		mt, ok := byName[t.Name]
+		if !ok || mt.Rows == 0 {
+			continue
+		}
+		entry, ok := entries[dataPath(t.Name)]
+		if !ok {
+			continue
+		}
+
+		report(8+(applied*84)/max(1, len(byName)), "importing "+t.Name)
+		applied++
+
+		n, warn, err := s.importTable(ctx, tx, orgID, t, mt, entry, importContext{
+			archiveKey: archiveKey,
+			orgCipher:  orgCipher,
+			userMap:    userMap,
+			actor:      opts.ActorUserID,
+			conflict:   opts.Conflict,
+			selected:   selected,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if n > 0 {
+			result.RowCounts[t.Name] = n
+		}
+		result.Warnings = append(result.Warnings, warn...)
+	}
+
+	report(93, "restoring attachments")
+	if warn := s.restoreBlobs(ctx, entries, manifest); len(warn) > 0 {
+		result.Warnings = append(result.Warnings, warn...)
+	}
+
+	report(97, "checking mailboxes")
+	reconnect, err := s.repo.MarkMailboxesNeedingReconnect(ctx, tx, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if reconnect > 0 {
+		result.Warnings = append(result.Warnings, fmt.Sprintf(
+			"%d mailbox(es) have no usable credentials and are marked for reconnection.", reconnect))
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit import: %w", err)
+	}
+	report(100, "done")
+	return result, nil
+}
+
+// importContext is the per-import state every table needs.
+type importContext struct {
+	archiveKey []byte
+	orgCipher  *cipher.Cipher
+	userMap    map[uuid.UUID]uuid.UUID
+	// actor owns any row whose original owner has no account here.
+	actor    uuid.UUID
+	conflict models.OrgImportConflict
+	// selected is the set of groups this run applies, used to decide which
+	// references the import can actually satisfy.
+	selected map[models.OrgDataGroup]bool
+}
+
+// importTable streams one table's rows out of the archive and into the
+// destination, in batches.
+func (s *service) importTable(
+	ctx context.Context,
+	tx pgx.Tx,
+	orgID uuid.UUID,
+	t *Table,
+	mt ManifestTable,
+	entry *zip.File,
+	ic importContext,
+) (int64, []string, error) {
+	destCols, err := s.repo.TableColumns(ctx, t.Name)
+	if err != nil {
+		return 0, nil, fmt.Errorf("inspect %s: %w", t.Name, err)
+	}
+	if len(destCols) == 0 {
+		return 0, []string{fmt.Sprintf(
+			"This instance has no %s table, so those %d rows were skipped.", t.Name, mt.Rows)}, nil
+	}
+
+	// Only columns that exist on both sides and can actually be written. This
+	// is what lets an archive from a different release still apply, and it is
+	// also the guarantee that no name out of the archive reaches a query.
+	writable := map[string]bool{}
+	for _, c := range destCols {
+		if c.Writable() {
+			writable[c.Name] = true
+		}
+	}
+	insertCols := make([]string, 0, len(mt.Columns))
+	for _, c := range mt.Columns {
+		if writable[c] {
+			insertCols = append(insertCols, c)
+		}
+	}
+	if len(insertCols) == 0 {
+		return 0, []string{fmt.Sprintf("No column of %s matched this instance, so it was skipped.", t.Name)}, nil
+	}
+
+	var warnings []string
+	if dropped := len(mt.Columns) - len(insertCols); dropped > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: %d column(s) in the archive do not exist here and were ignored.", t.Name, dropped))
+	}
+
+	var pk []string
+	if ic.conflict == models.OrgImportConflictOverwrite {
+		if pk, err = s.repo.PrimaryKeyColumns(ctx, t.Name); err != nil {
+			return 0, nil, err
+		}
+		if len(pk) == 0 {
+			warnings = append(warnings, fmt.Sprintf(
+				"%s has no primary key, so existing rows there were kept rather than overwritten.", t.Name))
+		}
+	}
+
+	refs, err := s.referencePlan(ctx, t, destCols, ic.selected)
+	if err != nil {
+		return 0, nil, err
+	}
+	if len(refs.nullify) > 0 {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: %d reference(s) point at data this import does not include and were cleared.",
+			t.Name, len(refs.nullify)))
+	}
+
+	rc, err := entry.Open()
+	if err != nil {
+		return 0, nil, fmt.Errorf("open %s in archive: %w", t.Name, err)
+	}
+	defer rc.Close()
+
+	reader := bufio.NewReaderSize(rc, 256*1024)
+	batch := make([]json.RawMessage, 0, importBatchRows)
+	batchBytes := 0
+	var total int64
+
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		n, err := s.repo.InsertBatch(ctx, tx, t.Name, insertCols, batch, ic.conflict, pk)
+		if err != nil {
+			return err
+		}
+		total += n
+		batch = batch[:0]
+		batchBytes = 0
+		return nil
+	}
+
+	for {
+		line, err := readLine(reader)
+		if len(line) > 0 {
+			row, terr := s.importRow(ctx, orgID, t, line, refs, ic)
+			if terr != nil {
+				return 0, nil, terr
+			}
+			batch = append(batch, row)
+			batchBytes += len(row)
+			if len(batch) >= importBatchRows || batchBytes >= importBatchBytes {
+				if ferr := flush(); ferr != nil {
+					return 0, nil, ferr
+				}
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return 0, nil, fmt.Errorf("read %s from archive: %w", t.Name, err)
+		}
+	}
+	if err := flush(); err != nil {
+		return 0, nil, err
+	}
+
+	if skipped := mt.Rows - total; skipped > 0 && ic.conflict == models.OrgImportConflictSkip {
+		warnings = append(warnings, fmt.Sprintf(
+			"%s: %d row(s) already existed here and were kept as they are.", t.Name, skipped))
+	}
+	return total, warnings, nil
+}
+
+// importRow rewrites one archive row for this instance.
+func (s *service) importRow(
+	ctx context.Context,
+	orgID uuid.UUID,
+	t *Table,
+	line []byte,
+	refs *referencePlan,
+	ic importContext,
+) (json.RawMessage, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(line, &obj); err != nil {
+		return nil, fmt.Errorf("%s: archive row is not valid JSON: %w", t.Name, err)
+	}
+
+	// The destination workspace owns the rows now, whatever id they carried.
+	destOrg, err := json.Marshal(orgID.String())
+	if err != nil {
+		return nil, err
+	}
+	for _, c := range []string{"organization_id", "org_id"} {
+		if _, ok := obj[c]; ok {
+			obj[c] = destOrg
+		}
+	}
+
+	// People are matched by account, not by id: the same person has a
+	// different user id on every instance. An id with no match here (a member
+	// who left, or an account that never existed on this instance) would be a
+	// dangling foreign key, so it is blanked where the column allows it and
+	// redirected to the importer where it does not.
+	for c, notNull := range refs.users {
+		raw, ok := obj[c]
+		if !ok {
+			continue
+		}
+		id, perr := uuid.Parse(jsonString(raw))
+		if perr != nil {
+			continue
+		}
+		mapped, ok := ic.userMap[id]
+		if !ok {
+			if !notNull {
+				obj[c] = json.RawMessage(`null`)
+				continue
+			}
+			if ic.actor == uuid.Nil {
+				continue
+			}
+			mapped = ic.actor
+		}
+		enc, merr := json.Marshal(mapped.String())
+		if merr != nil {
+			return nil, merr
+		}
+		obj[c] = enc
+	}
+
+	// References whose target is not part of this run. They are nullable by
+	// construction (a NOT NULL one is covered by GroupRequires), so clearing
+	// them keeps the row valid instead of failing the whole import on a
+	// constraint the archive never promised to satisfy.
+	for _, c := range refs.nullify {
+		if _, ok := obj[c]; ok {
+			obj[c] = json.RawMessage(`null`)
+		}
+	}
+
+	for _, c := range t.ResetOnImport {
+		if _, ok := obj[c]; ok {
+			obj[c] = json.RawMessage(`null`)
+		}
+	}
+
+	for _, sc := range t.Secrets {
+		raw, ok := obj[sc.Column]
+		if !ok {
+			continue
+		}
+		stored := jsonString(raw)
+		if stored == "" {
+			continue
+		}
+		if !IsSealed(stored) {
+			// Exported without secrets, so the column is already blank or was
+			// never ciphertext. Nothing to re-key.
+			continue
+		}
+		if ic.archiveKey == nil {
+			// Sealed, but no passphrase. Blank it rather than storing a value
+			// this instance's keys can never open.
+			blankSecret(obj, sc)
+			continue
+		}
+		plain, oerr := OpenValue(ic.archiveKey, stored)
+		if oerr != nil {
+			return nil, fmt.Errorf("%s.%s: %w", t.Name, sc.Column, oerr)
+		}
+		resealed, rerr := s.sealSecret(ctx, sc, plain, ic.orgCipher)
+		if rerr != nil {
+			return nil, fmt.Errorf("%s.%s: %w", t.Name, sc.Column, rerr)
+		}
+		enc, merr := json.Marshal(resealed)
+		if merr != nil {
+			return nil, merr
+		}
+		obj[sc.Column] = enc
+	}
+
+	return json.Marshal(obj)
+}
+
+// sealSecret re-encrypts a plaintext under this instance's key for that domain.
+func (s *service) sealSecret(ctx context.Context, sc SecretColumn, plain string, orgCipher *cipher.Cipher) (string, error) {
+	switch sc.Domain {
+	case KeyDomainInstance:
+		if s.creds == nil {
+			return "", errors.New("this instance has no CREDENTIALS_ENCRYPTION_KEY, so mailbox credentials cannot be stored")
+		}
+		return s.creds.Encrypt(plain)
+	case KeyDomainOrgDEK:
+		if orgCipher == nil {
+			return "", errors.New("destination organization key unavailable")
+		}
+		return orgCipher.Encrypt(ctx, plain)
+	}
+	return "", fmt.Errorf("column %s has no key domain", sc.Column)
+}
+
+// referencePlan is how one table's foreign keys are handled on the way in.
+type referencePlan struct {
+	// users maps a person-naming column to whether it is NOT NULL.
+	users map[string]bool
+	// nullify are columns pointing at data this import does not carry.
+	nullify []string
+}
+
+// referencePlan works out, for one table, which columns name a person and which
+// point at something this run will not have.
+//
+// Person columns are the ones with a declared foreign key to users, plus the
+// ones named for it that never got a constraint (owner_user_id, actor_user_id,
+// created_by_user_id). Both halves are needed: the catalog misses the
+// unconstrained ones, and the naming convention misses created_by, assigned_to,
+// actor_id and the rest.
+func (s *service) referencePlan(
+	ctx context.Context,
+	t *Table,
+	destCols []repository.ColumnInfo,
+	selected map[models.OrgDataGroup]bool,
+) (*referencePlan, error) {
+	fks, err := s.repo.ForeignKeyRefs(ctx, t.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	notNull := make(map[string]bool, len(destCols))
+	for _, c := range destCols {
+		notNull[c.Name] = c.NotNull
+	}
+
+	plan := &referencePlan{users: map[string]bool{}}
+
+	for column, target := range fks {
+		if target == "users" {
+			plan.users[column] = notNull[column]
+			continue
+		}
+		if target == "organizations" || target == t.Name {
+			continue
+		}
+		// A target this run writes is satisfiable; anything else is not.
+		if dep, known := TableByName[target]; known && !dep.ImportSkip && selected[dep.Group] {
+			continue
+		}
+		// NOT NULL crossings are meant to be impossible (GroupRequires closes
+		// over them). Leave one alone rather than write a NULL the column
+		// rejects: a clear constraint error beats a silent corruption.
+		if notNull[column] {
+			continue
+		}
+		plan.nullify = append(plan.nullify, column)
+	}
+
+	for _, c := range destCols {
+		if _, already := plan.users[c.Name]; already {
+			continue
+		}
+		if c.Name == "user_id" || strings.HasSuffix(c.Name, "_user_id") {
+			plan.users[c.Name] = c.NotNull
+		}
+	}
+
+	sort.Strings(plan.nullify)
+	return plan, nil
+}
+
+// mergeOrganization applies the archive's workspace settings onto the
+// destination org. Identity, ownership, and lifecycle columns are excluded:
+// an archive must not be able to hand a workspace to someone else or schedule
+// it for deletion.
+func (s *service) mergeOrganization(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, m *Manifest) error {
+	if len(m.Organization) == 0 {
+		return nil
+	}
+	destCols, err := s.repo.TableColumns(ctx, "organizations")
+	if err != nil {
+		return err
+	}
+	cols := make([]string, 0, len(destCols))
+	for _, c := range destCols {
+		if !c.Writable() || orgMergeExcluded[c.Name] {
+			continue
+		}
+		if _, present := m.Organization[c.Name]; present {
+			cols = append(cols, c.Name)
+		}
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(m.Organization)
+	if err != nil {
+		return err
+	}
+	return s.repo.MergeOrganization(ctx, tx, orgID, cols, raw)
+}
+
+// orgMergeExcluded are the organization columns an archive may never set.
+var orgMergeExcluded = map[string]bool{
+	"id":                     true,
+	"owner_user_id":          true,
+	"slug":                   true,
+	"created_at":             true,
+	"deletion_scheduled_at":  true,
+	"deletion_scheduled_for": true,
+}
+
+// buildUserMap resolves archive members to destination accounts by email.
+// Anyone without an account here has their rows reassigned to the importer,
+// which keeps every foreign key valid without an archive being able to conjure
+// accounts on the destination instance.
+func (s *service) buildUserMap(ctx context.Context, m *Manifest, actor uuid.UUID) (map[uuid.UUID]uuid.UUID, []models.OrgArchiveUser, error) {
+	out := make(map[uuid.UUID]uuid.UUID, len(m.Members))
+	if len(m.Members) == 0 {
+		return out, nil, nil
+	}
+
+	emails := make([]string, 0, len(m.Members))
+	for _, u := range m.Members {
+		emails = append(emails, strings.ToLower(strings.TrimSpace(u.Email)))
+	}
+	found, err := s.repo.ResolveUsersByEmail(ctx, emails)
+	if err != nil {
+		return nil, nil, fmt.Errorf("match members: %w", err)
+	}
+
+	var unknown []models.OrgArchiveUser
+	for _, u := range m.Members {
+		if id, ok := found[strings.ToLower(strings.TrimSpace(u.Email))]; ok {
+			out[u.ID] = id
+			continue
+		}
+		if actor != uuid.Nil {
+			out[u.ID] = actor
+		}
+		unknown = append(unknown, u)
+	}
+	return out, unknown, nil
+}
+
+// restoreBlobs writes the archive's objects back into this instance's storage
+// under their original keys, so the rows that reference them resolve.
+func (s *service) restoreBlobs(ctx context.Context, entries map[string]*zip.File, m *Manifest) []string {
+	if len(m.Blobs) == 0 {
+		return nil
+	}
+	if s.blobs == nil {
+		return []string{fmt.Sprintf(
+			"Object storage is not configured here, so %d attachment(s) in the archive were not restored.", len(m.Blobs))}
+	}
+
+	var failed int
+	for _, b := range m.Blobs {
+		entry, ok := entries[b.Path]
+		if !ok {
+			failed++
+			continue
+		}
+		rc, err := entry.Open()
+		if err != nil {
+			failed++
+			continue
+		}
+		err = s.blobs.Put(ctx, b.Key, rc, "")
+		_ = rc.Close()
+		if err != nil {
+			failed++
+		}
+	}
+	if failed > 0 {
+		return []string{fmt.Sprintf("%d attachment(s) could not be restored to object storage.", failed)}
+	}
+	return nil
+}
+
+// resolveArchiveKey derives the archive key when the archive has secrets and a
+// passphrase was supplied.
+func (s *service) resolveArchiveKey(m *Manifest, passphrase string) ([]byte, error) {
+	if m.Secrets == nil || passphrase == "" {
+		return nil, nil
+	}
+	return DeriveArchiveKey(passphrase, m.Secrets)
+}
+
+// ---------- archive reading helpers ----------
+
+func indexEntries(zr *zip.Reader) map[string]*zip.File {
+	out := make(map[string]*zip.File, len(zr.File))
+	for _, f := range zr.File {
+		out[f.Name] = f
+	}
+	return out
+}
+
+func readManifest(entries map[string]*zip.File) (*Manifest, error) {
+	entry, ok := entries[manifestPath]
+	if !ok {
+		return nil, errors.New("archive has no manifest.json, so it is not a Warmbly organization archive")
+	}
+	rc, err := entry.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	var m Manifest
+	dec := json.NewDecoder(io.LimitReader(rc, maxManifestBytes))
+	if err := dec.Decode(&m); err != nil {
+		return nil, fmt.Errorf("archive manifest is unreadable: %w", err)
+	}
+	return &m, nil
+}
+
+func manifestTables(m *Manifest) map[string]ManifestTable {
+	out := make(map[string]ManifestTable, len(m.Tables))
+	for _, t := range m.Tables {
+		out[t.Name] = t
+	}
+	return out
+}
+
+// readLine reads one newline-terminated record of any length. bufio.Scanner is
+// not usable here: a single inbox row can carry a megabyte of message body,
+// well past the Scanner token cap.
+func readLine(r *bufio.Reader) ([]byte, error) {
+	line, err := r.ReadBytes('\n')
+	line = trimNewline(line)
+	return line, err
+}
+
+func trimNewline(b []byte) []byte {
+	for len(b) > 0 && (b[len(b)-1] == '\n' || b[len(b)-1] == '\r') {
+		b = b[:len(b)-1]
+	}
+	return b
+}

--- a/internal/app/orgtransfer/jobs.go
+++ b/internal/app/orgtransfer/jobs.go
@@ -1,0 +1,531 @@
+package orgtransfer
+
+import (
+	"archive/zip"
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Transfers run in the process that accepted the request rather than through a
+// queue, for one reason: the passphrase must never be written down. It lives in
+// this process's memory for the length of the run and nowhere else — not in the
+// job row, not in Redis, not in an environment variable.
+//
+// The cost of that is an orphaned job if the process restarts mid-run, which
+// staleTransferDeadline cleans up.
+const (
+	staleTransferDeadline = 6 * time.Hour
+	jobHistoryLimit       = 25
+)
+
+// ---------- export ----------
+
+func (s *service) RequestExport(
+	ctx context.Context,
+	orgID uuid.UUID,
+	userID *uuid.UUID,
+	req *models.CreateOrgExportRequest,
+) (*models.OrgExportJob, *errx.Error) {
+	if req == nil {
+		req = &models.CreateOrgExportRequest{}
+	}
+	if req.IncludeSecrets {
+		if err := ValidatePassphrase(req.Passphrase); err != nil {
+			return nil, errx.New(errx.BadRequest, err.Error())
+		}
+		if s.creds == nil {
+			return nil, errx.New(errx.BadRequest,
+				"This instance has no CREDENTIALS_ENCRYPTION_KEY, so there are no mailbox credentials to carry. Export without credentials instead.")
+		}
+	} else {
+		// A passphrase without the flag is a mistake worth surfacing rather
+		// than quietly producing an archive with no credentials in it.
+		req.Passphrase = ""
+	}
+	if s.blobs == nil {
+		return nil, errx.New(errx.BadRequest, "Object storage is not configured on this instance, so an archive cannot be stored.")
+	}
+
+	active, err := s.repo.HasActiveExport(ctx, orgID)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	if active {
+		return nil, errx.New(errx.Conflict, "An export is already running for this workspace. Wait for it to finish.")
+	}
+
+	job := &models.OrgExportJob{
+		OrganizationID: orgID,
+		RequestedBy:    userID,
+		Groups:         NormalizeGroups(req.Groups),
+		IncludeSecrets: req.IncludeSecrets,
+	}
+	if err := s.repo.CreateExportJob(ctx, job); err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+
+	// Detached context: the archive keeps building after the request returns.
+	passphrase := req.Passphrase
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), staleTransferDeadline)
+		defer cancel()
+		if err := s.runExport(runCtx, job, passphrase); err != nil {
+			sentry.CaptureException(err)
+			_ = s.repo.FailExportJob(context.WithoutCancel(ctx), job.ID, err.Error())
+		}
+	}()
+
+	return job, nil
+}
+
+// runExport builds the archive and records the outcome on the job.
+func (s *service) runExport(ctx context.Context, job *models.OrgExportJob, passphrase string) error {
+	if err := s.repo.UpdateExportProgress(ctx, job.ID, 1, "starting"); err != nil {
+		return err
+	}
+
+	// Spool to disk rather than memory: a full workspace archive is routinely
+	// larger than anything worth holding in RAM, and blob storage wants a
+	// length up front anyway.
+	tmp, err := os.CreateTemp("", "warmbly-export-*.zip")
+	if err != nil {
+		return fmt.Errorf("create temporary archive: %w", err)
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+
+	digest := sha256.New()
+	counter := &countingWriter{w: io.MultiWriter(tmp, digest)}
+
+	manifest, err := s.ExportTo(ctx, job.OrganizationID, ExportOptions{
+		Groups:     job.Groups,
+		Passphrase: passphrase,
+	}, counter, func(percent int, stage string) {
+		_ = s.repo.UpdateExportProgress(ctx, job.ID, percent, stage)
+	})
+	if err != nil {
+		return err
+	}
+
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	key := archiveObjectKey(job.OrganizationID, job.ID)
+	if err := s.blobs.Put(ctx, key, tmp, "application/zip"); err != nil {
+		return fmt.Errorf("store archive: %w", err)
+	}
+
+	counts := make(map[string]int64, len(manifest.Tables))
+	for _, t := range manifest.Tables {
+		counts[t.Name] = t.Rows
+	}
+	return s.repo.CompleteExportJob(ctx, job.ID, key, counter.n,
+		hex.EncodeToString(digest.Sum(nil)), counts, time.Now().Add(models.OrgExportRetention))
+}
+
+func (s *service) GetExport(ctx context.Context, orgID, id uuid.UUID) (*models.OrgExportJob, *errx.Error) {
+	job, err := s.repo.GetExportJob(ctx, orgID, id)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	if job == nil {
+		return nil, errx.ErrNotFound
+	}
+	return job, nil
+}
+
+func (s *service) ListExports(ctx context.Context, orgID uuid.UUID) ([]models.OrgExportJob, *errx.Error) {
+	jobs, err := s.repo.ListExportJobs(ctx, orgID, jobHistoryLimit)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	return jobs, nil
+}
+
+func (s *service) OpenExport(ctx context.Context, orgID, id uuid.UUID) (io.ReadCloser, *models.OrgExportJob, *errx.Error) {
+	job, xerr := s.GetExport(ctx, orgID, id)
+	if xerr != nil {
+		return nil, nil, xerr
+	}
+	switch job.Status {
+	case models.OrgTransferStatusCompleted:
+	case models.OrgTransferStatusExpired:
+		return nil, nil, errx.New(errx.NotFound, "This archive has expired. Run a new export.")
+	default:
+		return nil, nil, errx.New(errx.Conflict, "This export is not finished yet.")
+	}
+	if job.ArchiveKey == nil || s.blobs == nil {
+		return nil, nil, errx.New(errx.NotFound, "This archive is no longer stored.")
+	}
+
+	body, err := s.blobs.Get(ctx, *job.ArchiveKey)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, nil, errx.New(errx.NotFound, "This archive could not be read from storage.")
+	}
+	return body, job, nil
+}
+
+func (s *service) DeleteExport(ctx context.Context, orgID, id uuid.UUID) *errx.Error {
+	key, err := s.repo.DeleteExportJob(ctx, orgID, id)
+	if err != nil {
+		sentry.CaptureException(err)
+		return errx.InternalError()
+	}
+	if key != "" && s.blobs != nil {
+		if err := s.blobs.Delete(ctx, key); err != nil {
+			sentry.CaptureException(err)
+		}
+	}
+	return nil
+}
+
+// ---------- import ----------
+
+func (s *service) Preflight(
+	ctx context.Context,
+	orgID uuid.UUID,
+	archive ReaderAtSizer,
+	passphrase string,
+) (*models.OrgImportPreflight, *errx.Error) {
+	zr, err := zip.NewReader(archive, archive.Size())
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "That file is not a readable archive.")
+	}
+	entries := indexEntries(zr)
+
+	manifest, err := readManifest(entries)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+
+	out := &models.OrgImportPreflight{
+		Archive:   manifest.Info(),
+		Conflicts: map[string]int64{},
+		Warnings:  []string{},
+	}
+
+	if manifest.Secrets != nil && passphrase != "" {
+		if _, err := DeriveArchiveKey(passphrase, manifest.Secrets); err != nil {
+			if errors.Is(err, ErrWrongPassphrase) {
+				return nil, errx.New(errx.BadRequest, "That passphrase does not open this archive.")
+			}
+			return nil, errx.New(errx.BadRequest, err.Error())
+		}
+		out.SecretsUnsealed = true
+	}
+	switch {
+	case manifest.Secrets == nil:
+		out.Warnings = append(out.Warnings, "This archive was exported without credentials, so every mailbox and integration will need reconnecting.")
+	case !out.SecretsUnsealed:
+		out.Warnings = append(out.Warnings, "Enter the export passphrase to bring mailbox credentials across; without it every mailbox will need reconnecting.")
+	case s.creds == nil:
+		out.Warnings = append(out.Warnings, "This instance has no CREDENTIALS_ENCRYPTION_KEY, so mailbox credentials cannot be stored here.")
+	}
+
+	// Who lands where.
+	emails := make([]string, 0, len(manifest.Members))
+	for _, m := range manifest.Members {
+		emails = append(emails, lowerTrim(m.Email))
+	}
+	known, rerr := s.repo.ResolveUsersByEmail(ctx, emails)
+	if rerr != nil {
+		sentry.CaptureException(rerr)
+		return nil, errx.InternalError()
+	}
+	for _, m := range manifest.Members {
+		if _, ok := known[lowerTrim(m.Email)]; !ok {
+			out.UnknownMembers = append(out.UnknownMembers, m)
+		}
+	}
+
+	// What already exists here, and what this instance cannot take.
+	for _, mt := range manifest.Tables {
+		t, known := TableByName[mt.Name]
+		if !known || t.ImportSkip {
+			continue
+		}
+		destCols, err := s.repo.TableColumns(ctx, mt.Name)
+		if err != nil {
+			sentry.CaptureException(err)
+			return nil, errx.InternalError()
+		}
+		if len(destCols) == 0 {
+			out.SkippedTables = append(out.SkippedTables, mt.Name)
+			continue
+		}
+		if mt.Rows == 0 {
+			continue
+		}
+		pk, err := s.repo.PrimaryKeyColumns(ctx, mt.Name)
+		if err != nil || len(pk) == 0 {
+			continue
+		}
+		entry, ok := entries[dataPath(mt.Name)]
+		if !ok {
+			continue
+		}
+		n, err := s.countConflicts(ctx, mt.Name, pk, entry)
+		if err != nil {
+			// A conflict count is advisory; failing the whole preflight over
+			// one unreadable table helps nobody.
+			continue
+		}
+		if n > 0 {
+			out.Conflicts[mt.Name] = n
+		}
+	}
+
+	if len(out.SkippedTables) > 0 {
+		out.Warnings = append(out.Warnings, fmt.Sprintf(
+			"%d table(s) in this archive do not exist on this instance and will be skipped. It was probably exported from a newer release.",
+			len(out.SkippedTables)))
+	}
+	return out, nil
+}
+
+// countConflicts samples a table's keys to report how many rows already exist.
+// It reads a bounded prefix: the number is there to warn, not to be exact, and
+// scanning a million-row inbox table twice for a preview is not worth it.
+const conflictSampleRows = 2000
+
+func (s *service) countConflicts(ctx context.Context, table string, pk []string, entry *zip.File) (int64, error) {
+	rc, err := entry.Open()
+	if err != nil {
+		return 0, err
+	}
+	defer rc.Close()
+
+	rows, err := readRows(rc, conflictSampleRows)
+	if err != nil {
+		return 0, err
+	}
+	return s.repo.CountExisting(ctx, table, pk, rows)
+}
+
+func (s *service) RequestImport(
+	ctx context.Context,
+	orgID uuid.UUID,
+	userID *uuid.UUID,
+	archive ReaderAtSizer,
+	req *models.CreateOrgImportRequest,
+) (*models.OrgImportJob, *errx.Error) {
+	if req == nil {
+		req = &models.CreateOrgImportRequest{}
+	}
+	if req.ConflictStrategy == "" {
+		req.ConflictStrategy = models.OrgImportConflictSkip
+	}
+	if req.ConflictStrategy != models.OrgImportConflictSkip && req.ConflictStrategy != models.OrgImportConflictOverwrite {
+		return nil, errx.New(errx.BadRequest, "conflict_strategy must be skip or overwrite")
+	}
+
+	active, err := s.repo.HasActiveImport(ctx, orgID)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	if active {
+		return nil, errx.New(errx.Conflict, "An import is already running for this workspace. Wait for it to finish.")
+	}
+
+	zr, err := zip.NewReader(archive, archive.Size())
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "That file is not a readable archive.")
+	}
+	manifest, err := readManifest(indexEntries(zr))
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+	if err := manifest.Validate(); err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+	// Fail on a bad passphrase now, not two hours into applying rows.
+	if manifest.Secrets != nil && req.Passphrase != "" {
+		if _, err := DeriveArchiveKey(req.Passphrase, manifest.Secrets); err != nil {
+			return nil, errx.New(errx.BadRequest, "That passphrase does not open this archive.")
+		}
+	}
+
+	size := archive.Size()
+	job := &models.OrgImportJob{
+		OrganizationID:   orgID,
+		RequestedBy:      userID,
+		ArchiveBytes:     &size,
+		SourceManifest:   manifest.Info(),
+		Groups:           NormalizeGroups(req.Groups),
+		ConflictStrategy: req.ConflictStrategy,
+	}
+
+	// Keep the upload until the import succeeds, so a failure can be retried
+	// without asking someone to re-upload several gigabytes.
+	if s.blobs != nil {
+		key := uploadObjectKey(orgID, uuid.New())
+		if err := s.blobs.Put(ctx, key, io.NewSectionReader(archive, 0, size), "application/zip"); err != nil {
+			sentry.CaptureException(err)
+			return nil, errx.New(errx.Internal, "The archive could not be stored for import.")
+		}
+		job.ArchiveKey = &key
+	}
+
+	if err := s.repo.CreateImportJob(ctx, job); err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+
+	actor := uuid.Nil
+	if userID != nil {
+		actor = *userID
+	}
+	passphrase := req.Passphrase
+	groups := job.Groups
+	conflict := job.ConflictStrategy
+
+	go func() {
+		runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), staleTransferDeadline)
+		defer cancel()
+
+		// The caller spooled the upload somewhere and handed us ownership; it
+		// is only certainly finished with once the import is.
+		if closer, ok := archive.(io.Closer); ok {
+			defer func() { _ = closer.Close() }()
+		}
+
+		_ = s.repo.UpdateImportProgress(runCtx, job.ID, 1, "starting")
+		result, err := s.ImportFrom(runCtx, orgID, archive, ImportOptions{
+			Groups:      groups,
+			Conflict:    conflict,
+			Passphrase:  passphrase,
+			ActorUserID: actor,
+		}, func(percent int, stage string) {
+			_ = s.repo.UpdateImportProgress(runCtx, job.ID, percent, stage)
+		})
+		if err != nil {
+			sentry.CaptureException(err)
+			_ = s.repo.FailImportJob(runCtx, job.ID, err.Error())
+			return
+		}
+		_ = s.repo.CompleteImportJob(runCtx, job.ID, result.RowCounts, result.Warnings)
+
+		// The upload has done its job; it holds a whole workspace, so it does
+		// not linger past the point it could still be useful.
+		if job.ArchiveKey != nil && s.blobs != nil {
+			if derr := s.blobs.Delete(runCtx, *job.ArchiveKey); derr != nil {
+				sentry.CaptureException(derr)
+			}
+		}
+	}()
+
+	return job, nil
+}
+
+func (s *service) GetImport(ctx context.Context, orgID, id uuid.UUID) (*models.OrgImportJob, *errx.Error) {
+	job, err := s.repo.GetImportJob(ctx, orgID, id)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	if job == nil {
+		return nil, errx.ErrNotFound
+	}
+	return job, nil
+}
+
+func (s *service) ListImports(ctx context.Context, orgID uuid.UUID) ([]models.OrgImportJob, *errx.Error) {
+	jobs, err := s.repo.ListImportJobs(ctx, orgID, jobHistoryLimit)
+	if err != nil {
+		sentry.CaptureException(err)
+		return nil, errx.InternalError()
+	}
+	return jobs, nil
+}
+
+// ---------- maintenance ----------
+
+// PurgeExpiredExports deletes archives past their retention window and fails
+// any transfer whose process died mid-run.
+func (s *service) PurgeExpiredExports(ctx context.Context) (int, error) {
+	expired, err := s.repo.ListExpiredExports(ctx, time.Now(), 200)
+	if err != nil {
+		return 0, err
+	}
+	var purged int
+	for i := range expired {
+		job := &expired[i]
+		if job.ArchiveKey != nil && s.blobs != nil {
+			if derr := s.blobs.Delete(ctx, *job.ArchiveKey); derr != nil {
+				sentry.CaptureException(derr)
+			}
+		}
+		if err := s.repo.MarkExportExpired(ctx, job.ID); err != nil {
+			sentry.CaptureException(err)
+			continue
+		}
+		purged++
+	}
+
+	if err := s.repo.FailStaleTransfers(ctx, time.Now().Add(-staleTransferDeadline)); err != nil {
+		sentry.CaptureException(err)
+	}
+	return purged, nil
+}
+
+// ---------- helpers ----------
+
+// countingWriter records how many bytes went through, so the job can report
+// the archive's size without stat-ing the temporary file.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}
+
+func lowerTrim(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+
+// readRows reads up to limit newline-delimited records from an archive entry.
+func readRows(r io.Reader, limit int) ([]json.RawMessage, error) {
+	br := bufio.NewReaderSize(r, 256*1024)
+	out := make([]json.RawMessage, 0, limit)
+	for len(out) < limit {
+		line, err := readLine(br)
+		if len(line) > 0 {
+			out = append(out, append(json.RawMessage(nil), line...))
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+	}
+	return out, nil
+}

--- a/internal/app/orgtransfer/manifest.go
+++ b/internal/app/orgtransfer/manifest.go
@@ -1,0 +1,172 @@
+package orgtransfer
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ArchiveKind identifies the file so a wrong upload fails on the manifest
+// rather than halfway through writing rows.
+const ArchiveKind = "warmbly.organization-archive"
+
+// Archive layout. A plain zip, so an operator can unzip it and read the data
+// with nothing but a text editor:
+//
+//	manifest.json          what this archive is, and what is in it
+//	data/<table>.ndjson    one JSON object per row, column-name keyed
+//	blobs/<n>-<name>       attachment and avatar bytes
+//
+// Rows are newline-delimited rather than one big array so a table with a
+// million rows never has to be held in memory on either side.
+const (
+	manifestPath = "manifest.json"
+	dataPrefix   = "data/"
+	blobPrefix   = "blobs/"
+)
+
+// dataPath is where one table's rows live inside the archive.
+func dataPath(table string) string { return dataPrefix + table + ".ndjson" }
+
+// Manifest is the archive's header. Everything the importer needs to decide
+// what it is looking at before it reads a single row.
+type Manifest struct {
+	Kind          string `json:"kind"`
+	FormatVersion int    `json:"format_version"`
+
+	// SourceInstance is the exporting instance's public URL host, and
+	// SourceAppVersion its release. Both are informational: the importer keys
+	// off FormatVersion and the per-table column lists, never off these.
+	SourceInstance   string    `json:"source_instance"`
+	SourceAppVersion string    `json:"source_app_version"`
+	ExportedAt       time.Time `json:"exported_at"`
+
+	// Organization is the workspace row itself, verbatim. It is merged onto
+	// the destination workspace rather than inserted, so it lives here instead
+	// of in a one-row data file.
+	Organization map[string]any `json:"organization"`
+
+	OrganizationID   uuid.UUID `json:"organization_id"`
+	OrganizationName string    `json:"organization_name"`
+
+	Groups []models.OrgDataGroup `json:"groups"`
+	Tables []ManifestTable       `json:"tables"`
+	Blobs  []ManifestBlob        `json:"blobs"`
+
+	// Members lets the importer resolve people to destination accounts without
+	// reading the members table first. No password material: an archive can
+	// never mint a working login.
+	Members []models.OrgArchiveUser `json:"members"`
+
+	// Secrets is present only when credentials were sealed into the archive.
+	Secrets *SecretsHeader `json:"secrets,omitempty"`
+}
+
+// ManifestTable records what was written for one relation. Columns are stored
+// because the destination schema may differ: the importer intersects this list
+// with the columns it actually has, so an archive from an older or newer
+// release still applies.
+type ManifestTable struct {
+	Name    string              `json:"name"`
+	Group   models.OrgDataGroup `json:"group"`
+	Rows    int64               `json:"rows"`
+	Columns []string            `json:"columns"`
+	// SecretColumns are the columns whose values were sealed. Empty when the
+	// export ran without secrets, in which case those columns are blank.
+	SecretColumns []string `json:"secret_columns,omitempty"`
+	// Truncated marks a table whose export hit the row ceiling.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// ManifestBlob is one object-storage object carried by the archive.
+type ManifestBlob struct {
+	// Key is the object key as the source instance stored it.
+	Key string `json:"key"`
+	// Path is where the bytes live inside this archive.
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	// Table and Column say which row referenced it, so a failed blob can be
+	// reported against something the user recognises.
+	Table  string `json:"table"`
+	Column string `json:"column"`
+}
+
+// SecretsHeader describes how the archive's secret values were sealed. The
+// passphrase is never stored; Verifier exists so a wrong one is caught before
+// anything is written rather than surfacing as a mailbox that cannot log in.
+type SecretsHeader struct {
+	Algorithm string `json:"algorithm"`
+	Salt      string `json:"salt"`
+	Time      uint32 `json:"time"`
+	Memory    uint32 `json:"memory"`
+	Threads   uint8  `json:"threads"`
+	Verifier  string `json:"verifier"`
+}
+
+// Info reduces a manifest to the summary the dashboard shows.
+func (m *Manifest) Info() *models.OrgArchiveInfo {
+	counts := make(map[string]int64, len(m.Tables))
+	for _, t := range m.Tables {
+		counts[t.Name] = t.Rows
+	}
+	return &models.OrgArchiveInfo{
+		FormatVersion:    m.FormatVersion,
+		SourceInstance:   m.SourceInstance,
+		SourceAppVersion: m.SourceAppVersion,
+		OrganizationID:   m.OrganizationID,
+		OrganizationName: m.OrganizationName,
+		ExportedAt:       m.ExportedAt,
+		Groups:           m.Groups,
+		HasSecrets:       m.Secrets != nil,
+		RowCounts:        counts,
+		BlobCount:        len(m.Blobs),
+		Members:          m.Members,
+	}
+}
+
+// Validate rejects a file that is not a Warmbly archive, or one this build
+// cannot read, before any of it is applied.
+func (m *Manifest) Validate() error {
+	if m.Kind != ArchiveKind {
+		return fmt.Errorf("not a Warmbly organization archive (found kind %q)", m.Kind)
+	}
+	if m.FormatVersion <= 0 {
+		return fmt.Errorf("archive has no format version")
+	}
+	if m.FormatVersion > models.OrgTransferFormatVersion {
+		return fmt.Errorf(
+			"archive was written in format version %d, but this instance reads up to version %d. Upgrade this instance, then import again.",
+			m.FormatVersion, models.OrgTransferFormatVersion)
+	}
+	if m.OrganizationID == uuid.Nil {
+		return fmt.Errorf("archive names no organization")
+	}
+	return nil
+}
+
+// blobArchivePath builds a collision-free, traversal-free path for one blob.
+// Object keys contain slashes and arbitrary characters; the index prefix keeps
+// two objects with the same basename apart.
+func blobArchivePath(index int, key string) string {
+	base := path.Base(strings.TrimSuffix(key, "/"))
+	base = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '.', r == '-', r == '_':
+			return r
+		}
+		return '_'
+	}, base)
+	if base == "" || base == "." || base == ".." {
+		base = "object"
+	}
+	if len(base) > 80 {
+		base = base[len(base)-80:]
+	}
+	return fmt.Sprintf("%s%06d-%s", blobPrefix, index, base)
+}

--- a/internal/app/orgtransfer/seal.go
+++ b/internal/app/orgtransfer/seal.go
@@ -1,0 +1,172 @@
+package orgtransfer
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/crypto/argon2"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Secret values inside an archive are sealed under a key derived from the
+// operator's passphrase, not under either instance's keys. That is the only
+// arrangement that works: the source's keys mean nothing on the destination,
+// and a key that travelled inside the archive would protect nothing.
+//
+// The passphrase is used once on each side and never stored.
+
+const (
+	sealAlgorithm = "argon2id-aes256gcm"
+
+	// sealPrefix marks a sealed value. Sealed and unsealed columns are both
+	// strings, so without it an importer reading an unsealed archive would
+	// hand ciphertext to the mailbox layer as if it were a password.
+	sealPrefix = "wbx1:"
+
+	// Argon2id parameters. Deliberately heavier than the login hash in
+	// internal/pkg/argon2: this key guards every mailbox credential in a
+	// workspace, the derivation happens once per archive rather than once per
+	// sign-in, and the attacker gets the file to grind offline.
+	sealTime    = uint32(4)
+	sealMemory  = uint32(256 * 1024) // 256 MB
+	sealThreads = uint8(4)
+	sealKeyLen  = uint32(32)
+	sealSaltLen = 16
+
+	// verifierPlaintext is sealed with the derived key at export so import can
+	// tell a wrong passphrase from a corrupt archive.
+	verifierPlaintext = "warmbly.archive.verifier.v1"
+)
+
+// ErrWrongPassphrase is returned when the supplied passphrase does not open
+// the archive's secrets.
+var ErrWrongPassphrase = errors.New("passphrase does not match this archive")
+
+// ErrSecretsNotSealed is returned when a sealed value is read without a key.
+var ErrSecretsNotSealed = errors.New("archive secrets are sealed and no passphrase was supplied")
+
+// ValidatePassphrase enforces the floor for a secrets passphrase.
+func ValidatePassphrase(p string) error {
+	if len([]rune(p)) < models.MinOrgExportPassphraseLength {
+		return fmt.Errorf("passphrase must be at least %d characters", models.MinOrgExportPassphraseLength)
+	}
+	if len(p) > 1024 {
+		return errors.New("passphrase must be at most 1024 bytes")
+	}
+	return nil
+}
+
+// NewSecretsHeader derives a fresh archive key from the passphrase and returns
+// the header that lets an importer derive the same key.
+func NewSecretsHeader(passphrase string) (*SecretsHeader, []byte, error) {
+	if err := ValidatePassphrase(passphrase); err != nil {
+		return nil, nil, err
+	}
+	salt := make([]byte, sealSaltLen)
+	if _, err := io.ReadFull(rand.Reader, salt); err != nil {
+		return nil, nil, fmt.Errorf("generate salt: %w", err)
+	}
+
+	hdr := &SecretsHeader{
+		Algorithm: sealAlgorithm,
+		Salt:      base64.StdEncoding.EncodeToString(salt),
+		Time:      sealTime,
+		Memory:    sealMemory,
+		Threads:   sealThreads,
+	}
+	key := argon2.IDKey([]byte(passphrase), salt, hdr.Time, hdr.Memory, hdr.Threads, sealKeyLen)
+
+	verifier, err := SealValue(key, verifierPlaintext)
+	if err != nil {
+		return nil, nil, err
+	}
+	hdr.Verifier = verifier
+	return hdr, key, nil
+}
+
+// DeriveArchiveKey reproduces the archive key from a passphrase and header,
+// and checks it against the header's verifier so a typo fails immediately.
+func DeriveArchiveKey(passphrase string, hdr *SecretsHeader) ([]byte, error) {
+	if hdr == nil {
+		return nil, errors.New("archive carries no secrets")
+	}
+	if hdr.Algorithm != sealAlgorithm {
+		return nil, fmt.Errorf("unsupported secret algorithm %q", hdr.Algorithm)
+	}
+	salt, err := base64.StdEncoding.DecodeString(hdr.Salt)
+	if err != nil || len(salt) == 0 {
+		return nil, errors.New("archive has a malformed secret salt")
+	}
+	// Clamp the work factors so a hostile archive cannot ask this process to
+	// allocate an unbounded amount of memory just by claiming it needs it.
+	if hdr.Memory == 0 || hdr.Memory > 1024*1024 || hdr.Time == 0 || hdr.Time > 16 || hdr.Threads == 0 {
+		return nil, errors.New("archive declares unreasonable key derivation parameters")
+	}
+
+	key := argon2.IDKey([]byte(passphrase), salt, hdr.Time, hdr.Memory, hdr.Threads, sealKeyLen)
+
+	plain, err := OpenValue(key, hdr.Verifier)
+	if err != nil || plain != verifierPlaintext {
+		return nil, ErrWrongPassphrase
+	}
+	return key, nil
+}
+
+// SealValue encrypts one plaintext value for the archive.
+func SealValue(key []byte, plaintext string) (string, error) {
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	sealed := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return sealPrefix + base64.StdEncoding.EncodeToString(sealed), nil
+}
+
+// OpenValue decrypts a value produced by SealValue.
+func OpenValue(key []byte, sealed string) (string, error) {
+	if !IsSealed(sealed) {
+		return "", errors.New("value is not sealed")
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(sealed, sealPrefix))
+	if err != nil {
+		return "", fmt.Errorf("sealed value is not valid base64: %w", err)
+	}
+	gcm, err := newGCM(key)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < gcm.NonceSize() {
+		return "", errors.New("sealed value is truncated")
+	}
+	nonce, ct := raw[:gcm.NonceSize()], raw[gcm.NonceSize():]
+	plain, err := gcm.Open(nil, nonce, ct, nil)
+	if err != nil {
+		return "", ErrWrongPassphrase
+	}
+	return string(plain), nil
+}
+
+// IsSealed reports whether a value carries the archive seal marker.
+func IsSealed(v string) bool { return strings.HasPrefix(v, sealPrefix) }
+
+func newGCM(key []byte) (cipher.AEAD, error) {
+	if len(key) != int(sealKeyLen) {
+		return nil, errors.New("archive key has the wrong length")
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return cipher.NewGCM(block)
+}

--- a/internal/app/orgtransfer/service.go
+++ b/internal/app/orgtransfer/service.go
@@ -1,0 +1,181 @@
+// Package orgtransfer moves a whole organization between Warmbly instances.
+//
+// The problem it solves is concrete: someone runs a self-hosted instance, wants
+// to move to the cloud (or the other way, or between two self-hosts), and needs
+// their workspace to arrive intact — mailboxes, campaigns, contacts, sequences,
+// suppression, CRM, inbox history, and the send state that stops a migrated
+// mailbox from sending twice as much mail on the day it moves.
+//
+// Shape of the thing:
+//
+//   - Export walks every org-owned relation into a zip archive of newline
+//     delimited JSON, one file per table, plus the attachment bytes.
+//   - Import reads that archive back into a destination workspace, remapping
+//     the people and clearing the fields that only meant something on the
+//     instance the archive came from.
+//   - Rows travel as jsonb in both directions, so Postgres does every type
+//     conversion and no Go-side column mapping can drift from the schema.
+//
+// Secrets get their own treatment. Warmbly seals mailbox credentials under an
+// instance key and everything else under a per-organization DEK, and neither
+// key is portable. So an export opens them locally and re-seals them under a
+// key derived from an operator-supplied passphrase, and an import reverses
+// that against its own keys. Without the passphrase the archive still applies;
+// mailboxes simply arrive needing a reconnect.
+package orgtransfer
+
+import (
+	"context"
+	"io"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/infrastructure/storage"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Service is the public API for organization archives.
+type Service interface {
+	// RequestExport queues an archive build and returns the job.
+	RequestExport(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, req *models.CreateOrgExportRequest) (*models.OrgExportJob, *errx.Error)
+	GetExport(ctx context.Context, orgID, id uuid.UUID) (*models.OrgExportJob, *errx.Error)
+	ListExports(ctx context.Context, orgID uuid.UUID) ([]models.OrgExportJob, *errx.Error)
+	// OpenExport streams a finished archive for download.
+	OpenExport(ctx context.Context, orgID, id uuid.UUID) (io.ReadCloser, *models.OrgExportJob, *errx.Error)
+	DeleteExport(ctx context.Context, orgID, id uuid.UUID) *errx.Error
+
+	// Preflight reads an uploaded archive and reports what applying it would
+	// do, without writing anything.
+	Preflight(ctx context.Context, orgID uuid.UUID, archive ReaderAtSizer, passphrase string) (*models.OrgImportPreflight, *errx.Error)
+	// RequestImport stores the archive and queues it for application.
+	RequestImport(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, archive ReaderAtSizer, req *models.CreateOrgImportRequest) (*models.OrgImportJob, *errx.Error)
+	GetImport(ctx context.Context, orgID, id uuid.UUID) (*models.OrgImportJob, *errx.Error)
+	ListImports(ctx context.Context, orgID uuid.UUID) ([]models.OrgImportJob, *errx.Error)
+
+	// ---- background-job entry point ----
+
+	// PurgeExpiredExports deletes archives past their retention window and
+	// closes out transfers whose process died mid-run.
+	PurgeExpiredExports(ctx context.Context) (int, error)
+
+	// ---- direct entry points for warmblyctl ----
+
+	// ExportTo writes an archive straight to w with no job row. The CLI runs
+	// on the box and streams to a file, so there is nothing to poll.
+	ExportTo(ctx context.Context, orgID uuid.UUID, opts ExportOptions, w io.Writer, progress ProgressFunc) (*Manifest, error)
+	// ImportFrom applies an archive with no job row, for the same reason.
+	ImportFrom(ctx context.Context, orgID uuid.UUID, archive ReaderAtSizer, opts ImportOptions, progress ProgressFunc) (*ImportResult, error)
+}
+
+// ReaderAtSizer is what a zip needs: random access plus a length. Both callers
+// have one (an uploaded file spooled to disk, or a file on the operator's box),
+// so the engine never has to hold an archive in memory.
+type ReaderAtSizer interface {
+	io.ReaderAt
+	Size() int64
+}
+
+// ProgressFunc reports how far along a transfer is. Percent is 0-100.
+type ProgressFunc func(percent int, stage string)
+
+// ExportOptions is the engine-level export request.
+type ExportOptions struct {
+	Groups []models.OrgDataGroup
+	// Passphrase, when set, seals credentials into the archive. Empty means
+	// secret columns are blanked and mailboxes import needing a reconnect.
+	Passphrase string
+}
+
+// ImportOptions is the engine-level import request.
+type ImportOptions struct {
+	Groups     []models.OrgDataGroup
+	Conflict   models.OrgImportConflict
+	Passphrase string
+	// ActorUserID owns any row whose original owner has no account here. It is
+	// the person running the import.
+	ActorUserID uuid.UUID
+}
+
+// ImportResult is what an import did.
+type ImportResult struct {
+	RowCounts map[string]int64
+	Warnings  []string
+	// SecretsApplied reports whether credentials were unsealed and re-keyed.
+	SecretsApplied bool
+}
+
+// InstanceInfo labels an archive with where it came from.
+type InstanceInfo struct {
+	PublicURL  string
+	AppVersion string
+}
+
+type service struct {
+	repo     repository.OrgTransferRepository
+	cipher   cipher.CipherService
+	creds    *encrypt.Encrypter
+	blobs    storage.Store
+	instance InstanceInfo
+}
+
+// NewService builds the transfer service.
+//
+// creds may be nil on an instance with no CREDENTIALS_ENCRYPTION_KEY; mailbox
+// credentials simply cannot be carried there, and the export says so rather
+// than writing an archive full of unreadable ciphertext.
+//
+// blobs may be nil for the CLI, which streams archives to the local filesystem
+// and has no reason to boot object storage; attachment bytes are then skipped.
+func NewService(
+	repo repository.OrgTransferRepository,
+	cipherSvc cipher.CipherService,
+	creds *encrypt.Encrypter,
+	blobs storage.Store,
+	instance InstanceInfo,
+) Service {
+	return &service{
+		repo:     repo,
+		cipher:   cipherSvc,
+		creds:    creds,
+		blobs:    blobs,
+		instance: instance,
+	}
+}
+
+// archiveObjectKey is where a finished export lives in blob storage.
+func archiveObjectKey(orgID, jobID uuid.UUID) string {
+	return "org-archives/" + orgID.String() + "/" + jobID.String() + ".warmbly.zip"
+}
+
+// uploadObjectKey is where an uploaded archive waits for its import job.
+func uploadObjectKey(orgID, jobID uuid.UUID) string {
+	return "org-archives/" + orgID.String() + "/import-" + jobID.String() + ".warmbly.zip"
+}
+
+// ArchiveFilename is the name a downloaded archive lands under.
+func ArchiveFilename(orgName string, jobID uuid.UUID) string {
+	slug := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r == ' ', r == '_', r == '.':
+			return '-'
+		}
+		return -1
+	}, orgName)
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		slug = "workspace"
+	}
+	if len(slug) > 48 {
+		slug = strings.Trim(slug[:48], "-")
+	}
+	return slug + "-" + jobID.String()[:8] + ".warmbly.zip"
+}

--- a/internal/app/orgtransfer/spec.go
+++ b/internal/app/orgtransfer/spec.go
@@ -1,0 +1,717 @@
+package orgtransfer
+
+import "github.com/warmbly/warmbly/internal/models"
+
+// KeyDomain names which key a sealed column was encrypted under. Warmbly has
+// two, and an archive that confuses them produces mailboxes that authenticate
+// against nothing:
+//
+//   - the instance credential key (CREDENTIALS_ENCRYPTION_KEY) seals mailbox
+//     credentials, because the worker reads them without an org context
+//   - the per-organization DEK seals everything else, because those values are
+//     org assets and the DEK is what the KMS actually wraps
+//
+// Both are instance-local, so both have to be opened at export and re-sealed
+// against the destination's own keys at import.
+type KeyDomain uint8
+
+const (
+	// KeyDomainNone marks a column that is not ciphertext.
+	KeyDomainNone KeyDomain = iota
+	// KeyDomainInstance is the CREDENTIALS_ENCRYPTION_KEY AES-GCM encrypter.
+	KeyDomainInstance
+	// KeyDomainOrgDEK is the per-organization data encryption key.
+	KeyDomainOrgDEK
+)
+
+// BlobKind says how to get an object key out of a column's value.
+type BlobKind uint8
+
+const (
+	// BlobKindKey means the column holds the object key verbatim.
+	BlobKindKey BlobKind = iota
+	// BlobKindPublicURL means the column holds a browser-loadable URL that the
+	// key can be recovered from. Avatars are stored as URLs because that is
+	// what the dashboard renders, and the two storage backends build them
+	// differently, so the key is recovered by locating its known prefix.
+	BlobKindPublicURL
+)
+
+// BlobColumn is one column whose object travels with the archive.
+type BlobColumn struct {
+	Column string
+	Kind   BlobKind
+}
+
+// SecretColumn is one encrypted-at-rest column.
+type SecretColumn struct {
+	Column string
+	Domain KeyDomain
+	// Guard, when set, names a boolean column that must be true for this
+	// column to hold ciphertext. email_tasks predates unconditional sealing,
+	// so its rows carry a flag rather than a format that can be sniffed.
+	Guard string
+}
+
+// Table is one exported relation and the policy for moving it.
+type Table struct {
+	Name  string
+	Group models.OrgDataGroup
+
+	// Scope is the WHERE fragment selecting this table's rows for one
+	// organization. $1 is the organization id.
+	Scope string
+
+	// Secrets are columns holding ciphertext that must be re-keyed.
+	Secrets []SecretColumn
+
+	// Blobs are columns pointing at an object whose bytes travel alongside
+	// the rows.
+	Blobs []BlobColumn
+
+	// ResetOnImport are columns set to NULL on the way in because they name
+	// something that exists only on the source instance.
+	ResetOnImport []string
+
+	// ImportSkip exports the table for the record but never writes it back.
+	ImportSkip bool
+
+	// Note explains a non-obvious policy choice; surfaced in the docs table.
+	Note string
+}
+
+// Scope fragments. Written as subqueries rather than joins so every scope is a
+// plain WHERE clause and the reader can stay a single generic SELECT.
+const (
+	scopeOrg       = `organization_id = $1`
+	scopeOrgAlt    = `org_id = $1`
+	orgMailboxes   = `(SELECT id FROM email_accounts WHERE organization_id = $1)`
+	orgCampaigns   = `(SELECT id FROM campaigns WHERE organization_id = $1)`
+	orgContacts    = `(SELECT id FROM contacts WHERE organization_id = $1)`
+	orgTasks       = `(SELECT id FROM tasks WHERE email_account_id IN ` + orgMailboxes + `)`
+	orgThreads     = `(SELECT DISTINCT thread_id FROM unibox_emails WHERE email_id IN ` + orgMailboxes + `)`
+	orgPipelines   = `(SELECT id FROM pipelines WHERE organization_id = $1)`
+	orgInvitations = `(SELECT id FROM organization_invitations WHERE organization_id = $1)`
+	orgTeams       = `(SELECT id FROM teams WHERE organization_id = $1)`
+	orgAPIKeys     = `(SELECT id FROM api_keys WHERE organization_id = $1)`
+	orgSessions    = `(SELECT id FROM agent_sessions WHERE org_id = $1)`
+	orgPlacements  = `(SELECT id FROM placement_tests WHERE organization_id = $1)`
+)
+
+// Tables is every relation an archive carries, in dependency order. Import
+// applies them top to bottom, so a table must never appear before something it
+// references. Export order does not matter but follows the same list so the
+// archive reads in a sensible order when someone unzips it.
+//
+// The organizations row itself is not here: it is written into the manifest and
+// merged onto the destination workspace rather than inserted as a row.
+var Tables = []Table{
+	// ---------- core: the workspace itself ----------
+	{
+		Name: "organization_roles", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "organization_members", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+		Note:  "Members are matched to destination accounts by email; unknown emails become invitations.",
+	},
+	{
+		Name: "organization_member_roles", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "organization_invitations", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "organization_invitation_roles", Group: models.OrgDataGroupCore,
+		Scope: `invitation_id IN ` + orgInvitations,
+	},
+	{
+		Name: "teams", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "team_members", Group: models.OrgDataGroupCore,
+		Scope: `team_id IN ` + orgTeams,
+	},
+	{
+		Name: "email_accounts", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+		// Worker placement is a property of the instance the mailbox runs on,
+		// never of the mailbox. The destination assigns its own.
+		ResetOnImport: []string{"worker_id"},
+	},
+	{
+		Name: "email_accounts_smtp_imap", Group: models.OrgDataGroupCore,
+		Scope: `email_account_id IN ` + orgMailboxes,
+		Secrets: []SecretColumn{
+			{Column: "smtp_host", Domain: KeyDomainInstance},
+			{Column: "smtp_user", Domain: KeyDomainInstance},
+			{Column: "smtp_password", Domain: KeyDomainInstance},
+			{Column: "imap_host", Domain: KeyDomainInstance},
+			{Column: "imap_user", Domain: KeyDomainInstance},
+			{Column: "imap_password", Domain: KeyDomainInstance},
+		},
+	},
+	{
+		Name: "email_accounts_oauth", Group: models.OrgDataGroupCore,
+		Scope: `email_account_id IN ` + orgMailboxes,
+		Secrets: []SecretColumn{
+			{Column: "access_token", Domain: KeyDomainInstance},
+			{Column: "refresh_token", Domain: KeyDomainInstance},
+		},
+	},
+	{
+		Name: "email_account_behavior", Group: models.OrgDataGroupCore,
+		Scope: `email_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "tags", Group: models.OrgDataGroupCore,
+		// Labels are user-scoped in the schema, so they are collected by what
+		// the organization's own rows reference. Scoping them by owning user
+		// instead would drag that user's other workspaces into the archive.
+		Scope: `id IN (SELECT tag_id FROM email_tags WHERE email_id IN ` + orgMailboxes + `)
+		     OR id IN (SELECT tag_id FROM campaign_email_tags WHERE campaign_id IN ` + orgCampaigns + `)`,
+		Note: "Only tags this workspace actually uses travel; tags are owned by a user, not an organization.",
+	},
+	{
+		Name: "email_tags", Group: models.OrgDataGroupCore,
+		Scope: `email_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "api_keys", Group: models.OrgDataGroupCore,
+		Scope:         scopeOrg,
+		ResetOnImport: []string{"last_used_at", "last_request_ip"},
+		Note:          "Only the key hash travels, so existing keys keep working after the move without the secret ever leaving the source.",
+	},
+	{
+		Name: "webhook_endpoints", Group: models.OrgDataGroupCore,
+		Scope:         scopeOrg,
+		ResetOnImport: []string{"last_success_at", "last_failure_at", "last_failure_reason", "consecutive_failures", "first_failure_at", "auto_disabled_at", "disabled_reason"},
+	},
+	{
+		Name: "oauth_applications", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "oauth_access_grants", Group: models.OrgDataGroupCore,
+		Scope:         scopeOrg,
+		ResetOnImport: []string{"last_used_at"},
+	},
+	{
+		Name: "outreach_settings", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "org_ai_settings", Group: models.OrgDataGroupCore,
+		Scope: scopeOrgAlt,
+	},
+	{
+		Name: "advisor_settings", Group: models.OrgDataGroupCore,
+		Scope: scopeOrg,
+	},
+
+	// ---------- contacts ----------
+	{
+		Name: "categories", Group: models.OrgDataGroupContacts,
+		Scope: `id IN (SELECT category_id FROM contact_categories WHERE contact_id IN ` + orgContacts + `)
+		     OR id IN (SELECT category_id FROM unibox_thread_labels WHERE thread_id IN ` + orgThreads + `)`,
+		Note: "Same user-scoped-label rule as tags.",
+	},
+	{
+		Name: "contacts", Group: models.OrgDataGroupContacts,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "contact_categories", Group: models.OrgDataGroupContacts,
+		Scope: `contact_id IN ` + orgContacts,
+	},
+	{
+		Name: "contact_notes", Group: models.OrgDataGroupContacts,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "contact_activities", Group: models.OrgDataGroupContacts,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "suppressed_recipients", Group: models.OrgDataGroupContacts,
+		Scope: scopeOrg,
+		Note:  "Suppression must travel, or the destination re-mails people who already opted out.",
+	},
+	{
+		Name: "contact_research_runs", Group: models.OrgDataGroupContacts,
+		Scope: scopeOrgAlt,
+	},
+
+	// ---------- campaigns ----------
+	{
+		Name: "folders", Group: models.OrgDataGroupCampaigns,
+		Scope: `id IN (SELECT folder_id FROM campaign_folders WHERE campaign_id IN ` + orgCampaigns + `)`,
+	},
+	{
+		Name: "campaigns", Group: models.OrgDataGroupCampaigns,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "campaign_folders", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "sequences", Group: models.OrgDataGroupCampaigns,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "campaign_attachments", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+		Blobs: []BlobColumn{{Column: "s3_key", Kind: BlobKindKey}},
+	},
+	{
+		Name: "campaign_senders", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_email_tags", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_advanced_settings", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_ab_variants", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_leads", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_ab_assignments", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "campaign_contact_progress", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+		Note:  "Carries per-contact step position, so a running campaign resumes instead of restarting from step one.",
+	},
+	{
+		Name: "campaign_daily_sends", Group: models.OrgDataGroupCampaigns,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "preflight_reports", Group: models.OrgDataGroupCampaigns,
+		Scope: scopeOrg,
+	},
+
+	// ---------- CRM ----------
+	{
+		Name: "pipelines", Group: models.OrgDataGroupCRM,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "pipeline_stages", Group: models.OrgDataGroupCRM,
+		Scope: `pipeline_id IN ` + orgPipelines,
+	},
+	{
+		Name: "crm_task_types", Group: models.OrgDataGroupCRM,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "deals", Group: models.OrgDataGroupCRM,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "crm_tasks", Group: models.OrgDataGroupCRM,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "meeting_bookings", Group: models.OrgDataGroupCRM,
+		Scope: scopeOrg,
+	},
+
+	// ---------- automations and integrations ----------
+	{
+		Name: "integration_connections", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+		Secrets: []SecretColumn{
+			{Column: "config_encrypted", Domain: KeyDomainOrgDEK},
+			{Column: "access_token_encrypted", Domain: KeyDomainOrgDEK},
+			{Column: "refresh_token_encrypted", Domain: KeyDomainOrgDEK},
+		},
+		ResetOnImport: []string{"last_synced_at", "last_error", "last_error_at", "health_checked_at"},
+	},
+	{
+		Name: "automations", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "integration_event_subscriptions", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "integration_field_mappings", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "integration_sync_runs", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "automation_runs", Group: models.OrgDataGroupAutomations,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "lead_sync_sources", Group: models.OrgDataGroupAutomations,
+		Scope:         scopeOrg,
+		ResetOnImport: []string{"last_synced_at", "last_result", "last_error"},
+	},
+
+	// ---------- assistant ----------
+	{
+		Name: "ai_skills", Group: models.OrgDataGroupAI,
+		Scope: scopeOrgAlt,
+	},
+	{
+		Name: "ai_mcp_servers", Group: models.OrgDataGroupAI,
+		Scope: scopeOrgAlt,
+		Secrets: []SecretColumn{
+			{Column: "credentials_encrypted", Domain: KeyDomainOrgDEK},
+		},
+		ResetOnImport: []string{"last_error"},
+	},
+	{
+		Name: "ai_tool_policies", Group: models.OrgDataGroupAI,
+		Scope: scopeOrgAlt,
+	},
+	{
+		Name: "agent_sessions", Group: models.OrgDataGroupAI,
+		Scope: scopeOrgAlt,
+	},
+	{
+		Name: "agent_messages", Group: models.OrgDataGroupAI,
+		Scope: `session_id IN ` + orgSessions,
+	},
+	{
+		Name: "ai_thread_drafts", Group: models.OrgDataGroupAI,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "compose_drafts", Group: models.OrgDataGroupAI,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "reply_templates", Group: models.OrgDataGroupAI,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "reply_intents", Group: models.OrgDataGroupAI,
+		Scope: scopeOrg,
+	},
+
+	// ---------- warmup ----------
+	{
+		Name: "warmup_routing_rules", Group: models.OrgDataGroupWarmup,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "warmup_statistics", Group: models.OrgDataGroupWarmup,
+		Scope: `email_account_id IN ` + orgMailboxes,
+		Note:  "Warmup volume history travels so the destination resumes the ramp instead of restarting at the floor.",
+	},
+	{
+		Name: "warmup_appeals", Group: models.OrgDataGroupWarmup,
+		Scope: `email_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "warmup_invalid_token_attempts", Group: models.OrgDataGroupWarmup,
+		Scope: `email_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "warmup_spam_reports", Group: models.OrgDataGroupWarmup,
+		Scope: `reporter_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "warmup_pool_participants", Group: models.OrgDataGroupWarmup,
+		Scope:      `email_account_id IN ` + orgMailboxes,
+		ImportSkip: true,
+		Note:       "Pool rows are instance-global, so membership is re-earned on the destination rather than asserted by an archive.",
+	},
+	{
+		Name: "warmup_admin_actions", Group: models.OrgDataGroupWarmup,
+		Scope:      `email_account_id IN ` + orgMailboxes,
+		ImportSkip: true,
+		Note:       "Records what a platform admin on the source instance did; meaningless as an assertion about the destination.",
+	},
+
+	// ---------- inbox ----------
+	{
+		Name: "unibox_mailboxes", Group: models.OrgDataGroupInbox,
+		Scope: `email_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "unibox_emails", Group: models.OrgDataGroupInbox,
+		Scope: `email_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "unibox_thread_labels", Group: models.OrgDataGroupInbox,
+		Scope: `thread_id IN ` + orgThreads,
+	},
+	{
+		Name: "unibox_snoozes", Group: models.OrgDataGroupInbox,
+		Scope: `thread_id IN ` + orgThreads,
+	},
+	{
+		Name: "email_message_map", Group: models.OrgDataGroupInbox,
+		Scope: `email_id IN ` + orgMailboxes,
+		Note:  "Maps provider message ids to internal ones, so replies still thread after the move.",
+	},
+	{
+		Name: "email_history_ids", Group: models.OrgDataGroupInbox,
+		Scope:      `email_id IN ` + orgMailboxes,
+		ImportSkip: true,
+		Note:       "A sync checkpoint from the source. Replaying it would make the destination skip everything that arrived between export and import, so it re-syncs from scratch instead.",
+	},
+	{
+		Name: "email_delta_links", Group: models.OrgDataGroupInbox,
+		Scope:      `email_id IN ` + orgMailboxes,
+		ImportSkip: true,
+		Note:       "Same reason as email_history_ids.",
+	},
+
+	// ---------- send pipeline ----------
+	{
+		Name: "tasks", Group: models.OrgDataGroupSending,
+		Scope: `email_account_id IN ` + orgMailboxes,
+		// The handle belongs to the source instance's queue.
+		ResetOnImport: []string{"cloud_task_name"},
+	},
+	{
+		Name: "email_tasks", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+		Secrets: []SecretColumn{
+			{Column: "subject", Domain: KeyDomainOrgDEK, Guard: "encrypted"},
+			{Column: "body", Domain: KeyDomainOrgDEK, Guard: "encrypted"},
+			{Column: "body_html", Domain: KeyDomainOrgDEK, Guard: "encrypted"},
+			{Column: "body_plain", Domain: KeyDomainOrgDEK, Guard: "encrypted"},
+		},
+	},
+	{
+		Name: "campaign_tasks", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "warmup_tasks", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "warmup_tokens", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "task_failures", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "task_dead_letters", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "task_execution_keys", Group: models.OrgDataGroupSending,
+		Scope: `task_id IN ` + orgTasks,
+	},
+	{
+		Name: "daily_email_counts", Group: models.OrgDataGroupSending,
+		Scope: `email_account_id IN ` + orgMailboxes,
+		Note:  "Today's counter travels, so a mailbox cannot double its daily volume by being migrated mid-day.",
+	},
+	{
+		Name: "email_account_daily_plan", Group: models.OrgDataGroupSending,
+		Scope: `email_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "email_account_errors", Group: models.OrgDataGroupSending,
+		Scope: `email_account_id IN ` + orgMailboxes,
+	},
+	{
+		Name: "tracked_links", Group: models.OrgDataGroupSending,
+		Scope: `campaign_id IN ` + orgCampaigns,
+		Note:  "Click tickets already in the wild keep resolving after the move, provided the tracking domain follows.",
+	},
+
+	// ---------- delivery events ----------
+	{
+		Name: "deliverability_events", Group: models.OrgDataGroupEvents,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "placement_tests", Group: models.OrgDataGroupEvents,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "placement_results", Group: models.OrgDataGroupEvents,
+		Scope: `test_id IN ` + orgPlacements,
+	},
+	{
+		Name: "webhook_deliveries", Group: models.OrgDataGroupEvents,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "webhook_event_drops", Group: models.OrgDataGroupEvents,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "api_key_usage_logs", Group: models.OrgDataGroupEvents,
+		Scope: `api_key_id IN ` + orgAPIKeys,
+	},
+
+	// ---------- logs ----------
+	{
+		Name: "audit_logs", Group: models.OrgDataGroupLogs,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "campaign_logs", Group: models.OrgDataGroupLogs,
+		Scope: `campaign_id IN ` + orgCampaigns,
+	},
+	{
+		Name: "notifications", Group: models.OrgDataGroupLogs,
+		Scope:         scopeOrg,
+		ResetOnImport: []string{"email_state", "email_due_at", "email_attempts"},
+		Note:          "Pending digest state is cleared so an import cannot re-send a month of notification emails.",
+	},
+	{
+		Name: "advisor_runs", Group: models.OrgDataGroupLogs,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "advisor_findings", Group: models.OrgDataGroupLogs,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "advisor_feedback", Group: models.OrgDataGroupLogs,
+		Scope: scopeOrg,
+	},
+	{
+		Name: "advisor_narrations", Group: models.OrgDataGroupLogs,
+		Scope: scopeOrg,
+	},
+
+	// ---------- billing: exported for the record, never applied ----------
+	{
+		Name: "subscriptions", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrg, ImportSkip: true,
+		Note: "Stripe identifiers belong to the source instance's Stripe account; the destination issues its own subscription.",
+	},
+	{
+		Name: "credit_ledger", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrgAlt, ImportSkip: true,
+		Note: "Importing a balance would mint credits the destination was never paid for.",
+	},
+	{
+		Name: "credit_ledger_transactions", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrgAlt, ImportSkip: true,
+	},
+	{
+		Name: "referral_earnings_ledger", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrgAlt, ImportSkip: true,
+	},
+	{
+		Name: "referral_earnings_transactions", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrgAlt, ImportSkip: true,
+	},
+	{
+		Name: "discount_redemptions", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrg, ImportSkip: true,
+	},
+	{
+		Name: "organization_limit_overrides", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrg, ImportSkip: true,
+		Note: "A plan override is a grant by one platform's operators, not a property the workspace carries with it.",
+	},
+	{
+		Name: "limit_increase_requests", Group: models.OrgDataGroupBilling,
+		Scope: scopeOrg, ImportSkip: true,
+	},
+}
+
+// ExcludedTables are org-owned relations an archive deliberately never carries,
+// with the reason. Kept as data so the docs page and the coverage test both
+// read from one list instead of restating it.
+var ExcludedTables = map[string]string{
+	"organization_encrypted_keys":  "The organization's data key, wrapped by the source instance's KMS. The destination cannot unwrap it, and shipping it would put every org secret behind one exported blob.",
+	"api_idempotency_keys":         "A short-lived replay cache for in-flight API requests.",
+	"realtime_events":              "The websocket outbox. Every row is already delivered or expired.",
+	"integration_oauth_states":     "In-flight OAuth handshakes, valid for minutes and bound to the source instance's redirect URL.",
+	"oauth_authorization_codes":    "Single-use authorization codes, valid for seconds.",
+	"scheduled_deletions":          "Instance lifecycle state. Importing a pending deletion would schedule the destination workspace for destruction.",
+	"dedicated_worker_assignments": "Worker topology, which is a property of the instance rather than the workspace.",
+	"warmup_pools":                 "Instance-global pool definitions shared by every workspace on the instance.",
+	"warmup_conversations":         "The instance's shared warmup content library, not workspace data.",
+	"sessions":                     "Live login sessions. They are bound to the source instance's signing key and must not survive a move.",
+}
+
+// TableByName indexes Tables for lookup during import.
+var TableByName = func() map[string]*Table {
+	m := make(map[string]*Table, len(Tables))
+	for i := range Tables {
+		m[Tables[i].Name] = &Tables[i]
+	}
+	return m
+}()
+
+// GroupTables returns the tables belonging to the selected groups, in
+// dependency order. An empty selection means every group.
+func GroupTables(groups []models.OrgDataGroup) []*Table {
+	want := make(map[models.OrgDataGroup]bool, len(groups))
+	for _, g := range groups {
+		want[g] = true
+	}
+	out := make([]*Table, 0, len(Tables))
+	for i := range Tables {
+		t := &Tables[i]
+		if len(want) == 0 || want[t.Group] || t.Group == models.OrgDataGroupCore {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// NormalizeGroups validates a requested group list, adds core (which every
+// archive needs to be importable at all), and closes over the catalog's
+// dependencies so a selection can never be one that fails on a foreign key.
+func NormalizeGroups(groups []models.OrgDataGroup) []models.OrgDataGroup {
+	if len(groups) == 0 {
+		return append([]models.OrgDataGroup(nil), models.AllOrgDataGroups...)
+	}
+
+	valid := make(map[models.OrgDataGroup]bool, len(models.AllOrgDataGroups))
+	for _, g := range models.AllOrgDataGroups {
+		valid[g] = true
+	}
+
+	requires := models.GroupRequirements()
+	seen := map[models.OrgDataGroup]bool{models.OrgDataGroupCore: true}
+	queue := append([]models.OrgDataGroup(nil), groups...)
+	for len(queue) > 0 {
+		g := queue[0]
+		queue = queue[1:]
+		if seen[g] || !valid[g] {
+			continue
+		}
+		seen[g] = true
+		queue = append(queue, requires[g]...)
+	}
+
+	// Emit in catalog order so the result is stable whatever order the caller
+	// asked in, which keeps the job row and the manifest comparable.
+	out := make([]models.OrgDataGroup, 0, len(seen))
+	for _, g := range models.AllOrgDataGroups {
+		if seen[g] {
+			out = append(out, g)
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/db/migrations/000085_org_data_transfer.down.sql
+++ b/internal/infrastructure/db/migrations/000085_org_data_transfer.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS org_import_jobs;
+DROP TABLE IF EXISTS org_export_jobs;

--- a/internal/infrastructure/db/migrations/000085_org_data_transfer.up.sql
+++ b/internal/infrastructure/db/migrations/000085_org_data_transfer.up.sql
@@ -1,0 +1,103 @@
+-- Organization data transfer: portable workspace archives.
+--
+-- An export walks every org-owned table into a single archive file so a
+-- workspace can move between instances (self-host to cloud, cloud to
+-- self-host, or one self-host to another). An import reads that archive back.
+--
+-- Both are long-running and produce an artifact, so they are job rows rather
+-- than request-scoped work: the dashboard polls/subscribes for progress and
+-- downloads the result when it lands.
+--
+-- The option columns are typed rather than a jsonb blob because the option set
+-- is fixed and small (which data groups, and whether secrets travel). The one
+-- jsonb column on each side holds data that is genuinely free-form and only
+-- ever read back for display: the source archive's manifest, per-table row
+-- counts, and the import's warning list.
+
+CREATE TABLE IF NOT EXISTS org_export_jobs (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    requested_by     uuid REFERENCES users (id) ON DELETE SET NULL,
+
+    status           text NOT NULL DEFAULT 'queued'
+                     CHECK (status IN ('queued', 'running', 'completed', 'failed', 'expired')),
+
+    -- Data groups included in this archive. Empty means every group.
+    groups           text[] NOT NULL DEFAULT '{}',
+    -- Whether mailbox and integration credentials were re-sealed into the
+    -- archive under the requester's passphrase. The passphrase itself is
+    -- never stored; a wrong one simply fails to unseal at import time.
+    include_secrets  boolean NOT NULL DEFAULT false,
+    format_version   integer NOT NULL DEFAULT 1,
+
+    progress_percent smallint NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100),
+    progress_stage   text NOT NULL DEFAULT '',
+
+    archive_key      text,
+    archive_bytes    bigint,
+    archive_sha256   text,
+    row_counts       jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+    error_message    text,
+    started_at       timestamptz,
+    completed_at     timestamptz,
+    -- Archives hold a full copy of a workspace, so they are not kept forever.
+    expires_at       timestamptz,
+    created_at       timestamptz NOT NULL DEFAULT NOW(),
+    updated_at       timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_export_jobs_org
+    ON org_export_jobs (organization_id, created_at DESC);
+
+-- The runner claims work through this index; keeping it partial means the
+-- scan stays tiny no matter how much export history accumulates.
+CREATE INDEX IF NOT EXISTS idx_org_export_jobs_pending
+    ON org_export_jobs (created_at)
+    WHERE status IN ('queued', 'running');
+
+CREATE INDEX IF NOT EXISTS idx_org_export_jobs_expiry
+    ON org_export_jobs (expires_at)
+    WHERE status = 'completed';
+
+CREATE TABLE IF NOT EXISTS org_import_jobs (
+    id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id   uuid NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    requested_by      uuid REFERENCES users (id) ON DELETE SET NULL,
+
+    status            text NOT NULL DEFAULT 'queued'
+                      CHECK (status IN ('queued', 'running', 'completed', 'failed')),
+
+    -- Cleared once the import succeeds: the uploaded archive holds the whole
+    -- workspace and is only kept while a retry might still need it.
+    archive_key       text,
+    archive_bytes     bigint,
+    archive_sha256    text,
+    -- The manifest as it was written by the source instance. Read back only to
+    -- show the operator what they are importing, so it stays a blob.
+    source_manifest   jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+    groups            text[] NOT NULL DEFAULT '{}',
+    -- What to do when a row in the archive already exists here by primary key.
+    conflict_strategy text NOT NULL DEFAULT 'skip'
+                      CHECK (conflict_strategy IN ('skip', 'overwrite')),
+
+    progress_percent  smallint NOT NULL DEFAULT 0 CHECK (progress_percent BETWEEN 0 AND 100),
+    progress_stage    text NOT NULL DEFAULT '',
+
+    row_counts        jsonb NOT NULL DEFAULT '{}'::jsonb,
+    warnings          jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    error_message     text,
+    started_at        timestamptz,
+    completed_at      timestamptz,
+    created_at        timestamptz NOT NULL DEFAULT NOW(),
+    updated_at        timestamptz NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_org_import_jobs_org
+    ON org_import_jobs (organization_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_org_import_jobs_pending
+    ON org_import_jobs (created_at)
+    WHERE status IN ('queued', 'running');

--- a/internal/jobs/org_transfer.go
+++ b/internal/jobs/org_transfer.go
@@ -1,0 +1,80 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+
+	"github.com/warmbly/warmbly/internal/app/orgtransfer"
+)
+
+// OrgTransferJob keeps the workspace-archive tables honest. It deletes archives
+// past their retention window (each one is a full copy of a workspace, so they
+// do not accumulate) and closes out any export or import whose process died
+// mid-run.
+//
+// Transfers themselves execute in the process that accepted the request, so
+// that the operator's passphrase is never persisted anywhere. That is exactly
+// what makes the second half of this job necessary: a restart would otherwise
+// leave a job showing "running" forever.
+type OrgTransferJob struct {
+	svc orgtransfer.Service
+}
+
+// NewOrgTransferJob constructs the job.
+func NewOrgTransferJob(svc orgtransfer.Service) *OrgTransferJob {
+	return &OrgTransferJob{svc: svc}
+}
+
+// Run performs one tick. Errors are reported and swallowed so the scheduler
+// keeps ticking; the next tick retries whatever did not land.
+func (j *OrgTransferJob) Run(ctx context.Context) {
+	if j.svc == nil {
+		return
+	}
+	if _, err := j.svc.PurgeExpiredExports(ctx); err != nil {
+		sentry.CaptureException(err)
+	}
+}
+
+// OrgTransferScheduler runs the job on a fixed interval.
+type OrgTransferScheduler struct {
+	job      *OrgTransferJob
+	interval time.Duration
+	stopCh   chan struct{}
+}
+
+// NewOrgTransferScheduler builds a scheduler. Hourly is ample: the retention
+// window is measured in days and the stale-job deadline in hours.
+func NewOrgTransferScheduler(job *OrgTransferJob, interval time.Duration) *OrgTransferScheduler {
+	return &OrgTransferScheduler{
+		job:      job,
+		interval: interval,
+		stopCh:   make(chan struct{}),
+	}
+}
+
+// Start runs Run() on every tick until ctx is cancelled or Stop() is called.
+func (s *OrgTransferScheduler) Start(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+
+	s.job.Run(ctx)
+
+	for {
+		select {
+		case <-ticker.C:
+			s.job.Run(ctx)
+		case <-s.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop halts the scheduler.
+func (s *OrgTransferScheduler) Stop() {
+	close(s.stopCh)
+}

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -90,7 +90,10 @@ const (
 	AuditEntityAutomation     AuditEntityType = "automation"
 	AuditEntityLeadSyncSource AuditEntityType = "lead_sync_source"
 	AuditEntityMeeting        AuditEntityType = "meeting"
-	AuditEntityRole           AuditEntityType = "role"
+
+	// Workspace archives (export/import for moving between instances).
+	AuditEntityOrgArchive AuditEntityType = "org_archive"
+	AuditEntityRole       AuditEntityType = "role"
 
 	// Referral program. referral = the share code / attribution; referral_credit
 	// = a reward or clawback on the referrer's earnings ledger.

--- a/internal/models/org_transfer.go
+++ b/internal/models/org_transfer.go
@@ -1,0 +1,318 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// OrgTransferFormatVersion is the archive layout version written into every
+// manifest. Bump it only for a change an older importer could not read; the
+// importer already tolerates unknown tables and unknown columns, so adding
+// either is not a format change.
+const OrgTransferFormatVersion = 1
+
+// OrgTransferStatus is the lifecycle of one export or import job. Export adds
+// "expired": the archive is deleted from blob storage after its retention
+// window, and the row survives so the history stays honest about what ran.
+type OrgTransferStatus string
+
+const (
+	OrgTransferStatusQueued    OrgTransferStatus = "queued"
+	OrgTransferStatusRunning   OrgTransferStatus = "running"
+	OrgTransferStatusCompleted OrgTransferStatus = "completed"
+	OrgTransferStatusFailed    OrgTransferStatus = "failed"
+	OrgTransferStatusExpired   OrgTransferStatus = "expired"
+)
+
+// IsTerminal reports whether a job has stopped moving.
+func (s OrgTransferStatus) IsTerminal() bool {
+	switch s {
+	case OrgTransferStatusCompleted, OrgTransferStatusFailed, OrgTransferStatusExpired:
+		return true
+	}
+	return false
+}
+
+// OrgDataGroup names one slice of a workspace. Groups exist so a migration can
+// leave the bulky history behind: "core" plus "contacts" plus "campaigns"
+// rebuilds a working workspace, while "inbox" and "events" can multiply the
+// archive size by a hundred on a busy org without changing what it does.
+type OrgDataGroup string
+
+const (
+	// OrgDataGroupCore is the workspace itself: the organization row, members,
+	// roles, teams, settings, API keys, webhooks, and the mailbox records.
+	// Always included; an archive without it cannot be imported.
+	OrgDataGroupCore OrgDataGroup = "core"
+	// OrgDataGroupContacts is contacts, categories, notes, activities, and
+	// suppression.
+	OrgDataGroupContacts OrgDataGroup = "contacts"
+	// OrgDataGroupCampaigns is campaigns, sequences, senders, attachments, and
+	// per-campaign settings.
+	OrgDataGroupCampaigns OrgDataGroup = "campaigns"
+	// OrgDataGroupCRM is pipelines, deals, CRM tasks, and meeting bookings.
+	OrgDataGroupCRM OrgDataGroup = "crm"
+	// OrgDataGroupAutomations is automations, integrations, and lead sync.
+	OrgDataGroupAutomations OrgDataGroup = "automations"
+	// OrgDataGroupAI is the assistant: sessions, messages, skills, MCP servers,
+	// and AI settings.
+	OrgDataGroupAI OrgDataGroup = "ai"
+	// OrgDataGroupWarmup is warmup participation, statistics, and appeals.
+	OrgDataGroupWarmup OrgDataGroup = "warmup"
+	// OrgDataGroupInbox is the unified inbox: mailboxes, threads, message
+	// bodies, and mailbox sync checkpoints. Usually the largest group.
+	OrgDataGroupInbox OrgDataGroup = "inbox"
+	// OrgDataGroupSending is the send pipeline: tasks, their payloads, and
+	// per-day counters.
+	OrgDataGroupSending OrgDataGroup = "sending"
+	// OrgDataGroupEvents is delivery, tracking, and placement history.
+	OrgDataGroupEvents OrgDataGroup = "events"
+	// OrgDataGroupLogs is audit logs, campaign logs, and notifications.
+	OrgDataGroupLogs OrgDataGroup = "logs"
+	// OrgDataGroupBilling is subscription, credit ledger, and referral state.
+	// Never applied verbatim on import: the destination instance owns billing.
+	OrgDataGroupBilling OrgDataGroup = "billing"
+)
+
+// AllOrgDataGroups is every group in display order. The dashboard renders the
+// toggle list from this, so order here is the order the user sees.
+var AllOrgDataGroups = []OrgDataGroup{
+	OrgDataGroupCore,
+	OrgDataGroupContacts,
+	OrgDataGroupCampaigns,
+	OrgDataGroupCRM,
+	OrgDataGroupAutomations,
+	OrgDataGroupAI,
+	OrgDataGroupWarmup,
+	OrgDataGroupInbox,
+	OrgDataGroupSending,
+	OrgDataGroupEvents,
+	OrgDataGroupLogs,
+	OrgDataGroupBilling,
+}
+
+// OrgDataGroupInfo describes a group for the settings UI.
+type OrgDataGroupInfo struct {
+	Key         OrgDataGroup `json:"key"`
+	Label       string       `json:"label"`
+	Description string       `json:"description"`
+	// Required groups cannot be switched off.
+	Required bool `json:"required"`
+	// Heavy marks the groups that dominate archive size on a busy workspace,
+	// so the UI can warn before someone exports a decade of inbox history.
+	Heavy bool `json:"heavy"`
+	// Requires names the groups this one cannot travel without, because its
+	// rows hold NOT NULL references into them. Selecting a group selects these
+	// too, on the server and in the dashboard, so what the toggles show is
+	// what the archive actually gets.
+	Requires []OrgDataGroup `json:"requires,omitempty"`
+}
+
+// OrgDataGroupCatalog is the user-facing description of every group, and the
+// single source of truth for the dependencies between them.
+//
+// Each Requires entry is a NOT NULL foreign key crossing a group boundary:
+// campaign_leads keys on a contact, unibox_thread_labels on a category,
+// campaign_logs on a campaign. Leaving the target behind would not degrade an
+// import, it would abort it. Nullable crossings need no entry — the importer
+// blanks those when their target is not part of the run.
+var OrgDataGroupCatalog = []OrgDataGroupInfo{
+	{Key: OrgDataGroupCore, Label: "Workspace", Description: "Organization, members, roles, teams, mailboxes, API keys, webhooks, and settings.", Required: true},
+	{Key: OrgDataGroupContacts, Label: "Contacts", Description: "Contacts, categories, notes, activities, and the suppression list."},
+	{Key: OrgDataGroupCampaigns, Label: "Campaigns", Description: "Campaigns, sequences, senders, attachments, and per-campaign settings.", Requires: []OrgDataGroup{OrgDataGroupContacts}},
+	{Key: OrgDataGroupCRM, Label: "CRM", Description: "Pipelines, deals, tasks, and meeting bookings."},
+	{Key: OrgDataGroupAutomations, Label: "Automations", Description: "Automations, connected integrations, and lead sync sources."},
+	{Key: OrgDataGroupAI, Label: "Assistant", Description: "Assistant sessions and messages, skills, MCP servers, and AI settings."},
+	{Key: OrgDataGroupWarmup, Label: "Warmup", Description: "Warmup participation, routing rules, statistics, and appeals."},
+	{Key: OrgDataGroupInbox, Label: "Inbox", Description: "Unified inbox threads, message bodies, and mailbox sync state.", Heavy: true, Requires: []OrgDataGroup{OrgDataGroupContacts}},
+	{Key: OrgDataGroupSending, Label: "Send history", Description: "Queued and completed send tasks with their payloads.", Heavy: true},
+	{Key: OrgDataGroupEvents, Label: "Delivery events", Description: "Bounces, complaints, opens, clicks, and placement tests.", Heavy: true},
+	{Key: OrgDataGroupLogs, Label: "Logs", Description: "Audit log, campaign logs, and notifications.", Heavy: true, Requires: []OrgDataGroup{OrgDataGroupCampaigns}},
+	{Key: OrgDataGroupBilling, Label: "Billing history", Description: "Subscription, credit ledger, and referral records. Read-only on import: the destination instance owns billing."},
+}
+
+// GroupRequirements indexes the catalog's dependencies for closure walks.
+func GroupRequirements() map[OrgDataGroup][]OrgDataGroup {
+	out := make(map[OrgDataGroup][]OrgDataGroup, len(OrgDataGroupCatalog))
+	for _, g := range OrgDataGroupCatalog {
+		if len(g.Requires) > 0 {
+			out[g.Key] = g.Requires
+		}
+	}
+	return out
+}
+
+// OrgImportConflict is what to do when the archive carries a row whose primary
+// key already exists in the destination.
+type OrgImportConflict string
+
+const (
+	// OrgImportConflictSkip keeps the row that is already here. The safe
+	// default: an import never destroys data that was not in the archive.
+	OrgImportConflictSkip OrgImportConflict = "skip"
+	// OrgImportConflictOverwrite replaces the existing row with the archive's.
+	OrgImportConflictOverwrite OrgImportConflict = "overwrite"
+)
+
+// OrgExportJob is one archive build.
+type OrgExportJob struct {
+	ID             uuid.UUID         `json:"id"`
+	OrganizationID uuid.UUID         `json:"organization_id"`
+	RequestedBy    *uuid.UUID        `json:"requested_by,omitempty"`
+	Status         OrgTransferStatus `json:"status"`
+
+	Groups         []OrgDataGroup `json:"groups"`
+	IncludeSecrets bool           `json:"include_secrets"`
+	FormatVersion  int            `json:"format_version"`
+
+	ProgressPercent int    `json:"progress_percent"`
+	ProgressStage   string `json:"progress_stage"`
+
+	ArchiveKey    *string          `json:"-"`
+	ArchiveBytes  *int64           `json:"archive_bytes,omitempty"`
+	ArchiveSHA256 *string          `json:"archive_sha256,omitempty"`
+	RowCounts     map[string]int64 `json:"row_counts"`
+
+	ErrorMessage *string    `json:"error_message,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+// TotalRows sums every table's row count, for the "12,481 rows" summary line.
+func (j *OrgExportJob) TotalRows() int64 {
+	var total int64
+	for _, n := range j.RowCounts {
+		total += n
+	}
+	return total
+}
+
+// OrgImportJob is one archive application.
+type OrgImportJob struct {
+	ID             uuid.UUID         `json:"id"`
+	OrganizationID uuid.UUID         `json:"organization_id"`
+	RequestedBy    *uuid.UUID        `json:"requested_by,omitempty"`
+	Status         OrgTransferStatus `json:"status"`
+
+	ArchiveKey     *string         `json:"-"`
+	ArchiveBytes   *int64          `json:"archive_bytes,omitempty"`
+	ArchiveSHA256  *string         `json:"archive_sha256,omitempty"`
+	SourceManifest *OrgArchiveInfo `json:"source_manifest,omitempty"`
+
+	Groups           []OrgDataGroup    `json:"groups"`
+	ConflictStrategy OrgImportConflict `json:"conflict_strategy"`
+
+	ProgressPercent int    `json:"progress_percent"`
+	ProgressStage   string `json:"progress_stage"`
+
+	RowCounts map[string]int64 `json:"row_counts"`
+	Warnings  []string         `json:"warnings"`
+
+	ErrorMessage *string    `json:"error_message,omitempty"`
+	StartedAt    *time.Time `json:"started_at,omitempty"`
+	CompletedAt  *time.Time `json:"completed_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+// OrgArchiveInfo is the manifest summary the dashboard shows before an import
+// runs and stores on the job afterwards. It is the subset of the on-disk
+// manifest that is safe and useful to display.
+type OrgArchiveInfo struct {
+	FormatVersion    int              `json:"format_version"`
+	SourceInstance   string           `json:"source_instance"`
+	SourceAppVersion string           `json:"source_app_version"`
+	OrganizationID   uuid.UUID        `json:"organization_id"`
+	OrganizationName string           `json:"organization_name"`
+	ExportedAt       time.Time        `json:"exported_at"`
+	Groups           []OrgDataGroup   `json:"groups"`
+	HasSecrets       bool             `json:"has_secrets"`
+	RowCounts        map[string]int64 `json:"row_counts"`
+	BlobCount        int              `json:"blob_count"`
+	Members          []OrgArchiveUser `json:"members"`
+}
+
+// TotalRows sums the manifest's per-table counts.
+func (a *OrgArchiveInfo) TotalRows() int64 {
+	var total int64
+	for _, n := range a.RowCounts {
+		total += n
+	}
+	return total
+}
+
+// OrgArchiveUser is a member carried by the archive. The importer matches
+// these to destination accounts by email; there is no password material here,
+// so an archive can never mint a usable login on the destination.
+type OrgArchiveUser struct {
+	ID        uuid.UUID `json:"id"`
+	Email     string    `json:"email"`
+	FirstName string    `json:"first_name"`
+	LastName  string    `json:"last_name"`
+	Role      string    `json:"role"`
+	IsOwner   bool      `json:"is_owner"`
+}
+
+// CreateOrgExportRequest is the export endpoint's body.
+type CreateOrgExportRequest struct {
+	// Groups to include. Empty means every group.
+	Groups []OrgDataGroup `json:"groups,omitempty"`
+	// IncludeSecrets re-seals mailbox and integration credentials into the
+	// archive under Passphrase so the destination can bring mailboxes back up
+	// without every user reconnecting. Requires Passphrase.
+	IncludeSecrets bool `json:"include_secrets,omitempty"`
+	// Passphrase protects the secrets bundle. Never stored: it is used once to
+	// derive the archive's sealing key and then discarded.
+	Passphrase string `json:"passphrase,omitempty"`
+}
+
+// CreateOrgImportRequest is the import endpoint's options form field. The
+// archive itself arrives as the multipart file.
+type CreateOrgImportRequest struct {
+	// Groups to apply. Empty means every group present in the archive.
+	Groups []OrgDataGroup `json:"groups,omitempty"`
+	// ConflictStrategy decides what happens to rows that already exist here.
+	ConflictStrategy OrgImportConflict `json:"conflict_strategy,omitempty"`
+	// Passphrase unseals the archive's secrets bundle. Omit it and the import
+	// still runs; mailboxes and integrations just arrive needing a reconnect.
+	Passphrase string `json:"passphrase,omitempty"`
+}
+
+// OrgImportPreflight is what the dashboard shows before anything is written:
+// what the archive holds, and what will happen when it is applied.
+type OrgImportPreflight struct {
+	Archive *OrgArchiveInfo `json:"archive"`
+	// SecretsUnsealed reports whether the supplied passphrase actually opened
+	// the secrets bundle, so the UI can say "12 mailboxes will reconnect
+	// automatically" rather than promising it blindly.
+	SecretsUnsealed bool `json:"secrets_unsealed"`
+	// Conflicts is the per-table count of primary keys already present here.
+	Conflicts map[string]int64 `json:"conflicts"`
+	// UnknownMembers are archive members with no account on this instance.
+	// They are imported as pending invitations rather than as new accounts.
+	UnknownMembers []OrgArchiveUser `json:"unknown_members"`
+	// SkippedTables are tables in the archive this instance does not have,
+	// usually because the archive came from a newer release.
+	SkippedTables []string `json:"skipped_tables"`
+	Warnings      []string `json:"warnings"`
+}
+
+// MaxOrgArchiveUploadBytes caps an uploaded archive. A full workspace with
+// inbox history can be large, but not this large, and the cap keeps a hostile
+// upload from filling the disk before the manifest is ever read.
+const MaxOrgArchiveUploadBytes = 8 << 30 // 8 GiB
+
+// OrgExportRetention is how long a finished archive stays downloadable. It is
+// a complete copy of a workspace sitting in blob storage, so it does not live
+// forever; the operator can always run another export.
+const OrgExportRetention = 7 * 24 * time.Hour
+
+// MinOrgExportPassphraseLength is the floor for a secrets passphrase. The
+// passphrase is the only thing standing between the archive file and every
+// mailbox credential in the workspace, so it is held to a higher bar than a
+// login password.
+const MinOrgExportPassphraseLength = 12

--- a/internal/repository/pg_orgtransfer.go
+++ b/internal/repository/pg_orgtransfer.go
@@ -1,0 +1,801 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OrgTransferRepository moves whole organizations in and out of the database.
+//
+// Unlike every other repository here it is deliberately schema-generic: it
+// reads and writes tables by name rather than through typed structs. That is
+// the only way an archive stays correct as the schema grows, and it is why
+// rows travel as jsonb — Postgres converts every column type in both
+// directions, so arrays, jsonb, tsvector, inet, and enums need no Go-side
+// mapping that could drift.
+//
+// Identifier safety: table names come from the compiled registry, and column
+// names are always intersected against the destination catalog before they
+// reach a query. Nothing from an uploaded archive is ever interpolated.
+type OrgTransferRepository interface {
+	// ---- schema introspection ----
+
+	// TableColumns returns the destination's columns for a table, or nil when
+	// the table does not exist here at all.
+	TableColumns(ctx context.Context, table string) ([]ColumnInfo, error)
+	// PrimaryKeyColumns returns the table's primary key, empty when it has none.
+	PrimaryKeyColumns(ctx context.Context, table string) ([]string, error)
+	// ForeignKeyRefs maps each column with a declared foreign key to the table
+	// it points at. The importer uses it to find references whose target is not
+	// part of this import, and asking the catalog means a constraint added
+	// later is covered without a code change.
+	ForeignKeyRefs(ctx context.Context, table string) (map[string]string, error)
+
+	// ---- export ----
+
+	// StreamScoped calls fn once per row with that row as a JSON object. The
+	// slice is only valid for the duration of the call.
+	StreamScoped(ctx context.Context, table, scope string, orgID uuid.UUID, fn func(row []byte) error) error
+	OrganizationRow(ctx context.Context, orgID uuid.UUID) ([]byte, error)
+	ArchiveMembers(ctx context.Context, orgID uuid.UUID) ([]models.OrgArchiveUser, error)
+
+	// ---- import ----
+
+	// CountExisting reports how many of the supplied primary-key values are
+	// already present, for the preflight report.
+	CountExisting(ctx context.Context, table string, pk []string, rows []json.RawMessage) (int64, error)
+	// InsertBatch writes rows into table, honouring the conflict strategy.
+	InsertBatch(ctx context.Context, tx pgx.Tx, table string, cols []string, rows []json.RawMessage, conflict models.OrgImportConflict, pk []string) (int64, error)
+	// MergeOrganization applies the archive's organization row onto an
+	// existing workspace, restricted to cols.
+	MergeOrganization(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, cols []string, row json.RawMessage) error
+	// ResolveUsersByEmail maps lowercased emails to destination user ids.
+	ResolveUsersByEmail(ctx context.Context, emails []string) (map[string]uuid.UUID, error)
+	// MarkMailboxesNeedingReconnect flags imported mailboxes whose credentials
+	// did not travel, so the dashboard prompts for a reconnect instead of the
+	// worker failing every send against an empty password.
+	MarkMailboxesNeedingReconnect(ctx context.Context, tx pgx.Tx, orgID uuid.UUID) (int64, error)
+	// Begin starts the import transaction.
+	Begin(ctx context.Context) (pgx.Tx, error)
+
+	// ---- export jobs ----
+
+	CreateExportJob(ctx context.Context, j *models.OrgExportJob) error
+	GetExportJob(ctx context.Context, orgID, id uuid.UUID) (*models.OrgExportJob, error)
+	ListExportJobs(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OrgExportJob, error)
+	UpdateExportProgress(ctx context.Context, id uuid.UUID, percent int, stage string) error
+	CompleteExportJob(ctx context.Context, id uuid.UUID, key string, size int64, sha string, counts map[string]int64, expiresAt time.Time) error
+	FailExportJob(ctx context.Context, id uuid.UUID, reason string) error
+	DeleteExportJob(ctx context.Context, orgID, id uuid.UUID) (string, error)
+	ListExpiredExports(ctx context.Context, now time.Time, limit int) ([]models.OrgExportJob, error)
+	MarkExportExpired(ctx context.Context, id uuid.UUID) error
+	HasActiveExport(ctx context.Context, orgID uuid.UUID) (bool, error)
+
+	// ---- import jobs ----
+
+	CreateImportJob(ctx context.Context, j *models.OrgImportJob) error
+	GetImportJob(ctx context.Context, orgID, id uuid.UUID) (*models.OrgImportJob, error)
+	ListImportJobs(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OrgImportJob, error)
+	UpdateImportProgress(ctx context.Context, id uuid.UUID, percent int, stage string) error
+	CompleteImportJob(ctx context.Context, id uuid.UUID, counts map[string]int64, warnings []string) error
+	FailImportJob(ctx context.Context, id uuid.UUID, reason string) error
+	HasActiveImport(ctx context.Context, orgID uuid.UUID) (bool, error)
+
+	// FailStaleTransfers closes out jobs whose process died mid-run. Transfers
+	// execute in the accepting process (so a passphrase is never persisted),
+	// which means a restart leaves a job running forever without this.
+	FailStaleTransfers(ctx context.Context, before time.Time) error
+}
+
+// ColumnInfo is one destination column. Generated and identity columns cannot
+// be written, so they are filtered out of every INSERT; NotNull decides whether
+// a reference the import cannot satisfy can be blanked or has to be redirected.
+type ColumnInfo struct {
+	Name        string
+	IsGenerated bool
+	IsIdentity  bool
+	NotNull     bool
+}
+
+// Writable reports whether the column accepts a supplied value.
+func (c ColumnInfo) Writable() bool { return !c.IsGenerated && !c.IsIdentity }
+
+type orgTransferRepository struct {
+	DB *db.DB
+}
+
+func NewOrgTransferRepository(database *db.DB) OrgTransferRepository {
+	return &orgTransferRepository{DB: database}
+}
+
+// quoteIdent renders one identifier safely. Every identifier reaching this
+// point has already been matched against the catalog; quoting is the second
+// line of defence and the reason a column named "order" works at all.
+func quoteIdent(name string) string {
+	return pgx.Identifier{name}.Sanitize()
+}
+
+func quoteIdents(names []string) string {
+	out := make([]string, len(names))
+	for i, n := range names {
+		out[i] = quoteIdent(n)
+	}
+	return strings.Join(out, ", ")
+}
+
+func (r *orgTransferRepository) Begin(ctx context.Context) (pgx.Tx, error) {
+	return r.DB.Begin(ctx)
+}
+
+// ---------- schema introspection ----------
+
+func (r *orgTransferRepository) TableColumns(ctx context.Context, table string) ([]ColumnInfo, error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT a.attname,
+		       a.attgenerated <> '' AS is_generated,
+		       a.attidentity <> ''  AS is_identity,
+		       a.attnotnull         AS not_null
+		  FROM pg_attribute a
+		  JOIN pg_class c     ON c.oid = a.attrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE n.nspname = 'public'
+		   AND c.relname = $1
+		   AND c.relkind = 'r'
+		   AND a.attnum > 0
+		   AND NOT a.attisdropped
+		 ORDER BY a.attnum
+	`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ColumnInfo
+	for rows.Next() {
+		var c ColumnInfo
+		if err := rows.Scan(&c.Name, &c.IsGenerated, &c.IsIdentity, &c.NotNull); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (r *orgTransferRepository) PrimaryKeyColumns(ctx context.Context, table string) ([]string, error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT a.attname
+		  FROM pg_index i
+		  JOIN pg_class c     ON c.oid = i.indrelid
+		  JOIN pg_namespace n ON n.oid = c.relnamespace
+		  JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = ANY (i.indkey)
+		 WHERE n.nspname = 'public'
+		   AND c.relname = $1
+		   AND i.indisprimary
+		 ORDER BY array_position(i.indkey, a.attnum)
+	`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		out = append(out, name)
+	}
+	return out, rows.Err()
+}
+
+func (r *orgTransferRepository) ForeignKeyRefs(ctx context.Context, table string) (map[string]string, error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT a.attname, rc.relname
+		  FROM pg_constraint con
+		  JOIN pg_class c      ON c.oid = con.conrelid
+		  JOIN pg_namespace n  ON n.oid = c.relnamespace
+		  JOIN pg_class rc     ON rc.oid = con.confrelid
+		  JOIN pg_attribute a  ON a.attrelid = c.oid AND a.attnum = ANY (con.conkey)
+		 WHERE con.contype = 'f'
+		   AND n.nspname = 'public'
+		   AND c.relname = $1
+	`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var column, target string
+		if err := rows.Scan(&column, &target); err != nil {
+			return nil, err
+		}
+		out[column] = target
+	}
+	return out, rows.Err()
+}
+
+// ---------- export ----------
+
+// StreamScoped reads a table with to_jsonb so every column type is rendered by
+// Postgres itself. It runs inside a transaction with the statement timeout
+// lifted: the pool sets a 60s default, and a full inbox export legitimately
+// runs longer than that.
+func (r *orgTransferRepository) StreamScoped(ctx context.Context, table, scope string, orgID uuid.UUID, fn func(row []byte) error) error {
+	tx, err := r.DB.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `SET LOCAL statement_timeout = 0`); err != nil {
+		return fmt.Errorf("lift statement timeout: %w", err)
+	}
+
+	q := `SELECT to_jsonb(t) FROM public.` + quoteIdent(table) + ` t WHERE ` + scope
+	rows, err := tx.Query(ctx, q, orgID)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", table, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return fmt.Errorf("scan %s: %w", table, err)
+		}
+		if err := fn(raw); err != nil {
+			return err
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("read %s: %w", table, err)
+	}
+	return nil
+}
+
+func (r *orgTransferRepository) OrganizationRow(ctx context.Context, orgID uuid.UUID) ([]byte, error) {
+	var raw []byte
+	err := r.DB.QueryRow(ctx, `SELECT to_jsonb(o) FROM organizations o WHERE o.id = $1`, orgID).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return raw, err
+}
+
+func (r *orgTransferRepository) ArchiveMembers(ctx context.Context, orgID uuid.UUID) ([]models.OrgArchiveUser, error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT u.id, u.email, u.first_name, u.last_name, m.role,
+		       (o.owner_user_id = u.id) AS is_owner
+		  FROM organization_members m
+		  JOIN users u         ON u.id = m.user_id
+		  JOIN organizations o ON o.id = m.organization_id
+		 WHERE m.organization_id = $1
+		 ORDER BY is_owner DESC, u.email
+	`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.OrgArchiveUser
+	for rows.Next() {
+		var u models.OrgArchiveUser
+		if err := rows.Scan(&u.ID, &u.Email, &u.FirstName, &u.LastName, &u.Role, &u.IsOwner); err != nil {
+			return nil, err
+		}
+		out = append(out, u)
+	}
+	return out, rows.Err()
+}
+
+// ---------- import ----------
+
+func (r *orgTransferRepository) CountExisting(ctx context.Context, table string, pk []string, rows []json.RawMessage) (int64, error) {
+	if len(pk) == 0 || len(rows) == 0 {
+		return 0, nil
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return 0, err
+	}
+	// Compare the candidate keys against the live table by projecting both
+	// sides through the table's own row type, so a uuid in the archive matches
+	// a uuid column rather than being compared as text.
+	q := `
+		SELECT count(*)
+		  FROM jsonb_populate_recordset(NULL::public.` + quoteIdent(table) + `, $1::jsonb) AS c
+		 WHERE EXISTS (
+		       SELECT 1 FROM public.` + quoteIdent(table) + ` AS e
+		        WHERE ` + matchClause(pk) + `
+		 )`
+	var n int64
+	if err := r.DB.QueryRow(ctx, q, payload).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count existing %s: %w", table, err)
+	}
+	return n, nil
+}
+
+// matchClause builds `e.a IS NOT DISTINCT FROM c.a AND ...` for a key.
+func matchClause(pk []string) string {
+	parts := make([]string, len(pk))
+	for i, c := range pk {
+		parts[i] = "e." + quoteIdent(c) + " IS NOT DISTINCT FROM c." + quoteIdent(c)
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func (r *orgTransferRepository) InsertBatch(
+	ctx context.Context,
+	tx pgx.Tx,
+	table string,
+	cols []string,
+	rows []json.RawMessage,
+	conflict models.OrgImportConflict,
+	pk []string,
+) (int64, error) {
+	if len(rows) == 0 || len(cols) == 0 {
+		return 0, nil
+	}
+	payload, err := json.Marshal(rows)
+	if err != nil {
+		return 0, err
+	}
+
+	quoted := quoteIdents(cols)
+	q := `INSERT INTO public.` + quoteIdent(table) + ` (` + quoted + `)
+	      SELECT ` + quoted + `
+	        FROM jsonb_populate_recordset(NULL::public.` + quoteIdent(table) + `, $1::jsonb)`
+
+	switch {
+	case conflict == models.OrgImportConflictOverwrite && len(pk) > 0:
+		sets := make([]string, 0, len(cols))
+		key := make(map[string]bool, len(pk))
+		for _, c := range pk {
+			key[c] = true
+		}
+		for _, c := range cols {
+			if key[c] {
+				continue
+			}
+			sets = append(sets, quoteIdent(c)+" = EXCLUDED."+quoteIdent(c))
+		}
+		if len(sets) == 0 {
+			// Every column is part of the key, so there is nothing to update.
+			q += ` ON CONFLICT DO NOTHING`
+		} else {
+			q += ` ON CONFLICT (` + quoteIdents(pk) + `) DO UPDATE SET ` + strings.Join(sets, ", ")
+		}
+	default:
+		// Untargeted, so it covers every unique constraint on the table, not
+		// just the primary key. An archive row that collides on a secondary
+		// unique index is skipped rather than aborting the whole import.
+		q += ` ON CONFLICT DO NOTHING`
+	}
+
+	tag, err := tx.Exec(ctx, q, payload)
+	if err != nil {
+		return 0, fmt.Errorf("insert into %s: %w", table, err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (r *orgTransferRepository) MergeOrganization(ctx context.Context, tx pgx.Tx, orgID uuid.UUID, cols []string, row json.RawMessage) error {
+	if len(cols) == 0 {
+		return nil
+	}
+	sets := make([]string, len(cols))
+	for i, c := range cols {
+		sets[i] = quoteIdent(c) + " = s." + quoteIdent(c)
+	}
+	q := `UPDATE organizations o
+	         SET ` + strings.Join(sets, ", ") + `
+	        FROM jsonb_populate_record(NULL::organizations, $1::jsonb) AS s
+	       WHERE o.id = $2`
+	if _, err := tx.Exec(ctx, q, row, orgID); err != nil {
+		return fmt.Errorf("merge organization: %w", err)
+	}
+	return nil
+}
+
+// MarkMailboxesNeedingReconnect finds mailboxes in the org that have no usable
+// credentials — no OAuth row, and no SMTP/IMAP row with a password — and moves
+// them to 'revoked', which is the state the dashboard already renders as
+// "reconnect this mailbox".
+func (r *orgTransferRepository) MarkMailboxesNeedingReconnect(ctx context.Context, tx pgx.Tx, orgID uuid.UUID) (int64, error) {
+	tag, err := tx.Exec(ctx, `
+		UPDATE email_accounts ea
+		   SET status = 'revoked', updated_at = NOW()
+		 WHERE ea.organization_id = $1
+		   AND ea.status <> 'revoked'
+		   AND NOT EXISTS (
+		         SELECT 1 FROM email_accounts_oauth o
+		          WHERE o.email_account_id = ea.id
+		            AND COALESCE(o.refresh_token, '') <> ''
+		   )
+		   AND NOT EXISTS (
+		         SELECT 1 FROM email_accounts_smtp_imap s
+		          WHERE s.email_account_id = ea.id
+		            AND COALESCE(s.smtp_password, '') <> ''
+		   )
+	`, orgID)
+	if err != nil {
+		return 0, fmt.Errorf("flag mailboxes needing reconnect: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+func (r *orgTransferRepository) ResolveUsersByEmail(ctx context.Context, emails []string) (map[string]uuid.UUID, error) {
+	out := make(map[string]uuid.UUID, len(emails))
+	if len(emails) == 0 {
+		return out, nil
+	}
+	rows, err := r.DB.Query(ctx, `SELECT id, lower(email) FROM users WHERE lower(email) = ANY($1)`, emails)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id uuid.UUID
+		var email string
+		if err := rows.Scan(&id, &email); err != nil {
+			return nil, err
+		}
+		out[email] = id
+	}
+	return out, rows.Err()
+}
+
+// ---------- export jobs ----------
+
+const exportJobCols = `id, organization_id, requested_by, status, groups, include_secrets,
+	format_version, progress_percent, progress_stage, archive_key, archive_bytes,
+	archive_sha256, row_counts, error_message, started_at, completed_at, expires_at,
+	created_at, updated_at`
+
+func scanExportJob(row pgx.Row) (*models.OrgExportJob, error) {
+	var j models.OrgExportJob
+	var groups []string
+	var counts []byte
+	if err := row.Scan(
+		&j.ID, &j.OrganizationID, &j.RequestedBy, &j.Status, &groups, &j.IncludeSecrets,
+		&j.FormatVersion, &j.ProgressPercent, &j.ProgressStage, &j.ArchiveKey, &j.ArchiveBytes,
+		&j.ArchiveSHA256, &counts, &j.ErrorMessage, &j.StartedAt, &j.CompletedAt, &j.ExpiresAt,
+		&j.CreatedAt, &j.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	j.Groups = toGroups(groups)
+	j.RowCounts = decodeCounts(counts)
+	return &j, nil
+}
+
+func toGroups(in []string) []models.OrgDataGroup {
+	out := make([]models.OrgDataGroup, len(in))
+	for i, g := range in {
+		out[i] = models.OrgDataGroup(g)
+	}
+	return out
+}
+
+func fromGroups(in []models.OrgDataGroup) []string {
+	out := make([]string, len(in))
+	for i, g := range in {
+		out[i] = string(g)
+	}
+	return out
+}
+
+func decodeCounts(raw []byte) map[string]int64 {
+	out := map[string]int64{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &out)
+	}
+	return out
+}
+
+func (r *orgTransferRepository) CreateExportJob(ctx context.Context, j *models.OrgExportJob) error {
+	return r.DB.QueryRow(ctx, `
+		INSERT INTO org_export_jobs (organization_id, requested_by, groups, include_secrets, format_version)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id, status, created_at, updated_at
+	`, j.OrganizationID, j.RequestedBy, fromGroups(j.Groups), j.IncludeSecrets, models.OrgTransferFormatVersion,
+	).Scan(&j.ID, &j.Status, &j.CreatedAt, &j.UpdatedAt)
+}
+
+func (r *orgTransferRepository) GetExportJob(ctx context.Context, orgID, id uuid.UUID) (*models.OrgExportJob, error) {
+	j, err := scanExportJob(r.DB.QueryRow(ctx,
+		`SELECT `+exportJobCols+` FROM org_export_jobs WHERE id = $1 AND organization_id = $2`, id, orgID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return j, err
+}
+
+func (r *orgTransferRepository) ListExportJobs(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OrgExportJob, error) {
+	rows, err := r.DB.Query(ctx,
+		`SELECT `+exportJobCols+` FROM org_export_jobs WHERE organization_id = $1 ORDER BY created_at DESC LIMIT $2`,
+		orgID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []models.OrgExportJob{}
+	for rows.Next() {
+		j, err := scanExportJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *j)
+	}
+	return out, rows.Err()
+}
+
+func (r *orgTransferRepository) UpdateExportProgress(ctx context.Context, id uuid.UUID, percent int, stage string) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_export_jobs
+		   SET progress_percent = $2, progress_stage = $3, updated_at = NOW()
+		 WHERE id = $1
+	`, id, clampPercent(percent), stage)
+	return err
+}
+
+func (r *orgTransferRepository) CompleteExportJob(ctx context.Context, id uuid.UUID, key string, size int64, sha string, counts map[string]int64, expiresAt time.Time) error {
+	raw, err := json.Marshal(counts)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec(ctx, `
+		UPDATE org_export_jobs
+		   SET status = 'completed', progress_percent = 100, progress_stage = 'done',
+		       archive_key = $2, archive_bytes = $3, archive_sha256 = $4,
+		       row_counts = $5, expires_at = $6, completed_at = NOW(), updated_at = NOW()
+		 WHERE id = $1
+	`, id, key, size, sha, raw, expiresAt)
+	return err
+}
+
+func (r *orgTransferRepository) FailExportJob(ctx context.Context, id uuid.UUID, reason string) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_export_jobs
+		   SET status = 'failed', error_message = $2, completed_at = NOW(), updated_at = NOW()
+		 WHERE id = $1
+	`, id, truncateReason(reason))
+	return err
+}
+
+// DeleteExportJob removes the row and returns the archive key so the caller can
+// drop the object too.
+func (r *orgTransferRepository) DeleteExportJob(ctx context.Context, orgID, id uuid.UUID) (string, error) {
+	var key *string
+	err := r.DB.QueryRow(ctx, `
+		DELETE FROM org_export_jobs WHERE id = $1 AND organization_id = $2 RETURNING archive_key
+	`, id, orgID).Scan(&key)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if key == nil {
+		return "", nil
+	}
+	return *key, nil
+}
+
+func (r *orgTransferRepository) ListExpiredExports(ctx context.Context, now time.Time, limit int) ([]models.OrgExportJob, error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT `+exportJobCols+`
+		  FROM org_export_jobs
+		 WHERE status = 'completed' AND expires_at IS NOT NULL AND expires_at < $1
+		 ORDER BY expires_at
+		 LIMIT $2
+	`, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []models.OrgExportJob{}
+	for rows.Next() {
+		j, err := scanExportJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *j)
+	}
+	return out, rows.Err()
+}
+
+func (r *orgTransferRepository) MarkExportExpired(ctx context.Context, id uuid.UUID) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_export_jobs
+		   SET status = 'expired', archive_key = NULL, progress_stage = 'expired', updated_at = NOW()
+		 WHERE id = $1
+	`, id)
+	return err
+}
+
+func (r *orgTransferRepository) HasActiveExport(ctx context.Context, orgID uuid.UUID) (bool, error) {
+	var exists bool
+	err := r.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM org_export_jobs WHERE organization_id = $1 AND status IN ('queued', 'running')
+		)`, orgID).Scan(&exists)
+	return exists, err
+}
+
+// ---------- import jobs ----------
+
+const importJobCols = `id, organization_id, requested_by, status, archive_key, archive_bytes,
+	archive_sha256, source_manifest, groups, conflict_strategy, progress_percent, progress_stage,
+	row_counts, warnings, error_message, started_at, completed_at, created_at, updated_at`
+
+func scanImportJob(row pgx.Row) (*models.OrgImportJob, error) {
+	var j models.OrgImportJob
+	var groups []string
+	var manifest, counts, warnings []byte
+	if err := row.Scan(
+		&j.ID, &j.OrganizationID, &j.RequestedBy, &j.Status, &j.ArchiveKey, &j.ArchiveBytes,
+		&j.ArchiveSHA256, &manifest, &groups, &j.ConflictStrategy, &j.ProgressPercent, &j.ProgressStage,
+		&counts, &warnings, &j.ErrorMessage, &j.StartedAt, &j.CompletedAt, &j.CreatedAt, &j.UpdatedAt,
+	); err != nil {
+		return nil, err
+	}
+	j.Groups = toGroups(groups)
+	j.RowCounts = decodeCounts(counts)
+	j.Warnings = []string{}
+	if len(warnings) > 0 {
+		_ = json.Unmarshal(warnings, &j.Warnings)
+	}
+	if len(manifest) > 2 {
+		var info models.OrgArchiveInfo
+		if json.Unmarshal(manifest, &info) == nil {
+			j.SourceManifest = &info
+		}
+	}
+	return &j, nil
+}
+
+func (r *orgTransferRepository) CreateImportJob(ctx context.Context, j *models.OrgImportJob) error {
+	manifest, err := json.Marshal(j.SourceManifest)
+	if err != nil {
+		return err
+	}
+	return r.DB.QueryRow(ctx, `
+		INSERT INTO org_import_jobs
+		  (organization_id, requested_by, archive_key, archive_bytes, archive_sha256,
+		   source_manifest, groups, conflict_strategy)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		RETURNING id, status, created_at, updated_at
+	`, j.OrganizationID, j.RequestedBy, j.ArchiveKey, j.ArchiveBytes, j.ArchiveSHA256,
+		manifest, fromGroups(j.Groups), j.ConflictStrategy,
+	).Scan(&j.ID, &j.Status, &j.CreatedAt, &j.UpdatedAt)
+}
+
+func (r *orgTransferRepository) GetImportJob(ctx context.Context, orgID, id uuid.UUID) (*models.OrgImportJob, error) {
+	j, err := scanImportJob(r.DB.QueryRow(ctx,
+		`SELECT `+importJobCols+` FROM org_import_jobs WHERE id = $1 AND organization_id = $2`, id, orgID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return j, err
+}
+
+func (r *orgTransferRepository) ListImportJobs(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OrgImportJob, error) {
+	rows, err := r.DB.Query(ctx,
+		`SELECT `+importJobCols+` FROM org_import_jobs WHERE organization_id = $1 ORDER BY created_at DESC LIMIT $2`,
+		orgID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := []models.OrgImportJob{}
+	for rows.Next() {
+		j, err := scanImportJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *j)
+	}
+	return out, rows.Err()
+}
+
+func (r *orgTransferRepository) UpdateImportProgress(ctx context.Context, id uuid.UUID, percent int, stage string) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_import_jobs
+		   SET progress_percent = $2, progress_stage = $3, updated_at = NOW()
+		 WHERE id = $1
+	`, id, clampPercent(percent), stage)
+	return err
+}
+
+func (r *orgTransferRepository) CompleteImportJob(ctx context.Context, id uuid.UUID, counts map[string]int64, warnings []string) error {
+	rawCounts, err := json.Marshal(counts)
+	if err != nil {
+		return err
+	}
+	if warnings == nil {
+		warnings = []string{}
+	}
+	rawWarnings, err := json.Marshal(warnings)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec(ctx, `
+		UPDATE org_import_jobs
+		   SET status = 'completed', progress_percent = 100, progress_stage = 'done',
+		       row_counts = $2, warnings = $3, completed_at = NOW(), updated_at = NOW()
+		 WHERE id = $1
+	`, id, rawCounts, rawWarnings)
+	return err
+}
+
+func (r *orgTransferRepository) FailImportJob(ctx context.Context, id uuid.UUID, reason string) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_import_jobs
+		   SET status = 'failed', error_message = $2, completed_at = NOW(), updated_at = NOW()
+		 WHERE id = $1
+	`, id, truncateReason(reason))
+	return err
+}
+
+func (r *orgTransferRepository) HasActiveImport(ctx context.Context, orgID uuid.UUID) (bool, error) {
+	var exists bool
+	err := r.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+		  SELECT 1 FROM org_import_jobs WHERE organization_id = $1 AND status IN ('queued', 'running')
+		)`, orgID).Scan(&exists)
+	return exists, err
+}
+
+func (r *orgTransferRepository) FailStaleTransfers(ctx context.Context, before time.Time) error {
+	const reason = "The instance restarted while this was running. Start it again."
+	if _, err := r.DB.Exec(ctx, `
+		UPDATE org_export_jobs
+		   SET status = 'failed', error_message = $2, completed_at = NOW(), updated_at = NOW()
+		 WHERE status IN ('queued', 'running') AND updated_at < $1
+	`, before, reason); err != nil {
+		return err
+	}
+	_, err := r.DB.Exec(ctx, `
+		UPDATE org_import_jobs
+		   SET status = 'failed', error_message = $2, completed_at = NOW(), updated_at = NOW()
+		 WHERE status IN ('queued', 'running') AND updated_at < $1
+	`, before, reason)
+	return err
+}
+
+func clampPercent(p int) int {
+	if p < 0 {
+		return 0
+	}
+	if p > 100 {
+		return 100
+	}
+	return p
+}
+
+// truncateReason keeps a runaway driver error from filling the column.
+func truncateReason(s string) string {
+	const max = 4000
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "…"
+}

--- a/web/src/app/app/settings/data/ExportPanel.tsx
+++ b/web/src/app/app/settings/data/ExportPanel.tsx
@@ -1,0 +1,165 @@
+// Export panel — pick what travels, decide whether credentials come too.
+
+import React from "react";
+import toast from "react-hot-toast";
+import { KeyRoundIcon, Loader2Icon } from "lucide-react";
+import { TextInput } from "@/components/ui/field";
+import { useConfirm } from "@/hooks/context/confirm";
+import { useCreateOrgExport } from "@/lib/api/hooks/app/orgtransfer/useOrgTransfer";
+import type { OrgDataGroup, OrgDataGroupInfo } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { expandGroups } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { Toggle } from "../_components/SectionShell";
+import GroupPicker from "./GroupPicker";
+
+export default function ExportPanel({
+    groups,
+    minPassphrase,
+    loading,
+    onStarted,
+}: {
+    groups: OrgDataGroupInfo[];
+    minPassphrase: number;
+    loading?: boolean;
+    onStarted: () => void;
+}) {
+    const confirm = useConfirm();
+    const createExport = useCreateOrgExport();
+
+    // Everything is on by default: a migration that quietly leaves data behind
+    // is worse than one that takes a while.
+    const [selected, setSelected] = React.useState<Set<OrgDataGroup>>(new Set());
+    const [includeSecrets, setIncludeSecrets] = React.useState(false);
+    const [passphrase, setPassphrase] = React.useState("");
+    const [repeat, setRepeat] = React.useState("");
+
+    React.useEffect(() => {
+        if (groups.length > 0 && selected.size === 0) {
+            setSelected(new Set(groups.map((g) => g.key)));
+        }
+        // Only seeds the initial selection; later toggles are the user's.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [groups]);
+
+    function toggle(key: OrgDataGroup) {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            // Re-expand so ticking a group pulls in what it cannot travel
+            // without, exactly as the server would.
+            return expandGroups(next, groups);
+        });
+    }
+
+    const passphraseTooShort = passphrase.length > 0 && passphrase.length < minPassphrase;
+    const passphraseMismatch = repeat.length > 0 && passphrase !== repeat;
+    const canSubmit =
+        !createExport.isPending &&
+        !loading &&
+        (!includeSecrets ||
+            (passphrase.length >= minPassphrase && passphrase === repeat));
+
+    async function start() {
+        const run = async () => {
+            try {
+                await createExport.mutateAsync({
+                    groups: Array.from(selected),
+                    include_secrets: includeSecrets,
+                    passphrase: includeSecrets ? passphrase : undefined,
+                });
+                setPassphrase("");
+                setRepeat("");
+                onStarted();
+            } catch (e) {
+                toast.error((e as { message?: string })?.message ?? "Could not start the export.");
+            }
+        };
+
+        if (includeSecrets) {
+            confirm.show(
+                "This archive will contain every mailbox password and access token in the workspace, protected only by the passphrase you just typed. Anyone with both the file and the passphrase can send mail as these mailboxes. Continue?",
+                run,
+            );
+            return;
+        }
+        await run();
+    }
+
+    return (
+        <div className="space-y-4">
+            <GroupPicker
+                groups={groups}
+                selected={selected}
+                onToggle={toggle}
+                disabled={createExport.isPending}
+            />
+
+            <div className="rounded-md border border-slate-200 px-3 py-2.5">
+                <div className="flex items-start gap-3">
+                    <div className="min-w-0 flex-1">
+                        <div className="text-[12.5px] font-medium text-slate-900 leading-tight inline-flex items-center gap-1.5">
+                            <KeyRoundIcon className="w-3 h-3 text-slate-400" />
+                            Include mailbox credentials
+                        </div>
+                        <div className="text-[11.5px] text-slate-500 leading-tight mt-0.5">
+                            Mailbox passwords, OAuth tokens and integration keys are sealed into
+                            the archive under a passphrase you choose. Import it with the same
+                            passphrase and mailboxes come up connected. Leave this off and they
+                            arrive needing a reconnect.
+                        </div>
+                    </div>
+                    <Toggle
+                        on={includeSecrets}
+                        onChange={setIncludeSecrets}
+                        disabled={createExport.isPending}
+                    />
+                </div>
+
+                {includeSecrets && (
+                    <div className="mt-3 pt-3 border-t border-slate-200/70 space-y-2">
+                        <TextInput
+                            value={passphrase}
+                            onChange={setPassphrase}
+                            type="password"
+                            autoComplete="new-password"
+                            placeholder={`Passphrase (at least ${minPassphrase} characters)`}
+                            disabled={createExport.isPending}
+                            className="w-full"
+                        />
+                        <TextInput
+                            value={repeat}
+                            onChange={setRepeat}
+                            type="password"
+                            autoComplete="new-password"
+                            placeholder="Repeat the passphrase"
+                            disabled={createExport.isPending}
+                            className="w-full"
+                        />
+                        <p className="text-[11px] leading-relaxed text-amber-700">
+                            {passphraseTooShort
+                                ? `Use at least ${minPassphrase} characters.`
+                                : passphraseMismatch
+                                    ? "The two passphrases do not match."
+                                    : "Warmbly never stores this passphrase. Lose it and the credentials in the archive cannot be recovered, so you would have to export again."}
+                        </p>
+                    </div>
+                )}
+            </div>
+
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={start}
+                    disabled={!canSubmit}
+                    className="h-7 px-3 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {createExport.isPending && <Loader2Icon className="w-3 h-3 animate-spin" />}
+                    Start export
+                </button>
+                <span className="text-[11.5px] text-slate-500">
+                    Large workspaces take a while. You can leave this page.
+                </span>
+            </div>
+        </div>
+    );
+}

--- a/web/src/app/app/settings/data/GroupPicker.tsx
+++ b/web/src/app/app/settings/data/GroupPicker.tsx
@@ -1,0 +1,80 @@
+// The data-group checklist shared by the export and import panels.
+//
+// Groups come from the server's own catalog rather than a copy here, so a new
+// group appears in the dashboard the moment the backend knows about it.
+
+import { CheckIcon } from "lucide-react";
+import type { OrgDataGroup, OrgDataGroupInfo } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { dependentsOf } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+
+export default function GroupPicker({
+    groups,
+    selected,
+    onToggle,
+    disabled,
+}: {
+    groups: OrgDataGroupInfo[];
+    selected: Set<OrgDataGroup>;
+    onToggle: (key: OrgDataGroup) => void;
+    disabled?: boolean;
+}) {
+    if (groups.length === 0) {
+        return <div className="text-[12px] text-slate-400">Loading data groups…</div>;
+    }
+
+    return (
+        <div className="rounded-md border border-slate-200 divide-y divide-slate-200/70 overflow-hidden">
+            {groups.map((g) => {
+                const on = g.required || selected.has(g.key);
+                // A group another selected group depends on cannot be unticked
+                // on its own: the import would fail on a foreign key.
+                const pinnedBy = dependentsOf(g.key, selected, groups);
+                const locked = g.required || pinnedBy.length > 0 || disabled;
+                return (
+                    <button
+                        key={g.key}
+                        type="button"
+                        disabled={locked}
+                        onClick={() => onToggle(g.key)}
+                        className={`w-full flex items-start gap-2.5 px-3 py-2.5 text-left transition-colors ${
+                            locked ? "cursor-default" : "hover:bg-slate-50"
+                        }`}
+                    >
+                        <span
+                            className={`mt-px shrink-0 size-[15px] rounded-[4px] border inline-flex items-center justify-center transition-colors ${
+                                on
+                                    ? "bg-sky-600 border-sky-600 text-white"
+                                    : "bg-white border-slate-300"
+                            } ${locked ? "opacity-60" : ""}`}
+                        >
+                            {on && <CheckIcon className="w-2.5 h-2.5" strokeWidth={3} />}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                            <span className="flex items-center gap-1.5">
+                                <span className="text-[12.5px] font-medium text-slate-900">{g.label}</span>
+                                {g.required && (
+                                    <span className="text-[10px] uppercase tracking-[0.08em] font-medium rounded-sm px-1 bg-slate-100 text-slate-500">
+                                        Always
+                                    </span>
+                                )}
+                                {!g.required && pinnedBy.length > 0 && (
+                                    <span className="text-[10px] uppercase tracking-[0.08em] font-medium rounded-sm px-1 bg-slate-100 text-slate-500">
+                                        Needed by {pinnedBy.map((d) => d.label).join(", ")}
+                                    </span>
+                                )}
+                                {g.heavy && (
+                                    <span className="text-[10px] uppercase tracking-[0.08em] font-medium rounded-sm px-1 bg-amber-50 text-amber-700">
+                                        Large
+                                    </span>
+                                )}
+                            </span>
+                            <span className="block text-[11.5px] text-slate-500 leading-tight mt-0.5">
+                                {g.description}
+                            </span>
+                        </span>
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/web/src/app/app/settings/data/ImportPanel.tsx
+++ b/web/src/app/app/settings/data/ImportPanel.tsx
@@ -1,0 +1,303 @@
+// Import panel — upload an archive, read what it would do, then apply it.
+//
+// The preflight step is the point of this screen. It reads the archive and
+// reports what lands, what already exists, and who has no account here, all
+// without writing anything, so "apply" is never a leap of faith.
+
+import React from "react";
+import toast from "react-hot-toast";
+import { AlertTriangleIcon, FileArchiveIcon, Loader2Icon } from "lucide-react";
+import { TextInput } from "@/components/ui/field";
+import { useConfirm } from "@/hooks/context/confirm";
+import {
+    useCreateOrgImport,
+    usePreflightOrgImport,
+} from "@/lib/api/hooks/app/orgtransfer/useOrgTransfer";
+import type {
+    OrgDataGroup,
+    OrgDataGroupInfo,
+    OrgImportConflict,
+    OrgImportPreflight,
+} from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { expandGroups, totalRows } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import GroupPicker from "./GroupPicker";
+import { formatBytes } from "./format";
+
+export default function ImportPanel({
+    groups,
+    onStarted,
+}: {
+    groups: OrgDataGroupInfo[];
+    onStarted: () => void;
+}) {
+    const confirm = useConfirm();
+    const preflight = usePreflightOrgImport();
+    const createImport = useCreateOrgImport();
+
+    const fileRef = React.useRef<HTMLInputElement>(null);
+    const [file, setFile] = React.useState<File | null>(null);
+    const [passphrase, setPassphrase] = React.useState("");
+    const [report, setReport] = React.useState<OrgImportPreflight | null>(null);
+    const [selected, setSelected] = React.useState<Set<OrgDataGroup>>(new Set());
+    const [conflict, setConflict] = React.useState<OrgImportConflict>("skip");
+
+    function pickFile(next: File | null) {
+        setFile(next);
+        setReport(null);
+    }
+
+    function toggle(key: OrgDataGroup) {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(key)) next.delete(key);
+            else next.add(key);
+            // Re-expand so ticking a group pulls in what it cannot travel
+            // without, exactly as the server would.
+            return expandGroups(next, groups);
+        });
+    }
+
+    async function check() {
+        if (!file) return;
+        try {
+            const result = await preflight.mutateAsync({ file, passphrase });
+            setReport(result);
+            // Default to everything the archive actually carries.
+            setSelected(expandGroups(result.archive.groups, groups));
+        } catch (e) {
+            setReport(null);
+            toast.error((e as { message?: string })?.message ?? "That archive could not be read.");
+        }
+    }
+
+    async function apply() {
+        if (!file || !report) return;
+        const conflictTotal = Object.values(report.conflicts).reduce((a, b) => a + b, 0);
+        const message =
+            conflict === "overwrite" && conflictTotal > 0
+                ? `This will replace ${conflictTotal.toLocaleString()} existing row(s) in this workspace with the archive's versions. That cannot be undone. Continue?`
+                : `This will add the contents of "${report.archive.organization_name}" to this workspace. Continue?`;
+
+        confirm.show(message, async () => {
+            try {
+                await createImport.mutateAsync({
+                    file,
+                    options: {
+                        groups: Array.from(selected),
+                        conflict_strategy: conflict,
+                    },
+                    passphrase,
+                });
+                pickFile(null);
+                setPassphrase("");
+                if (fileRef.current) fileRef.current.value = "";
+                onStarted();
+            } catch (e) {
+                toast.error((e as { message?: string })?.message ?? "Could not start the import.");
+            }
+        });
+    }
+
+    return (
+        <div className="space-y-4">
+            <div className="rounded-md border border-dashed border-slate-300 px-3 py-4 flex flex-col sm:flex-row sm:items-center gap-3">
+                <FileArchiveIcon className="w-4 h-4 text-slate-400 shrink-0" />
+                <div className="min-w-0 flex-1">
+                    <div className="text-[12.5px] font-medium text-slate-900 leading-tight">
+                        {file ? file.name : "Choose an archive"}
+                    </div>
+                    <div className="text-[11.5px] text-slate-500 leading-tight mt-0.5">
+                        {file
+                            ? formatBytes(file.size)
+                            : "A .warmbly.zip file exported from this or another instance."}
+                    </div>
+                </div>
+                <input
+                    ref={fileRef}
+                    type="file"
+                    accept=".zip,application/zip"
+                    className="hidden"
+                    onChange={(e) => pickFile(e.target.files?.[0] ?? null)}
+                />
+                <button
+                    type="button"
+                    onClick={() => fileRef.current?.click()}
+                    className="self-start h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 transition-colors shrink-0"
+                >
+                    {file ? "Choose another" : "Choose file"}
+                </button>
+            </div>
+
+            {file && (
+                <div className="space-y-2">
+                    <TextInput
+                        value={passphrase}
+                        onChange={setPassphrase}
+                        type="password"
+                        autoComplete="current-password"
+                        placeholder="Export passphrase (only if the archive carries credentials)"
+                        className="w-full"
+                    />
+                    <button
+                        type="button"
+                        onClick={check}
+                        disabled={preflight.isPending}
+                        className="h-7 px-3 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] font-medium text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                    >
+                        {preflight.isPending && <Loader2Icon className="w-3 h-3 animate-spin" />}
+                        Check this archive
+                    </button>
+                </div>
+            )}
+
+            {report && (
+                <>
+                    <ArchiveSummary report={report} />
+
+                    <div>
+                        <div className="text-[11px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">
+                            What to apply
+                        </div>
+                        <GroupPicker
+                            groups={groups.filter((g) => report.archive.groups.includes(g.key))}
+                            selected={selected}
+                            onToggle={toggle}
+                            disabled={createImport.isPending}
+                        />
+                    </div>
+
+                    <div>
+                        <div className="text-[11px] uppercase tracking-[0.14em] text-slate-400 font-medium mb-1.5">
+                            Rows that already exist here
+                        </div>
+                        <div className="flex flex-col sm:flex-row gap-2">
+                            <ConflictChoice
+                                active={conflict === "skip"}
+                                onClick={() => setConflict("skip")}
+                                title="Keep what is here"
+                                body="The archive only adds rows this workspace does not already have."
+                            />
+                            <ConflictChoice
+                                active={conflict === "overwrite"}
+                                onClick={() => setConflict("overwrite")}
+                                title="Replace with the archive"
+                                body="Existing rows are overwritten by the archive's versions. Cannot be undone."
+                                danger
+                            />
+                        </div>
+                    </div>
+
+                    <div className="flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={apply}
+                            disabled={createImport.isPending}
+                            className="h-7 px-3 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                        >
+                            {createImport.isPending && <Loader2Icon className="w-3 h-3 animate-spin" />}
+                            Import into this workspace
+                        </button>
+                        <span className="text-[11.5px] text-slate-500">
+                            Applied in one transaction: it either lands completely or not at all.
+                        </span>
+                    </div>
+                </>
+            )}
+        </div>
+    );
+}
+
+function ArchiveSummary({ report }: { report: OrgImportPreflight }) {
+    const a = report.archive;
+    const conflictTotal = Object.values(report.conflicts).reduce((x, y) => x + y, 0);
+
+    return (
+        <div className="rounded-md border border-slate-200 bg-slate-50/50 px-3 py-2.5 space-y-2">
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <Fact label="Workspace" value={a.organization_name} />
+                <Fact label="Exported" value={new Date(a.exported_at).toLocaleDateString()} />
+                <Fact label="Rows" value={totalRows(a.row_counts).toLocaleString()} />
+                <Fact label="Attachments" value={String(a.blob_count)} />
+            </div>
+
+            <div className="text-[11.5px] text-slate-600 leading-relaxed">
+                {a.has_secrets
+                    ? report.secrets_unsealed
+                        ? "Credentials are sealed in this archive and your passphrase opens them, so mailboxes will arrive connected."
+                        : "Credentials are sealed in this archive, but the passphrase above does not open them yet."
+                    : "This archive carries no credentials, so mailboxes will arrive needing a reconnect."}
+            </div>
+
+            {conflictTotal > 0 && (
+                <div className="text-[11.5px] text-slate-600">
+                    {conflictTotal.toLocaleString()} row(s) in the archive already exist in this
+                    workspace.
+                </div>
+            )}
+
+            {report.unknown_members.length > 0 && (
+                <div className="text-[11.5px] text-slate-600">
+                    {report.unknown_members.length} member(s) have no account on this instance
+                    ({report.unknown_members.slice(0, 3).map((m) => m.email).join(", ")}
+                    {report.unknown_members.length > 3 ? ", …" : ""}). Their rows will be
+                    reassigned to you.
+                </div>
+            )}
+
+            {report.warnings.map((w) => (
+                <div key={w} className="flex items-start gap-1.5 text-[11.5px] text-amber-700">
+                    <AlertTriangleIcon className="w-3 h-3 mt-0.5 shrink-0" />
+                    <span className="leading-relaxed">{w}</span>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+    return (
+        <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                {label}
+            </div>
+            <div className="text-[12.5px] text-slate-900 truncate">{value}</div>
+        </div>
+    );
+}
+
+function ConflictChoice({
+    active,
+    onClick,
+    title,
+    body,
+    danger,
+}: {
+    active: boolean;
+    onClick: () => void;
+    title: string;
+    body: string;
+    danger?: boolean;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={`flex-1 text-left rounded-md border px-3 py-2 transition-colors ${
+                active
+                    ? danger
+                        ? "border-red-300 bg-red-50/60"
+                        : "border-sky-400 bg-sky-50/60"
+                    : "border-slate-200 hover:border-slate-300"
+            }`}
+        >
+            <div
+                className={`text-[12.5px] font-medium leading-tight ${
+                    active && danger ? "text-red-700" : "text-slate-900"
+                }`}
+            >
+                {title}
+            </div>
+            <div className="text-[11.5px] text-slate-500 leading-tight mt-0.5">{body}</div>
+        </button>
+    );
+}

--- a/web/src/app/app/settings/data/TransferHistory.tsx
+++ b/web/src/app/app/settings/data/TransferHistory.tsx
@@ -1,0 +1,237 @@
+// Export and import history, with live progress on anything still running.
+
+import React from "react";
+import toast from "react-hot-toast";
+import {
+    AlertTriangleIcon,
+    DownloadIcon,
+    Loader2Icon,
+    Trash2Icon,
+    UploadIcon,
+} from "lucide-react";
+import { useConfirm } from "@/hooks/context/confirm";
+import { downloadOrgExport } from "@/lib/api/client/app/orgtransfer/orgTransfer";
+import { useDeleteOrgExport } from "@/lib/api/hooks/app/orgtransfer/useOrgTransfer";
+import type { OrgExportJob, OrgImportJob } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { totalRows } from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { formatBytes, formatExpiry } from "./format";
+
+export default function TransferHistory({
+    exports,
+    imports,
+    loading,
+}: {
+    exports: OrgExportJob[];
+    imports: OrgImportJob[];
+    loading?: boolean;
+}) {
+    if (loading) {
+        return <div className="text-[12px] text-slate-400">Loading…</div>;
+    }
+    if (exports.length === 0 && imports.length === 0) {
+        return (
+            <div className="text-[12.5px] text-slate-500">
+                No archives yet. Start an export above, or import one from another instance.
+            </div>
+        );
+    }
+
+    return (
+        <div className="rounded-md border border-slate-200 divide-y divide-slate-200/70 overflow-hidden">
+            {exports.map((job) => (
+                <ExportRow key={job.id} job={job} />
+            ))}
+            {imports.map((job) => (
+                <ImportRow key={job.id} job={job} />
+            ))}
+        </div>
+    );
+}
+
+function ExportRow({ job }: { job: OrgExportJob }) {
+    const confirm = useConfirm();
+    const remove = useDeleteOrgExport();
+    const [downloading, setDownloading] = React.useState(false);
+
+    const running = job.status === "queued" || job.status === "running";
+
+    async function download() {
+        setDownloading(true);
+        try {
+            const { blob, filename } = await downloadOrgExport(job.id);
+            // Object URL rather than a direct link, because the endpoint needs
+            // the bearer token an anchor cannot carry.
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch {
+            toast.error("That archive could not be downloaded.");
+        } finally {
+            setDownloading(false);
+        }
+    }
+
+    return (
+        <Row
+            icon={<DownloadIcon className="w-3.5 h-3.5 text-slate-400" />}
+            title="Export"
+            job={job}
+            detail={
+                job.status === "completed"
+                    ? [
+                          `${totalRows(job.row_counts).toLocaleString()} rows`,
+                          formatBytes(job.archive_bytes),
+                          job.include_secrets ? "with credentials" : "no credentials",
+                          formatExpiry(job.expires_at),
+                      ]
+                          .filter(Boolean)
+                          .join(" · ")
+                    : undefined
+            }
+            actions={
+                <>
+                    {job.status === "completed" && (
+                        <button
+                            type="button"
+                            onClick={download}
+                            disabled={downloading}
+                            className="h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-[12px] text-slate-700 hover:text-slate-900 inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
+                        >
+                            {downloading && <Loader2Icon className="w-3 h-3 animate-spin" />}
+                            Download
+                        </button>
+                    )}
+                    {!running && (
+                        <button
+                            type="button"
+                            aria-label="Delete archive"
+                            onClick={() =>
+                                confirm.show(
+                                    "Delete this archive? The file is removed from storage and cannot be downloaded again.",
+                                    () => remove.mutateAsync(job.id),
+                                )
+                            }
+                            className="h-7 w-7 rounded-md border border-slate-200 hover:border-red-300 text-slate-400 hover:text-red-600 inline-flex items-center justify-center transition-colors"
+                        >
+                            <Trash2Icon className="w-3.5 h-3.5" />
+                        </button>
+                    )}
+                </>
+            }
+        />
+    );
+}
+
+function ImportRow({ job }: { job: OrgImportJob }) {
+    return (
+        <Row
+            icon={<UploadIcon className="w-3.5 h-3.5 text-slate-400" />}
+            title={
+                job.source_manifest
+                    ? `Import from ${job.source_manifest.organization_name}`
+                    : "Import"
+            }
+            job={job}
+            detail={
+                job.status === "completed"
+                    ? `${totalRows(job.row_counts).toLocaleString()} rows applied`
+                    : undefined
+            }
+            warnings={job.warnings}
+        />
+    );
+}
+
+function Row({
+    icon,
+    title,
+    job,
+    detail,
+    actions,
+    warnings,
+}: {
+    icon: React.ReactNode;
+    title: string;
+    job: OrgExportJob | OrgImportJob;
+    detail?: string;
+    actions?: React.ReactNode;
+    warnings?: string[];
+}) {
+    const running = job.status === "queued" || job.status === "running";
+
+    return (
+        <div className="px-3 py-2.5">
+            <div className="flex items-start gap-2.5">
+                <span className="mt-0.5 shrink-0">{icon}</span>
+                <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                        <span className="text-[12.5px] font-medium text-slate-900">{title}</span>
+                        <StatusPill status={job.status} />
+                        <span className="text-[11px] text-slate-400">
+                            {new Date(job.created_at).toLocaleString()}
+                        </span>
+                    </div>
+
+                    {detail && (
+                        <div className="text-[11.5px] text-slate-500 leading-tight mt-0.5">
+                            {detail}
+                        </div>
+                    )}
+
+                    {running && (
+                        <div className="mt-1.5">
+                            <div className="h-1 rounded-full bg-slate-100 overflow-hidden">
+                                <div
+                                    className="h-full bg-sky-500 transition-[width] duration-500"
+                                    style={{ width: `${Math.max(2, job.progress_percent)}%` }}
+                                />
+                            </div>
+                            <div className="text-[11px] text-slate-500 mt-1">
+                                {job.progress_percent}% · {job.progress_stage || "starting"}
+                            </div>
+                        </div>
+                    )}
+
+                    {job.status === "failed" && job.error_message && (
+                        <div className="flex items-start gap-1.5 text-[11.5px] text-red-700 mt-1">
+                            <AlertTriangleIcon className="w-3 h-3 mt-0.5 shrink-0" />
+                            <span className="leading-relaxed">{job.error_message}</span>
+                        </div>
+                    )}
+
+                    {warnings?.map((w) => (
+                        <div key={w} className="flex items-start gap-1.5 text-[11.5px] text-amber-700 mt-1">
+                            <AlertTriangleIcon className="w-3 h-3 mt-0.5 shrink-0" />
+                            <span className="leading-relaxed">{w}</span>
+                        </div>
+                    ))}
+                </div>
+
+                {actions && <div className="flex items-center gap-1.5 shrink-0">{actions}</div>}
+            </div>
+        </div>
+    );
+}
+
+function StatusPill({ status }: { status: string }) {
+    const tone =
+        status === "completed"
+            ? "bg-emerald-50 text-emerald-700"
+            : status === "failed"
+                ? "bg-red-50 text-red-700"
+                : status === "expired"
+                    ? "bg-slate-100 text-slate-500"
+                    : "bg-sky-50 text-sky-700";
+    return (
+        <span
+            className={`text-[10px] uppercase tracking-[0.08em] font-medium rounded-sm px-1 ${tone}`}
+        >
+            {status}
+        </span>
+    );
+}

--- a/web/src/app/app/settings/data/format.ts
+++ b/web/src/app/app/settings/data/format.ts
@@ -1,0 +1,23 @@
+// Shared formatting for the Data settings page.
+
+export function formatBytes(n: number | undefined): string {
+    if (!n || n <= 0) return "—";
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    let value = n;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit += 1;
+    }
+    return `${unit === 0 ? value : value.toFixed(1)} ${units[unit]}`;
+}
+
+/** "in 6 days" / "in 3 hours" / "expired", for an archive's retention. */
+export function formatExpiry(at: Date | string | undefined): string {
+    if (!at) return "";
+    const ms = new Date(at).getTime() - Date.now();
+    if (ms <= 0) return "expired";
+    const hours = Math.round(ms / 3_600_000);
+    if (hours < 24) return `expires in ${hours}h`;
+    return `expires in ${Math.round(hours / 24)}d`;
+}

--- a/web/src/app/app/settings/data/page.tsx
+++ b/web/src/app/app/settings/data/page.tsx
@@ -1,0 +1,100 @@
+// Settings → Data. Move this workspace to or from another Warmbly instance.
+//
+// Backed by:
+//   GET    /organization/current/transfer/groups
+//   POST   /organization/current/export
+//   GET    /organization/current/export
+//   GET    /organization/current/export/:id/download
+//   DELETE /organization/current/export/:id
+//   POST   /organization/current/import/preflight
+//   POST   /organization/current/import
+//   GET    /organization/current/import
+//
+// Owner-only, matching the danger zone: an export with credentials is the most
+// sensitive file this product produces, and an import rewrites the workspace.
+
+import React from "react";
+import toast from "react-hot-toast";
+import { DownloadIcon, UploadIcon } from "lucide-react";
+import useFeatureAccess from "@/hooks/useFeatureAccess";
+import { useOrgExports, useOrgImports, useOrgTransferGroups } from "@/lib/api/hooks/app/orgtransfer/useOrgTransfer";
+import { Section, SectionShell } from "../_components/SectionShell";
+import ExportPanel from "./ExportPanel";
+import ImportPanel from "./ImportPanel";
+import TransferHistory from "./TransferHistory";
+
+export default function DataSettingsPage() {
+    const access = useFeatureAccess();
+    const groups = useOrgTransferGroups();
+    const exports = useOrgExports();
+    const imports = useOrgImports();
+
+    if (!access.isOwner) {
+        return (
+            <SectionShell
+                title="Data"
+                description="Move this workspace to or from another Warmbly instance."
+            >
+                <Section eyebrow="Restricted">
+                    <p className="text-[12.5px] text-slate-500 leading-relaxed">
+                        Only the workspace owner can export or import workspace data. An
+                        export contains every contact, message and mailbox credential in
+                        the workspace, so it is held to the same bar as deleting it.
+                    </p>
+                </Section>
+            </SectionShell>
+        );
+    }
+
+    return (
+        <SectionShell
+            title="Data"
+            description="Move this workspace to or from another Warmbly instance."
+        >
+            <Section
+                eyebrow="Export"
+                description="Write the whole workspace to a single archive file you can import on another instance."
+                actions={
+                    <span className="inline-flex items-center gap-1.5 text-[11px] text-slate-400">
+                        <DownloadIcon className="w-3 h-3" />
+                        {groups.data ? `Kept for ${groups.data.retention_days} days` : ""}
+                    </span>
+                }
+            >
+                <ExportPanel
+                    groups={groups.data?.groups ?? []}
+                    minPassphrase={groups.data?.min_passphrase ?? 12}
+                    loading={groups.isLoading}
+                    onStarted={() => toast.success("Export started. It keeps running if you leave this page.")}
+                />
+            </Section>
+
+            <Section
+                eyebrow="Archives"
+                description="Exports from this workspace. Each one is a full copy, so they expire."
+            >
+                <TransferHistory
+                    exports={exports.data ?? []}
+                    imports={imports.data ?? []}
+                    loading={exports.isLoading || imports.isLoading}
+                />
+            </Section>
+
+            <Section
+                eyebrow="Import"
+                description="Apply an archive exported from another instance to this workspace."
+                actions={
+                    <span className="inline-flex items-center gap-1.5 text-[11px] text-slate-400">
+                        <UploadIcon className="w-3 h-3" />
+                        Nothing is written until you confirm
+                    </span>
+                }
+            >
+                <ImportPanel
+                    groups={groups.data?.groups ?? []}
+                    onStarted={() => toast.success("Import started. It keeps running if you leave this page.")}
+                />
+            </Section>
+        </SectionShell>
+    );
+}

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -17,6 +17,7 @@ import {
     BoxesIcon,
     BriefcaseIcon,
     CreditCardIcon,
+    DatabaseIcon,
     GaugeIcon,
     GiftIcon,
     Loader2Icon,
@@ -80,6 +81,7 @@ const GROUPS: SectionGroup[] = [
     {
         label: "Advanced",
         items: [
+            { path: "data", label: "Data", icon: DatabaseIcon, description: "Export this workspace, or import one from another instance.", ownerOnly: true },
             { path: "danger", label: "Danger zone", icon: AlertOctagonIcon, description: "Irreversible actions." },
         ],
     },

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -327,6 +327,12 @@ export function useRealtimeEvents() {
           // strip and every nav badge at once.
           advisor_finding: [['advisor']],
           settings: [['organizations', 'current']],
+          // Workspace archives: an export starting or an import landing changes
+          // both lists on the settings Data page.
+          org_archive: [
+            ['organizations', 'exports'],
+            ['organizations', 'imports'],
+          ],
           unibox: [['unibox']],
           crm_note: [['crm'], ['contacts']],
           crm_pipeline: [['crm', 'pipelines'], ['crm', 'deals']],

--- a/web/src/lib/api/client/app/orgtransfer/orgTransfer.ts
+++ b/web/src/lib/api/client/app/orgtransfer/orgTransfer.ts
@@ -1,0 +1,113 @@
+import type {
+    CreateOrgExportPayload,
+    CreateOrgImportOptions,
+    OrgExportJob,
+    OrgImportJob,
+    OrgImportPreflight,
+    OrgTransferGroupsResponse,
+} from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import Client from "../../Client";
+import Request from "../../Request";
+import getToken from "@/lib/helper/getToken";
+
+export async function getOrgTransferGroups(): Promise<OrgTransferGroupsResponse> {
+    return await Request<OrgTransferGroupsResponse>({
+        method: "GET",
+        url: `/organization/current/transfer/groups`,
+        authorization: true,
+    });
+}
+
+export async function createOrgExport(data: CreateOrgExportPayload): Promise<OrgExportJob> {
+    return await Request<OrgExportJob>({
+        method: "POST",
+        url: `/organization/current/export`,
+        data,
+        authorization: true,
+    });
+}
+
+export async function listOrgExports(): Promise<OrgExportJob[]> {
+    const res = await Request<{ data: OrgExportJob[] }>({
+        method: "GET",
+        url: `/organization/current/export`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function deleteOrgExport(id: string): Promise<void> {
+    await Request<void>({
+        method: "DELETE",
+        url: `/organization/current/export/${id}`,
+        authorization: true,
+    });
+}
+
+export async function listOrgImports(): Promise<OrgImportJob[]> {
+    const res = await Request<{ data: OrgImportJob[] }>({
+        method: "GET",
+        url: `/organization/current/import`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function preflightOrgImport(
+    file: File,
+    passphrase: string,
+): Promise<OrgImportPreflight> {
+    const form = new FormData();
+    form.append("file", file);
+    if (passphrase) form.append("passphrase", passphrase);
+    return await Request<OrgImportPreflight>({
+        method: "POST",
+        url: `/organization/current/import/preflight`,
+        data: form,
+        authorization: true,
+    });
+}
+
+export async function createOrgImport(
+    file: File,
+    options: CreateOrgImportOptions,
+    passphrase: string,
+): Promise<OrgImportJob> {
+    const form = new FormData();
+    form.append("file", file);
+    form.append("options", JSON.stringify(options));
+    if (passphrase) form.append("passphrase", passphrase);
+    return await Request<OrgImportJob>({
+        method: "POST",
+        url: `/organization/current/import`,
+        data: form,
+        authorization: true,
+    });
+}
+
+/**
+ * Downloads a finished archive.
+ *
+ * The endpoint is bearer-authenticated, so a plain anchor href cannot fetch it.
+ * The blob is pulled through the same client and handed to the browser as an
+ * object URL, which also means the caller can show progress while it streams.
+ */
+export async function downloadOrgExport(id: string): Promise<{ blob: Blob; filename: string }> {
+    const token = getToken();
+    const res = await Client.request<Blob>({
+        method: "GET",
+        url: `/organization/current/export/${id}/download`,
+        responseType: "blob",
+        headers: token?.access_token
+            ? { Authorization: `Bearer ${token.access_token}` }
+            : undefined,
+    });
+
+    // Prefer the server's filename; fall back to something recognisable.
+    const disposition = String(res.headers?.["content-disposition"] ?? "");
+    const match = /filename="?([^"]+)"?/.exec(disposition);
+    return {
+        blob: res.data,
+        filename: match?.[1] ?? `workspace-${id.slice(0, 8)}.warmbly.zip`,
+    };
+}

--- a/web/src/lib/api/hooks/app/orgtransfer/useOrgTransfer.ts
+++ b/web/src/lib/api/hooks/app/orgtransfer/useOrgTransfer.ts
@@ -1,0 +1,104 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+    createOrgExport,
+    createOrgImport,
+    deleteOrgExport,
+    getOrgTransferGroups,
+    listOrgExports,
+    listOrgImports,
+    preflightOrgImport,
+} from "@/lib/api/client/app/orgtransfer/orgTransfer";
+import type {
+    CreateOrgExportPayload,
+    CreateOrgImportOptions,
+    OrgExportJob,
+    OrgImportJob,
+} from "@/lib/api/models/app/orgtransfer/OrgTransfer";
+import { useCurrentOrg } from "@/stores/useAppStore";
+
+/** True while a job is still moving, so the list knows to keep polling. */
+function isActive(job: { status: string }): boolean {
+    return job.status === "queued" || job.status === "running";
+}
+
+// A running transfer has no realtime event of its own — the audit spine only
+// fires when a job is created or finishes — so an in-flight job is polled for
+// its progress bar. The interval drops to nothing the moment none are active.
+function progressInterval<T extends { status: string }>(jobs: T[] | undefined): number | false {
+    return jobs?.some(isActive) ? 2000 : false;
+}
+
+export function useOrgTransferGroups() {
+    const org = useCurrentOrg();
+    return useQuery({
+        queryKey: ["organizations", "transfer-groups", org?.id ?? null],
+        queryFn: getOrgTransferGroups,
+        staleTime: 5 * 60_000,
+        enabled: !!org,
+    });
+}
+
+export function useOrgExports() {
+    const org = useCurrentOrg();
+    return useQuery({
+        queryKey: ["organizations", "exports", org?.id ?? null],
+        queryFn: listOrgExports,
+        enabled: !!org,
+        refetchInterval: (query) => progressInterval(query.state.data as OrgExportJob[] | undefined),
+    });
+}
+
+export function useOrgImports() {
+    const org = useCurrentOrg();
+    return useQuery({
+        queryKey: ["organizations", "imports", org?.id ?? null],
+        queryFn: listOrgImports,
+        enabled: !!org,
+        refetchInterval: (query) => progressInterval(query.state.data as OrgImportJob[] | undefined),
+    });
+}
+
+export function useCreateOrgExport() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: CreateOrgExportPayload) => createOrgExport(data),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["organizations", "exports"] });
+        },
+    });
+}
+
+export function useDeleteOrgExport() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (id: string) => deleteOrgExport(id),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["organizations", "exports"] });
+        },
+    });
+}
+
+export function usePreflightOrgImport() {
+    return useMutation({
+        mutationFn: ({ file, passphrase }: { file: File; passphrase: string }) =>
+            preflightOrgImport(file, passphrase),
+    });
+}
+
+export function useCreateOrgImport() {
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: ({
+            file,
+            options,
+            passphrase,
+        }: {
+            file: File;
+            options: CreateOrgImportOptions;
+            passphrase: string;
+        }) => createOrgImport(file, options, passphrase),
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["organizations", "imports"] });
+        },
+    });
+}

--- a/web/src/lib/api/models/app/orgtransfer/OrgTransfer.ts
+++ b/web/src/lib/api/models/app/orgtransfer/OrgTransfer.ts
@@ -1,0 +1,175 @@
+// Workspace archives: the shapes behind Settings → Data.
+//
+// Mirrors internal/models/org_transfer.go. An archive is a portable copy of the
+// whole workspace, used to move between a self-hosted instance and the cloud
+// (in either direction).
+
+export type OrgTransferStatus =
+    | "queued"
+    | "running"
+    | "completed"
+    | "failed"
+    | "expired";
+
+export type OrgDataGroup =
+    | "core"
+    | "contacts"
+    | "campaigns"
+    | "crm"
+    | "automations"
+    | "ai"
+    | "warmup"
+    | "inbox"
+    | "sending"
+    | "events"
+    | "logs"
+    | "billing";
+
+export type OrgImportConflict = "skip" | "overwrite";
+
+/** One selectable slice of a workspace, described by the server. */
+export interface OrgDataGroupInfo {
+    key: OrgDataGroup;
+    label: string;
+    description: string;
+    /** Required groups cannot be switched off. */
+    required: boolean;
+    /** Heavy groups dominate archive size on a busy workspace. */
+    heavy: boolean;
+    /**
+     * Groups this one cannot travel without, because its rows hold NOT NULL
+     * references into them. The server closes over these anyway; the picker
+     * applies them too so the toggles match what the archive actually gets.
+     */
+    requires?: OrgDataGroup[];
+}
+
+/**
+ * Expands a selection over the catalog's dependencies, mirroring the server's
+ * NormalizeGroups. Required groups are always in.
+ */
+export function expandGroups(
+    selected: Iterable<OrgDataGroup>,
+    catalog: OrgDataGroupInfo[],
+): Set<OrgDataGroup> {
+    const byKey = new Map(catalog.map((g) => [g.key, g]));
+    const out = new Set<OrgDataGroup>(catalog.filter((g) => g.required).map((g) => g.key));
+    const queue = [...selected];
+    while (queue.length > 0) {
+        const key = queue.pop() as OrgDataGroup;
+        if (out.has(key) || !byKey.has(key)) continue;
+        out.add(key);
+        queue.push(...(byKey.get(key)?.requires ?? []));
+    }
+    return out;
+}
+
+/** The selected groups that depend on `key`, so unticking it can explain itself. */
+export function dependentsOf(
+    key: OrgDataGroup,
+    selected: Set<OrgDataGroup>,
+    catalog: OrgDataGroupInfo[],
+): OrgDataGroupInfo[] {
+    return catalog.filter((g) => selected.has(g.key) && (g.requires ?? []).includes(key));
+}
+
+export interface OrgTransferGroupsResponse {
+    groups: OrgDataGroupInfo[];
+    format_version: number;
+    min_passphrase: number;
+    retention_days: number;
+}
+
+/** A member carried by an archive. Never contains password material. */
+export interface OrgArchiveUser {
+    id: string;
+    email: string;
+    first_name: string;
+    last_name: string;
+    role: string;
+    is_owner: boolean;
+}
+
+/** What an archive says about itself. */
+export interface OrgArchiveInfo {
+    format_version: number;
+    source_instance: string;
+    source_app_version: string;
+    organization_id: string;
+    organization_name: string;
+    exported_at: Date;
+    groups: OrgDataGroup[];
+    has_secrets: boolean;
+    row_counts: Record<string, number>;
+    blob_count: number;
+    members: OrgArchiveUser[];
+}
+
+export interface OrgExportJob {
+    id: string;
+    organization_id: string;
+    requested_by?: string;
+    status: OrgTransferStatus;
+    groups: OrgDataGroup[];
+    include_secrets: boolean;
+    format_version: number;
+    progress_percent: number;
+    progress_stage: string;
+    archive_bytes?: number;
+    archive_sha256?: string;
+    row_counts: Record<string, number>;
+    error_message?: string;
+    started_at?: Date;
+    completed_at?: Date;
+    expires_at?: Date;
+    created_at: Date;
+    updated_at: Date;
+}
+
+export interface OrgImportJob {
+    id: string;
+    organization_id: string;
+    requested_by?: string;
+    status: OrgTransferStatus;
+    archive_bytes?: number;
+    archive_sha256?: string;
+    source_manifest?: OrgArchiveInfo;
+    groups: OrgDataGroup[];
+    conflict_strategy: OrgImportConflict;
+    progress_percent: number;
+    progress_stage: string;
+    row_counts: Record<string, number>;
+    warnings: string[];
+    error_message?: string;
+    started_at?: Date;
+    completed_at?: Date;
+    created_at: Date;
+    updated_at: Date;
+}
+
+/** What applying an archive would do, computed without writing anything. */
+export interface OrgImportPreflight {
+    archive: OrgArchiveInfo;
+    secrets_unsealed: boolean;
+    conflicts: Record<string, number>;
+    unknown_members: OrgArchiveUser[];
+    skipped_tables: string[];
+    warnings: string[];
+}
+
+export interface CreateOrgExportPayload {
+    groups?: OrgDataGroup[];
+    include_secrets?: boolean;
+    passphrase?: string;
+}
+
+export interface CreateOrgImportOptions {
+    groups?: OrgDataGroup[];
+    conflict_strategy?: OrgImportConflict;
+}
+
+/** Sums a job's per-table counts for the "12,481 rows" summary line. */
+export function totalRows(counts: Record<string, number> | undefined): number {
+    if (!counts) return 0;
+    return Object.values(counts).reduce((sum, n) => sum + n, 0);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -45,6 +45,7 @@ import WorkspaceSettingsPage from './app/app/settings/workspace/page';
 import SkillsSettingsPage from './app/app/settings/ai-skills/page';
 import ConnectionsSettingsPage from './app/app/settings/connections/page';
 import DangerSettingsPage from './app/app/settings/danger/page';
+import DataSettingsPage from './app/app/settings/data/page';
 import BillingSettingsPage from './app/app/settings/billing/page';
 import ReferralSettingsPage from './app/app/settings/referral/page';
 import LimitsSettingsPage from './app/app/settings/limits/page';
@@ -339,6 +340,7 @@ const router = createBrowserRouter([
               { path: "oauth-apps", element: <OAuthAppsPage /> },
               { path: "webhooks", element: <WebhooksSettingsPage /> },
               { path: "connections", element: <ConnectionsSettingsPage /> },
+              { path: "data", element: <DataSettingsPage /> },
               { path: "danger", element: <DangerSettingsPage /> },
             ],
           },


### PR DESCRIPTION
## What this adds

A workspace archive: one file holding everything an organization owns, so a customer can move between instances — self-hosted to cloud, cloud to self-hosted, or between two self-hosts.

- **Export** walks every org-owned relation into a zip of newline-delimited JSON, one file per table, plus attachment bytes.
- **Import** reads it back into a destination workspace, remapping people and clearing the fields that only meant something on the instance the archive came from.
- **Surfaces:** Settings → Data in the dashboard (owner-only), and `warmblyctl org list|export|import` for self-hosters with shell access.

Rows travel as `jsonb` in both directions (`to_jsonb` out, `jsonb_populate_recordset` in), so Postgres does every type conversion and no Go-side column mapping can drift from arrays, jsonb, tsvector, inet or enums. Adding a *column* to an existing table needs no code change; only new tables need registering.

## Coverage was verified, not assumed

The schema was derived from all 85 migrations and checked mechanically: every one of the organization-owned relations is either in `Tables` (110) or in `ExcludedTables` (10) with the reason it must not travel. Nothing is unaccounted for.

## Credentials

Warmbly has **two** key domains and they are not interchangeable:

| Domain | Seals | Why |
|---|---|---|
| `CREDENTIALS_ENCRYPTION_KEY` | mailbox SMTP/IMAP + OAuth tokens | the worker reads them without an org context |
| per-organization DEK | integration tokens, MCP credentials, message bodies | those are org assets and the DEK is what KMS wraps |

Neither is portable, so an export opens them locally and re-seals them under an argon2id key derived from an operator-supplied passphrase; an import reverses that against its own keys. The passphrase is never stored on either instance. Without it the archive still applies and mailboxes arrive marked for reconnection.

## Two bugs found and fixed during the build

- **Cross-group foreign keys.** Selecting only "Inbox" would have aborted the import on `unibox_thread_labels.category_id` — a NOT NULL FK into the Contacts group, and `ON CONFLICT DO NOTHING` does not cover FK violations. Fixed with a dependency closure in the group catalog for NOT NULL crossings, plus runtime nulling of *nullable* references whose target isn't in the run. **All 4095 possible group selections were checked exhaustively and are satisfiable.**
- **User references that aren't org members.** A departed member still referenced by `audit_logs.actor_id` would have written a dangling user id and failed the FK. Now blanked where nullable, redirected to the importer where not.

## Design calls worth reviewing

- **Transfers run in the accepting process, not a queue.** That is the only arrangement where the passphrase is never written down. The cost is an orphaned job if the process restarts, which the new hourly sweep closes out.
- **Import is one transaction.** A multi-GB import will hold a long transaction and defer vacuum. Judged worth it: a half-applied workspace is much worse than a slow one. Flagging it as a real operational tradeoff.
- **Owner-only, not a permission bit.** An export with credentials is the most sensitive artifact this product can produce, so it sits at the same level as deleting the organization.

## Deliberately not imported

Billing, plan limit overrides, worker placement, mailbox sync checkpoints, warmup pool membership and scheduled deletions are exported for the record but never applied — each belongs to the instance rather than the workspace. Full table in the guide.

## Also

`AGENTS.md` now records that a migration adding an org-scoped table is not done until that table is registered in `spec.go`. Without that rule the next migration silently falls out of every archive and nobody finds out until a customer's migration lands missing data.

## Verification

`gofmt -l` clean, `make lint` (golangci-lint) clean, `pnpm typecheck` + `pnpm lint` clean in `web/` and `docs/` with no new warnings in any touched file.

Not exercised against a live database — Docker was unavailable in this environment, so the schema work was done by parsing the migrations rather than introspecting a running instance.
