### PR TITLE
fix: a campaign email can be sent twice when the progress write after dispatch is lost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -740,10 +740,16 @@ When extending anti-fraud logic in this repo:
 
 ## Send Outcome Loop
 
-A campaign step is stamped sent (`campaign_contact_progress.sent_at`, task `completed`, daily counters) the moment the backend hands the `SEND_EMAIL` to a worker, before anything has left the mailbox. What keeps that honest is the worker's per-task result on `jobs.worker-events`: every send is answered with exactly one `EMAIL_SENT` or `EMAIL_FAILED`, and the consumer's `HandleEmailFailed` (`internal/app/consumer/event_send_result.go`) walks the stamp back (clears `sent_at`, counts the attempt, gives back the daily counters, logs to the campaign feed, reopens a campaign that completed meanwhile). Routing retries the step on the next tick and drops the lead as `failed` after `config.CampaignSendMaxAttempts`.
+A campaign step is RESERVED before the `SEND_EMAIL` goes on the bus and stamped sent right after. `ReserveSend` (`internal/repository/pg_campaign_progress.go`) writes `campaign_contact_progress.dispatched_at` + `dispatch_task_id` and takes the day's counters in ONE transaction; the step's `sent_at` follows the dispatch and is the timing stamp follow-up pacing reads. Routing treats a step as attempted when EITHER is set, so a crash or a failed progress write between the two can no longer look like "never sent" and email the same person twice (issue #169).
+
+What resolves a reservation is the worker's per-task result on `jobs.worker-events`: every send is answered with exactly one `EMAIL_SENT` or `EMAIL_FAILED`. `HandleEmailSent` persists the Message-ID and repairs a missing `sent_at` (`StampDispatchedSend`); `HandleEmailFailed` walks the whole thing back (clears `sent_at` AND `dispatched_at`, counts the attempt, gives back the daily counters, logs to the campaign feed, reopens a campaign that completed meanwhile). Routing retries the step on the next tick and drops the lead as `failed` after `config.CampaignSendMaxAttempts`.
 
 Rules that follow from this:
 
+- never dispatch a send that is not reserved. A reservation that cannot be written means the task retries; a claim refused (`reserved == false`) means another tick already has that pair in flight, and the task ends `skipped_duplicate`
+- resolve every reservation exactly once: `RecordEmailSent` on a successful hand-off, `ReleaseSend` when the command PROVABLY never left (no worker, worker offline), `RecordSendFailure` on a worker failure. A failure of the publish call itself is ambiguous (`tasks.ErrSendDispatchUnknown`) and must NOT be released
+- a reservation nobody answers is resolved by `StartStuckSendReclaimer` in the consumer after `config.CampaignSendReclaimAfterMinutes`: it believes a task that carries a Message-ID (stamps it) and otherwise walks the step back as a failed attempt. Without it a dead worker parks a lead in flight forever
+- the day's counters belong to the reservation, not the stamp, so a lost stamp can never let the daily cap over-send
 - a worker must always answer a `SEND_EMAIL` it acked; a failure path that returns without producing `EMAIL_FAILED` leaves the lead at "processing" forever. Use `failSend` in `event_send_email.go`
 - the per-task result is always `EMAIL_FAILED`; the typed account events (`EMAIL_AUTH_ERROR` and friends) are raised in addition and carry an `EmailErrorEvent`, never a `SendEmailResult`
 - the backend refuses to publish a send to a worker that is not heartbeating (`tasks.NewWorkerLiveness`), because a command queued for a dead worker is never executed and never answered

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -417,6 +417,10 @@ func main() {
 	// Start dead worker detection (every 5 minutes)
 	go jobsService.StartDeadWorkerDetection(ctx, 5*time.Minute)
 
+	// Resolve campaign sends that were reserved and dispatched but whose worker
+	// result never came back, so a lead is never held in flight forever.
+	go jobsService.StartStuckSendReclaimer(ctx, 5*time.Minute)
+
 	// Mirror Redis heartbeats into workers.last_seen_at every 60s
 	// so the admin dashboard can render liveness without touching Redis.
 	go jobsService.StartWorkerHeartbeatSync(ctx, 60*time.Second)

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -75,6 +75,8 @@ A lead is **Processing** only while steps remain, so a finished campaign reads a
 
 A step counts as sent only once the sending worker has handed it to the mailbox provider. If the worker cannot send (the mailbox was still loading, the provider refused the message, a storage hiccup), the step goes back to the queue, the failure appears in **Needs attention** with the reason, and the next pass retries it. After five failed attempts the lead is marked **Failed** and dropped from the campaign, so a mailbox that can never send does not loop forever. A recipient the mail server refuses outright is not retried: it is recorded as a **Bounced** lead straight away and goes through the same bounce handling (suppression, guardrails, webhooks) as a bounce notice. A campaign that finished while a send was still in flight reopens to retry it.
 
+No contact is emailed the same step twice. Each step is recorded as attempted before the send is handed to a worker, so a crash, a restart, or a database hiccup in the moment between the two cannot make the step look unsent and send it again. The trade-off is a step whose outcome is genuinely unknown, when the worker stops responding mid-send: after 30 minutes with no answer the step is treated as a failed attempt, appears in **Needs attention**, and is retried like any other failure.
+
 ## Scheduling
 
 Campaigns send only inside the **weekly sending windows** you define, in the campaign's timezone. Each day is independent, with different hours or several windows per day, set from presets like `Mon-Fri 9-5` or by dragging on the grid (which is Monday-first).

--- a/docs/content/docs/guides/workspace-export-import.mdx
+++ b/docs/content/docs/guides/workspace-export-import.mdx
@@ -88,6 +88,7 @@ Some things belong to an instance rather than to a workspace, so they are not ap
 | Domain authentication timings | The verdict travels (public DNS reads the same anywhere), but the destination re-checks before it can stop any sending, so a mailbox is never blocked on an observation the new instance never made |
 | Scheduled deletions | A pending deletion from the source must never follow the workspace to its new home |
 | Failure and delivery counters | A webhook endpoint's failure streak and auto-disable state, and whether a notification's email already went out, describe what happened on the source. They start fresh, so an endpoint is not pre-disabled on the new instance and a notification is not re-sent |
+| Sends still in flight | A campaign step handed to a worker on the source has no worker on the destination to report back, so it arrives queued and is sent there instead of waiting forever. Steps already sent keep their history |
 
 An import runs as one transaction. If anything fails, nothing lands and the workspace is untouched.
 

--- a/internal/app/consumer/event_send_result.go
+++ b/internal/app/consumer/event_send_result.go
@@ -23,8 +23,12 @@ import (
 var errSendResultEarly = errors.New("send result arrived before the task was stamped; retrying")
 
 // HandleEmailSent confirms a send the worker delivered to the provider. The
-// control plane stamped the task when it handed the send over, so the only
-// thing left to persist is the Message-ID the worker actually put on the wire.
+// control plane reserves the step before it hands the send over and stamps it
+// right after, so this normally only persists the Message-ID the worker put on
+// the wire. It is also the repair path: when the stamp was lost between the
+// dispatch and the control plane's write (a crash, or a failed progress write),
+// the delivered email would otherwise leave no sent_at for follow-up pacing to
+// read, so a reserved step is stamped here from the worker's own confirmation.
 func (s *JobsService) HandleEmailSent(ctx context.Context, result models.SendEmailResult) error {
 	if s.TaskRepo == nil || result.TaskID == uuid.Nil {
 		return nil
@@ -42,17 +46,44 @@ func (s *JobsService) HandleEmailSent(ctx context.Context, result models.SendEma
 			log.Warn().Err(err).Str("task_id", task.ID.String()).Msg("could not record worker message id")
 		}
 	}
+	if task.TaskType == "campaign" {
+		s.repairCampaignSendStamp(ctx, task)
+	}
 	return nil
 }
 
+// repairCampaignSendStamp completes a reserved campaign step the control plane
+// never stamped. A no-op in the normal case, where the stamp is already there.
+func (s *JobsService) repairCampaignSendStamp(ctx context.Context, task *repository.Task) {
+	if s.CampaignProgressRepo == nil {
+		return
+	}
+	ct, err := s.TaskRepo.GetCampaignTask(ctx, task.ID)
+	if err != nil || ct == nil || ct.CampaignID == nil || ct.ContactID == nil || ct.SequenceID == nil {
+		return
+	}
+	repaired, err := s.CampaignProgressRepo.StampDispatchedSend(ctx, *ct.CampaignID, *ct.ContactID, *ct.SequenceID)
+	if err != nil {
+		log.Warn().Err(err).Str("task_id", task.ID.String()).Msg("could not repair the campaign send stamp")
+		return
+	}
+	if repaired {
+		log.Warn().
+			Str("task_id", task.ID.String()).
+			Str("campaign_id", ct.CampaignID.String()).
+			Str("contact_id", ct.ContactID.String()).
+			Msg("stamped a delivered campaign send the control plane never recorded")
+	}
+}
+
 // HandleEmailFailed walks back a send the worker could not deliver. The
-// control plane stamps a task sent the moment it hands it to a worker, so
-// without this the lead would sit at "processing" forever with no email ever
-// leaving. For a campaign send the step's sent_at is cleared so the next tick
-// retries it, the day's counters give the send back, the failure is written to
-// the campaign's activity log, and a campaign that completed while the send
-// was in flight is reopened. Once the retry cap is spent the lead is marked
-// failed and routing drops it.
+// control plane reserves a step and stamps it sent the moment it hands it to a
+// worker, so without this the lead would sit at "processing" forever with no
+// email ever leaving. For a campaign send the step's reservation and sent_at
+// are cleared so the next tick retries it, the day's counters give the send
+// back, the failure is written to the campaign's activity log, and a campaign
+// that completed while the send was in flight is reopened. Once the retry cap
+// is spent the lead is marked failed and routing drops it.
 func (s *JobsService) HandleEmailFailed(ctx context.Context, result models.SendEmailResult) error {
 	if s.TaskRepo == nil || result.TaskID == uuid.Nil {
 		return nil
@@ -92,15 +123,18 @@ func (s *JobsService) HandleEmailFailed(ctx context.Context, result models.SendE
 
 	switch task.TaskType {
 	case "campaign":
-		return s.failCampaignSend(ctx, task, reason, code)
+		return s.failCampaignSend(ctx, task, reason, code, nil)
 	case "email":
 		s.notifyUserSendFailed(ctx, task, reason)
 	}
 	return nil
 }
 
-// failCampaignSend is the campaign half of HandleEmailFailed.
-func (s *JobsService) failCampaignSend(ctx context.Context, task *repository.Task, reason, code string) error {
+// failCampaignSend is the campaign half of HandleEmailFailed. countedOn is the
+// day the send was counted against, for giving the daily counters back; nil
+// reads it off the task, which is right for a worker result but not for the
+// reclaimer, whose sends can be counted on an earlier day.
+func (s *JobsService) failCampaignSend(ctx context.Context, task *repository.Task, reason, code string, countedOn *time.Time) error {
 	ct, err := s.TaskRepo.GetCampaignTask(ctx, task.ID)
 	if err != nil {
 		return err
@@ -137,11 +171,14 @@ func (s *JobsService) failCampaignSend(ctx context.Context, task *repository.Tas
 		if has, herr := s.CampaignProgressRepo.HasSentSteps(ctx, campaignID, *ct.ContactID); herr == nil {
 			newLead = !has
 		}
-		countedOn := time.Now()
-		if task.CompletedAt != nil {
-			countedOn = *task.CompletedAt
+		day := time.Now()
+		switch {
+		case countedOn != nil:
+			day = *countedOn
+		case task.CompletedAt != nil:
+			day = *task.CompletedAt
 		}
-		if derr := s.CampaignRepo.DecrementCampaignDailySend(ctx, campaignID, countedOn, newLead); derr != nil {
+		if derr := s.CampaignRepo.DecrementCampaignDailySend(ctx, campaignID, day, newLead); derr != nil {
 			log.Warn().Err(derr).Str("campaign_id", campaignID.String()).Msg("could not give back the failed send's daily count")
 		}
 	}

--- a/internal/app/consumer/event_send_result_live_test.go
+++ b/internal/app/consumer/event_send_result_live_test.go
@@ -91,9 +91,11 @@ func newSendResultFixture(t *testing.T, handle *db.DB) *sendResultFixture {
 	return f
 }
 
-// stampSend does what the backend's campaign tick does after handing a send
-// to the worker: a completed task, the progress stamp, and the day's counters.
-func (f *sendResultFixture) stampSend(t *testing.T, s *JobsService) uuid.UUID {
+// dispatch does what the backend's campaign tick does around a send: the
+// reservation (which also counts the day's send) before the command goes on
+// the bus, and nothing after it. The stamp is left to the caller so a test can
+// reproduce the crash window the reservation exists for.
+func (f *sendResultFixture) dispatch(t *testing.T, s *JobsService) uuid.UUID {
 	t.Helper()
 	ctx := context.Background()
 	taskID := uuid.New()
@@ -107,11 +109,21 @@ func (f *sendResultFixture) stampSend(t *testing.T, s *JobsService) uuid.UUID {
 	if err := s.TaskRepo.UpdateCampaignTaskTracking(ctx, taskID, f.contact, f.step); err != nil {
 		t.Fatalf("tracking: %v", err)
 	}
+	reserved, err := s.CampaignProgressRepo.ReserveSend(ctx, f.campaign, f.contact, f.step, taskID, true)
+	if err != nil || !reserved {
+		t.Fatalf("reserve send: reserved=%v err=%v", reserved, err)
+	}
+	return taskID
+}
+
+// stampSend is a full tick: the reservation, the dispatch, and the stamp that
+// follows it.
+func (f *sendResultFixture) stampSend(t *testing.T, s *JobsService) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	taskID := f.dispatch(t, s)
 	if err := s.CampaignProgressRepo.RecordEmailSent(ctx, f.campaign, f.contact, f.step); err != nil {
 		t.Fatalf("record sent: %v", err)
-	}
-	if err := s.CampaignRepo.IncrementCampaignDailySend(ctx, f.campaign, true); err != nil {
-		t.Fatalf("increment daily: %v", err)
 	}
 	if err := s.TaskRepo.UpdateTaskStatusWithLock(ctx, taskID, "completed"); err != nil {
 		t.Fatalf("complete task: %v", err)

--- a/internal/app/consumer/send_reservation_live_test.go
+++ b/internal/app/consumer/send_reservation_live_test.go
@@ -1,0 +1,352 @@
+package jobs
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Live checks of the pre-send reservation (issue #169) against a real
+// Postgres. Skipped unless WARMBLY_TEST_DB is set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/consumer/ -run Live -v
+//
+// The bug these cover: the send goes on the bus first and the progress write
+// happens after, so a crash or a failed write in between left the step looking
+// "never sent" and routing offered it again, emailing the same person twice.
+// The reservation is what closes that window, so every one of these has to hold
+// against the real routing query, not a mock.
+
+func liveDB(t *testing.T) *db.DB {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	return handle
+}
+
+func liveJobsService(handle *db.DB) *JobsService {
+	return &JobsService{
+		TaskRepo:             repository.NewTaskRepository(handle.Pool),
+		CampaignRepo:         repository.NewCampaignRepostory(handle),
+		CampaignProgressRepo: repository.NewCampaignProgressRepository(handle.Pool),
+		CampaignLogRepo:      repository.NewCampaignLogRepository(handle),
+		ContactRepo:          repository.NewContactRepostory(handle),
+	}
+}
+
+// nextPair asks routing what it would send next, exactly as the scheduler does.
+func (f *sendResultFixture) nextPair(t *testing.T, s *JobsService) *repository.ContactSequencePair {
+	t.Helper()
+	pair, _, err := s.CampaignProgressRepo.FindNextRoutedPair(context.Background(), f.campaign, "created_at", "asc", "", false, false)
+	if err != nil {
+		t.Fatalf("next pair: %v", err)
+	}
+	return pair
+}
+
+// TestLiveDispatchedSendIsNeverOfferedTwice is the regression the issue asks
+// for: dispatch a send, let the progress write fail (here: never happen at
+// all), then run routing again. The same (contact, step) must not come back.
+func TestLiveDispatchedSendIsNeverOfferedTwice(t *testing.T) {
+	handle := liveDB(t)
+	ctx := context.Background()
+	s := liveJobsService(handle)
+	f := newSendResultFixture(t, handle)
+
+	if pair := f.nextPair(t, s); pair == nil || pair.SequenceID != f.step {
+		t.Fatalf("precondition: the lead's first step should be routable, got %+v", pair)
+	}
+
+	// The tick reserves, dispatches, and then dies before it can stamp.
+	taskID := f.dispatch(t, s)
+
+	var sentAt, dispatchedAt *time.Time
+	if err := handle.Pool.QueryRow(ctx, `SELECT sent_at, dispatched_at FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).
+		Scan(&sentAt, &dispatchedAt); err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if sentAt != nil {
+		t.Fatal("precondition: the stamp must be missing for this to reproduce the bug")
+	}
+	if dispatchedAt == nil {
+		t.Fatal("the send was dispatched without a reservation")
+	}
+
+	if pair := f.nextPair(t, s); pair != nil {
+		t.Fatalf("routing offered the same step a second time: %+v (this is issue #169)", pair)
+	}
+
+	// The day's counters were taken by the reservation, so a lost stamp cannot
+	// let the new-lead cap over-send either.
+	var sent, newLeads int
+	if err := handle.Pool.QueryRow(ctx, `SELECT emails_sent, new_leads_started FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent, &newLeads); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 1 || newLeads != 1 {
+		t.Fatalf("daily counters = %d/%d, want 1/1", sent, newLeads)
+	}
+
+	// The worker's own confirmation repairs the missing stamp, so follow-up
+	// pacing has the timing it needs.
+	if err := s.HandleEmailSent(ctx, models.SendEmailResult{
+		TaskID: taskID, Success: true, MessageID: "<repaired@test.local>",
+	}); err != nil {
+		t.Fatalf("handle sent: %v", err)
+	}
+	if err := handle.Pool.QueryRow(ctx, `SELECT sent_at FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).
+		Scan(&sentAt); err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if sentAt == nil {
+		t.Fatal("EMAIL_SENT did not repair the missing stamp")
+	}
+	if pair := f.nextPair(t, s); pair != nil {
+		t.Fatalf("routing offered the step after the repair: %+v", pair)
+	}
+
+	// Repairing twice must not move the stamp: a redelivered EMAIL_SENT is a
+	// no-op, not a second send's timestamp.
+	first := *sentAt
+	if err := s.HandleEmailSent(ctx, models.SendEmailResult{TaskID: taskID, Success: true, MessageID: "<repaired@test.local>"}); err != nil {
+		t.Fatalf("handle sent (duplicate): %v", err)
+	}
+	if err := handle.Pool.QueryRow(ctx, `SELECT sent_at FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).
+		Scan(&sentAt); err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if !sentAt.Equal(first) {
+		t.Fatalf("a duplicate EMAIL_SENT moved the stamp from %v to %v", first, *sentAt)
+	}
+}
+
+// TestLiveReserveSendClaimsAStepExactlyOnce covers the other way the same email
+// went out twice: two ticks that both picked the same pair.
+func TestLiveReserveSendClaimsAStepExactlyOnce(t *testing.T) {
+	handle := liveDB(t)
+	ctx := context.Background()
+	s := liveJobsService(handle)
+	f := newSendResultFixture(t, handle)
+
+	first, err := s.CampaignProgressRepo.ReserveSend(ctx, f.campaign, f.contact, f.step, uuid.New(), true)
+	if err != nil || !first {
+		t.Fatalf("first reservation: claimed=%v err=%v", first, err)
+	}
+	second, err := s.CampaignProgressRepo.ReserveSend(ctx, f.campaign, f.contact, f.step, uuid.New(), true)
+	if err != nil {
+		t.Fatalf("second reservation: %v", err)
+	}
+	if second {
+		t.Fatal("two ticks both claimed the same step; both would have sent")
+	}
+
+	// The refused claim must not have charged the day a second time.
+	var sent int
+	if err := handle.Pool.QueryRow(ctx, `SELECT emails_sent FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 1 {
+		t.Fatalf("emails_sent = %d after a refused claim, want 1", sent)
+	}
+
+	// A step already stamped sent is equally unclaimable.
+	if err := s.CampaignProgressRepo.RecordEmailSent(ctx, f.campaign, f.contact, f.step); err != nil {
+		t.Fatalf("record sent: %v", err)
+	}
+	third, err := s.CampaignProgressRepo.ReserveSend(ctx, f.campaign, f.contact, f.step, uuid.New(), true)
+	if err != nil {
+		t.Fatalf("third reservation: %v", err)
+	}
+	if third {
+		t.Fatal("a step already sent was claimed again")
+	}
+}
+
+// TestLiveReleaseSendReturnsTheStep covers the path where the command provably
+// never left: the step goes straight back to routing, with its count, and
+// without spending an attempt.
+func TestLiveReleaseSendReturnsTheStep(t *testing.T) {
+	handle := liveDB(t)
+	ctx := context.Background()
+	s := liveJobsService(handle)
+	f := newSendResultFixture(t, handle)
+
+	if _, err := s.CampaignProgressRepo.ReserveSend(ctx, f.campaign, f.contact, f.step, uuid.New(), true); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+	if err := s.CampaignProgressRepo.ReleaseSend(ctx, f.campaign, f.contact, f.step, true); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+
+	pair := f.nextPair(t, s)
+	if pair == nil || pair.SequenceID != f.step || !pair.IsNewLead {
+		t.Fatalf("a released step should be routable again as a new lead, got %+v", pair)
+	}
+	var sent, newLeads, attempts int
+	if err := handle.Pool.QueryRow(ctx, `SELECT COALESCE(emails_sent, 0), COALESCE(new_leads_started, 0) FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent, &newLeads); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 0 || newLeads != 0 {
+		t.Fatalf("daily counters after release = %d/%d, want 0/0", sent, newLeads)
+	}
+	if err := handle.Pool.QueryRow(ctx, `SELECT send_attempts FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).Scan(&attempts); err != nil {
+		t.Fatalf("read attempts: %v", err)
+	}
+	if attempts != 0 {
+		t.Fatalf("a send that never left spent %d attempts, want 0", attempts)
+	}
+
+	// A release after the step was stamped (the worker answered first) must
+	// never undo a real send.
+	if err := s.CampaignProgressRepo.RecordEmailSent(ctx, f.campaign, f.contact, f.step); err != nil {
+		t.Fatalf("record sent: %v", err)
+	}
+	if err := s.CampaignProgressRepo.ReleaseSend(ctx, f.campaign, f.contact, f.step, true); err != nil {
+		t.Fatalf("late release: %v", err)
+	}
+	if pair := f.nextPair(t, s); pair != nil {
+		t.Fatalf("a late release un-sent a delivered email: %+v", pair)
+	}
+}
+
+// TestLiveStuckDispatchIsReclaimed covers the send nobody ever answered: the
+// worker died mid-send, so no EMAIL_SENT and no EMAIL_FAILED. The lead must not
+// sit in flight forever.
+func TestLiveStuckDispatchIsReclaimed(t *testing.T) {
+	handle := liveDB(t)
+	ctx := context.Background()
+	s := liveJobsService(handle)
+	f := newSendResultFixture(t, handle)
+
+	taskID := f.dispatch(t, s)
+	if err := s.TaskRepo.UpdateTaskStatusWithLock(ctx, taskID, "completed"); err != nil {
+		t.Fatalf("complete task: %v", err)
+	}
+
+	// Nothing is reclaimed while the outcome could still arrive.
+	s.reclaimStuckSends(ctx)
+	if pair := f.nextPair(t, s); pair != nil {
+		t.Fatalf("a fresh dispatch was reclaimed too early: %+v", pair)
+	}
+
+	// Age it past the window.
+	if _, err := handle.Pool.Exec(ctx, `UPDATE campaign_contact_progress
+		SET dispatched_at = NOW() - make_interval(mins => $4)
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`,
+		f.campaign, f.contact, f.step, config.CampaignSendReclaimAfterMinutes+5); err != nil {
+		t.Fatalf("age dispatch: %v", err)
+	}
+	s.reclaimStuckSends(ctx)
+
+	var sentAt, dispatchedAt *time.Time
+	var attempts int
+	if err := handle.Pool.QueryRow(ctx, `SELECT sent_at, dispatched_at, send_attempts FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).
+		Scan(&sentAt, &dispatchedAt, &attempts); err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if sentAt != nil || dispatchedAt != nil {
+		t.Fatalf("the reclaimed step still looks in flight: sent=%v dispatched=%v", sentAt, dispatchedAt)
+	}
+	if attempts != 1 {
+		t.Fatalf("the lost send spent %d attempts, want 1", attempts)
+	}
+	if pair := f.nextPair(t, s); pair == nil || pair.SequenceID != f.step {
+		t.Fatalf("a reclaimed step should be retryable, got %+v", pair)
+	}
+	var sent int
+	if err := handle.Pool.QueryRow(ctx, `SELECT emails_sent FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 0 {
+		t.Fatalf("emails_sent = %d after a reclaim, want the count given back", sent)
+	}
+	var status string
+	if err := handle.Pool.QueryRow(ctx, `SELECT status FROM campaigns WHERE id = $1`, f.campaign).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != "active" {
+		t.Fatalf("campaign status = %s, want active (reopened for the retry)", status)
+	}
+	var logs int
+	if err := handle.Pool.QueryRow(ctx, `SELECT COUNT(*) FROM campaign_logs
+		WHERE campaign_id = $1 AND event_type = 'email_failed' AND metadata->>'code' = 'SEND_OUTCOME_LOST'`, f.campaign).Scan(&logs); err != nil {
+		t.Fatal(err)
+	}
+	if logs != 1 {
+		t.Fatalf("the lost outcome produced %d activity log entries, want 1", logs)
+	}
+
+	// A second pass has nothing left to do.
+	s.reclaimStuckSends(ctx)
+	if err := handle.Pool.QueryRow(ctx, `SELECT send_attempts FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).Scan(&attempts); err != nil {
+		t.Fatalf("read attempts: %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("a second reclaim pass spent another attempt (%d)", attempts)
+	}
+}
+
+// TestLiveReclaimBelievesADeliveredSend covers the other half: when the worker
+// did report a Message-ID, the email left. The reclaimer must stamp it, never
+// send it again.
+func TestLiveReclaimBelievesADeliveredSend(t *testing.T) {
+	handle := liveDB(t)
+	ctx := context.Background()
+	s := liveJobsService(handle)
+	f := newSendResultFixture(t, handle)
+
+	taskID := f.dispatch(t, s)
+	if err := s.TaskRepo.UpdateTaskMessageID(ctx, taskID, "<delivered@test.local>"); err != nil {
+		t.Fatalf("set message id: %v", err)
+	}
+	if _, err := handle.Pool.Exec(ctx, `UPDATE campaign_contact_progress
+		SET dispatched_at = NOW() - make_interval(mins => $4)
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`,
+		f.campaign, f.contact, f.step, config.CampaignSendReclaimAfterMinutes+5); err != nil {
+		t.Fatalf("age dispatch: %v", err)
+	}
+
+	s.reclaimStuckSends(ctx)
+
+	var sentAt *time.Time
+	var attempts int
+	if err := handle.Pool.QueryRow(ctx, `SELECT sent_at, send_attempts FROM campaign_contact_progress
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`, f.campaign, f.contact, f.step).
+		Scan(&sentAt, &attempts); err != nil {
+		t.Fatalf("read progress: %v", err)
+	}
+	if sentAt == nil {
+		t.Fatal("a send the worker confirmed was not stamped")
+	}
+	if attempts != 0 {
+		t.Fatalf("a delivered send was charged %d retry attempts", attempts)
+	}
+	if pair := f.nextPair(t, s); pair != nil {
+		t.Fatalf("a delivered send was offered again: %+v", pair)
+	}
+}

--- a/internal/app/consumer/stuck_send_reclaimer.go
+++ b/internal/app/consumer/stuck_send_reclaimer.go
@@ -1,0 +1,121 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// stuckSendBatch caps how many reservations one pass resolves. The next tick
+// mops up any overflow.
+const stuckSendBatch = 200
+
+// A campaign step is reserved before its SEND_EMAIL goes on the bus and is
+// resolved by the worker's answer: EMAIL_SENT stamps it, EMAIL_FAILED walks it
+// back. When neither ever arrives — the worker died mid-send, or the result was
+// lost — the reservation would hold the lead in flight forever, because routing
+// deliberately refuses to offer a step whose outcome is unknown.
+//
+// This sweep is what ends that state. After
+// config.CampaignSendReclaimAfterMinutes it treats the outcome as lost and
+// walks the step back through the same path a worker failure takes: the
+// attempt is counted, the day's counters are given back, the failure is written
+// to the campaign's activity log, and the lead is dropped once the retry cap is
+// spent. A worker that did answer with a Message-ID is believed instead, and
+// its step is stamped rather than retried.
+func (s *JobsService) StartStuckSendReclaimer(ctx context.Context, interval time.Duration) {
+	if s.TaskRepo == nil || s.CampaignProgressRepo == nil {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweepCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+			s.reclaimStuckSends(sweepCtx)
+			cancel()
+		}
+	}
+}
+
+func (s *JobsService) reclaimStuckSends(ctx context.Context) {
+	window := time.Duration(config.CampaignSendReclaimAfterMinutes) * time.Minute
+	stuck, err := s.CampaignProgressRepo.ListStuckDispatches(ctx, window, stuckSendBatch)
+	if err != nil {
+		log.Warn().Err(err).Msg("stuck send reclaim: could not list unresolved dispatches")
+		return
+	}
+	reclaimed, stamped := 0, 0
+	for _, d := range stuck {
+		outcome, rerr := s.reclaimStuckSend(ctx, d)
+		if rerr != nil {
+			log.Warn().Err(rerr).Str("campaign_id", d.CampaignID.String()).Str("contact_id", d.ContactID.String()).Msg("stuck send reclaim: could not resolve dispatch")
+			continue
+		}
+		switch outcome {
+		case "stamped":
+			stamped++
+		case "reclaimed":
+			reclaimed++
+		}
+	}
+	if reclaimed > 0 || stamped > 0 {
+		log.Info().Int("reclaimed", reclaimed).Int("stamped", stamped).Msg("stuck send reclaim: resolved unanswered dispatches")
+	}
+}
+
+// reclaimStuckSend resolves one unanswered reservation. Returns what it did so
+// the sweep can report it: "stamped" (the worker had in fact reported a
+// Message-ID), "reclaimed" (walked back for retry), or "" (nothing to do).
+func (s *JobsService) reclaimStuckSend(ctx context.Context, d repository.StuckDispatch) (string, error) {
+	var task *repository.Task
+	if d.TaskID != nil {
+		var err error
+		if task, err = s.TaskRepo.GetTask(ctx, *d.TaskID); err != nil {
+			return "", err
+		}
+	}
+	if task == nil {
+		// Nothing left to attribute the outcome to: the task was never
+		// recorded, or it aged out of retention. Walk the step back directly
+		// rather than leaving the lead in flight for good.
+		_, _, rolled, err := s.CampaignProgressRepo.RecordSendFailure(ctx, d.CampaignID, d.ContactID, d.SequenceID,
+			"the send was never answered by a worker")
+		if err != nil {
+			return "", err
+		}
+		if rolled {
+			return "reclaimed", nil
+		}
+		return "", nil
+	}
+	if task.MessageID != "" {
+		// The worker put a Message-ID on the wire, so the email did leave; only
+		// the stamp was lost. Never retry this one.
+		ok, serr := s.CampaignProgressRepo.StampDispatchedSend(ctx, d.CampaignID, d.ContactID, d.SequenceID)
+		if serr != nil {
+			return "", serr
+		}
+		if ok {
+			return "stamped", nil
+		}
+		return "", nil
+	}
+
+	reason := "the sending worker never reported an outcome for this email"
+	if err := s.TaskRepo.RecordTaskFailure(ctx, task.ID, "Send outcome lost", reason); err != nil {
+		return "", err
+	}
+	dispatchedAt := d.DispatchedAt
+	if err := s.failCampaignSend(ctx, task, reason, "SEND_OUTCOME_LOST", &dispatchedAt); err != nil {
+		return "", err
+	}
+	return "reclaimed", nil
+}

--- a/internal/app/orgtransfer/spec.go
+++ b/internal/app/orgtransfer/spec.go
@@ -313,7 +313,14 @@ var Tables = []Table{
 	{
 		Name: "campaign_contact_progress", Group: models.OrgDataGroupCampaigns,
 		Scope: `campaign_id IN ` + orgCampaigns,
-		Note:  "Carries per-contact step position, so a running campaign resumes instead of restarting from step one.",
+		// The send reservation names a task on the source instance. Carried
+		// over, a step still in flight at export time would arrive looking
+		// dispatched with no task and no worker result to ever resolve it, so
+		// the lead would never be emailed. Cleared, an unsent step is simply
+		// queued again; a sent one keeps its sent_at, which is what routing and
+		// follow-up pacing actually read.
+		ResetOnImport: []string{"dispatched_at", "dispatch_task_id"},
+		Note:          "Carries per-contact step position, so a running campaign resumes instead of restarting from step one.",
 	},
 	{
 		Name: "campaign_daily_sends", Group: models.OrgDataGroupCampaigns,

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -86,6 +86,21 @@ const (
 	// follow-up early; a task that fired on time always passes.
 	CampaignNotDueGraceSeconds = 60
 
+	// CampaignSendReclaimAfterMinutes is how long a reserved-but-unresolved send
+	// (dispatched_at set, no worker result, no sent_at) is left alone before the
+	// reclaimer treats its outcome as lost and walks it back as a failed
+	// attempt. A live worker answers every SEND_EMAIL within seconds, so this
+	// only ever fires when the worker died mid-send or the result was lost, and
+	// it must stay well clear of a slow provider handshake.
+	CampaignSendReclaimAfterMinutes = 30
+
+	// CampaignSendStampAttempts is how many times the control plane retries the
+	// sent_at stamp after a send is already on the bus. The reservation is what
+	// keeps the step from being re-sent, so a lost stamp is a pacing problem,
+	// not a duplicate — but it is still worth a couple of quick retries before
+	// falling back to the worker result to repair it.
+	CampaignSendStampAttempts = 3
+
 	// Webhook/integration fan-out throttle. Caps how many events of a single
 	// type one org can fan out to its webhooks + integration sinks
 	// (Slack/Discord/CRM) per minute — the backstop against a campaign "notify"

--- a/internal/infrastructure/db/migrations/000093_campaign_send_reservation.down.sql
+++ b/internal/infrastructure/db/migrations/000093_campaign_send_reservation.down.sql
@@ -1,0 +1,7 @@
+DROP INDEX IF EXISTS idx_campaign_progress_in_flight;
+
+ALTER TABLE campaign_contact_progress
+    DROP COLUMN IF EXISTS dispatch_task_id,
+    DROP COLUMN IF EXISTS dispatched_at;
+
+-- task_status keeps 'skipped_duplicate': Postgres cannot drop an enum value.

--- a/internal/infrastructure/db/migrations/000093_campaign_send_reservation.up.sql
+++ b/internal/infrastructure/db/migrations/000093_campaign_send_reservation.up.sql
@@ -1,0 +1,24 @@
+-- A campaign step is reserved BEFORE its SEND_EMAIL goes on the bus, so a crash
+-- or a failed progress write between dispatch and the sent_at stamp can no
+-- longer look like "never attempted" and send the same email a second time.
+-- dispatched_at is the durable attempt record; sent_at stays the timing stamp
+-- routing paces follow-ups from. dispatch_task_id ties the reservation to the
+-- task whose worker result resolves it.
+ALTER TABLE campaign_contact_progress
+    ADD COLUMN IF NOT EXISTS dispatched_at timestamptz,
+    ADD COLUMN IF NOT EXISTS dispatch_task_id uuid;
+
+-- Every already-sent step was, by definition, dispatched.
+UPDATE campaign_contact_progress
+SET dispatched_at = sent_at
+WHERE sent_at IS NOT NULL AND dispatched_at IS NULL;
+
+-- The reclaimer sweeps only reservations with no outcome yet; keep that scan
+-- off the full table.
+CREATE INDEX IF NOT EXISTS idx_campaign_progress_in_flight
+    ON campaign_contact_progress (dispatched_at)
+    WHERE sent_at IS NULL AND dispatched_at IS NOT NULL;
+
+-- A tick that finds the pair it selected already reserved by another tick ends
+-- here instead of sending a duplicate.
+ALTER TYPE public.task_status ADD VALUE IF NOT EXISTS 'skipped_duplicate';

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -81,15 +81,13 @@ type CampaignRepository interface {
 	// AdvanceRampLevel advances the persisted ramp level once per UTC day.
 	// Idempotent and a no-op when ramp is disabled or already advanced today.
 	AdvanceRampLevel(ctx context.Context, campaignID uuid.UUID) error
-	// IncrementCampaignDailySend bumps today's send counters; newLead also
-	// increments new_leads_started (a position-1 send).
-	IncrementCampaignDailySend(ctx context.Context, campaignID uuid.UUID, newLead bool) error
 	// CountNewLeadsStartedToday returns new_leads_started for the current UTC
 	// day (0 when no row exists yet).
 	CountNewLeadsStartedToday(ctx context.Context, campaignID uuid.UUID) (int, error)
-	// DecrementCampaignDailySend gives back a counted send the worker could not
-	// deliver, against the day it was counted on (sentAt), so the new-lead cap
-	// and the campaign daily limit do not charge for mail that never left.
+	// DecrementCampaignDailySend gives back a send that never left, against the
+	// day it was counted on (sentAt), so the new-lead cap does not charge for
+	// it. The matching increment lives in CampaignProgressRepository.ReserveSend,
+	// which counts the send in the same transaction that reserves it.
 	DecrementCampaignDailySend(ctx context.Context, campaignID uuid.UUID, sentAt time.Time, newLead bool) error
 	// ReopenAfterSendFailure flips a campaign that completed while a send was
 	// still in flight back to active, so the failed step is retried instead of
@@ -1823,7 +1821,7 @@ func (r *campaignRepository) AdvanceRampLevel(ctx context.Context, campaignID uu
 	return err
 }
 
-// DecrementCampaignDailySend reverses IncrementCampaignDailySend for a send
+// DecrementCampaignDailySend reverses the count ReserveSend took for a send
 // that failed in the worker. Clamped at zero; a missing row is left alone.
 func (r *campaignRepository) DecrementCampaignDailySend(ctx context.Context, campaignID uuid.UUID, sentAt time.Time, newLead bool) error {
 	newLeadDec := 0
@@ -1852,24 +1850,6 @@ func (r *campaignRepository) ReopenAfterSendFailure(ctx context.Context, campaig
 		return false, err
 	}
 	return tag.RowsAffected() > 0, nil
-}
-
-// IncrementCampaignDailySend bumps today's per-campaign send counters. newLead
-// also increments new_leads_started (a position-1 send) so the new-lead cap can
-// read it back.
-func (r *campaignRepository) IncrementCampaignDailySend(ctx context.Context, campaignID uuid.UUID, newLead bool) error {
-	newLeadInc := 0
-	if newLead {
-		newLeadInc = 1
-	}
-	_, err := r.DB.Exec(ctx, `
-		INSERT INTO campaign_daily_sends (campaign_id, send_date, emails_sent, new_leads_started)
-		VALUES ($1, CURRENT_DATE, 1, $2)
-		ON CONFLICT (campaign_id, send_date)
-		DO UPDATE SET emails_sent = campaign_daily_sends.emails_sent + 1,
-		              new_leads_started = campaign_daily_sends.new_leads_started + $2
-	`, campaignID, newLeadInc)
-	return err
 }
 
 // CountNewLeadsStartedToday returns new_leads_started for the current UTC day.

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -73,13 +73,48 @@ type CampaignSequencePair struct {
 	SequenceID uuid.UUID
 }
 
+// StuckDispatch is a send that was reserved and handed to a worker but whose
+// outcome never came back: no EMAIL_SENT stamped it, no EMAIL_FAILED walked it
+// back. The reclaimer resolves these.
+type StuckDispatch struct {
+	CampaignID   uuid.UUID
+	ContactID    uuid.UUID
+	SequenceID   uuid.UUID
+	TaskID       *uuid.UUID
+	DispatchedAt time.Time
+}
+
 // CampaignProgressRepository defines methods for campaign progress tracking
 type CampaignProgressRepository interface {
+	// ReserveSend claims (campaign, contact, step) for one send BEFORE the
+	// command goes on the bus, which is what lets a later tick tell "dispatched,
+	// outcome unknown" apart from "never attempted". It stamps dispatched_at and
+	// counts the send against the day's counters in one transaction, and reports
+	// false when the step is already in flight or already sent — in which case
+	// the caller must NOT dispatch. Resolve every reservation exactly once:
+	// RecordEmailSent on a successful hand-off, ReleaseSend when the command
+	// provably never left, RecordSendFailure on a worker failure.
+	ReserveSend(ctx context.Context, campaignID, contactID, sequenceID, taskID uuid.UUID, newLead bool) (bool, error)
+	// ReleaseSend gives a reservation back when the send provably never reached
+	// the bus (no worker assigned, worker offline), so the step is retried on the
+	// next tick without spending an attempt. Only an unstamped reservation is
+	// touched, so it can never undo a real send.
+	ReleaseSend(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, newLead bool) error
 	// Record email status
 	RecordEmailSent(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error
-	// RecordSendFailure walks back a step the worker could not send: sent_at is
-	// cleared so routing offers the step again, and the attempt is counted. It
-	// returns the attempts so far and whether the lead has now exhausted
+	// StampDispatchedSend is the repair path for a send whose reservation was
+	// written but whose sent_at stamp was lost (the control plane died, or its
+	// write failed, between the dispatch and the stamp). The worker's own
+	// EMAIL_SENT calls it, so a delivered email always ends up with the timing
+	// stamp follow-up pacing reads. Returns true when it actually repaired one.
+	StampDispatchedSend(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error)
+	// ListStuckDispatches returns reservations older than olderThan that no
+	// worker result ever resolved.
+	ListStuckDispatches(ctx context.Context, olderThan time.Duration, limit int) ([]StuckDispatch, error)
+	// RecordSendFailure walks back a step the worker could not send: the
+	// reservation and sent_at are cleared so routing offers the step again, and
+	// the attempt is counted. It returns the attempts so far and whether the
+	// lead has now exhausted
 	// config.CampaignSendMaxAttempts. rolledBack is false when there was
 	// nothing to walk back (a duplicate result, or the send was already retried).
 	RecordSendFailure(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, reason string) (attempts int, exhausted bool, rolledBack bool, err error)
@@ -162,24 +197,166 @@ func NewCampaignProgressRepository(db *pgxpool.Pool) CampaignProgressRepository 
 	return &campaignProgressRepository{db: db}
 }
 
+// ReserveSend claims the step for one send before the command is published.
+// The claim and the day's counters move together because both must survive a
+// crash in the dispatch window: a reservation without its count would let the
+// daily cap over-send, and a count without its reservation would charge for a
+// send nobody ever made.
+//
+// The ON CONFLICT ... WHERE is the whole exactly-once gate: a row already in
+// flight (dispatched_at set) or already sent updates nothing and returns no
+// row, so two ticks that picked the same pair cannot both dispatch. A step
+// walked back after a worker failure has both cleared and is claimable again.
+func (r *campaignProgressRepository) ReserveSend(ctx context.Context, campaignID, contactID, sequenceID, taskID uuid.UUID, newLead bool) (bool, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var claimed bool
+	err = tx.QueryRow(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, dispatched_at, dispatch_task_id)
+		VALUES ($1, $2, $3, NOW(), $4)
+		ON CONFLICT (campaign_id, contact_id, sequence_id)
+		DO UPDATE SET dispatched_at = NOW(), dispatch_task_id = $4, failed_at = NULL, failure_reason = ''
+		WHERE campaign_contact_progress.sent_at IS NULL
+		  AND campaign_contact_progress.dispatched_at IS NULL
+		RETURNING true
+	`, campaignID, contactID, sequenceID, taskID).Scan(&claimed)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	newLeadInc := 0
+	if newLead {
+		newLeadInc = 1
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO campaign_daily_sends (campaign_id, send_date, emails_sent, new_leads_started)
+		VALUES ($1, CURRENT_DATE, 1, $2)
+		ON CONFLICT (campaign_id, send_date)
+		DO UPDATE SET emails_sent = campaign_daily_sends.emails_sent + 1,
+		              new_leads_started = campaign_daily_sends.new_leads_started + $2
+	`, campaignID, newLeadInc); err != nil {
+		return false, err
+	}
+	return true, tx.Commit(ctx)
+}
+
+// ReleaseSend undoes a reservation whose command never left, counters included.
+// Guarded on sent_at IS NULL so a reservation that was stamped in the meantime
+// (the worker answered first) is never released.
+func (r *campaignProgressRepository) ReleaseSend(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, newLead bool) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var released bool
+	err = tx.QueryRow(ctx, `
+		UPDATE campaign_contact_progress
+		SET dispatched_at = NULL, dispatch_task_id = NULL
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3
+		  AND sent_at IS NULL AND dispatched_at IS NOT NULL
+		RETURNING true
+	`, campaignID, contactID, sequenceID).Scan(&released)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		return err
+	}
+
+	newLeadDec := 0
+	if newLead {
+		newLeadDec = 1
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE campaign_daily_sends
+		SET emails_sent = GREATEST(emails_sent - 1, 0),
+		    new_leads_started = GREATEST(new_leads_started - $2, 0)
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE
+	`, campaignID, newLeadDec); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
 // RecordEmailSent stamps a step as handed to the worker. A retry after a
 // worker-reported failure clears the failure marker again; send_attempts is
-// kept as history so the retry cap still holds.
+// kept as history so the retry cap still holds. dispatched_at is backfilled for
+// callers that stamp without reserving first (action nodes, instant chains),
+// so "attempted" is never narrower than "sent".
 func (r *campaignProgressRepository) RecordEmailSent(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error {
 	query := `
-		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
-		VALUES ($1, $2, $3, NOW())
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at, dispatched_at)
+		VALUES ($1, $2, $3, NOW(), NOW())
 		ON CONFLICT (campaign_id, contact_id, sequence_id)
-		DO UPDATE SET sent_at = NOW(), failed_at = NULL, failure_reason = ''
+		DO UPDATE SET sent_at = NOW(),
+		              dispatched_at = COALESCE(campaign_contact_progress.dispatched_at, NOW()),
+		              failed_at = NULL, failure_reason = ''
 	`
 
 	_, err := r.db.Exec(ctx, query, campaignID, contactID, sequenceID)
 	return err
 }
 
-// RecordSendFailure clears sent_at on a stamped step and counts the attempt.
-// Only a row that is currently stamped sent is touched, so a duplicate worker
-// result after the step was already walked back (or re-sent) is a no-op.
+// StampDispatchedSend stamps a reservation the control plane never got to
+// stamp itself. Guarded on dispatched_at so it can only ever complete a send
+// somebody really reserved, and on sent_at so it never moves a stamp that is
+// already there.
+func (r *campaignProgressRepository) StampDispatchedSend(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) (bool, error) {
+	tag, err := r.db.Exec(ctx, `
+		UPDATE campaign_contact_progress
+		SET sent_at = NOW(), failed_at = NULL, failure_reason = ''
+		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3
+		  AND sent_at IS NULL AND dispatched_at IS NOT NULL
+	`, campaignID, contactID, sequenceID)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// ListStuckDispatches returns reservations no worker result ever resolved,
+// oldest first.
+func (r *campaignProgressRepository) ListStuckDispatches(ctx context.Context, olderThan time.Duration, limit int) ([]StuckDispatch, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT campaign_id, contact_id, sequence_id, dispatch_task_id, dispatched_at
+		FROM campaign_contact_progress
+		WHERE sent_at IS NULL
+		  AND dispatched_at IS NOT NULL
+		  AND dispatched_at < NOW() - make_interval(secs => $1)
+		ORDER BY dispatched_at ASC
+		LIMIT $2
+	`, olderThan.Seconds(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []StuckDispatch
+	for rows.Next() {
+		var s StuckDispatch
+		if err := rows.Scan(&s.CampaignID, &s.ContactID, &s.SequenceID, &s.TaskID, &s.DispatchedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// RecordSendFailure clears the reservation and sent_at on a step and counts the
+// attempt. Only a row that is currently in flight or stamped sent is touched,
+// so a duplicate worker result after the step was already walked back (or
+// re-sent) is a no-op.
 func (r *campaignProgressRepository) RecordSendFailure(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, reason string) (int, bool, bool, error) {
 	if len(reason) > 500 {
 		reason = reason[:500]
@@ -187,11 +364,13 @@ func (r *campaignProgressRepository) RecordSendFailure(ctx context.Context, camp
 	query := `
 		UPDATE campaign_contact_progress
 		SET sent_at = NULL,
+		    dispatched_at = NULL,
+		    dispatch_task_id = NULL,
 		    send_attempts = send_attempts + 1,
 		    failed_at = NOW(),
 		    failure_reason = $4
 		WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3
-		  AND sent_at IS NOT NULL
+		  AND (sent_at IS NOT NULL OR dispatched_at IS NOT NULL)
 		RETURNING send_attempts
 	`
 	var attempts int
@@ -605,7 +784,11 @@ func (r *campaignProgressRepository) GetLatestCampaignSequenceForContact(ctx con
 //
 // A contact who has never been sent starts at the entry step (position 1). A
 // step is sent only if the route reaches it, so branch-only steps are never sent
-// linearly, and a routed step that was already sent (a loop) stops the contact.
+// linearly, and a routed step that was already ATTEMPTED (a loop) stops the
+// contact. Attempted means sent_at OR dispatched_at: a step reserved before its
+// command went on the bus counts, even if the sent_at stamp was lost, which is
+// what stops a crash or a failed progress write in that window from handing the
+// same email to a worker twice.
 // A contact whose step failed in the worker more than CampaignSendMaxAttempts
 // times is dropped, the same way a bounced or suppressed contact is.
 //
@@ -857,7 +1040,8 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 		LEFT JOIN LATERAL (
 			SELECT array_agg(sequence_id) AS ids
 			FROM campaign_contact_progress p2
-			WHERE p2.campaign_id = $1 AND p2.contact_id = cl.contact_id AND p2.sent_at IS NOT NULL
+			WHERE p2.campaign_id = $1 AND p2.contact_id = cl.contact_id
+			  AND (p2.sent_at IS NOT NULL OR p2.dispatched_at IS NOT NULL)
 		) ss ON true
 		WHERE cl.campaign_id = $1
 		  AND NOT EXISTS (

--- a/internal/scheduler/live_integration_test.go
+++ b/internal/scheduler/live_integration_test.go
@@ -663,3 +663,118 @@ func TestLiveWaitNodeGatesTheStepAfterIt(t *testing.T) {
 		t.Fatalf("deferred slot %s is not ~90 minutes out", at)
 	}
 }
+
+// TestLiveInFlightSendIsNotOfferedAgain is issue #169 at the scheduler level:
+// lead A's first email is on the bus but its sent_at stamp never landed (the
+// tick died, or the progress write failed). The scheduler must move on to lead
+// B instead of handing A's step back and emailing them twice.
+func TestLiveInFlightSendIsNotOfferedAgain(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+
+	var step1, leadA uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM sequences WHERE campaign_id = $1 AND position = 0`, f.campaign).Scan(&step1); err != nil {
+		t.Fatalf("load step 1: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT contact_id FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&leadA); err != nil {
+		t.Fatalf("load lead A: %v", err)
+	}
+
+	leadB := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields, created_at)
+		VALUES ($1, $2, $3, $4, 'Live', 'Second', '', '', '{}', NOW() + interval '1 second')`,
+		leadB, f.user, f.org, "lead-"+leadB.String()[:8]+"@test.local"); err != nil {
+		t.Fatalf("insert lead B: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, 1)`,
+		f.campaign, leadB); err != nil {
+		t.Fatalf("add lead B: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM campaign_leads WHERE contact_id = $1`, leadB)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM contacts WHERE id = $1`, leadB)
+	})
+
+	// A's send was reserved and dispatched; the stamp never landed.
+	progress := repository.NewCampaignProgressRepository(pool)
+	reserved, err := progress.ReserveSend(ctx, f.campaign, leadA, step1, uuid.New(), true)
+	if err != nil || !reserved {
+		t.Fatalf("reserve A's send: reserved=%v err=%v", reserved, err)
+	}
+
+	s := liveScheduler(t, handle, pool)
+	_, pair, _, err := s.CalculateNextCampaignTime(ctx, f.campaign)
+	if err != nil {
+		t.Fatalf("want lead B's first step, got err=%v", err)
+	}
+	if pair == nil || pair.ContactID != leadB {
+		t.Fatalf("want lead B, got %+v (A's in-flight send was offered again: issue #169)", pair)
+	}
+
+	// With B dispatched too, nothing is left: the campaign completes rather than
+	// re-offering either in-flight step.
+	if reserved, err := progress.ReserveSend(ctx, f.campaign, leadB, step1, uuid.New(), true); err != nil || !reserved {
+		t.Fatalf("reserve B's send: reserved=%v err=%v", reserved, err)
+	}
+	if _, pair, _, err = s.CalculateNextCampaignTime(ctx, f.campaign); !errors.Is(err, ErrCampaignCompleted) || pair != nil {
+		t.Fatalf("want ErrCampaignCompleted with no pair once both sends are in flight, got pair=%v err=%v", pair, err)
+	}
+}
+
+// TestLiveInFlightFollowUpIsNotOfferedAgain covers the same window one step
+// further in: the follow-up, not the first email, is the one whose stamp was
+// lost. Routing reaches it through the branch, so the loop guard is what has to
+// stop it.
+func TestLiveInFlightFollowUpIsNotOfferedAgain(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+
+	step2 := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+			body_plain, body_html, wait_after, position, kind)
+		VALUES ($1, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', 0, 1, 'email')`,
+		step2, f.campaign, f.org); err != nil {
+		t.Fatalf("insert step 2: %v", err)
+	}
+	var step1, contact uuid.UUID
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM sequences WHERE campaign_id = $1 AND position = 0`, f.campaign).Scan(&step1); err != nil {
+		t.Fatalf("load step 1: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT contact_id FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&contact); err != nil {
+		t.Fatalf("load contact: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE sequences SET conditions = jsonb_build_object('branches', jsonb_build_array(
+			jsonb_build_object('branch_id', 'live-else', 'target_step_id', $1::text)))
+		WHERE campaign_id = $2 AND position = 0`, step2.String(), f.campaign); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at, dispatched_at)
+		VALUES ($1, $2, $3, NOW(), NOW())`, f.campaign, contact, step1); err != nil {
+		t.Fatalf("stamp step 1 sent: %v", err)
+	}
+
+	progress := repository.NewCampaignProgressRepository(pool)
+	s := liveScheduler(t, handle, pool)
+
+	// The follow-up is due now (wait_after 0) and would be sent...
+	if _, pair, _, err := s.CalculateNextCampaignTime(ctx, f.campaign); err != nil || pair == nil || pair.SequenceID != step2 {
+		t.Fatalf("precondition: step 2 should be due, got pair=%v err=%v", pair, err)
+	}
+	// ...so dispatch it, and lose the stamp.
+	if reserved, err := progress.ReserveSend(ctx, f.campaign, contact, step2, uuid.New(), false); err != nil || !reserved {
+		t.Fatalf("reserve the follow-up: reserved=%v err=%v", reserved, err)
+	}
+	if _, pair, _, err := s.CalculateNextCampaignTime(ctx, f.campaign); !errors.Is(err, ErrCampaignCompleted) || pair != nil {
+		t.Fatalf("the in-flight follow-up was offered again: pair=%v err=%v", pair, err)
+	}
+}

--- a/internal/tasks/campaign_send_live_test.go
+++ b/internal/tasks/campaign_send_live_test.go
@@ -1,0 +1,412 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
+	"github.com/warmbly/warmbly/internal/repository"
+	"github.com/warmbly/warmbly/internal/scheduler"
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+// End-to-end checks of the campaign send path (issue #169) against a real
+// Postgres. Skipped unless WARMBLY_TEST_DB is set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/tasks/ -run Live -v
+//
+// These drive the real HandleCampaignTask over the real scheduler, routing and
+// repositories, with only the bus and KMS stubbed, because the bug being fixed
+// lives exactly in the ordering between "the command is published" and "the
+// progress row is written". A stubbed repository proves nothing about it.
+
+// breakingProgressRepo wraps the real repository and fails RecordEmailSent on
+// demand, which is precisely the "progress write is best-effort" failure the
+// issue is about. Everything else passes straight through to Postgres.
+type breakingProgressRepo struct {
+	repository.CampaignProgressRepository
+	breakStamp bool
+}
+
+func (b *breakingProgressRepo) RecordEmailSent(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error {
+	if b.breakStamp {
+		return errors.New("simulated transient database error on the progress write")
+	}
+	return b.CampaignProgressRepository.RecordEmailSent(ctx, campaignID, contactID, sequenceID)
+}
+
+type sendFixture struct {
+	pool                      *pgxpool.Pool
+	user, org, mailbox        uuid.UUID
+	campaign, step            uuid.UUID
+	leadA, leadB              uuid.UUID
+	svc                       *tasksService
+	sender                    *recordingSender
+	progress                  *breakingProgressRepo
+	realProgress              repository.CampaignProgressRepository
+	emailAAddr, emailBAddress string
+}
+
+func newSendFixture(t *testing.T) *sendFixture {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	ctx := context.Background()
+	handle, err := db.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	pool := handle.Pool
+
+	f := &sendFixture{
+		pool: pool, user: uuid.New(), org: uuid.New(), mailbox: uuid.New(),
+		campaign: uuid.New(), step: uuid.New(), leadA: uuid.New(), leadB: uuid.New(),
+	}
+	f.emailAAddr = "lead-a-" + f.leadA.String()[:8] + "@test.local"
+	f.emailBAddress = "lead-b-" + f.leadB.String()[:8] + "@test.local"
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'Live', 'Test')`,
+		f.user, "live-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'Live Send', $2, $3)`,
+		f.org, "live-"+f.org.String()[:8], f.user)
+	// A mailbox with no min-gap, so nothing but the reservation decides whether
+	// a send happens. Worker assignment lives in the stubbed sender.
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name,
+	          signature_plain, signature_html, provider, status, campaign_limit, min_wait_time, timezone)
+	      VALUES ($1, $2, $3, $4, 'Live', '', '', 'smtp_imap', 'active', 50, 0, 'UTC')`,
+		f.mailbox, f.user, f.org, "live-"+f.mailbox.String()[:8]+"@test.local")
+	exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, status,
+	          daily_limit, timezone, days, start_time, end_time, rotation_mode, updated_at, created_at)
+	      VALUES ($1, $2, $3, 'Live Send', '', 'active', 50, 'UTC', 127, '00:00', '23:59',
+	              'least_recently_used', NOW(), NOW())`, f.campaign, f.user, f.org)
+	exec(`INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+	          body_plain, body_html, wait_after, position, kind)
+	      VALUES ($1, $2, $3, 'Step 1', 'Hi', 'Hello', '<p>Hello</p>', 0, 0, 'email')`, f.step, f.campaign, f.org)
+	for i, c := range []struct {
+		id    uuid.UUID
+		email string
+	}{{f.leadA, f.emailAAddr}, {f.leadB, f.emailBAddress}} {
+		exec(`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields, verification_status, created_at)
+		      VALUES ($1, $2, $3, $4, 'Live', 'Contact', '', '', '{}', 'valid', NOW() + make_interval(secs => $5))`,
+			c.id, f.user, f.org, c.email, float64(i))
+		exec(`INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, $3)`, f.campaign, c.id, i)
+	}
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM task_failures WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM task_execution_keys WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM campaign_tasks WHERE task_id IN (SELECT id FROM tasks WHERE email_account_id = $1)`, f.mailbox},
+			{`DELETE FROM tasks WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM campaign_logs WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_daily_sends WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_contact_progress WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaign_leads WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM sequences WHERE campaign_id = $1`, f.campaign},
+			{`DELETE FROM campaigns WHERE id = $1`, f.campaign},
+			{`DELETE FROM email_accounts WHERE id = $1`, f.mailbox},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		} {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+
+	enc, err := encrypt.NewEncrypter([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("encrypter: %v", err)
+	}
+	emailRepo := repository.NewEmailRepostory(handle, enc)
+	campaignRepo := repository.NewCampaignRepostory(handle)
+	contactRepo := repository.NewContactRepostory(handle)
+	logRepo := repository.NewCampaignLogRepository(handle)
+	f.realProgress = repository.NewCampaignProgressRepository(pool)
+	f.progress = &breakingProgressRepo{CampaignProgressRepository: f.realProgress}
+	taskRepo := repository.NewTaskRepository(pool)
+	f.sender = &recordingSender{}
+	f.svc = &tasksService{
+		tasksClient:          noopTaskScheduler{},
+		scheduler:            scheduler.NewSchedulerService(taskRepo, repository.NewWarmupRepository(pool), f.progress, emailRepo, campaignRepo, contactRepo, logRepo),
+		cipherService:        noopCipher{},
+		emailSender:          f.sender,
+		taskRepo:             taskRepo,
+		campaignProgressRepo: f.progress,
+		emailRepo:            emailRepo,
+		campaignRepo:         campaignRepo,
+		contactRepo:          contactRepo,
+		campaignLogRepo:      logRepo,
+		trackedLinkRepo:      repository.NewTrackedLinkRepository(pool),
+	}
+	return f
+}
+
+// newTask writes one due, pending campaign task the way the chain does. It
+// bypasses CreateTaskWithLock's one-pending-task guard, because a test that
+// races two ticks needs two.
+func (f *sendFixture) newTask(t *testing.T) uuid.UUID {
+	t.Helper()
+	ctx := context.Background()
+	taskID := uuid.New()
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO tasks (id, task_type, email_account_id, status, message_id, scheduled_at, created_at, updated_at)
+		VALUES ($1, 'campaign', $2, 'pending', '', NOW(), NOW(), NOW())`, taskID, f.mailbox); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := f.pool.Exec(ctx, `INSERT INTO campaign_tasks (task_id, campaign_id) VALUES ($1, $2)`,
+		taskID, f.campaign); err != nil {
+		t.Fatalf("create campaign task: %v", err)
+	}
+	return taskID
+}
+
+// tick runs the real handler on a fresh due task, exactly as the scheduler
+// callback does. Each tick leaves a successor behind, so they are cancelled
+// first to keep every tick in the test deliberate.
+func (f *sendFixture) tick(t *testing.T) uuid.UUID {
+	t.Helper()
+	if _, err := f.pool.Exec(context.Background(),
+		`UPDATE tasks SET status = 'cancelled' WHERE status = 'pending' AND id IN (
+			SELECT task_id FROM campaign_tasks WHERE campaign_id = $1)`, f.campaign); err != nil {
+		t.Fatalf("clear pending tasks: %v", err)
+	}
+	taskID := f.newTask(t)
+	if xerr := f.svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
+		t.Fatalf("campaign tick: %v", xerr)
+	}
+	return taskID
+}
+
+type progressRow struct {
+	sentAt, dispatchedAt *time.Time
+	attempts             int
+}
+
+func (f *sendFixture) progressFor(t *testing.T, contact uuid.UUID) *progressRow {
+	t.Helper()
+	var r progressRow
+	err := f.pool.QueryRow(context.Background(), `SELECT sent_at, dispatched_at, send_attempts
+		FROM campaign_contact_progress WHERE campaign_id = $1 AND contact_id = $2 AND sequence_id = $3`,
+		f.campaign, contact, f.step).Scan(&r.sentAt, &r.dispatchedAt, &r.attempts)
+	if err != nil {
+		return nil
+	}
+	return &r
+}
+
+// TestLiveCampaignTickReservesBeforeItDispatches is the ordering the whole fix
+// rests on: when the tick hands a send to the bus, the durable record of that
+// attempt is already committed.
+func TestLiveCampaignTickReservesBeforeItDispatches(t *testing.T) {
+	f := newSendFixture(t)
+
+	f.tick(t)
+	if f.sender.count() != 1 {
+		t.Fatalf("the tick dispatched %d sends, want 1", f.sender.count())
+	}
+	row := f.progressFor(t, f.leadA)
+	if row == nil || row.dispatchedAt == nil {
+		t.Fatalf("the send went out without a reservation: %+v", row)
+	}
+	if row.sentAt == nil {
+		t.Fatal("a healthy tick should also stamp sent_at")
+	}
+	var sent, newLeads int
+	if err := f.pool.QueryRow(context.Background(), `SELECT emails_sent, new_leads_started FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent, &newLeads); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 1 || newLeads != 1 {
+		t.Fatalf("daily counters = %d/%d, want 1/1", sent, newLeads)
+	}
+}
+
+// TestLiveLostProgressWriteDoesNotResend is issue #169 end to end: the send is
+// dispatched, the progress write fails, and the next tick must serve the OTHER
+// lead rather than emailing the first one twice.
+func TestLiveLostProgressWriteDoesNotResend(t *testing.T) {
+	f := newSendFixture(t)
+
+	f.progress.breakStamp = true
+	f.tick(t)
+	if f.sender.count() != 1 {
+		t.Fatalf("first tick dispatched %d sends, want 1", f.sender.count())
+	}
+	row := f.progressFor(t, f.leadA)
+	if row == nil || row.dispatchedAt == nil {
+		t.Fatalf("no reservation survived the failed stamp: %+v", row)
+	}
+	if row.sentAt != nil {
+		t.Fatal("precondition: the stamp was supposed to fail")
+	}
+	// The failure is visible, not swallowed.
+	var logged int
+	if err := f.pool.QueryRow(context.Background(), `SELECT COUNT(*) FROM campaign_logs
+		WHERE campaign_id = $1 AND metadata->>'code' = 'PROGRESS_WRITE_FAILED'`, f.campaign).Scan(&logged); err != nil {
+		t.Fatal(err)
+	}
+	if logged != 1 {
+		t.Fatalf("a failed progress write produced %d activity log entries, want 1", logged)
+	}
+
+	// Next tick: lead A must not be served again.
+	f.progress.breakStamp = false
+	f.tick(t)
+	if f.sender.count() != 2 {
+		t.Fatalf("second tick dispatched a total of %d sends, want 2", f.sender.count())
+	}
+	if rowB := f.progressFor(t, f.leadB); rowB == nil || rowB.dispatchedAt == nil {
+		t.Fatalf("the second tick did not serve the other lead: %+v", rowB)
+	}
+	if again := f.progressFor(t, f.leadA); again.sentAt != nil {
+		t.Fatal("lead A was served a second time (this is issue #169)")
+	}
+
+	// And with both leads dispatched, a third tick sends nothing at all.
+	f.tick(t)
+	if f.sender.count() != 2 {
+		t.Fatalf("a third tick sent %d in total; every lead was already served", f.sender.count())
+	}
+}
+
+// TestLiveUndispatchableSendKeepsItsStepRoutable covers the other side: when
+// the command provably never left, the reservation must be given back so the
+// lead is retried rather than silently dropped.
+func TestLiveUndispatchableSendKeepsItsStepRoutable(t *testing.T) {
+	f := newSendFixture(t)
+
+	f.sender.setFail(ErrWorkerOffline)
+	f.tick(t)
+	if f.sender.count() != 0 {
+		t.Fatal("nothing should have been published")
+	}
+	if row := f.progressFor(t, f.leadA); row != nil && row.dispatchedAt != nil {
+		t.Fatalf("a send that never left kept its reservation: %+v", row)
+	}
+	var sent int
+	if err := f.pool.QueryRow(context.Background(), `SELECT COALESCE(emails_sent, 0) FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&sent); err != nil && err.Error() != "no rows in result set" {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if sent != 0 {
+		t.Fatalf("emails_sent = %d for a send that never left", sent)
+	}
+
+	// The lead is still first in line once the worker is back.
+	f.sender.setFail(nil)
+	f.tick(t)
+	if f.sender.count() != 1 {
+		t.Fatalf("the retried send did not go out (%d dispatched)", f.sender.count())
+	}
+	if row := f.progressFor(t, f.leadA); row == nil || row.sentAt == nil {
+		t.Fatalf("lead A was not served on the retry: %+v", row)
+	}
+}
+
+// TestLiveAmbiguousDispatchKeepsItsReservation covers the one failure that is
+// NOT safe to retry: the publish call itself failed, so the bus may have taken
+// the command. That reservation has to stand until an outcome arrives.
+func TestLiveAmbiguousDispatchKeepsItsReservation(t *testing.T) {
+	f := newSendFixture(t)
+
+	f.sender.setFail(ErrSendDispatchUnknown)
+	f.tick(t)
+	row := f.progressFor(t, f.leadA)
+	if row == nil || row.dispatchedAt == nil {
+		t.Fatalf("an ambiguous dispatch gave its reservation back: %+v", row)
+	}
+	if row.sentAt != nil {
+		t.Fatal("an ambiguous dispatch must not be stamped sent")
+	}
+
+	// The next tick serves the other lead, never this one.
+	f.sender.setFail(nil)
+	f.tick(t)
+	if f.sender.count() != 1 {
+		t.Fatalf("second tick dispatched %d sends, want 1", f.sender.count())
+	}
+	if rowB := f.progressFor(t, f.leadB); rowB == nil || rowB.sentAt == nil {
+		t.Fatalf("the second tick did not serve the other lead: %+v", rowB)
+	}
+}
+
+// TestLiveConcurrentTicksSendOnce covers two ticks racing on the same pair,
+// which is the other way one recipient got two copies.
+func TestLiveConcurrentTicksSendOnce(t *testing.T) {
+	f := newSendFixture(t)
+	ctx := context.Background()
+
+	// One lead only, so both ticks must pick the SAME (contact, step) pair.
+	if _, err := f.pool.Exec(ctx, `DELETE FROM campaign_leads WHERE campaign_id = $1 AND contact_id = $2`,
+		f.campaign, f.leadB); err != nil {
+		t.Fatalf("drop lead B: %v", err)
+	}
+
+	// Both ticks are created up front, so both see the same routing state.
+	var taskIDs []uuid.UUID
+	for i := 0; i < 2; i++ {
+		taskIDs = append(taskIDs, f.newTask(t))
+	}
+	var wg sync.WaitGroup
+	for _, id := range taskIDs {
+		wg.Add(1)
+		go func(id uuid.UUID) {
+			defer wg.Done()
+			_ = f.svc.HandleCampaignTask(&proto.ProcessTask{TaskId: id.String()})
+		}(id)
+	}
+	wg.Wait()
+
+	// Whatever the interleaving, no contact may be dispatched twice and the
+	// day may not be charged more than the number of sends.
+	var rows, dispatched, sent int
+	if err := f.pool.QueryRow(ctx, `SELECT COUNT(*), COUNT(*) FILTER (WHERE dispatched_at IS NOT NULL), COUNT(*) FILTER (WHERE sent_at IS NOT NULL)
+		FROM campaign_contact_progress WHERE campaign_id = $1`, f.campaign).Scan(&rows, &dispatched, &sent); err != nil {
+		t.Fatal(err)
+	}
+	if dispatched != f.sender.count() {
+		t.Fatalf("%d sends went out but %d steps are reserved", f.sender.count(), dispatched)
+	}
+	var counted int
+	if err := f.pool.QueryRow(ctx, `SELECT COALESCE(emails_sent, 0) FROM campaign_daily_sends
+		WHERE campaign_id = $1 AND send_date = CURRENT_DATE`, f.campaign).Scan(&counted); err != nil {
+		t.Fatalf("read daily counters: %v", err)
+	}
+	if counted != f.sender.count() {
+		t.Fatalf("the day counted %d sends but %d went out", counted, f.sender.count())
+	}
+	// The single lead may only have been emailed once, whichever tick won.
+	if f.sender.count() != 1 || dispatched != 1 || rows != 1 {
+		t.Fatalf("one lead, two ticks: sends=%d reserved=%d rows=%d, want 1/1/1", f.sender.count(), dispatched, rows)
+	}
+	// ...and the losing tick ended as a skipped duplicate, not as a send.
+	var skipped int
+	if err := f.pool.QueryRow(ctx, `SELECT COUNT(*) FROM tasks WHERE email_account_id = $1 AND status = 'skipped_duplicate'`, f.mailbox).Scan(&skipped); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("sends=%d reserved=%d sent=%d skipped_duplicate=%d", f.sender.count(), dispatched, sent, skipped)
+}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -554,6 +554,40 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			config.Domain, campaign.ID.String(), contact.ID.String())
 	}
 
+	// STEP 15.9: Reserve the send BEFORE it goes on the bus. Once the command is
+	// published the recipient's copy is committed, so the record of the attempt
+	// has to exist first: without it, a crash or a failed progress write between
+	// the dispatch and the sent_at stamp leaves the step looking "never sent"
+	// and the next tick emails the same person again (issue #169). The
+	// reservation also counts the send against the day's counters, so a lost
+	// stamp can never let the daily cap over-send either.
+	reserved, rerr := s.campaignProgressRepo.ReserveSend(ctx, campaign.ID, contact.ID, sequence.ID, taskID, nextPair.IsNewLead)
+	if rerr != nil {
+		// The attempt could not be made durable, so it must not be made at all.
+		// Retry the whole task rather than sending something nothing remembers.
+		sentry.CaptureException(rerr)
+		s.taskRepo.RecordTaskFailure(ctx, taskID, "Could not reserve the send", rerr.Error())
+		s.recordSchedulerFailure(ctx, campaign.ID, "send_reservation_failed",
+			fmt.Sprintf("Could not record the send to %s before dispatching it; retrying", contact.Email), rerr)
+		if uerr := s.taskRepo.UpdateTaskStatus(ctx, taskID, "pending"); uerr != nil {
+			sentry.CaptureException(uerr)
+		}
+		executionStatus = "failed"
+		return errx.InternalError()
+	}
+	if !reserved {
+		// Another tick already has this (contact, step) in flight or delivered.
+		// End this one instead of sending a second copy, and keep the chain
+		// alive for whoever is next.
+		log.Warn().Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).
+			Str("contact_id", contact.ID.String()).Str("sequence_id", sequence.ID.String()).
+			Msg("campaign send skipped: the step is already in flight or sent")
+		_ = s.taskRepo.UpdateTaskStatusWithLock(ctx, taskID, "skipped_duplicate")
+		_ = s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
+		executionStatus = "completed"
+		return nil
+	}
+
 	// STEP 16: Send email to worker via Kafka
 	emailMsg := EmailMessage{
 		From:           account.Email,
@@ -574,6 +608,18 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		// The send never reached a worker (none assigned, worker offline, bus
 		// or storage down). Nothing is stamped sent; the task is dead-lettered
 		// for the retry loop and the chain is re-seeded by the reconciler.
+		//
+		// Give the reservation back so the next tick retries the step — but ONLY
+		// when the command provably never left. A failure of the publish call
+		// itself is ambiguous (the bus may have taken it), so that reservation
+		// stands and is resolved by the worker's own result, or by the reclaimer
+		// if none ever comes.
+		if !errors.Is(err, ErrSendDispatchUnknown) {
+			if relErr := s.campaignProgressRepo.ReleaseSend(ctx, campaign.ID, contact.ID, sequence.ID, nextPair.IsNewLead); relErr != nil {
+				sentry.CaptureException(relErr)
+				log.Error().Err(relErr).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to release the reservation for a send that never left; the reclaimer will retry it")
+			}
+		}
 		s.taskRepo.RecordTaskFailure(ctx, taskID, "Send failed", err.Error())
 		if s.campaignLogRepo != nil {
 			s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
@@ -640,17 +686,30 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	taskRecord.MessageID = messageID
 	taskRecord.Status = "completed"
 
-	// STEP 17: Update campaign progress
-	if err := s.campaignProgressRepo.RecordEmailSent(ctx, campaign.ID, contact.ID, sequence.ID); err != nil {
-		// Log but don't fail
-		log.Warn().Err(err).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to record email sent")
-	}
-
-	// Bump today's per-campaign counters. newLead counts ONLY a genuinely-sent
-	// position-1 (first-step) email, so the new-lead/day cap can never under-count
-	// and over-send. Skipped/suppressed/failed tasks never reach this point.
-	if err := s.campaignRepo.IncrementCampaignDailySend(ctx, campaign.ID, nextPair.IsNewLead); err != nil {
-		log.Warn().Err(err).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to increment campaign daily send counter")
+	// STEP 17: Stamp the step sent. The reservation already made the attempt
+	// durable, so this is the timing stamp follow-up pacing reads, not the
+	// duplicate guard — but losing it still parks the lead, so retry it, and
+	// escalate rather than whispering when every retry fails. The worker's own
+	// EMAIL_SENT repairs it downstream if it never lands.
+	// Today's counters were bumped by the reservation, inside the same
+	// transaction, so the new-lead/day cap can never under-count.
+	if err := s.stampSendRecorded(ctx, campaign.ID, contact.ID, sequence.ID); err != nil {
+		sentry.CaptureException(err)
+		log.Error().Err(err).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Str("contact_id", contact.ID.String()).Msg("Failed to record email sent; the worker result will repair the stamp")
+		if s.campaignLogRepo != nil {
+			s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+				CampaignID: campaign.ID,
+				EventType:  "progress_write_failed",
+				Message:    fmt.Sprintf("The email to %s was sent but recording it failed; it will not be sent again", contact.Email),
+				Metadata: map[string]interface{}{
+					"level":       "error",
+					"code":        "PROGRESS_WRITE_FAILED",
+					"contact_id":  contact.ID.String(),
+					"sequence_id": sequence.ID.String(),
+					"error":       err.Error(),
+				},
+			})
+		}
 	}
 
 	// Publish campaign progress summary to Pub/Sub for real-time dashboard updates
@@ -1096,6 +1155,28 @@ func campaignOrgID(campaign *Campaign) string {
 		return ""
 	}
 	return campaign.OrganizationID.String()
+}
+
+// stampSendRecorded writes the sent_at stamp for a send already on the bus,
+// retrying a transient database error instead of tolerating it. The email
+// cannot be un-sent at this point, so a single failed write used to be enough
+// to make routing offer the same step again (issue #169); the reservation now
+// prevents that, and these retries keep the lead's pacing correct too.
+func (s *tasksService) stampSendRecorded(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) error {
+	var err error
+	for attempt := 1; attempt <= config.CampaignSendStampAttempts; attempt++ {
+		if err = s.campaignProgressRepo.RecordEmailSent(ctx, campaignID, contactID, sequenceID); err == nil {
+			return nil
+		}
+		if attempt < config.CampaignSendStampAttempts {
+			select {
+			case <-ctx.Done():
+				return err
+			case <-time.After(time.Duration(attempt) * 250 * time.Millisecond):
+			}
+		}
+	}
+	return err
 }
 
 // recordSchedulerFailure writes a campaign-scoped, reviewable failure to the

--- a/internal/tasks/campaign_task_live_test.go
+++ b/internal/tasks/campaign_task_live_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,12 +236,37 @@ func (noopCipher) Cipher(ctx context.Context, orgID uuid.UUID) (*cipher.Cipher, 
 
 // recordingSender stands in for the worker dispatch: the tick's real side
 // effect is the stamped send, and this is what makes it observable without a
-// live worker.
-type recordingSender struct{ sent int }
+// live worker. fail makes Send behave like a dispatch that could not be
+// published, which is what the reservation tests need; the mutex is there
+// because those tests run ticks concurrently.
+type recordingSender struct {
+	mu   sync.Mutex
+	sent int
+	fail error
+}
 
 func (r *recordingSender) Send(ctx context.Context, taskID uuid.UUID, msg EmailMessage, account models.Email) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.fail != nil {
+		return r.fail
+	}
 	r.sent++
 	return nil
+}
+
+// count reads the send tally under the lock.
+func (r *recordingSender) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sent
+}
+
+// setFail makes every subsequent Send return err (nil restores dispatch).
+func (r *recordingSender) setFail(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fail = err
 }
 
 // liveCampaignService wires the real repositories the campaign tick uses.
@@ -387,8 +413,8 @@ func TestLiveHealthyCampaignStillSends(t *testing.T) {
 		t.Fatalf("campaign tick returned an error: %v", xerr)
 	}
 
-	if sender.sent != 1 {
-		t.Fatalf("sender saw %d sends, want 1", sender.sent)
+	if sender.count() != 1 {
+		t.Fatalf("sender saw %d sends, want 1", sender.count())
 	}
 	if n := f.sendsRecorded(t); n != 1 {
 		t.Fatalf("%d sends stamped, want 1", n)

--- a/internal/tasks/email_sender.go
+++ b/internal/tasks/email_sender.go
@@ -56,6 +56,14 @@ type WorkerLiveness interface {
 // worker and the dead-letter retry replays the task.
 var ErrWorkerOffline = errors.New("the mailbox's sending worker is offline")
 
+// ErrSendDispatchUnknown wraps a failure of the publish call itself. Every
+// other Send failure happens before anything is published and is safe to retry
+// immediately; this one is not, because the bus may have taken the command and
+// a worker may still deliver it. A campaign send that fails this way keeps its
+// reservation and is left to the worker result (or the reclaimer) rather than
+// being offered again.
+var ErrSendDispatchUnknown = errors.New("the send was not confirmed as queued and may already be on its way to a worker")
+
 type emailSender struct {
 	emailRepo repository.EmailRepository
 	publisher events.Publisher
@@ -128,7 +136,7 @@ func (s *emailSender) Send(ctx context.Context, taskID uuid.UUID, msg EmailMessa
 
 	// Publish send email event to worker
 	if err := s.publisher.PublishSendEmail(ctx, *workerID, params); err != nil {
-		return fmt.Errorf("failed to publish send email event: %w", err)
+		return fmt.Errorf("%w: %v", ErrSendDispatchUnknown, err)
 	}
 
 	return nil


### PR DESCRIPTION
Closes #169.

## The window

`SEND_EMAIL` went on the bus first and the progress row was written after, best-effort:

```go
s.emailSender.Send(...)                                   // committed as far as the recipient is concerned
...
if err := s.campaignProgressRepo.RecordEmailSent(...); err != nil {
    log.Warn()...Msg("Failed to record email sent")        // tolerated
}
```

`FindNextRoutedPair` decides "never been sent" from `sent_at`, so anything that broke in between made the step look unsent and the next tick emailed the same person again. As the issue says, this needed no crash: one transient database error was enough.

## The fix

**A durable pre-send reservation.** `ReserveSend` writes `campaign_contact_progress.dispatched_at` + `dispatch_task_id` and takes the day's counters in one transaction, *before* the dispatch. Routing now treats a step as attempted on `sent_at` **OR** `dispatched_at`, so the window cannot produce a second email. `sent_at` stays what it was: the timing stamp follow-up pacing reads.

The claim is `ON CONFLICT ... DO UPDATE ... WHERE sent_at IS NULL AND dispatched_at IS NULL`, which is exactly-once, so it also closes the second duplicate path the issue did not mention: two ticks that both selected the same pair. The loser ends `skipped_duplicate` instead of sending.

**Every reservation is resolved exactly once.** `RecordEmailSent` on a good hand-off, `ReleaseSend` when the command provably never left (no worker, worker offline), `RecordSendFailure` on a worker failure. A failure of the publish call itself is ambiguous, so it gets its own sentinel (`ErrSendDispatchUnknown`) and keeps its reservation rather than being retried into a possible duplicate.

**The progress write is no longer best-effort** (part 1 of the suggested direction): it retries, and a total failure is an error-level log plus a red `PROGRESS_WRITE_FAILED` entry in the campaign's activity feed.

**Downstream now repairs it** — the gap the issue called out in `HandleEmailSent`. It stamps a reserved step the control plane never recorded, from the worker's own confirmation. And a new `StartStuckSendReclaimer` in the consumer resolves reservations nobody ever answered (30 min): it believes a task carrying a Message-ID and stamps it, otherwise walks the step back as a failed attempt, so a worker that died mid-send cannot park a lead in flight forever.

The daily counters moved onto the reservation, so a lost stamp can no longer let the new-lead cap over-send either. `dispatched_at` / `dispatch_task_id` are in `ResetOnImport`: a task id means nothing on another instance, and an imported in-flight step would otherwise never be emailed.

## Tests

The regression the issue asks for — dispatch a send, fail the progress write, run routing again — is `TestLiveLostProgressWriteDoesNotResend`, driving the real `HandleCampaignTask` with only the bus and KMS stubbed. 13 live tests in three layers: the routing query and reclaimer (`send_reservation_live_test.go`), the scheduler (`live_integration_test.go`), and the send path (`campaign_send_live_test.go`), covering the lost stamp, an offline worker, an ambiguous publish, two ticks racing one lead, and both reclaim outcomes.

Each guard was checked by ablation rather than assumed: reverting the routing change makes `TestLiveDispatchedSendIsNeverOfferedTwice` report "routing offered the same step a second time", and removing the reservation entirely makes the end-to-end test show lead A emailed twice while lead B gets nothing.

`make fmt`, `make lint`, `make check-migrations`, the full Go suite and `pnpm types:check` / `pnpm lint` in `docs/` all pass. Migration renumbered to `000093` after `000092_org_id_not_null` landed on main.

## Not covered

One leg of the manual stack run: an actual SMTP delivery into Mailpit. The dev box could not give a clean run (the blob store is not shared between a containerised backend and a native worker, and sandbox mailboxes point at host ports no container can reach). Through the real Docker stack I did confirm the production wiring reserves before dispatch, stamps after, and walks both back on a worker `EMAIL_FAILED`. The remaining leg exercises worker code this PR does not touch.
