### PR TITLE
fix: one waiting lead no longer parks the whole campaign (#171)

### DIFF
--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -77,6 +77,10 @@ Returns the `AdvancedOutreachSettings` object directly (not wrapped in an envelo
 }
 ```
 
+<Callout type="info" title="Send-time optimization is stored, not yet applied">
+The `send_time_optimization` block is accepted and returned, but campaign scheduling does not place sends by it yet. Sends follow the campaign schedule and each mailbox's own sending profile; recipient-timezone placement is planned.
+</Callout>
+
 ## Update outreach settings
 
 `PATCH /outreach/settings`

--- a/docs/content/docs/guides/sequences.mdx
+++ b/docs/content/docs/guides/sequences.mdx
@@ -55,6 +55,8 @@ Spacing belongs to the **target** step, not a separate node, so there is no wait
 
 Because the wait belongs to the target, every path into that step uses the same wait. Spacing follow-ups out keeps your sending pattern natural; see [Deliverability](/guides/deliverability/).
 
+Waits are per contact. A contact waiting three days for a follow-up does not hold up anyone else: other contacts' first emails and due follow-ups keep sending in the meantime, and the campaign only pauses when nothing is due for anyone.
+
 <Callout type="info" title="Instant branches skip the wait">
 A path that runs instantly fires the moment the event happens, so the target's wait does not apply and the control is hidden.
 </Callout>

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -611,16 +611,26 @@ func (r *campaignProgressRepository) GetLatestCampaignSequenceForContact(ctx con
 //
 // Conditions are evaluated SEND-RELATIVE with a three-valued result: a contact
 // whose next step isn't decidable yet (an engagement window still open) is not
-// returned; instead the soonest re-check time is returned (second value) so the
-// scheduler defers and checks again exactly then. Returns (nil, nil, nil) when
-// the campaign is genuinely complete (no sendable and nothing pending).
+// returned.
+//
+// Only a pair that is DUE is returned: a new lead is due now; a routed step is
+// due wait_after days after the contact's last step (plus a wait node's
+// minutes). The first due contact in list order wins. Contacts whose next step
+// is due later never block the ones behind them: without this, the one lead
+// routed to a "wait 3 days" follow-up parks the whole campaign for 3 days while
+// every other lead's first email sits queued. When nothing is due, the second
+// value is the soonest moment something will be (a step becoming due or a
+// condition window closing) so the scheduler defers exactly until then.
+// Returns (nil, nil, nil) when the campaign is genuinely complete.
 func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, campaignID uuid.UUID, orderBy, orderDir, orderField string, prioritizeNewLeads, excludeNewLeads bool) (*ContactSequencePair, *time.Time, error) {
-	// 1. Load steps (position + branch tree) once, ordered by position.
+	// 1. Load steps (position + branch tree + wait) once, ordered by position.
 	type stepInfo struct {
-		id uuid.UUID
-		bc models.BranchConditions
+		id          uuid.UUID
+		bc          models.BranchConditions
+		waitAfter   int
+		waitMinutes int // a "wait" node's own delay, gating the step after it
 	}
-	srows, err := r.db.Query(ctx, `SELECT id, conditions FROM sequences WHERE campaign_id = $1 ORDER BY position ASC, created_at ASC`, campaignID)
+	srows, err := r.db.Query(ctx, `SELECT id, conditions, wait_after, kind, action FROM sequences WHERE campaign_id = $1 ORDER BY position ASC, created_at ASC`, campaignID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -628,13 +638,20 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 	idxByID := map[uuid.UUID]int{}
 	for srows.Next() {
 		var si stepInfo
-		var raw []byte
-		if serr := srows.Scan(&si.id, &raw); serr != nil {
+		var raw, action []byte
+		var kind string
+		if serr := srows.Scan(&si.id, &raw, &si.waitAfter, &kind, &action); serr != nil {
 			srows.Close()
 			return nil, nil, serr
 		}
 		if len(raw) > 0 {
 			_ = json.Unmarshal(raw, &si.bc)
+		}
+		if kind != "email" && len(action) > 0 {
+			var cfg models.ActionConfig
+			if json.Unmarshal(action, &cfg) == nil && cfg.Type == "wait" && cfg.WaitMinutes != nil && *cfg.WaitMinutes > 0 {
+				si.waitMinutes = *cfg.WaitMinutes
+			}
 		}
 		idxByID[si.id] = len(steps)
 		steps = append(steps, si)
@@ -868,7 +885,18 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		return nil, nil, err
 	}
 	defer rows.Close()
-	var earliestWait *time.Time
+	// nextDue is the soonest moment anything becomes sendable: a step whose
+	// wait elapses or a condition window that closes. Only reported when no
+	// contact is due right now.
+	var nextDue *time.Time
+	noteDue := func(at time.Time) {
+		if nextDue == nil || at.Before(*nextDue) {
+			nextDue = &at
+		}
+	}
+	// A task fires at (or a breath before) the slot it was scheduled for, so
+	// "due" tolerates the same grace the scheduler's hard-floor check does.
+	dueBy := now.Add(config.CampaignNotDueGraceSeconds * time.Second)
 	for rows.Next() {
 		var contactID uuid.UUID
 		var lastSeq *uuid.UUID
@@ -920,9 +948,7 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		if res.wait != nil {
 			// Not decidable yet — remember the soonest window so the scheduler
 			// can re-check exactly then instead of guessing or completing.
-			if earliestWait == nil || res.wait.Before(*earliestWait) {
-				earliestWait = res.wait
-			}
+			noteDue(*res.wait)
 			continue
 		}
 		if res.stop || res.target == nil {
@@ -939,14 +965,26 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		if already {
 			continue
 		}
+		// When is this step due? Skip it (but remember when) if not yet: the
+		// contacts behind this one may be sendable right now.
+		if !isNew && sentAt != nil {
+			due := sentAt.Add(24 * time.Hour * time.Duration(steps[idxByID[*res.target]].waitAfter))
+			if last, ok := idxByID[*lastSeq]; ok && steps[last].waitMinutes > 0 {
+				due = due.Add(time.Duration(steps[last].waitMinutes) * time.Minute)
+			}
+			if due.After(dueBy) {
+				noteDue(due)
+				continue
+			}
+		}
 		return &ContactSequencePair{ContactID: contactID, SequenceID: *res.target, IsNewLead: isNew}, nil, nil
 	}
 	if rerr := rows.Err(); rerr != nil {
 		return nil, nil, rerr
 	}
-	// Nobody sendable now. If contacts are waiting on a window, hand back the
-	// soonest re-check time so the scheduler defers rather than completing.
-	return nil, earliestWait, nil
+	// Nobody sendable now. Hand back the soonest moment somebody will be so the
+	// scheduler defers until then rather than completing.
+	return nil, nextDue, nil
 }
 
 // branchHasPositiveReplyCondition reports whether a branch is a "reply branch":

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -134,18 +134,24 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 					"Daily new-lead cap reached; deferring remaining new leads to tomorrow",
 					map[string]interface{}{"max_new_leads_per_day": campaign.MaxNewLeadsPerDay})
 				deferTime := s.deferToNextDay(campaign)
+				// A follow-up that comes due before tomorrow must not wait for
+				// the new-lead cap to reset.
+				if recheckAt != nil && recheckAt.Before(deferTime) {
+					deferTime = *recheckAt
+				}
 				// Return a DEFERRAL, never a sendable pair: the caller only checks
 				// err for deferrals, so a nil-error here would send a new lead and
 				// blow past the cap. nil pair + sentinel = reschedule, don't send.
 				return deferTime, nil, accounts[0].ID, ErrCampaignDeferred
 			}
 		}
-		// Some contacts are waiting on a condition window (e.g. "if didn't open
-		// within 3 days"). Defer and re-check exactly when the soonest window
-		// elapses, instead of marking the campaign complete.
+		// Nothing is due yet: every remaining contact is inside a step's wait
+		// or a condition window (e.g. "if didn't open within 3 days"). Defer
+		// and re-check exactly when the soonest one elapses, instead of
+		// marking the campaign complete.
 		if recheckAt != nil {
-			s.logCampaignDecision(ctx, campaignID, "awaiting_condition_window",
-				"Waiting on a branch condition window; re-checking when it elapses",
+			s.logCampaignDecision(ctx, campaignID, "awaiting_next_step",
+				"No step is due yet; re-checking when the next wait elapses",
 				map[string]interface{}{"recheck_at": recheckAt.UTC().Format(time.RFC3339)})
 			return *recheckAt, nil, accounts[0].ID, ErrCampaignDeferred
 		}

--- a/internal/scheduler/live_integration_test.go
+++ b/internal/scheduler/live_integration_test.go
@@ -536,3 +536,130 @@ func TestLiveFollowUpWaitIsHonored(t *testing.T) {
 	}
 	t.Logf("follow-up correctly deferred to %s", at.UTC().Format("2006-01-02 15:04:05"))
 }
+
+// TestLiveWaitingFollowUpDoesNotBlockOtherLeads is the multi-lead stall from
+// issue #171: lead A got step 1 and is routed to a "wait 3 days" follow-up,
+// lead B has never been sent. B's first email is due now and must be picked,
+// instead of the campaign parking on A's follow-up with B queued behind it.
+func TestLiveWaitingFollowUpDoesNotBlockOtherLeads(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+
+	step2 := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+			body_plain, body_html, wait_after, position, kind)
+		VALUES ($1, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', 3, 1, 'email')`,
+		step2, f.campaign, f.org); err != nil {
+		t.Fatalf("insert step 2: %v", err)
+	}
+	var step1, leadA uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM sequences WHERE campaign_id = $1 AND position = 0`, f.campaign).Scan(&step1); err != nil {
+		t.Fatalf("load step 1: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT contact_id FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&leadA); err != nil {
+		t.Fatalf("load lead A: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE sequences SET conditions = jsonb_build_object('branches', jsonb_build_array(
+			jsonb_build_object('branch_id', 'live-else', 'target_step_id', $1::text)))
+		WHERE campaign_id = $2 AND position = 0`, step2.String(), f.campaign); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+
+	// Lead B joins after A (created_at ordering puts A first) and has never
+	// been sent anything.
+	leadB := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields, created_at)
+		VALUES ($1, $2, $3, $4, 'Live', 'Second', '', '', '{}', NOW() + interval '1 second')`,
+		leadB, f.user, f.org, "lead-"+leadB.String()[:8]+"@test.local"); err != nil {
+		t.Fatalf("insert lead B: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, 1)`,
+		f.campaign, leadB); err != nil {
+		t.Fatalf("add lead B: %v", err)
+	}
+
+	// A's step 1 went out moments ago; A now routes to the wait-gated step 2.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
+		VALUES ($1, $2, $3, NOW())`, f.campaign, leadA, step1); err != nil {
+		t.Fatalf("stamp A step 1: %v", err)
+	}
+
+	s := liveScheduler(t, handle, pool)
+	at, pair, _, err := s.CalculateNextCampaignTime(ctx, f.campaign)
+	if err != nil {
+		t.Fatalf("want B's first step now, got err=%v at=%s", err, at)
+	}
+	if pair == nil || pair.ContactID != leadB || pair.SequenceID != step1 || !pair.IsNewLead {
+		t.Fatalf("want lead B / step 1 as a new lead, got %+v", pair)
+	}
+
+	// Once B has had step 1 too, nothing is due for 3 days: the campaign
+	// defers to then instead of completing or sending a follow-up early.
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
+		VALUES ($1, $2, $3, NOW())`, f.campaign, leadB, step1); err != nil {
+		t.Fatalf("stamp B step 1: %v", err)
+	}
+	at, pair, _, err = s.CalculateNextCampaignTime(ctx, f.campaign)
+	if !errors.Is(err, ErrCampaignDeferred) || pair != nil {
+		t.Fatalf("want ErrCampaignDeferred with no pair, got pair=%v err=%v", pair, err)
+	}
+	if until := time.Until(at); until < 71*time.Hour || until > 73*time.Hour {
+		t.Fatalf("deferred slot %s is not ~3 days out", at)
+	}
+}
+
+// TestLiveWaitNodeGatesTheStepAfterIt: a contact who passed through a "wait 90
+// minutes" node must not be routed onward by a tick that fires before the
+// delay elapses (multi-lead campaigns tick constantly).
+func TestLiveWaitNodeGatesTheStepAfterIt(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+
+	waitNode, step2 := uuid.New(), uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+			body_plain, body_html, wait_after, position, kind, action, conditions)
+		VALUES ($1, $2, $3, 'Wait', '', '', '', 0, 1, 'wait',
+			'{"type":"wait","wait_minutes":90}',
+			jsonb_build_object('branches', jsonb_build_array(
+				jsonb_build_object('branch_id', 'live-else', 'target_step_id', $5::text)))),
+		       ($4, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', 0, 2, 'email', '{}', '{}')`,
+		waitNode, f.campaign, f.org, step2, step2.String()); err != nil {
+		t.Fatalf("insert wait node + step 2: %v", err)
+	}
+	var contact uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT contact_id FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&contact); err != nil {
+		t.Fatalf("load contact: %v", err)
+	}
+	// step 1 -> wait -> step 2; the contact just passed the wait node.
+	if _, err := pool.Exec(ctx, `
+		UPDATE sequences SET conditions = jsonb_build_object('branches', jsonb_build_array(
+			jsonb_build_object('branch_id', 'live-else', 'target_step_id', $1::text)))
+		WHERE campaign_id = $2 AND position = 0`, waitNode.String(), f.campaign); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
+		VALUES ($1, $2, (SELECT id FROM sequences WHERE campaign_id = $1 AND position = 0), NOW() - interval '1 minute'),
+		       ($1, $2, $3, NOW())`, f.campaign, contact, waitNode); err != nil {
+		t.Fatalf("stamp progress: %v", err)
+	}
+
+	at, pair, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(ctx, f.campaign)
+	if !errors.Is(err, ErrCampaignDeferred) || pair != nil {
+		t.Fatalf("want ErrCampaignDeferred with no pair while the wait runs, got pair=%v err=%v", pair, err)
+	}
+	if until := time.Until(at); until < 85*time.Minute || until > 95*time.Minute {
+		t.Fatalf("deferred slot %s is not ~90 minutes out", at)
+	}
+}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -731,15 +731,13 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	// STEP 19: Publish events to Kafka
 	s.publishEmailSentEvent(ctx, taskRecord, account, campaign, contact, sequence)
 
-	// STEP 20: Create next campaign task
-	scheduledNext := nextTime
-	if s.advanced != nil && campaign.OrganizationID != nil {
-		if optimized, xerr := s.advanced.OptimizeSendTime(ctx, *campaign.OrganizationID, contact, nextTime); xerr == nil {
-			scheduledNext = optimized
-		}
-	}
-
-	if err := s.createCampaignTask(ctx, campaign.ID, account.ID, scheduledNext); err != nil {
+	// STEP 20: Create next campaign task. The successor serves whichever lead
+	// is due next, so it must never be shaped for the contact just emailed:
+	// send-time optimization used to push it to that contact's next preferred
+	// hour (tomorrow 09:00 by default after 17:00 UTC), leaving every other
+	// lead queued for a day. Recipient-time placement belongs in slot
+	// selection for the selected contact (issue #156), not here.
+	if err := s.createCampaignTask(ctx, campaign.ID, account.ID, nextTime); err != nil {
 		// Log but don't fail the current task
 		log.Warn().Err(err).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to create next campaign task")
 	}


### PR DESCRIPTION
Fixes #171 (the reopened multi-lead stall) and the "1 processing, rest queued for a day" behavior behind #161.

## Root causes

1. `FindNextRoutedPair` returned the first contact in list order whose route resolved, with no notion of when that step was due. `wait_after` was applied later in the scheduler. Since #172 the scheduler correctly refuses a not-yet-due follow-up and returns `ErrCampaignDeferred`, and the task handler parks the campaign's single wakeup at that slot. With 5 leads and a 2-step sequence: lead A gets step 1, the next tick routes A to step 2 (due in 3 days), the campaign parks for 3 days, leads B-E stay queued.
2. Independently, and pre-dating #172: `send_time_optimization` is on by default (UTC, preferred hours 9-11 and 14-16) and was applied to the *successor* wakeup after every send, shaped for the contact just emailed. Any send after 17:00 UTC pushed the next lead to 09:00 UTC tomorrow; a send at 12:00 pushed to 14:00; when the current hour was a preferred hour it produced a time in the past, firing immediately and defeating pacing.
3. Latent: `wait` action nodes only gated the successor tick they scheduled; any other tick routed the contact straight past the wait.

## Changes

- `FindNextRoutedPair` loads `wait_after`/`kind`/`action` per step, computes each candidate's due time, returns the first *due* contact in list order, and when nothing is due returns the soonest due moment (merged with condition-window rechecks) so the scheduler defers exactly until then.
- Scheduler: new-lead-cap deferral is `min(tomorrow, next due follow-up)`; deferral log event renamed to `awaiting_next_step`.
- Task handler: the successor wakeup is no longer shifted by send-time optimization. Recipient-time placement belongs in slot selection for the selected contact (#156).
- Docs: waits are per contact (`guides/sequences.mdx`); `send_time_optimization` is stored but not yet applied (`api/reference/deliverability-ops.mdx`).
- Tests: `TestLiveWaitingFollowUpDoesNotBlockOtherLeads` (the A/B scenario from the issue thread, then the ~3-day deferral once both have step 1) and `TestLiveWaitNodeGatesTheStepAfterIt`, run against the real Postgres alongside the existing `TestLiveFollowUpWaitIsHonored`.

## Verification

`gofmt -l` clean, `make lint` clean, hermetic tests for scheduler/repository/tasks pass, live tests pass against the docker dev DB, docs `types:check` and `lint` clean (two pre-existing warnings in `docs/hooks/useKeyboardShortcuts.ts`).