### PR TITLE
fix: release the selected IMAP mailbox before the LIST-STATUS poll so live sync keeps detecting new mail on Dovecot

### DIFF
--- a/internal/app/worker/wmail/sync_imap.go
+++ b/internal/app/worker/wmail/sync_imap.go
@@ -33,6 +33,9 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 	stats := &tickStats{}
 
 	client := w.SmtpImapData.ImapClient
+	// A mailbox left selected by the previous pass freezes LIST-STATUS on this
+	// connection, so release it before asking what changed.
+	client.ReleaseMailbox()
 	folders, err := client.Folders()
 	if err != nil {
 		return err

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -193,6 +193,17 @@ func (c *Client) SelectForSync(mailbox string) (uint32, *errx.MailError) {
 	return data.NumMessages, nil
 }
 
+// ReleaseMailbox drops the selected mailbox. Dovecot answers LIST-STATUS for
+// the selected mailbox with the values it held at SELECT, so a loop that keeps
+// INBOX selected never sees another change land. Servers without UNSELECT keep
+// the previous behaviour.
+func (c *Client) ReleaseMailbox() {
+	if c.client == nil || !c.client.Caps().Has(imap.CapUnselect) {
+		return
+	}
+	_ = c.client.Unselect().Wait()
+}
+
 // Fetched is one message's envelope as read by FetchEnvelopes, plus what
 // FetchBody needs to read its text parts later. Bodies are deliberately a
 // second step: the sync loop decides per message whether it is new and


### PR DESCRIPTION
Fixes #165.

## The problem

On Dovecot servers (Hostinger, cPanel, Mailcow) live sync imports exactly one batch per connection and then goes permanently silent, with nothing logged.

`Sync()` polls `LIST-STATUS` and calls `imapIncremental` only when `befBox.HighestModSeq != box.HighestModSeq`. The previous pass leaves INBOX selected (`SelectForSync` issues `EXAMINE INBOX (CONDSTORE)` and nothing ever releases it), and Dovecot answers `LIST-STATUS` for the *selected* mailbox with the values it held at SELECT. The comparison never becomes true, so the fetch is never attempted and the code believes nothing changed.

## The evidence

Held a single IMAP connection open while a message was delivered. Same connection throughout:

```
a2  before EXAMINE           MESSAGES 15  UIDNEXT 16  HIGHESTMODSEQ 21
a3  EXAMINE INBOX (CONDSTORE)
a4  after EXAMINE            MESSAGES 15  UIDNEXT 16  HIGHESTMODSEQ 21
        <-- a message is delivered to INBOX here -->
a5  INBOX still selected     MESSAGES 15  UIDNEXT 16  HIGHESTMODSEQ 21   <- frozen
a6  UNSELECT                 OK
a7  after UNSELECT           MESSAGES 16  UIDNEXT 17  HIGHESTMODSEQ 22   <- all three advance
```

This also rules out the approach in #95: `MESSAGES` and `UIDNEXT` freeze together with the mod-sequence, so an EXISTS/UIDNEXT fallback reads the same stale numbers and changes nothing.

## The fix

`Client.ReleaseMailbox()` sends `UNSELECT` (RFC 3691), and `Sync()` calls it before the `LIST-STATUS` poll. It is a no-op when the server does not advertise the capability, so servers without `UNSELECT` keep exactly the behaviour they have today. `imap.CapUnselect` is also satisfied by IMAP4rev2, which implies the command.

`UNSELECT` rather than `CLOSE` because the sync path opens the mailbox read-only and must never expunge.

## Validation

Running on a self-hosted install against Hostinger. Before the patch, a mailbox sat at mod-sequence 225 for a whole day and imported nothing. After it, that mailbox received its first message and another mailbox imported twice on the same connection without a restart.

`gofmt -l`, `go vet` and `golangci-lint v1.64.8` are clean on the touched packages.
