### PR TITLE
Fail closed when a campaign has no organization, and remove the state entirely

### DIFF
--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -71,6 +71,12 @@ Returned when the request cannot be processed due to invalid syntax.
 - Verify all required fields are present
 - Ensure field values match expected types
 
+**Specific 400 codes:**
+
+| `code` | Meaning |
+|--------|---------|
+| `no_organization` | The request needs a workspace and the caller has none selected. Every entitlement, limit and suppression rule is scoped to a workspace, so a write that would run unscoped is refused rather than run without those checks. API keys always carry their workspace; a dashboard session picks one at sign-in, so this normally means the session predates the workspace being chosen. Select a workspace and retry |
+
 ### 401 Unauthorized
 
 Returned when authentication fails.

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -87,7 +87,7 @@ Optional **campaign dates** bound when it may send. Leave both blank to run open
 
 The play and pause buttons work from the list row or the detail view. Starting moves the campaign to **active** and begins scheduling inside your windows and limits; pausing stops new scheduling immediately and resumes from where it left off.
 
-A campaign can pause itself: **paused, no accounts** when it loses every sender, **paused, trial expired** when a trial ends, and **auto-paused** when a guardrail trips. It moves to **finished** once every contact completes the sequence or its end date passes. Configured to do so, it also stops following up with a contact the moment they reply.
+A campaign can pause itself: **paused, no accounts** when it loses every sender, **paused, trial expired** when a trial ends, **auto-paused** when a guardrail trips, and plain **paused** if it ever loses its workspace, because unsubscribes, bounces and complaints are checked per workspace and cannot be honoured without one. It moves to **finished** once every contact completes the sequence or its end date passes. Configured to do so, it also stops following up with a contact the moment they reply.
 
 A finished campaign can be started again: after extending or clearing its end date, or adding new leads, pressing play resumes it. If there is genuinely nothing left to send it finishes again immediately with a message saying so.
 

--- a/docs/content/docs/guides/deliverability.mdx
+++ b/docs/content/docs/guides/deliverability.mdx
@@ -102,6 +102,8 @@ If a campaign has already been paused because every one of its mailboxes was gat
 
 **Suppression** is the safety net: a suppressed recipient is never emailed again by any campaign. Warmbly suppresses automatically on a bounce, a spam complaint, or an unsubscribe, because once someone has bounced or complained the safest response is to stop, not to keep collecting negative signals.
 
+The list is held per workspace, and the check runs against the sending campaign's workspace before every send. If a campaign somehow has no workspace, that check cannot be applied, so the campaign is paused with the reason in its activity feed instead of sending unchecked.
+
 Bounces are detected from the delivery-status report the recipient's server sends back. Only permanent failures (`5.x.x`, such as a nonexistent address) record a bounce and suppress; temporary ones (`4.x.x`, such as a full mailbox or greylisting) never do. This works the same for Gmail and Microsoft Graph mailboxes, where the send reports success and the bounce arrives later.
 
 ## How to read it

--- a/internal/api/handler/campaign.go
+++ b/internal/api/handler/campaign.go
@@ -76,6 +76,12 @@ func (h *Handler) PreviewCampaignTemplate(c *gin.Context) {
 func (h *Handler) CreateCampaign(c *gin.Context) {
 	userIDStr := middleware.GetUserID(c)
 	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		// A campaign with no workspace cannot be suppression-checked or
+		// entitlement-checked at send time, so it is never created.
+		errx.JSON(c, errx.ErrNoOrganization)
+		return
+	}
 
 	var data models.CreateCampaign
 

--- a/internal/api/handler/email_onboarding.go
+++ b/internal/api/handler/email_onboarding.go
@@ -31,6 +31,10 @@ type OnboardingSMTPIMAPRequest struct {
 func (h *Handler) StartEmailOAuth(c *gin.Context) {
 	userID := middleware.GetUserID(c)
 	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.ErrNoOrganization)
+		return
+	}
 
 	var req OnboardingOAuthStartRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -73,6 +77,10 @@ func (h *Handler) FinishEmailOAuth(c *gin.Context) {
 func (h *Handler) ConnectEmailSMTPIMAP(c *gin.Context) {
 	userIDStr := middleware.GetUserID(c)
 	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.ErrNoOrganization)
+		return
+	}
 
 	var req OnboardingSMTPIMAPRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -31,11 +31,17 @@ func (s *campaignService) Create(ctx context.Context, userID string, orgID *uuid
 		return nil, err
 	}
 
+	// A campaign carries its workspace from creation: suppression, the
+	// entitlement gate and the throttle below are all org-scoped, and a row
+	// without one would skip every one of them at send time.
+	if orgID == nil {
+		return nil, errx.ErrNoOrganization
+	}
+
 	// Daily creation throttle (config.DailyThrottleNewCampaigns). Caps
 	// per-day new-campaign rate per org so an unlimited plan can't be
-	// abused to ramp instantly. Scoped on org when present; otherwise
-	// best-effort skipped (the older campaign API allows orgless rows).
-	if orgID != nil && s.throttle != nil {
+	// abused to ramp instantly.
+	if s.throttle != nil {
 		if xerr := s.throttle.CheckAndIncrement(ctx, *orgID, dailythrottle.ResourceCampaign, config.DailyThrottleNewCampaigns); xerr != nil {
 			return nil, xerr
 		}

--- a/internal/app/email/handler.go
+++ b/internal/app/email/handler.go
@@ -230,7 +230,12 @@ func (s *emailService) resolveWarmupPoolType(ctx context.Context, account *model
 	if account.WarmupPoolType != "" {
 		return account.WarmupPoolType
 	}
-	if account.OrganizationID != nil && s.featureGate != nil {
+	// No organization means no entitlement to check, so the mailbox gets the
+	// lower-trust pool rather than defaulting into the paid one.
+	if account.OrganizationID == nil {
+		return "free"
+	}
+	if s.featureGate != nil {
 		isPaid, err := s.featureGate.IsPaidOrganization(ctx, *account.OrganizationID)
 		if err == nil && !isPaid {
 			return "free"

--- a/internal/app/email/onboarding.go
+++ b/internal/app/email/onboarding.go
@@ -59,12 +59,15 @@ func (s *emailService) OAuthStart(ctx context.Context, userID string, orgID *uui
 
 // guardMailboxThrottle bounds new-mailbox connection rate per org per
 // day so abuse paths (or accidents) can't connect 200 mailboxes in
-// one tab session. Caller-supplied orgID; nil means "best-effort
-// skip" (orgless flows are vanishing but still exist). The check
-// fires only on the actual create paths, not on OAuthStart, so
-// retrying a failed flow doesn't consume the day's budget.
+// one tab session. The budget is keyed by org, so a request without
+// one is refused rather than exempted. The check fires only on the
+// actual create paths, not on OAuthStart, so retrying a failed flow
+// doesn't consume the day's budget.
 func (s *emailService) guardMailboxThrottle(ctx context.Context, orgID *uuid.UUID) *errx.Error {
-	if s.throttle == nil || orgID == nil {
+	if orgID == nil {
+		return errx.ErrNoOrganization
+	}
+	if s.throttle == nil {
 		return nil
 	}
 	return s.throttle.CheckAndIncrement(ctx, *orgID, dailythrottle.ResourceMailbox, config.DailyThrottleNewMailboxes)
@@ -74,9 +77,13 @@ func (s *emailService) guardMailboxThrottle(ctx context.Context, orgID *uuid.UUI
 // Returns nil (allowed) for paid orgs and for trial orgs under the cap.
 // Trial orgs that have already connected one inbox get
 // ErrEmailOnboardInboxLimit; orgs without an active subscription or trial
-// get ErrEmailOnboardTrialExpired.
+// get ErrEmailOnboardTrialExpired. The cap is counted per org, so no org
+// means the cap cannot be applied and the connect is refused.
 func (s *emailService) guardInboxLimit(ctx context.Context, orgID *uuid.UUID) *errx.Error {
-	if s.featureGate == nil || orgID == nil {
+	if orgID == nil {
+		return errx.ErrNoOrganization
+	}
+	if s.featureGate == nil {
 		return nil
 	}
 	count, xerr := s.emailRepository.CountForOrganization(ctx, *orgID)
@@ -191,12 +198,6 @@ func (s *emailService) OnboardSMTPIMAP(ctx context.Context, userID string, orgID
 
 	if s.workerAssignment == nil {
 		return nil, errx.ErrEmailOnboardNoWorker
-	}
-
-	// Credentials are sealed with the organization DEK for the validation
-	// round-trip, so an org is required before we can onboard a mailbox.
-	if orgID == nil {
-		return nil, errx.ErrUser
 	}
 
 	// Pick any healthy worker for the one-shot validation handshake. Tier is

--- a/internal/app/token/gen.go
+++ b/internal/app/token/gen.go
@@ -67,6 +67,17 @@ func (s *tokenService) GenerateSession(ctx context.Context, userID uuid.UUID, em
 }
 
 func (s *tokenService) GenerateSessionWithOrg(ctx context.Context, userID uuid.UUID, email, ipaddr, userAgent, authProvider string, orgID *uuid.UUID) (*models.Token, *errx.Error) {
+	// A session always starts inside a workspace. Without one the caller would
+	// reach org-scoped writes with no tenant, and the rows they create are the
+	// ones that later skip suppression and the entitlement gate (issue #168).
+	if orgID == nil {
+		resolved, xerr := s.tokenRepository.DefaultOrganization(ctx, userID)
+		if xerr != nil {
+			return nil, xerr
+		}
+		orgID = resolved
+	}
+
 	ip, err := netip.ParseAddr(ipaddr)
 	if err != nil {
 		sentry.CaptureException(err)

--- a/internal/errx/common.go
+++ b/internal/errx/common.go
@@ -77,6 +77,14 @@ var (
 	ErrPasskeyExists   = New(Conflict, "This passkey is already registered.")
 	ErrPasskeyNone     = New(BadRequest, "No passkey was found for this account.")
 
+	// Organization
+	//
+	// Raised where a workspace is required to scope a write or a policy check.
+	// Every entitlement, limit and suppression rule is org-scoped, so a request
+	// without one is refused rather than run unscoped.
+	ErrNoOrganization = NewWithIdentifier(BadRequest, "no_organization",
+		"No workspace selected. Pick a workspace and try again.")
+
 	// Roles
 	ErrRoleName = New(BadRequest, "Role name length must be between 3 and 100 characters.")
 

--- a/internal/infrastructure/db/migrations/000092_org_id_not_null.down.sql
+++ b/internal/infrastructure/db/migrations/000092_org_id_not_null.down.sql
@@ -1,0 +1,6 @@
+-- Only the constraint is reversible. The backfill (and any recovery workspace
+-- it created) is one-way: nothing records which rows were NULL beforehand.
+ALTER TABLE campaigns      ALTER COLUMN organization_id DROP NOT NULL;
+ALTER TABLE contacts       ALTER COLUMN organization_id DROP NOT NULL;
+ALTER TABLE email_accounts ALTER COLUMN organization_id DROP NOT NULL;
+ALTER TABLE sequences      ALTER COLUMN organization_id DROP NOT NULL;

--- a/internal/infrastructure/db/migrations/000092_org_id_not_null.up.sql
+++ b/internal/infrastructure/db/migrations/000092_org_id_not_null.up.sql
@@ -1,0 +1,119 @@
+-- organization_id is the tenant key that scopes recipient suppression, the
+-- entitlement gate, and every org-scoped read. A NULL there removed the check
+-- instead of stopping the send (issue #168), so the four core tenant tables
+-- lose the NULL state entirely: legacy rows are attributed to their owner's
+-- organization first, then the column goes NOT NULL.
+
+-- Every orgless row still has a real owner (user_id is a NOT NULL FK to users).
+-- A user who lost, or never got, an organization gets a recovery workspace so
+-- their rows stay reachable instead of being deleted to satisfy the constraint.
+DO $$
+DECLARE
+    orphan_user uuid;
+    orphan_name text;
+    new_org     uuid;
+BEGIN
+    FOR orphan_user IN
+        SELECT DISTINCT o.uid
+        FROM (
+            SELECT user_id AS uid FROM campaigns      WHERE organization_id IS NULL
+            UNION SELECT user_id FROM contacts        WHERE organization_id IS NULL
+            UNION SELECT user_id FROM email_accounts  WHERE organization_id IS NULL
+        ) o
+        WHERE NOT EXISTS (
+            SELECT 1 FROM organization_members m WHERE m.user_id = o.uid
+        )
+    LOOP
+        SELECT COALESCE(NULLIF(u.first_name, '') || '''s Organization', 'My Organization')
+          INTO orphan_name
+          FROM users u WHERE u.id = orphan_user;
+
+        INSERT INTO organizations (id, name, slug, owner_user_id)
+        VALUES (gen_random_uuid(), orphan_name,
+                'recovered-' || replace(orphan_user::text, '-', ''), orphan_user)
+        RETURNING id INTO new_org;
+
+        -- permissions = -1 is the stored form of models.AllPermissions (0xFFFF)
+        -- in the smallint column, matching what organizationService.Create writes.
+        INSERT INTO organization_members (organization_id, user_id, role, permissions, accepted_at)
+        VALUES (new_org, orphan_user, 'owner', -1, NOW());
+
+        INSERT INTO crm_task_types (organization_id, name, color, position)
+        VALUES (new_org, 'Call', '#8b5cf6', 0),
+               (new_org, 'Email', '#0ea5e9', 1),
+               (new_org, 'Meeting', '#f59e0b', 2)
+        ON CONFLICT (organization_id, name) DO NOTHING;
+    END LOOP;
+END $$;
+
+-- Deterministic attribution: the organization the user owns, else their
+-- earliest-joined membership. Campaigns go first so contacts can prefer the
+-- organization of a campaign they are already a lead of.
+UPDATE campaigns c
+SET organization_id = (
+    SELECT m.organization_id
+    FROM organization_members m
+    LEFT JOIN organizations o ON o.id = m.organization_id
+    WHERE m.user_id = c.user_id
+    ORDER BY (o.owner_user_id = c.user_id) DESC, m.invited_at, m.organization_id
+    LIMIT 1
+)
+WHERE c.organization_id IS NULL;
+
+UPDATE contacts c
+SET organization_id = COALESCE(
+    (
+        SELECT ca.organization_id
+        FROM campaign_leads cl
+        JOIN campaigns ca ON ca.id = cl.campaign_id
+        WHERE cl.contact_id = c.id AND ca.organization_id IS NOT NULL
+        ORDER BY ca.created_at, ca.id
+        LIMIT 1
+    ),
+    (
+        SELECT m.organization_id
+        FROM organization_members m
+        LEFT JOIN organizations o ON o.id = m.organization_id
+        WHERE m.user_id = c.user_id
+        ORDER BY (o.owner_user_id = c.user_id) DESC, m.invited_at, m.organization_id
+        LIMIT 1
+    )
+)
+WHERE c.organization_id IS NULL;
+
+UPDATE email_accounts e
+SET organization_id = (
+    SELECT m.organization_id
+    FROM organization_members m
+    LEFT JOIN organizations o ON o.id = m.organization_id
+    WHERE m.user_id = e.user_id
+    ORDER BY (o.owner_user_id = e.user_id) DESC, m.invited_at, m.organization_id
+    LIMIT 1
+)
+WHERE e.organization_id IS NULL;
+
+-- A step belongs to whatever organization owns its campaign; campaign_id is a
+-- NOT NULL FK, so this always resolves once campaigns are backfilled.
+UPDATE sequences s
+SET organization_id = c.organization_id
+FROM campaigns c
+WHERE c.id = s.campaign_id AND s.organization_id IS NULL;
+
+-- A live session with no workspace is how an orgless row was created in the
+-- first place: every org-scoped write it reached ran with no tenant. Point
+-- existing sessions at the same organization a fresh login would now pick.
+UPDATE sessions s
+SET current_organization_id = (
+    SELECT m.organization_id
+    FROM organization_members m
+    LEFT JOIN organizations o ON o.id = m.organization_id
+    WHERE m.user_id = s.user_id AND o.deletion_scheduled_for IS NULL
+    ORDER BY (o.owner_user_id = s.user_id) DESC, m.invited_at, m.organization_id
+    LIMIT 1
+)
+WHERE s.current_organization_id IS NULL;
+
+ALTER TABLE campaigns      ALTER COLUMN organization_id SET NOT NULL;
+ALTER TABLE contacts       ALTER COLUMN organization_id SET NOT NULL;
+ALTER TABLE email_accounts ALTER COLUMN organization_id SET NOT NULL;
+ALTER TABLE sequences      ALTER COLUMN organization_id SET NOT NULL;

--- a/internal/repository/pg_sequence.go
+++ b/internal/repository/pg_sequence.go
@@ -130,7 +130,7 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 	defer tx.Rollback(ctx)
 
 	query := `
-		SELECT user_id
+		SELECT user_id, organization_id
 		FROM campaigns WHERE id = $1
 	`
 
@@ -139,11 +139,12 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 	}
 
 	var ownerID string
+	var orgID uuid.UUID
 	err = tx.QueryRow(
 		ctx,
 		query,
 		params...,
-	).Scan(&ownerID)
+	).Scan(&ownerID, &orgID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errx.ErrNotFound
@@ -160,16 +161,19 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 	var nextPos int
 	_ = tx.QueryRow(ctx, `SELECT COALESCE(MAX(position), 0) + 1 FROM sequences WHERE campaign_id = $1`, campaignID).Scan(&nextPos)
 
+	// organization_id is inherited from the campaign: a step that lost it is
+	// invisible to every org-scoped read and skips org-scoped send gates.
 	query = fmt.Sprintf(
 		`INSERT INTO sequences (
-			campaign_id, name, subject, body_plain, body_html, position
+			campaign_id, organization_id, name, subject, body_plain, body_html, position
 		 ) VALUES (
-			$1, $2, $3, $4, $5, $6
+			$1, $2, $3, $4, $5, $6, $7
 		 ) RETURNING %s`, SequenceSelect,
 	)
 
 	params = []any{
 		campaignID,
+		orgID,
 		config.SequenceDefaultName,
 		"",
 		"",

--- a/internal/repository/pg_token.go
+++ b/internal/repository/pg_token.go
@@ -27,6 +27,7 @@ type TokenRepository interface {
 
 	// Organization switching
 	UpdateCurrentOrganization(ctx context.Context, sessionID uuid.UUID, orgID *uuid.UUID) *errx.Error
+	DefaultOrganization(ctx context.Context, userID uuid.UUID) (*uuid.UUID, *errx.Error)
 }
 
 type tokenRepository struct {
@@ -400,4 +401,29 @@ func (r *tokenRepository) UpdateCurrentOrganization(ctx context.Context, session
 	}
 
 	return nil
+}
+
+// DefaultOrganization picks the workspace a new session starts in: the one the
+// user owns, else their earliest-joined membership. A session without one used
+// to reach org-scoped writes with no tenant, which is what let orgless rows be
+// created in the first place (issue #168). Returns nil only when the user
+// belongs to no organization at all.
+func (r *tokenRepository) DefaultOrganization(ctx context.Context, userID uuid.UUID) (*uuid.UUID, *errx.Error) {
+	const query = `
+		SELECT m.organization_id
+		FROM organization_members m
+		LEFT JOIN organizations o ON o.id = m.organization_id
+		WHERE m.user_id = $1 AND o.deletion_scheduled_for IS NULL
+		ORDER BY (o.owner_user_id = $1) DESC, m.invited_at, m.organization_id
+		LIMIT 1
+	`
+	var orgID uuid.UUID
+	if err := r.DB.QueryRow(ctx, query, userID).Scan(&orgID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		db.CaptureError(err, query, []any{userID}, "queryrow")
+		return nil, errx.InternalError()
+	}
+	return &orgID, nil
 }

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -127,9 +127,20 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		})
 	}
 
+	// STEP 5.4: Tenancy gate. organization_id is what scopes the entitlement
+	// check below and the recipient suppression check in STEP 7; missing it used
+	// to skip both and send anyway. Fail closed instead — an orgless campaign is
+	// stopped and surfaced, never mailed unchecked.
+	if campaign.OrganizationID == nil {
+		s.haltOrglessCampaign(ctx, campaign.ID, taskID)
+		executionStatus = "completed"
+		return nil
+	}
+	orgID := *campaign.OrganizationID
+
 	// STEP 5.5: Check if organization can send campaign emails (trial expired, etc.)
-	if s.featureGate != nil && campaign.OrganizationID != nil {
-		canSend, _ := s.featureGate.CanSendCampaignEmail(ctx, *campaign.OrganizationID)
+	if s.featureGate != nil {
+		canSend, _ := s.featureGate.CanSendCampaignEmail(ctx, orgID)
 		if !canSend {
 			// Organization cannot send - pause campaign
 			s.campaignRepo.UpdateStatus(ctx, campaign.ID, "paused_trial_expired")
@@ -139,9 +150,9 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		}
 
 		// Check daily limit
-		limit, _ := s.featureGate.GetDailyEmailLimit(ctx, *campaign.OrganizationID)
+		limit, _ := s.featureGate.GetDailyEmailLimit(ctx, orgID)
 		if limit >= 0 {
-			sentToday, err := s.campaignProgressRepo.CountEmailsSentTodayByOrganization(ctx, *campaign.OrganizationID)
+			sentToday, err := s.campaignProgressRepo.CountEmailsSentTodayByOrganization(ctx, orgID)
 			if err == nil && sentToday >= limit {
 				s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_daily_limit")
 				if s.campaignLogRepo != nil {
@@ -265,8 +276,8 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		return xerr
 	}
 
-	if s.advanced != nil && campaign.OrganizationID != nil {
-		suppressed, reason, sxerr := s.advanced.ShouldSuppressRecipient(ctx, *campaign.OrganizationID, contact.Email)
+	if s.advanced != nil {
+		suppressed, reason, sxerr := s.advanced.ShouldSuppressRecipient(ctx, orgID, contact.Email)
 		if sxerr != nil {
 			return sxerr
 		}
@@ -427,8 +438,8 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		bodyPlain = ExtractPlainTextFromHTML(bodyHTML)
 	}
 
-	if s.advanced != nil && campaign.OrganizationID != nil {
-		selection, sxerr := s.advanced.SelectVariant(ctx, *campaign.OrganizationID, campaign.ID, contact.ID, sequence.ID, subject, bodyHTML, bodyPlain)
+	if s.advanced != nil {
+		selection, sxerr := s.advanced.SelectVariant(ctx, orgID, campaign.ID, contact.ID, sequence.ID, subject, bodyHTML, bodyPlain)
 		if sxerr != nil {
 			return sxerr
 		}
@@ -445,7 +456,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	// zero-cost no-op when the body has no AI blocks. A generation failure fails
 	// the send (recorded like other send failures) so the task retries with the
 	// same cached output.
-	if campaign.OrganizationID != nil && s.aiProvider != nil && s.aiCredits != nil {
+	if s.aiProvider != nil && s.aiCredits != nil {
 		var aerr error
 		subject, bodyHTML, bodyPlain, aerr = s.resolveAIVariables(ctx, campaign, contact, sequence.ID, subject, bodyHTML, bodyPlain)
 		if aerr != nil {
@@ -776,6 +787,33 @@ func (s *tasksService) autoPauseCampaign(ctx context.Context, campaignID, taskID
 			CampaignID: campaignID,
 			EventType:  "auto_paused",
 			Message:    reason,
+		})
+	}
+}
+
+// haltOrglessCampaign stops a campaign that reached the send path with no
+// organization. Suppression and the entitlement gate are both org-scoped, so
+// there is no way to honour an unsubscribe, bounce or complaint for this
+// campaign — it is parked rather than sent unchecked. Since migration 000092
+// made campaigns.organization_id NOT NULL this should be unreachable, so it is
+// also reported to Sentry: reaching it means tenancy was lost somewhere else.
+func (s *tasksService) haltOrglessCampaign(ctx context.Context, campaignID, taskID uuid.UUID) {
+	const reason = "Campaign paused: it has no workspace, so unsubscribes, bounces and complaints cannot be checked before sending. Contact support to reattach it."
+
+	sentry.CaptureException(fmt.Errorf("campaign %s reached the send path with no organization", campaignID))
+	log.Error().Str("campaign_id", campaignID.String()).Str("task_id", taskID.String()).
+		Msg("campaign send blocked: no organization, suppression cannot be enforced")
+
+	if err := s.campaignRepo.UpdateStatusWithLock(ctx, campaignID, "paused"); err != nil {
+		sentry.CaptureException(err)
+	}
+	s.taskRepo.UpdateTaskStatus(ctx, taskID, "cancelled")
+	if s.campaignLogRepo != nil {
+		s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+			CampaignID: campaignID,
+			EventType:  "auto_paused",
+			Message:    reason,
+			Metadata:   map[string]interface{}{"level": "error", "code": "no_organization"},
 		})
 	}
 }

--- a/internal/tasks/campaign_task_live_test.go
+++ b/internal/tasks/campaign_task_live_test.go
@@ -1,0 +1,396 @@
+package tasks
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/advanced"
+	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
+	"github.com/warmbly/warmbly/internal/repository"
+	"github.com/warmbly/warmbly/internal/scheduler"
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+// Live checks of the campaign send path against a real Postgres. Skipped unless
+// WARMBLY_TEST_DB is set (same convention as internal/scheduler):
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/tasks/ -run Live -v
+//
+// What is worth proving here is that recipient suppression cannot be bypassed:
+// it is the control that stops mail to an address that unsubscribed, bounced or
+// complained, and it used to be skipped in full when the campaign had no
+// organization (issue #168). That only holds against the real query paths.
+
+func liveCampaignDB(t *testing.T) *db.DB {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	return handle
+}
+
+// campaignSendFixture is one org/user/mailbox/campaign/step/lead graph, ready
+// for a single campaign tick.
+type campaignSendFixture struct {
+	pool                                        *pgxpool.Pool
+	user, org, mailbox, campaign, step, contact uuid.UUID
+	contactEmail                                string
+}
+
+func newCampaignSendFixture(t *testing.T, pool *pgxpool.Pool) *campaignSendFixture {
+	t.Helper()
+	ctx := context.Background()
+	f := &campaignSendFixture{
+		pool: pool, user: uuid.New(), org: uuid.New(), mailbox: uuid.New(),
+		campaign: uuid.New(), step: uuid.New(), contact: uuid.New(),
+	}
+	f.contactEmail = "lead-" + f.contact.String()[:8] + "@test.local"
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'Live', 'Test')`,
+		f.user, "live-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'Live Test', $2, $3)`,
+		f.org, "live-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name,
+	          signature_plain, signature_html, provider, status, campaign_limit, min_wait_time, timezone)
+	      VALUES ($1, $2, $3, $4, 'Live', '', '', 'smtp_imap', 'active', 50, 0, 'UTC')`,
+		f.mailbox, f.user, f.org, "live-"+f.mailbox.String()[:8]+"@test.local")
+	// An always-open window so nothing the test observes comes from scheduling.
+	exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, status,
+	          daily_limit, timezone, days, start_time, end_time, rotation_mode, updated_at, created_at)
+	      VALUES ($1, $2, $3, 'Live Test', '', 'active', 50, 'UTC', 127, '00:00', '23:59',
+	              'least_recently_used', NOW(), NOW())`, f.campaign, f.user, f.org)
+	exec(`INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+	          body_plain, body_html, wait_after, position, kind)
+	      VALUES ($1, $2, $3, 'Step 1', 'Hi', 'Hello', '<p>Hello</p>', 0, 0, 'email')`,
+		f.step, f.campaign, f.org)
+	exec(`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields)
+	      VALUES ($1, $2, $3, $4, 'Live', 'Contact', '', '', '{}')`,
+		f.contact, f.user, f.org, f.contactEmail)
+	exec(`INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, 0)`, f.campaign, f.contact)
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM task_execution_keys WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM task_failures WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM campaign_tasks WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM tasks WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM campaign_logs WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_daily_sends WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_contact_progress WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_leads WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM sequences WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM suppressed_recipients WHERE organization_id = $1`, f.org},
+			{`DELETE FROM campaigns WHERE id = $1`, f.campaign},
+			{`DELETE FROM email_accounts WHERE id = $1`, f.mailbox},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM crm_task_types WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		} {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+	return f
+}
+
+// suppress puts the fixture's lead on the organization's suppression list, the
+// state a bounce, complaint or unsubscribe leaves behind.
+func (f *campaignSendFixture) suppress(t *testing.T, reason string) {
+	t.Helper()
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO suppressed_recipients (organization_id, email, reason, source)
+		 VALUES ($1, $2, $3, 'unsubscribe')`, f.org, f.contactEmail, reason); err != nil {
+		t.Fatalf("suppress: %v", err)
+	}
+}
+
+// dropOrganization detaches the campaign from its workspace, the pre-migration
+// state issue #168 reports. campaigns.organization_id is NOT NULL since
+// migration 000092, so the constraint is lifted for the duration of the test
+// and restored before anything else runs.
+func (f *campaignSendFixture) dropOrganization(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := f.pool.Exec(ctx, `ALTER TABLE campaigns ALTER COLUMN organization_id DROP NOT NULL`); err != nil {
+		t.Fatalf("drop not null: %v", err)
+	}
+	t.Cleanup(func() {
+		// Runs before the fixture teardown (LIFO), so the orgless row is gone
+		// by the time the constraint comes back.
+		if _, err := f.pool.Exec(context.Background(),
+			`UPDATE campaigns SET organization_id = $2 WHERE id = $1`, f.campaign, f.org); err != nil {
+			t.Errorf("restore campaign org: %v", err)
+		}
+		if _, err := f.pool.Exec(context.Background(),
+			`ALTER TABLE campaigns ALTER COLUMN organization_id SET NOT NULL`); err != nil {
+			t.Errorf("restore not null: %v", err)
+		}
+	})
+	if _, err := f.pool.Exec(ctx,
+		`UPDATE campaigns SET organization_id = NULL WHERE id = $1`, f.campaign); err != nil {
+		t.Fatalf("null out organization: %v", err)
+	}
+}
+
+// queueTick creates the pending campaign task a scheduler tick would run.
+func (f *campaignSendFixture) queueTick(t *testing.T, taskRepo repository.TaskRepository) uuid.UUID {
+	t.Helper()
+	taskID := uuid.New()
+	now := time.Now()
+	created, err := taskRepo.CreateTaskWithLock(context.Background(), &repository.Task{
+		ID: taskID, TaskType: "campaign", EmailAccountID: f.mailbox, Status: "pending", ScheduledAt: &now,
+	}, &repository.CampaignTask{TaskID: taskID, CampaignID: &f.campaign})
+	if err != nil || !created {
+		t.Fatalf("queue tick: created=%v err=%v", created, err)
+	}
+	return taskID
+}
+
+func (f *campaignSendFixture) sendsRecorded(t *testing.T) int {
+	t.Helper()
+	var n int
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM campaign_contact_progress WHERE campaign_id = $1 AND sent_at IS NOT NULL`,
+		f.campaign).Scan(&n); err != nil {
+		t.Fatalf("count sends: %v", err)
+	}
+	return n
+}
+
+func (f *campaignSendFixture) campaignStatus(t *testing.T) string {
+	t.Helper()
+	var status string
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT status FROM campaigns WHERE id = $1`, f.campaign).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	return status
+}
+
+func (f *campaignSendFixture) logEvents(t *testing.T) []string {
+	t.Helper()
+	rows, err := f.pool.Query(context.Background(),
+		`SELECT event_type FROM campaign_logs WHERE campaign_id = $1`, f.campaign)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var e string
+		if err := rows.Scan(&e); err != nil {
+			t.Fatalf("scan log: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// noopTaskScheduler stands in for the task queue. The tick writes the successor
+// `tasks` row itself; the local dev provider treats the enqueue as a no-op too,
+// so nothing about scheduling is being faked away here.
+type noopTaskScheduler struct{}
+
+func (noopTaskScheduler) CreateTask(ctx context.Context, taskData *proto.ProcessTask, scheduleTime time.Time) (string, error) {
+	return "", nil
+}
+func (noopTaskScheduler) DeleteTask(ctx context.Context, name string) error { return nil }
+
+// noopCipher stands in for the envelope-encryption warm-up the send path does
+// before dispatch. The tick only checks that a DEK resolves; nothing in these
+// tests encrypts, so KMS and Redis stay out of the harness.
+type noopCipher struct{}
+
+func (noopCipher) Cipher(ctx context.Context, orgID uuid.UUID) (*cipher.Cipher, error) {
+	return &cipher.Cipher{}, nil
+}
+
+// recordingSender stands in for the worker dispatch: the tick's real side
+// effect is the stamped send, and this is what makes it observable without a
+// live worker.
+type recordingSender struct{ sent int }
+
+func (r *recordingSender) Send(ctx context.Context, taskID uuid.UUID, msg EmailMessage, account models.Email) error {
+	r.sent++
+	return nil
+}
+
+// liveCampaignService wires the real repositories the campaign tick uses.
+// Everything that reaches outside Postgres (the worker dispatch, KMS, the task
+// queue) is stubbed; every gate under test runs against the real queries.
+func liveCampaignService(t *testing.T, handle *db.DB, sender EmailSender) *tasksService {
+	t.Helper()
+	pool := handle.Pool
+	enc, err := encrypt.NewEncrypter([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("encrypter: %v", err)
+	}
+
+	taskRepo := repository.NewTaskRepository(pool)
+	warmupRepo := repository.NewWarmupRepository(pool)
+	progressRepo := repository.NewCampaignProgressRepository(pool)
+	emailRepo := repository.NewEmailRepostory(handle, enc)
+	campaignRepo := repository.NewCampaignRepostory(handle)
+	contactRepo := repository.NewContactRepostory(handle)
+	logRepo := repository.NewCampaignLogRepository(handle)
+
+	adv := advanced.NewService(
+		repository.NewAdvancedOutreachRepository(pool),
+		campaignRepo, emailRepo, taskRepo, contactRepo, progressRepo,
+		repository.NewCRMRepository(pool),
+		repository.NewGroupRepostory(handle, models.Categories),
+		repository.NewUniboxRepository(handle),
+		nil, nil,
+	)
+
+	return &tasksService{
+		emailSender:   sender,
+		cipherService: noopCipher{},
+		tasksClient:   noopTaskScheduler{},
+		scheduler: scheduler.NewSchedulerService(
+			taskRepo, warmupRepo, progressRepo, emailRepo, campaignRepo, contactRepo, logRepo,
+		),
+		advanced:             adv,
+		taskRepo:             taskRepo,
+		warmupRepo:           warmupRepo,
+		campaignProgressRepo: progressRepo,
+		emailRepo:            emailRepo,
+		campaignRepo:         campaignRepo,
+		contactRepo:          contactRepo,
+		campaignLogRepo:      logRepo,
+	}
+}
+
+// The regression issue #168 asks for: a campaign with no organization, whose
+// recipient is on the suppression list, must not send.
+//
+// Suppression is enforced twice, and the missing tenant defeats both. Routing
+// excludes a suppressed lead by joining suppressed_recipients on the campaign's
+// organization_id, which matches nothing when that is NULL, so the scheduler
+// still hands the suppressed contact back (asserted here, because it is what
+// makes this a real regression rather than a test that passes by accident).
+// The send gate then has to be the thing that stops it.
+func TestLiveOrglessCampaignDoesNotSendToSuppressedRecipient(t *testing.T) {
+	handle := liveCampaignDB(t)
+	svc := liveCampaignService(t, handle, nil)
+	f := newCampaignSendFixture(t, handle.Pool)
+
+	f.suppress(t, "unsubscribed")
+	f.dropOrganization(t)
+
+	// Routing's own suppression filter is bypassed: the lead is still routable.
+	_, pair, _, err := svc.scheduler.CalculateNextCampaignTime(context.Background(), f.campaign)
+	if err != nil || pair == nil {
+		t.Fatalf("expected the suppressed lead to still route on an orgless campaign, got pair=%v err=%v", pair, err)
+	}
+
+	taskID := f.queueTick(t, svc.taskRepo)
+	if xerr := svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
+		t.Fatalf("campaign tick returned an error: %v", xerr)
+	}
+
+	if n := f.sendsRecorded(t); n != 0 {
+		t.Fatalf("orgless campaign sent to a suppressed recipient: %d sends recorded", n)
+	}
+	if got := f.campaignStatus(t); got != "paused" {
+		t.Fatalf("campaign status = %q, want paused (fail closed, not silently skipped)", got)
+	}
+	if events := f.logEvents(t); len(events) == 0 {
+		t.Fatal("nothing recorded in the campaign feed: the skipped check has to be visible")
+	}
+}
+
+// The control: with the organization intact, the same suppressed lead is
+// excluded by routing, so no send is even attempted. Without this the test
+// above would pass on a build that simply never sends anything.
+func TestLiveSuppressedRecipientIsSkipped(t *testing.T) {
+	handle := liveCampaignDB(t)
+	svc := liveCampaignService(t, handle, nil)
+	f := newCampaignSendFixture(t, handle.Pool)
+
+	// Before suppression the lead routes, so anything observed after it is
+	// suppression and not a broken fixture.
+	if _, pair, _, err := svc.scheduler.CalculateNextCampaignTime(context.Background(), f.campaign); err != nil || pair == nil {
+		t.Fatalf("fixture lead should route before suppression, got pair=%v err=%v", pair, err)
+	}
+
+	f.suppress(t, "hard bounce")
+
+	taskID := f.queueTick(t, svc.taskRepo)
+	if xerr := svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
+		t.Fatalf("campaign tick returned an error: %v", xerr)
+	}
+
+	if n := f.sendsRecorded(t); n != 0 {
+		t.Fatalf("suppressed recipient was mailed: %d sends recorded", n)
+	}
+	if got := f.campaignStatus(t); got != "completed" {
+		t.Fatalf("campaign status = %q, want completed (nothing left to send)", got)
+	}
+}
+
+// The state the fail-closed gate defends against is no longer reachable through
+// the schema: migration 000092 backfilled organization_id and made it NOT NULL.
+func TestLiveCampaignRequiresAnOrganization(t *testing.T) {
+	handle := liveCampaignDB(t)
+	f := newCampaignSendFixture(t, handle.Pool)
+
+	_, err := f.pool.Exec(context.Background(), `
+		INSERT INTO campaigns (id, user_id, organization_id, name, description, status,
+		    daily_limit, timezone, days, start_time, end_time, updated_at, created_at)
+		VALUES (gen_random_uuid(), $1, NULL, 'Orgless', '', 'draft', 50, 'UTC', 127,
+		        '00:00', '23:59', NOW(), NOW())`, f.user)
+	if err == nil {
+		t.Fatal("an orgless campaign was accepted: campaigns.organization_id must be NOT NULL")
+	}
+}
+
+// The other direction: an ordinary campaign, organization present and nothing
+// suppressed, still sends. Without this the fail-closed gate could be blocking
+// everything and the tests above would not notice.
+func TestLiveHealthyCampaignStillSends(t *testing.T) {
+	handle := liveCampaignDB(t)
+	sender := &recordingSender{}
+	svc := liveCampaignService(t, handle, sender)
+	f := newCampaignSendFixture(t, handle.Pool)
+
+	taskID := f.queueTick(t, svc.taskRepo)
+	if xerr := svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
+		t.Fatalf("campaign tick returned an error: %v", xerr)
+	}
+
+	if sender.sent != 1 {
+		t.Fatalf("sender saw %d sends, want 1", sender.sent)
+	}
+	if n := f.sendsRecorded(t); n != 1 {
+		t.Fatalf("%d sends stamped, want 1", n)
+	}
+}

--- a/internal/tasks/email_task.go
+++ b/internal/tasks/email_task.go
@@ -112,8 +112,27 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 			Msg("warmup health-check send (mailbox in active campaign, warmup off)")
 	}
 
+	// Tenancy gate: warmup entitlement, pool tier and the shared-pool safety
+	// signals are all org-scoped, so a mailbox with no workspace cannot be
+	// checked against any of them. Fail closed — it leaves the pool and stops
+	// warming rather than warming as if it were entitled.
+	if account.OrganizationID == nil {
+		if s.warmupHealth != nil {
+			// Both pools: without an org there is no reliable way to tell which
+			// one this mailbox was placed in.
+			_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, "free")
+			_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, "premium")
+		}
+		sentry.CaptureException(fmt.Errorf("email account %s reached warmup with no organization", account.ID))
+		log.Error().Str("task_id", taskID.String()).Str("email_account_id", account.ID.String()).
+			Msg("warmup blocked: mailbox has no organization, entitlement and pool policy cannot be checked")
+		_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_no_warmup_access")
+		executionStatus = "completed"
+		return nil
+	}
+
 	// STEP 3.5: Check if organization can use warmup (only paid orgs)
-	if s.featureGate != nil && account.OrganizationID != nil {
+	if s.featureGate != nil {
 		canWarmup, _ := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 		if !canWarmup {
 			if s.warmupHealth != nil {
@@ -646,7 +665,12 @@ func (s *tasksService) resolveWarmupPoolType(ctx context.Context, account *Email
 	if account.WarmupPoolType != "" {
 		return account.WarmupPoolType
 	}
-	if s.featureGate != nil && account.OrganizationID != nil {
+	// No organization means no entitlement to check, so the mailbox gets the
+	// lower-trust pool rather than defaulting into the paid one.
+	if account.OrganizationID == nil {
+		return "free"
+	}
+	if s.featureGate != nil {
 		isPaid, xerr := s.featureGate.IsPaidOrganization(ctx, *account.OrganizationID)
 		if xerr == nil && !isPaid {
 			return "free"

--- a/internal/tasks/user_email_task.go
+++ b/internal/tasks/user_email_task.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -108,7 +109,19 @@ func (s *tasksService) HandleUserEmailTask(task *proto.ProcessTask) *errx.Error 
 			Msg("user_email cancelled: mailbox not active")
 		return nil
 	}
-	if s.featureGate != nil && account.OrganizationID != nil {
+	// Tenancy gate: the entitlement check below is org-scoped, so a mailbox with
+	// no workspace would send without it. Fail closed.
+	if account.OrganizationID == nil {
+		sentry.CaptureException(fmt.Errorf("email account %s reached a unibox send with no organization", account.ID))
+		_ = s.taskRepo.RecordTaskFailure(ctx, taskID,
+			"Mailbox has no workspace",
+			"email account organization_id is NULL at execution time")
+		_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "cancelled")
+		log.Error().Str("task_id", taskID.String()).Str("email_account_id", account.ID.String()).
+			Msg("user_email cancelled: mailbox has no organization")
+		return nil
+	}
+	if s.featureGate != nil {
 		canUse, _ := s.featureGate.CanUseUnibox(ctx, *account.OrganizationID)
 		if !canUse {
 			_ = s.taskRepo.RecordTaskFailure(ctx, taskID,


### PR DESCRIPTION
Fixes #168.

## The bug

`campaign.OrganizationID == nil` turned two controls off instead of on: the trial/entitlement gate and, further down, recipient suppression.

It is worse than the report. Suppression is enforced **twice**, and the missing tenant defeats both. Routing excludes a suppressed lead with

```sql
NOT EXISTS (
  SELECT 1 FROM suppressed_recipients sr
  JOIN campaigns camp ON camp.organization_id = sr.organization_id
  WHERE camp.id = $1 AND LOWER(sr.email) = LOWER(c.email) ...
)
```

(`internal/repository/pg_campaign_progress.go:874`). With a NULL `organization_id` that join matches nothing, so the scheduler still hands the suppressed contact back and the send gate is the only thing left standing. That gate was the one being skipped.

Two live paths were manufacturing the state:

- `sequenceRepository.Create` inserted a step with no `organization_id` at all. There is one such row in the dev database today.
- `/emails/onboarding/*` had no workspace guard, and a session carries no organization until the client calls `POST /organization/switch/:id`.

And three abuse limits had the same shape, treating "no organization" as "exempt" rather than "refuse": `guardInboxLimit`, `guardMailboxThrottle`, and the daily campaign-creation throttle.

## The fix

**Fail closed.** `HandleCampaignTask` stops an orgless campaign before the entitlement gate, pauses it with the reason in its activity feed, and reports to Sentry; the downstream nil checks collapse into one non-nil `orgID`. Warmup and unibox sends get the same tenancy gate, and an orgless mailbox now resolves to the `free` warmup pool instead of defaulting into the paid one.

**Stop creating it.** Sequences inherit their campaign's organization. Campaign creation and mailbox onboarding refuse without a workspace (`errx.ErrNoOrganization`, stable code `no_organization`). The three limits above refuse instead of exempting. `GenerateSessionWithOrg` resolves the user's default workspace at sign-in, so the orgless session that produced these rows no longer exists.

**Remove it.** Migration `000092` backfills and sets `NOT NULL` on `organization_id` for `campaigns`, `contacts`, `email_accounts` and `sequences`, plus `sessions.current_organization_id`. Attribution is deterministic (the organization the user owns, else their earliest membership; contacts prefer the organization of a campaign they already lead). A user with no organization at all gets a recovery workspace, so no row is deleted to satisfy the constraint.

## Regression test

`TestLiveOrglessCampaignDoesNotSendToSuppressedRecipient` is the test the issue asks for. It first asserts the scheduler **still routes** the suppressed lead on an orgless campaign, so it cannot pass by accident, then asserts the tick refuses to send anyway. With the gate removed it fails, running all the way into the send.

Three more cover the rest: suppression with the organization present, the schema constraint, and `TestLiveHealthyCampaignStillSends` so the gate cannot be over-blocking.

## Verification

- migration exercised on a cloned dev database with orphan fixtures: down/up cycle clean, zero residual NULLs, recovery workspace created and attributed
- `make seed` under the constraint, and a fresh install applying straight to `NOT NULL`
- live API run: a new session carries its workspace with no `/switch` call, a created step inherits it, and orgless-session writes return 400 on campaigns, contacts and mailbox connect
- cross-instance workspace export/import lands 4 mailboxes, 30 contacts, 3 campaigns, 5 steps, all scoped to the destination workspace
- `make lint`, `gofmt`, the Go suite, and every `TestLive*` suite pass

## Note on the migration number

`main` is at `000091`, so the rule gives `000092`, but two sibling branches have each claimed `000092` as well. Whichever merges second needs renumbering.