### PR TITLE
feat: close critical deliverability and abuse-safety gaps across issues 139 through 148

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -67,6 +67,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/oauth"
 	"github.com/warmbly/warmbly/internal/app/oidcauth"
 	"github.com/warmbly/warmbly/internal/app/organization"
+	"github.com/warmbly/warmbly/internal/app/orgrisk"
 	"github.com/warmbly/warmbly/internal/app/orgtransfer"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
@@ -121,6 +122,7 @@ import (
 	"github.com/warmbly/warmbly/internal/pkg/generation"
 	"github.com/warmbly/warmbly/internal/pkg/geo"
 	"github.com/warmbly/warmbly/internal/pkg/idtoken"
+	"github.com/warmbly/warmbly/internal/pkg/signuprisk"
 	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/scheduler"
 	"github.com/warmbly/warmbly/internal/tasks"
@@ -256,6 +258,7 @@ func main() {
 
 	// Organization-wide audit trail
 	var auditService audit.AuditService
+	var orgRiskService orgrisk.Service
 
 	// Pub/Sub for realtime streaming
 	var streamingPublisher *pubsub.StreamingPublisher
@@ -741,6 +744,7 @@ func main() {
 		// Organization-wide audit trail (who did what, when, from where).
 		auditRepository := repository.NewAuditRepository(primaryDB.Pool)
 		auditService = audit.NewService(auditRepository, streamingPublisher)
+		orgRiskService = orgrisk.NewService(repository.NewOrgRiskRepository(primaryDB.Pool), auditService)
 		// Bridge audited mutations to typed customer webhooks (campaign/contact/
 		// template/CRM/team/role/settings/subscription .created/.updated/.deleted).
 		auditService.WireWebhookDispatcher(webhookService)
@@ -772,6 +776,7 @@ func main() {
 			userRepostory,
 			userService,
 		)
+		authService.WireSignupRisk(signuprisk.New(cache.Client, nil), orgRiskService)
 		// TOTP 2FA: the secret is sealed with a server-wide key (the per-user DEK
 		// is unreachable at login time). Wire the challenger into auth so the login
 		// gate can issue a pending challenge.
@@ -1100,6 +1105,7 @@ func main() {
 		// only the prod backend has a real cache; jobs / tests build
 		// emailService without one.
 		emailService.WireThrottle(dailyThrottleService)
+		emailService.WireMailboxRisk(orgRiskService)
 		// Seed Graph delta cursors when the reconciler reloads mailboxes.
 		emailService.WireGraphDelta(repository.NewEmailGraphDeltaRepository(primaryDB))
 		// The Gmail equivalent: without it a reloaded mailbox re-bootstraps its
@@ -1121,6 +1127,7 @@ func main() {
 		rateLimitService = ratelimit.NewService(cache, rateLimitRepository)
 		sequenceService = sequence.NewService(sequenceRepostory)
 		contactService = contact.NewService(contactRepostory, subscriptionRepository, planRepository, streamingPublisher)
+		contactService.WireImportSafety(repository.NewContactImportAssessmentRepository(primaryDB.Pool), orgRiskService, cache.Client)
 
 		// On-demand Google Sheets -> leads sync (backend-only / control plane).
 		// Reuses the integration service for the Google token + sheet reads and
@@ -1175,8 +1182,12 @@ func main() {
 		if aware, ok := schedulerService.(scheduler.DomainAuthAware); ok && instanceSettings != nil {
 			aware.WireDomainAuth(instanceSettings)
 		}
+		if aware, ok := schedulerService.(scheduler.OrgRiskAware); ok {
+			aware.WireOrgRisk(orgRiskService)
+		}
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
+		emailSendService.WireOrgRisk(orgRiskService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
 		// uniboxService is constructed here (rather than alongside the
 		// other service constructors above) because cancel-scheduled
@@ -1371,6 +1382,7 @@ func main() {
 		if instanceSettings != nil {
 			tasksService.SetDomainAuthPolicy(instanceSettings)
 		}
+		tasksService.SetOrgRiskPolicy(orgRiskService)
 
 		// Admin outreach composer — sends from the platform mailer
 		// (SES/SMTP) with a configurable Reply-To, audits every send.
@@ -1498,7 +1510,8 @@ func main() {
 			HeloHost: os.Getenv("EMAIL_VERIFY_HELO_HOST"), // e.g. verify.warmbly.com
 			MailFrom: os.Getenv("EMAIL_VERIFY_MAIL_FROM"), // e.g. verify@warmbly.com
 		})
-		emailVerifyService = emailverifyapp.NewService(contactRepostory, emailVerifier)
+		emailVerifyService = emailverifyapp.NewService(contactRepostory, emailVerifier, campaignRepostory)
+		campaignService.WireCampaignVerifier(emailVerifyService)
 		emailVerificationJob := jobs.NewEmailVerificationJob(emailVerifyService, 100)
 		emailVerificationScheduler := jobs.NewEmailVerificationScheduler(emailVerificationJob, 15*time.Minute)
 		go emailVerificationScheduler.Start(ctx)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -12,6 +12,7 @@ import (
 	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/warmbly/warmbly/internal/app/advanced"
+	"github.com/warmbly/warmbly/internal/app/audit"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	jobs "github.com/warmbly/warmbly/internal/app/consumer"
 	"github.com/warmbly/warmbly/internal/app/credits"
@@ -21,6 +22,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/integration"
 	"github.com/warmbly/warmbly/internal/app/nativeactions"
 	"github.com/warmbly/warmbly/internal/app/notification"
+	"github.com/warmbly/warmbly/internal/app/orgrisk"
 	"github.com/warmbly/warmbly/internal/app/replyclassify"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/webhook"
@@ -205,6 +207,8 @@ func main() {
 	crmRepo := repository.NewCRMRepository(primaryDB.Pool)
 	orgRepoConsumer := repository.NewOrganizationRepository(primaryDB.Pool)
 	advancedRepo := repository.NewAdvancedOutreachRepository(primaryDB.Pool)
+	auditService := audit.NewService(repository.NewAuditRepository(primaryDB.Pool), streamingPublisher)
+	orgRiskService := orgrisk.NewService(repository.NewOrgRiskRepository(primaryDB.Pool), auditService)
 
 	// Reply → integration fan-out. The consumer is where inbound replies are
 	// detected, so this is where "prospect replied" turns into a Slack ping /
@@ -408,6 +412,7 @@ func main() {
 	// Persist each mailbox's sending-domain SPF/DKIM/DMARC state (observe-only,
 	// not yet a send gate): sweep hourly, rechecking each domain at most daily.
 	go jobsService.StartAuthCheckSweep(ctx, 1*time.Hour, 24*time.Hour)
+	orgrisk.StartCorrelationSweep(ctx, orgRiskService, 24*time.Hour)
 
 	// Drains the durable delayed-engagement schedule (read/important/star) so the
 	// recipient-side dwell survives worker restarts. Short interval keeps the

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -63,12 +63,17 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/generation/edit` | `WRITE_CAMPAIGNS` |
 | POST | `/generation/ai-variable` | `WRITE_CAMPAIGNS` |
 
+`POST /campaigns/:id/start` runs recipient verification before scheduling. It verifies up to 100 unchecked recipients per request and stores `verification_status`, `verification_summary`, and `verification_checked_at`, which are returned on campaign reads. A `409 campaign_verification_pending` means verification is still progressing and the start can be retried. A projected hard-bounce rate above `5%` returns `422 campaign_projected_bounce_rate_high`; a rate from `2%` through `5%`, or any risky recipient, records a warning but allows the campaign to start.
+
 ### Contacts
 
 | Method | Path | API Permission |
 |--------|------|----------------|
 | POST | `/contacts/search` | `READ_CONTACTS` |
 | GET | `/contacts/custom-fields` | `READ_CONTACTS` |
+| POST | `/contacts/export` | `READ_CONTACTS` |
+| POST | `/contacts/import/preview` | `WRITE_CONTACTS` |
+| POST | `/contacts/import/commit` | `BULK_CONTACTS` |
 | POST | `/contacts` | `WRITE_CONTACTS` |
 | DELETE | `/contacts` | `BULK_CONTACTS` |
 | PATCH | `/contacts` | `BULK_CONTACTS` |
@@ -85,6 +90,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/contacts/research/batch` | `AI_RESEARCH` |
 
 `GET /contacts/custom-fields` lists the distinct custom-field keys used across your contacts (frequency-ranked), for building personalization pickers. It returns a flat string array under `data`, capped at 200 keys.
+
+`POST /contacts/import/commit` statically classifies every mapped address before writing contacts. Successful responses include `quality` with invalid, disposable, role-based, risky-TLD, and combined bad-address counts. An import whose invalid plus disposable share is above `25%` is recorded for review and rejected with `422 contact_import_quality_blocked` before any contacts are written.
 
 AI contact research charges credits (2 per run, billable even when it finds nothing) and only saves cited findings. See the [AI contact research](/guides/ai-contact-research/) guide. The batch endpoint accepts up to 500 contact ids and drains in the background.
 
@@ -134,6 +141,7 @@ The `agent-drafts` endpoints back the [inbox agent](/guides/inbox-agent/): the a
 | Method | Path | API Permission |
 |--------|------|----------------|
 | GET | `/templates`, `/templates/:id` | `READ_TEMPLATES` |
+| POST | `/templates/score` | `READ_TEMPLATES` |
 | POST/PATCH/DELETE | `/templates[/:id]` | `WRITE_TEMPLATES` |
 | GET | `/crm/pipelines`, `/crm/pipelines/:id` | `READ_CRM` |
 | POST/PATCH/DELETE | `/crm/pipelines[/:id][/stages[/:stageId]]` | `WRITE_CRM` |
@@ -141,6 +149,8 @@ The `agent-drafts` endpoints back the [inbox agent](/guides/inbox-agent/): the a
 | POST/PATCH/DELETE | `/crm/deals[/:id]` | `WRITE_CRM` |
 | GET | `/crm/tasks`, `/crm/tasks/:id` | `READ_CRM` |
 | POST/PATCH/DELETE | `/crm/tasks[/:id]` | `WRITE_CRM` |
+
+`POST /templates/score` accepts `subject`, `body_html`, `body_plain`, and optional `attachment_count` and `image_count`. It returns a `0-100` score, an issue list, and `hard`. A hard result does not prevent saving, but the enabled content-safety preflight guardrail pauses the campaign before that step is sent.
 
 ### Analytics and audit
 

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -171,6 +171,12 @@ Signup and invitation refusals carry their own `code`, so a client can branch on
 
 **How to fix:** on a self-hosted deployment these are configuration, not faults. See [accounts and access](/development/accounts-and-access/#registration-modes).
 
+#### Sending suspension
+
+| `code` | Status | Meaning |
+|--------|--------|---------|
+| `organization_sending_suspended` | 403 | The workspace risk state is `suspended`. Outbound sending stays blocked until the underlying abuse or correlation signals are reviewed and the state is cleared |
+
 ### 404 Not Found
 
 Returned when the requested resource doesn't exist.
@@ -216,6 +222,12 @@ Returned when the request conflicts with existing data.
 }
 ```
 
+**Specific 409 codes:**
+
+| `code` | Meaning |
+|--------|---------|
+| `campaign_verification_pending` | Campaign launch verified a bounded batch of unchecked recipients and more remain. Retry the start after verification progresses; no campaign mail is scheduled meanwhile |
+
 ### 422 Unprocessable
 
 Returned when validation fails on the request data.
@@ -236,6 +248,13 @@ Returned when validation fails on the request data.
   "request_id": "4bbbd1b2-8f86-47dd-8a7f-9476501ad20e"
 }
 ```
+
+**Specific 422 codes:**
+
+| `code` | Meaning |
+|--------|---------|
+| `contact_import_quality_blocked` | More than `25%` of the uploaded addresses are invalid or disposable. No contacts from that import were written |
+| `campaign_projected_bounce_rate_high` | Recipients that are invalid or disposable exceed `5%` of the campaign list. Fix or remove those leads before starting |
 
 ### 500 Internal Server Error
 

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -15,6 +15,8 @@ You need at least one active mailbox and a contact list. Warm new mailboxes befo
 
 The campaign starts as a **draft**. Nothing sends until you start it.
 
+Every email step is scored automatically while you edit. The `0-100` content check flags spam-heavy phrases, link density, HTML imbalance, excessive images, and attachments. Warnings remain editable and save normally. Set `check_content_safety` in the campaign's preflight settings to pause the campaign before a step with a severe result is sent. The setting is off by default, so the editor starts in advisory mode.
+
 ## Senders and rotation
 
 Pick mailboxes in **Sending accounts** three ways, and the first two combine:
@@ -55,6 +57,8 @@ Anything above `50`/day per cold mailbox needs positive reputation signals and a
 
 **Daily ramp-up** grows volume gradually instead of starting at full limit: **ramp start** (default `10`), **ramp increment** (default `5`), and **ramp ceiling** (default `50`). It applies as another minimum, so it only lowers today's volume while ramping. This is separate from mailbox warmup; the two work together.
 
+The mailbox's own cold graduation is another minimum. A fresh mailbox starts cold sending at `10`/day, or at its proven warmup volume once it has at least 21 days of warmup history, then gains `5`/day. Recent spam-folder placement cuts that daily ceiling by `25%`. Campaign settings can lower the result but cannot bypass it.
+
 **Lead flow** throttles new contacts with **Max new leads per day** (`0` for unlimited, up to `1000`). At the cap, follow-ups to in-flight contacts continue and new leads resume tomorrow. You can prioritize new leads over follow-ups, and choose whether to attempt addresses verification flagged risky.
 
 ### Adding leads
@@ -90,6 +94,8 @@ Optional **campaign dates** bound when it may send. Leave both blank to run open
 ## Start and stop
 
 The play and pause buttons work from the list row or the detail view. Starting moves the campaign to **active** and begins scheduling inside your windows and limits; pausing stops new scheduling immediately and resumes from where it left off.
+
+Before the status changes, launch verification checks unchecked recipients in batches of 100 and stores counts for valid, risky, invalid, disposable, catch-all, and pending addresses. If more checks remain, the launch waits and can be retried. A projected hard-bounce rate above `5%` blocks launch; `2%` through `5%`, or any risky result, produces a warning so you can clean the list before volume grows.
 
 A campaign can pause itself: **paused, no accounts** when it loses every sender, **paused, trial expired** when a trial ends, **auto-paused** when a guardrail trips, and plain **paused** if it ever loses its workspace, because unsubscribes, bounces and complaints are checked per workspace and cannot be honoured without one. It moves to **finished** once every contact completes the sequence or its end date passes. Configured to do so, it also stops following up with a contact the moment they reply.
 

--- a/docs/content/docs/guides/contacts-crm.mdx
+++ b/docs/content/docs/guides/contacts-crm.mdx
@@ -27,6 +27,8 @@ You must map at least one column to **Email**.
 
 Rows with a missing or invalid email are reported with a line number and reason rather than imported.
 
+Before writing any row, Warmbly also classifies the complete file for invalid, disposable, role-based, and risky-TLD addresses. The result includes this list-quality summary. If invalid plus disposable addresses exceed `25%` of the file, the whole import is recorded and blocked before contacts are written. Fix the source list and upload it again rather than removing only the visibly failed rows.
+
 **From Google Sheets**, a sheet is a reusable **sync source** rather than a one-time upload. Connect it once (Warmbly reads only the tab you choose and never writes back), paste the spreadsheet ID from the URL between `/d/` and `/edit`, pick the tab, map columns, then set duplicate handling, a label, and optionally a campaign to enroll into and categories to apply. **Nothing syncs automatically**: press **Sync now**, or save and sync immediately.
 
 Saved sources live in your Sync sources list to re-run, edit, or remove. Each sync dedupes on lowercased email using your chosen duplicate handling, so re-syncing a sheet with new rows is safe.

--- a/docs/content/docs/guides/deliverability.mdx
+++ b/docs/content/docs/guides/deliverability.mdx
@@ -104,7 +104,22 @@ If a campaign has already been paused because every one of its mailboxes was gat
 
 The list is held per workspace, and the check runs against the sending campaign's workspace before every send. If a campaign somehow has no workspace, that check cannot be applied, so the campaign is paused with the reason in its activity feed instead of sending unchecked.
 
-Bounces are detected from the delivery-status report the recipient's server sends back. Only permanent failures (`5.x.x`, such as a nonexistent address) record a bounce and suppress; temporary ones (`4.x.x`, such as a full mailbox or greylisting) never do. This works the same for Gmail and Microsoft Graph mailboxes, where the send reports success and the bounce arrives later.
+Bounces are detected both when SMTP rejects a recipient during the send and when a delivery-status report arrives later. Only permanent failures (`5.x.x`, such as a nonexistent address) record a bounce and suppress; temporary ones (`4.x.x`, such as a full mailbox or greylisting) never do. Authentication failures such as `5.7.515` mark the sending mailbox inactive so the same credentials are not retried indefinitely.
+
+Abuse-report feedback loops are parsed when a provider sends a standard ARF complaint. Warmbly records the complaint once, suppresses the original recipient, updates campaign and mailbox guardrails, and ignores unrelated forwarded messages rather than guessing that they are complaints.
+
+## Workspace risk states
+
+Mailbox health protects one sender. The workspace risk state protects the whole sending account when signals correlate across signups, imports, mailbox connections, billing fingerprints, or fresh-domain sending patterns.
+
+| State | Score | Effect |
+|-------|-------|--------|
+| `trusted` | below `20` | Normal sending and pool placement |
+| `watch` | `20-49` | Signals are retained and monitored |
+| `restricted` | `50-79` | Cold sending is capped at `10` per mailbox per day and warmup uses the lower-trust pool |
+| `suspended` | `80+` | Outbound sending is blocked |
+
+State transitions are audited and published live to teammates. The API exposes the state, score, reason, and evaluation time, but keeps raw correlation evidence private.
 
 ## How to read it
 

--- a/docs/content/docs/guides/security.mdx
+++ b/docs/content/docs/guides/security.mdx
@@ -15,6 +15,8 @@ Everything here lives under **Settings > Security** and concerns signing in to W
 
 A first sign-in with a new address via Google or Apple creates your account, workspace, and free trial automatically.
 
+Registration also evaluates disposable or role-based addresses, repeated normalized aliases, signup IP and ASN velocity, and hosting-network signals after CAPTCHA succeeds. Warmbly stores the signup IP, browser identifier, email risk score, and ASN for abuse correlation. These signals do not reveal whether another account exists, but they can move a new workspace into monitored or restricted sending until it establishes normal behavior.
+
 <Callout type="info" title="Passwordless by design">
 A passkey is tied to your device and unlocked with biometrics or a PIN, so it already proves both something you have and something you are or know. That is why it skips the emailed code.
 </Callout>

--- a/docs/content/docs/guides/warmup.mdx
+++ b/docs/content/docs/guides/warmup.mdx
@@ -38,7 +38,7 @@ A pool is the set of mailboxes that warm each other. Your mailbox only exchanges
 | `premium` | Paid organizations' mailboxes. The default for paid accounts, isolated from lower-trust traffic. |
 | `free` | Lower-trust or trial mailboxes, kept separate so free traffic never mixes into premium reputation. |
 
-The separation is never crossed silently. Warmbly spreads sends across many partners and recipient domains rather than looping the same two mailboxes, since tight reciprocal pairs are easy for providers to spot. **Pool quality matters more than pool size.**
+The separation is never crossed silently. Warmbly spreads sends across many partners and recipient domains rather than looping the same two mailboxes, since tight reciprocal pairs are easy for providers to spot. It also reads seven days of placement by recipient provider and downweights partners on providers where the sender is landing in spam. **Pool quality matters more than pool size.**
 
 Turning off outbound warmup does not remove a healthy mailbox from the recipient pool. Disconnecting it, losing warmup-plan access, or entering a quarantined or blocked state does.
 
@@ -52,7 +52,7 @@ Turning off outbound warmup does not remove a healthy mailbox from the recipient
 
 At defaults a mailbox sends 10 on day one, 11 the next, and levels off at 40 after roughly a month. You can change these per mailbox, but conservative defaults build the most durable reputation.
 
-Three things shape the real daily number: sends are spread across your warmup hours with jitter, the target is capped by how many eligible partners exist, and a mailbox whose health drops gets reduced volume and wider spacing until it recovers.
+Four things shape the real daily number: sends are spread across your warmup hours with jitter, the target is capped by how many eligible partners exist, a mailbox whose health drops gets reduced volume and wider spacing, and early spam-folder placement lowers the next target by `25%`. That placement brake holds the lower target across a rolling three-day window instead of allowing the normal ramp to erase a bad signal the next morning.
 
 <Callout type="info" title="Warmup and campaigns coexist">
   Keep warmup on after campaigns start. A mailbox backing a live campaign drops to at most five warmup messages per day, leaving the campaign as primary traffic. Warmup does not make repetitive or unwanted copy safe: you still need real targeting, personalization, suppression, and unsubscribe support.

--- a/internal/api/handler/auth.go
+++ b/internal/api/handler/auth.go
@@ -65,7 +65,7 @@ func (h *Handler) RegistrationStart(c *gin.Context) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), authRequestTimeout)
 	defer cancel()
 
-	resp, err := h.AuthService.RegistrationStart(ctx, &data, c.ClientIP())
+	resp, err := h.AuthService.RegistrationStart(ctx, &data, c.ClientIP(), c.Request.UserAgent())
 	if err != nil {
 		errx.Handle(c, err)
 		return

--- a/internal/api/handler/template_score.go
+++ b/internal/api/handler/template_score.go
@@ -10,15 +10,14 @@ import (
 )
 
 type scoreTemplateRequest struct {
-	Subject   string `json:"subject"`
-	BodyHTML  string `json:"body_html"`
-	BodyPlain string `json:"body_plain"`
+	Subject         string `json:"subject"`
+	BodyHTML        string `json:"body_html"`
+	BodyPlain       string `json:"body_plain"`
+	AttachmentCount int    `json:"attachment_count"`
+	ImageCount      int    `json:"image_count"`
 }
 
-// ScoreTemplateContent returns an advisory deliverability content score for a
-// campaign template (subject + body) before it is sent. Advisory only — it
-// never blocks sending — so the user gets content feedback on the mail that
-// actually reaches prospects, which warmup-only linting never covered.
+// ScoreTemplateContent returns the content score used by the send guardrail.
 func (h *Handler) ScoreTemplateContent(c *gin.Context) {
 	var req scoreTemplateRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -26,6 +25,9 @@ func (h *Handler) ScoreTemplateContent(c *gin.Context) {
 		return
 	}
 
-	res := warmlint.Score(req.Subject, req.BodyHTML, req.BodyPlain)
+	res := warmlint.ScoreWithOptions(req.Subject, req.BodyHTML, req.BodyPlain, warmlint.ScoreOptions{
+		AttachmentCount: req.AttachmentCount,
+		ImageCount:      req.ImageCount,
+	})
 	c.JSON(http.StatusOK, res)
 }

--- a/internal/app/advanced/inbound_bounce.go
+++ b/internal/app/advanced/inbound_bounce.go
@@ -15,6 +15,14 @@ import (
 // it through IngestDeliverabilityEvent (suppression + campaign progress +
 // breaker), keyed idempotently so re-delivered NDRs don't double-count.
 func (s *service) RecordInboundBounce(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, failedRecipient, reason string) *errx.Error {
+	return s.recordInboundDeliverability(ctx, emailAccountID, originalMessageID, failedRecipient, reason, models.DeliverabilityEventBounce, "inbound_ndr", "ndr:")
+}
+
+func (s *service) RecordInboundComplaint(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, recipient, feedbackType string) *errx.Error {
+	return s.recordInboundDeliverability(ctx, emailAccountID, originalMessageID, recipient, feedbackType, models.DeliverabilityEventComplaint, "inbound_fbl", "fbl:")
+}
+
+func (s *service) recordInboundDeliverability(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, recipient, reason string, eventType models.DeliverabilityEventType, provider, idempotencyPrefix string) *errx.Error {
 	originalMessageID = strings.Trim(strings.TrimSpace(originalMessageID), "<>")
 	if originalMessageID == "" {
 		return nil
@@ -39,13 +47,13 @@ func (s *service) RecordInboundBounce(ctx context.Context, emailAccountID uuid.U
 	}
 
 	req := &models.IngestDeliverabilityEventRequest{
-		EventType:      models.DeliverabilityEventBounce,
-		Provider:       "inbound_ndr",
+		EventType:      eventType,
+		Provider:       provider,
 		TaskID:         &task.ID,
-		RecipientEmail: failedRecipient,
+		RecipientEmail: recipient,
 		Reason:         reason,
 		// Same NDR re-synced (delta re-runs, reconnects) must not double-count.
-		IdempotencyKey: "ndr:" + originalMessageID,
+		IdempotencyKey: idempotencyPrefix + originalMessageID,
 	}
 
 	if ct, cerr := s.taskRepo.GetCampaignTask(ctx, task.ID); cerr == nil && ct != nil {

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -33,6 +33,7 @@ type Service interface {
 	DeleteABVariant(ctx context.Context, campaignID, variantID uuid.UUID) *errx.Error
 
 	RunPreflight(ctx context.Context, organizationID, campaignID uuid.UUID) (*models.PreflightReport, *errx.Error)
+	ContentSafetyEnabled(ctx context.Context, organizationID, campaignID uuid.UUID) (bool, *errx.Error)
 	GetDeliverabilityDashboard(ctx context.Context, organizationID uuid.UUID, from, to time.Time) (*models.DeliverabilityDashboard, *errx.Error)
 
 	IngestDeliverabilityEvent(ctx context.Context, organizationID uuid.UUID, req *models.IngestDeliverabilityEventRequest) *errx.Error
@@ -41,6 +42,7 @@ type Service interface {
 	// the original campaign send via its Message-ID and records a bounce
 	// deliverability event. Best-effort: unresolvable bounces are a no-op.
 	RecordInboundBounce(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, failedRecipient, reason string) *errx.Error
+	RecordInboundComplaint(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, recipient, feedbackType string) *errx.Error
 
 	ShouldSuppressRecipient(ctx context.Context, organizationID uuid.UUID, recipient string) (bool, string, *errx.Error)
 	// Unsubscribe suppresses a contact in response to a List-Unsubscribe action
@@ -1608,6 +1610,14 @@ func (s *service) RunPreflight(ctx context.Context, organizationID, campaignID u
 		return nil, toErrx(err)
 	}
 	return report, nil
+}
+
+func (s *service) ContentSafetyEnabled(ctx context.Context, organizationID, campaignID uuid.UUID) (bool, *errx.Error) {
+	settings, xerr := s.effectiveSettings(ctx, organizationID, campaignID)
+	if xerr != nil {
+		return false, xerr
+	}
+	return settings.Preflight.Enabled && settings.Preflight.CheckContentSafety, nil
 }
 
 func (s *service) GetDeliverabilityDashboard(ctx context.Context, organizationID uuid.UUID, from, to time.Time) (*models.DeliverabilityDashboard, *errx.Error) {

--- a/internal/app/auth/provision.go
+++ b/internal/app/auth/provision.go
@@ -18,7 +18,7 @@ import (
 //
 // invite, when it resolves, puts the account straight into the inviting
 // organization instead of a fresh empty one.
-func (s *authService) createAccount(ctx context.Context, address, passwordHash, referralCode, invite string) *errx.Error {
+func (s *authService) createAccount(ctx context.Context, address, passwordHash, referralCode, invite string, signup *models.RegistrationSession) *errx.Error {
 	email, perr := mail.ParseAddress(address)
 	if perr != nil {
 		return errx.ErrEmail
@@ -37,6 +37,11 @@ func (s *authService) createAccount(ctx context.Context, address, passwordHash, 
 
 	if err := s.userService.SaveUser(ctx, u); err != nil {
 		return err
+	}
+	if signup != nil {
+		if err := s.userRepository.SetSignupMetadata(ctx, u.ID, signup.SignupIP, signup.SignupUserAgent, signup.SignupEmailRisk, signup.SignupASN); err != nil {
+			sentry.CaptureException(err)
+		}
 	}
 
 	// An invited account joins the inviting org and stops there: no second
@@ -72,6 +77,15 @@ func (s *authService) createAccount(ctx context.Context, address, passwordHash, 
 		if err := s.trialService.StartFreeTrialWithOrg(ctx, u.ID, org.ID); err != nil {
 			sentry.CaptureException(err)
 			// Don't fail registration if trial creation fails
+		}
+	}
+	if s.orgRisk != nil && org != nil && signup != nil && signup.SignupRiskScore > 0 {
+		if err := s.orgRisk.RecordSignal(ctx, org.ID, "signup", signup.SignupRiskScore, "Signup metadata requires monitoring", map[string]any{
+			"signals":    signup.SignupSignals,
+			"email_risk": signup.SignupEmailRisk,
+			"asn":        signup.SignupASN,
+		}); err != nil {
+			sentry.CaptureException(err)
 		}
 	}
 

--- a/internal/app/auth/registration.go
+++ b/internal/app/auth/registration.go
@@ -13,7 +13,7 @@ import (
 	"github.com/warmbly/warmbly/internal/pkg/crypt"
 )
 
-func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipaddr string) (*models.AuthSession, *errx.Error) {
+func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipaddr, userAgent string) (*models.AuthSession, *errx.Error) {
 	if s.policy.DisablePasswordLogin {
 		return nil, errx.New(errx.Forbidden, "password sign-up is disabled on this deployment")
 	}
@@ -25,6 +25,21 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 	if xerr := s.captcha.Verify(ctx, data.Turnstile, ipaddr); xerr != nil {
 		sentry.CaptureException(xerr)
 		return nil, xerr
+	}
+
+	var signup *models.RegistrationSession
+	if s.signupRisk != nil {
+		assessment := s.signupRisk.Assess(ctx, data.Email, ipaddr, userAgent)
+		signup = &models.RegistrationSession{
+			SignupIP:        assessment.IP,
+			SignupUserAgent: assessment.UserAgent,
+			SignupEmailRisk: assessment.EmailRisk,
+			SignupASN:       assessment.ASN,
+			SignupRiskScore: assessment.Score,
+			SignupSignals:   assessment.Signals,
+		}
+	} else {
+		signup = &models.RegistrationSession{SignupIP: ipaddr, SignupUserAgent: userAgent}
 	}
 
 	if !crypt.ValidatePassword(data.Password) {
@@ -41,7 +56,7 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 	// nothing to confirm: create the account now rather than issuing a code
 	// nobody can receive. Every product surveyed defaults self-host to this.
 	if !s.policy.RequireEmailVerification || !s.mailDelivers {
-		if err := s.createAccount(ctx, data.Email, passwordHash, data.ReferralCode, data.Invite); err != nil {
+		if err := s.createAccount(ctx, data.Email, passwordHash, data.ReferralCode, data.Invite, signup); err != nil {
 			return nil, err
 		}
 		return &models.AuthSession{CodeRequired: false}, nil
@@ -84,11 +99,17 @@ func (s *authService) RegistrationStart(ctx context.Context, data *AuthData, ipa
 	}
 
 	session := &models.RegistrationSession{
-		CodeHash:     codeHash,
-		PasswordHash: passwordHash,
-		Nonce:        nonce,
-		ReferralCode: data.ReferralCode,
-		Invite:       data.Invite,
+		CodeHash:        codeHash,
+		PasswordHash:    passwordHash,
+		Nonce:           nonce,
+		ReferralCode:    data.ReferralCode,
+		Invite:          data.Invite,
+		SignupIP:        signup.SignupIP,
+		SignupUserAgent: signup.SignupUserAgent,
+		SignupEmailRisk: signup.SignupEmailRisk,
+		SignupASN:       signup.SignupASN,
+		SignupRiskScore: signup.SignupRiskScore,
+		SignupSignals:   signup.SignupSignals,
 	}
 
 	if err := s.saveRegistrationSession(ctx, sessionID, session, expiresAt); err != nil {
@@ -145,5 +166,5 @@ func (s *authService) RegistrationConfirm(ctx context.Context, data *ConfirmData
 		return err
 	}
 
-	return s.createAccount(ctx, token.Email, sess.PasswordHash, sess.ReferralCode, sess.Invite)
+	return s.createAccount(ctx, token.Email, sess.PasswordHash, sess.ReferralCode, sess.Invite, sess)
 }

--- a/internal/app/auth/service.go
+++ b/internal/app/auth/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/notify"
 	"github.com/warmbly/warmbly/internal/pkg/captcha"
+	"github.com/warmbly/warmbly/internal/pkg/signuprisk"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -40,13 +41,17 @@ type InstanceSettings interface {
 	AllowInvitedSignup(ctx context.Context) bool
 }
 
+type OrganizationRiskRecorder interface {
+	RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, score int, reason string, evidence map[string]any) error
+}
+
 type AuthService interface {
 	LoginStart(ctx context.Context, data *AuthData, ipaddr, userAgent string) (*models.AuthSession, *errx.Error)
 	LoginConfirm(ctx context.Context, data *ConfirmData, session, ipaddr, userAgent string) (*models.LoginResult, *errx.Error)
 	// WireTwoFA attaches the 2FA challenger (post-construction; nil = 2FA off).
 	WireTwoFA(t TwoFAChallenger)
 
-	RegistrationStart(ctx context.Context, data *AuthData, ipaddr string) (*models.AuthSession, *errx.Error)
+	RegistrationStart(ctx context.Context, data *AuthData, ipaddr, userAgent string) (*models.AuthSession, *errx.Error)
 	RegistrationConfirm(ctx context.Context, data *ConfirmData, session, ipaddr string) *errx.Error
 	// WireReferral attaches the referral attributor (post-construction; nil = no
 	// referral attribution at signup).
@@ -55,6 +60,7 @@ type AuthService interface {
 	// WireInstanceSettings attaches the database-backed instance settings
 	// (post-construction; nil keeps the permissive defaults).
 	WireInstanceSettings(s InstanceSettings)
+	WireSignupRisk(scorer *signuprisk.Scorer, risk OrganizationRiskRecorder)
 
 	// Native-app social sign-in: the client authenticates with the provider on
 	// device and exchanges the resulting ID token for a session. First sign-in
@@ -120,7 +126,9 @@ type authService struct {
 	// is only safe for Apple and Google.
 	identities repository.IdentityRepository
 	// oidc is the generic OpenID Connect provider, nil unless configured.
-	oidc OIDCProvider
+	oidc       OIDCProvider
+	signupRisk *signuprisk.Scorer
+	orgRisk    OrganizationRiskRecorder
 
 	// policy and mailDelivers govern whether an emailed code gates a login and
 	// whether public signups are open. Defaults are set in NewService so a
@@ -149,6 +157,11 @@ func (s *authService) WireReferral(r ReferralAttributor) { s.referral = r }
 // WireInstanceSettings attaches the instance settings document, so the signup
 // knobs on the admin page reach the registration paths.
 func (s *authService) WireInstanceSettings(set InstanceSettings) { s.settings = set }
+
+func (s *authService) WireSignupRisk(scorer *signuprisk.Scorer, risk OrganizationRiskRecorder) {
+	s.signupRisk = scorer
+	s.orgRisk = risk
+}
 
 func NewService(
 	authRepository repository.AuthRepository,

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -239,6 +239,31 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 		}
 	}
 
+	if s.verifier != nil {
+		summary, xerr := s.verifier.VerifyCampaign(ctx, cID)
+		if xerr != nil {
+			return xerr
+		}
+		if summary.Pending > 0 {
+			return errx.ErrCampaignVerificationPending
+		}
+		if summary.ProjectedHardBounceRate > 0.05 {
+			return errx.ErrCampaignProjectedBounce
+		}
+		if summary.ProjectedHardBounceRate >= 0.02 && s.campaignLogRepo != nil {
+			_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+				CampaignID: cID,
+				EventType:  "verification_warning",
+				Message:    "Campaign list has an elevated projected hard-bounce rate",
+				Metadata: map[string]interface{}{
+					"projected_hard_bounce_rate": summary.ProjectedHardBounceRate,
+					"invalid":                    summary.Invalid,
+					"disposable":                 summary.Disposable,
+				},
+			})
+		}
+	}
+
 	activeCampaigns, err := s.campaignRepository.CountActiveForOrganization(ctx, orgID)
 	if err != nil {
 		return errx.InternalError()

--- a/internal/app/campaign/service.go
+++ b/internal/app/campaign/service.go
@@ -38,6 +38,11 @@ type CampaignService interface {
 	// Campaign-scoped tracking domain (feature 5). Resolves the override's CNAME
 	// and flips verified on success; an unresolved record stays "pending".
 	VerifyCampaignTrackingDomain(ctx context.Context, orgID uuid.UUID, campaignID string) (*models.TrackingDomainStatus, *errx.Error)
+	WireCampaignVerifier(verifier CampaignVerifier)
+}
+
+type CampaignVerifier interface {
+	VerifyCampaign(ctx context.Context, campaignID uuid.UUID) (*models.CampaignVerificationSummary, *errx.Error)
 }
 
 type campaignService struct {
@@ -50,6 +55,11 @@ type campaignService struct {
 	scheduler          scheduler.SchedulerService
 	tasksClient        tasksched.Scheduler
 	streamingPublisher *pubsub.StreamingPublisher
+	verifier           CampaignVerifier
+}
+
+func (s *campaignService) WireCampaignVerifier(verifier CampaignVerifier) {
+	s.verifier = verifier
 }
 
 func NewService(

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -58,6 +59,9 @@ func (s *JobsService) HandleEmailAuthError(ctx context.Context, event models.Ema
 
 	// Mark email account as needing re-auth (set status to inactive)
 	if s.EmailRepository != nil {
+		if err := s.EmailRepository.MarkAuthFailure(ctx, emailAccountID, event.Message, time.Now().UTC()); err != nil {
+			log.Error().Err(err).Msg("Failed to mark mailbox domain authentication as failing")
+		}
 		inactive := "inactive"
 		if _, xerr := s.EmailRepository.Update(ctx, event.UserID, event.EmailAccountID, &models.UpdateEmail{
 			Status: &inactive,

--- a/internal/app/consumer/event_inbound_complaint.go
+++ b/internal/app/consumer/event_inbound_complaint.go
@@ -1,0 +1,18 @@
+package jobs
+
+import (
+	"context"
+
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func (s *JobsService) HandleInboundComplaint(ctx context.Context, event *models.JobEventInboundComplaint) error {
+	if s.AdvancedService == nil {
+		return nil
+	}
+	if xerr := s.AdvancedService.RecordInboundComplaint(ctx, event.EmailID, event.OriginalMessageID, event.Recipient, event.FeedbackType); xerr != nil {
+		log.Warn().Str("email_id", event.EmailID.String()).Str("original_message_id", event.OriginalMessageID).Str("error", xerr.Message).Msg("failed to record inbound complaint")
+	}
+	return nil
+}

--- a/internal/app/consumer/events.go
+++ b/internal/app/consumer/events.go
@@ -28,6 +28,7 @@ func (w *JobsService) InitEvents() {
 	w.eventHandlers = make(map[models.JobEventType]func(ctx context.Context, body any) error)
 	Register(w, models.JobEventTypeNewEmail, w.HandleNewEmail)
 	Register(w, models.JobEventTypeInboundBounce, w.HandleInboundBounce)
+	Register(w, models.JobEventTypeInboundComplaint, w.HandleInboundComplaint)
 	Register(w, models.JobEventTypeEmailUpdate, w.HandleUpdateEmail)
 	Register(w, models.JobEventTypeRemoveEmail, w.HandleRemoveEmail)
 	Register(w, models.JobEventTypeFlagsAdd, w.HandleFlagsAdd)

--- a/internal/app/contact/import.go
+++ b/internal/app/contact/import.go
@@ -15,6 +15,7 @@ import (
 	"github.com/warmbly/warmbly/internal/email"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/signuprisk"
 	"github.com/warmbly/warmbly/internal/utils"
 	"github.com/xuri/excelize/v2"
 )
@@ -142,26 +143,72 @@ func (s *contactService) ImportCommit(
 	}
 
 	parsed := make([]pendingRow, 0, len(data))
+	quality := &models.ContactImportQuality{}
 	for i, row := range data {
 		line := i + dataStart + 1 // 1-based for "open in Excel and jump"
 		p := pendingRow{line: line, raw: row}
 
 		contact, err := buildAddContact(row, opts.Mapping, subscribedDefault, opts.CampaignIDs, opts.CategoryIDs)
 		if err != "" {
+			quality.Invalid++
 			p.errMsg = err
 			parsed = append(parsed, p)
 			continue
 		}
 		contact.Email = strings.TrimSpace(contact.Email)
 		if contact.Email == "" || !email.IsValid(contact.Email) {
+			quality.Invalid++
 			p.errMsg = "missing or invalid email"
 			parsed = append(parsed, p)
 			continue
 		}
 		contact.Email = strings.ToLower(contact.Email)
+		addressQuality := signuprisk.ClassifyAddress(contact.Email)
+		if addressQuality.Disposable {
+			quality.Disposable++
+		}
+		if addressQuality.Role {
+			quality.Role++
+		}
+		if addressQuality.RiskyTLD {
+			quality.RiskyTLD++
+		}
 		p.contact = contact
 		p.ok = true
 		parsed = append(parsed, p)
+	}
+	if len(parsed) > 0 {
+		quality.BadAddressRatio = float64(quality.Invalid+quality.Disposable) / float64(len(parsed))
+	}
+	quality.Blocked = quality.BadAddressRatio > 0.25
+	if s.importAssessment != nil {
+		assessmentID, err := s.importAssessment.Create(ctx, orgID, uid, filename, len(parsed), quality)
+		if err != nil {
+			return nil, errx.InternalError()
+		}
+		quality.AssessmentID = assessmentID.String()
+	}
+	if s.velocity != nil {
+		key := "org-risk:imports:" + orgID.String() + ":" + time.Now().UTC().Format("2006-01-02")
+		if count, err := s.velocity.Incr(ctx, key).Result(); err == nil {
+			if count == 1 {
+				_ = s.velocity.Expire(ctx, key, 25*time.Hour).Err()
+			}
+			if count >= 5 && s.orgRisk != nil {
+				_ = s.orgRisk.RecordSignal(ctx, orgID, "import_velocity", 15, "High contact import velocity", map[string]any{"imports_today": count})
+			}
+		}
+	}
+	if (quality.BadAddressRatio >= 0.10 || quality.Role > 0 || quality.RiskyTLD > 0) && s.orgRisk != nil {
+		score := min(30, int(quality.BadAddressRatio*100))
+		_ = s.orgRisk.RecordSignal(ctx, orgID, "list_quality", score, "Contact import contains risky addresses", map[string]any{
+			"bad_address_ratio": quality.BadAddressRatio,
+			"role_addresses":    quality.Role,
+			"risky_tlds":        quality.RiskyTLD,
+		})
+	}
+	if quality.Blocked {
+		return nil, errx.ErrContactImportQuality
 	}
 
 	// Pre-check existing emails in one shot so we can route rows to
@@ -181,6 +228,7 @@ func (s *contactService) ImportCommit(
 		Total:     len(parsed),
 		StartedAt: startedAt,
 		Errors:    make([]models.ContactImportRowError, 0),
+		Quality:   quality,
 	}
 
 	// Bucket rows by target action. We send fresh inserts through

--- a/internal/app/contact/service.go
+++ b/internal/app/contact/service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
@@ -37,6 +38,7 @@ type ContactService interface {
 	// and performs the upsert / skip / dedup work. Returns per-row
 	// result counts plus a list of rows that failed (with reasons).
 	ImportCommit(ctx context.Context, userID string, orgID uuid.UUID, file io.Reader, filename string, opts *models.ContactImportCommit) (*models.ContactImportResult, *errx.Error)
+	WireImportSafety(repo repository.ContactImportAssessmentRepository, risk ImportRiskRecorder, velocity redis.Cmdable)
 
 	// ListCustomFieldKeys returns the org's distinct contact custom-field keys,
 	// frequency-ranked then alphabetical, capped at 200. Powers the dashboard
@@ -67,6 +69,19 @@ type contactService struct {
 	subRepo            repository.SubscriptionRepository
 	planRepo           repository.PlanRepository
 	streamingPublisher *pubsub.StreamingPublisher
+	importAssessment   repository.ContactImportAssessmentRepository
+	orgRisk            ImportRiskRecorder
+	velocity           redis.Cmdable
+}
+
+type ImportRiskRecorder interface {
+	RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, score int, reason string, evidence map[string]any) error
+}
+
+func (s *contactService) WireImportSafety(repo repository.ContactImportAssessmentRepository, risk ImportRiskRecorder, velocity redis.Cmdable) {
+	s.importAssessment = repo
+	s.orgRisk = risk
+	s.velocity = velocity
 }
 
 func NewService(

--- a/internal/app/email/onboarding.go
+++ b/internal/app/email/onboarding.go
@@ -169,6 +169,7 @@ func (s *emailService) OAuthFinish(ctx context.Context, userID, code, state stri
 		ExpiresAt:      tok.Expiry,
 	})
 	if xerr == nil && acc != nil {
+		s.recordMailboxVelocity(ctx, sess.OrganizationID)
 		s.syncWarmupPoolMembership(ctx, acc)
 		s.publishAccountEvent(ctx, pubsub.EventAccountConnected, acc)
 		s.dispatchAccountConnected(ctx, sess.OrganizationID, acc)
@@ -229,6 +230,7 @@ func (s *emailService) OnboardSMTPIMAP(ctx context.Context, userID string, orgID
 	if xerr != nil {
 		return nil, xerr
 	}
+	s.recordMailboxVelocity(ctx, orgID)
 
 	// Assign the long-term worker (free vs paid tier). Failure here is non-fatal:
 	// the scheduler will pick the account up on its next pass.
@@ -245,6 +247,23 @@ func (s *emailService) OnboardSMTPIMAP(ctx context.Context, userID string, orgID
 	// immediately; the reconciler is the fallback if this fails.
 	s.loadAccountBestEffort(ctx, acc.ID)
 	return acc, nil
+}
+
+func (s *emailService) recordMailboxVelocity(ctx context.Context, orgID *uuid.UUID) {
+	if orgID == nil || s.r == nil {
+		return
+	}
+	key := "org-risk:mailboxes:" + orgID.String() + ":" + time.Now().UTC().Format("2006010215")
+	count, err := s.r.Incr(ctx, key).Result()
+	if err != nil {
+		return
+	}
+	if count == 1 {
+		_ = s.r.Expire(ctx, key, 2*time.Hour).Err()
+	}
+	if count >= 5 && s.orgRisk != nil {
+		_ = s.orgRisk.RecordSignal(ctx, *orgID, "mailbox_velocity", 20, "Many mailboxes were connected in one hour", map[string]any{"mailboxes_per_hour": count})
+	}
 }
 
 // dispatchAccountConnected fires an email_account.connected webhook event

--- a/internal/app/email/service.go
+++ b/internal/app/email/service.go
@@ -64,6 +64,7 @@ type EmailService interface {
 	// set, account-lifecycle events fan out to customer webhook endpoints.
 	WireWebhooks(w webhook.Service)
 	WireThrottle(t dailythrottle.Service)
+	WireMailboxRisk(risk MailboxRiskRecorder)
 	// WireGraphDelta attaches the Graph delta-cursor repository so the worker
 	// reconciler can seed a mailbox's saved cursors when loading it.
 	WireGraphDelta(repo repository.EmailGraphDeltaRepository)
@@ -108,6 +109,11 @@ type emailService struct {
 	// (email_account.connected, email_account.removed) are dispatched to
 	// subscribed customer webhooks.
 	webhookService webhook.Service
+	orgRisk        MailboxRiskRecorder
+}
+
+type MailboxRiskRecorder interface {
+	RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, score int, reason string, evidence map[string]any) error
 }
 
 // SyncBudgetSource is the operator-editable sync fair-use section, satisfied
@@ -140,6 +146,10 @@ func (s *emailService) WireSyncBudget(src SyncBudgetSource) {
 // When unset, guardMailboxThrottle is a no-op.
 func (s *emailService) WireThrottle(t dailythrottle.Service) {
 	s.throttle = t
+}
+
+func (s *emailService) WireMailboxRisk(risk MailboxRiskRecorder) {
+	s.orgRisk = risk
 }
 
 // WireWebhooks attaches the webhook dispatcher after construction. Done

--- a/internal/app/emailsend/service.go
+++ b/internal/app/emailsend/service.go
@@ -48,6 +48,11 @@ type SendEmailResponse struct {
 
 type EmailSendService interface {
 	SendEmail(ctx context.Context, userID, orgID, accountID uuid.UUID, req *SendEmailRequest) (*SendEmailResponse, *errx.Error)
+	WireOrgRisk(risk OrgRiskPolicy)
+}
+
+type OrgRiskPolicy interface {
+	SendingSuspended(ctx context.Context, organizationID uuid.UUID) bool
 }
 
 type emailSendService struct {
@@ -58,6 +63,11 @@ type emailSendService struct {
 	tasksClient   tasksched.Scheduler
 	featureGate   feature.FeatureGateService
 	dailyThrottle dailythrottle.Service
+	orgRisk       OrgRiskPolicy
+}
+
+func (s *emailSendService) WireOrgRisk(risk OrgRiskPolicy) {
+	s.orgRisk = risk
 }
 
 func NewService(
@@ -81,6 +91,9 @@ func NewService(
 }
 
 func (s *emailSendService) SendEmail(ctx context.Context, userID, orgID, accountID uuid.UUID, req *SendEmailRequest) (*SendEmailResponse, *errx.Error) {
+	if s.orgRisk != nil && s.orgRisk.SendingSuspended(ctx, orgID) {
+		return nil, errx.NewWithIdentifier(errx.Forbidden, "organization_sending_suspended", "This workspace cannot send email while its risk status is suspended.")
+	}
 	// Ban-scope enforcement (migration 000045). Block outbound send
 	// when the admin set BanScopeSend, even if the user can otherwise
 	// log in and inspect their account.

--- a/internal/app/emailverify/service.go
+++ b/internal/app/emailverify/service.go
@@ -9,11 +9,14 @@ package emailverify
 
 import (
 	"context"
+	"sync"
 
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/pkg/emailverify"
+	"github.com/warmbly/warmbly/internal/pkg/signuprisk"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -30,18 +33,112 @@ type Service interface {
 	// VerifyPending verifies up to `limit` not-yet-checked contacts, persisting
 	// each result. Returns the number processed. Driven by the ticker scheduler.
 	VerifyPending(ctx context.Context, limit int) (int, *errx.Error)
+	VerifyCampaign(ctx context.Context, campaignID uuid.UUID) (*models.CampaignVerificationSummary, *errx.Error)
 }
 
 type service struct {
-	repo     repository.ContactRepository
-	verifier emailverify.Verifier
+	repo         repository.ContactRepository
+	campaignRepo repository.CampaignRepository
+	verifier     emailverify.Verifier
 }
 
 // NewService wires the verification service. verifier is the pluggable backend:
 // the in-house emailverify.SMTPVerifier in dev/self-host, or a paid provider
 // (ZeroBounce/NeverBounce/Bouncer) implementing the same interface in prod.
-func NewService(repo repository.ContactRepository, verifier emailverify.Verifier) Service {
-	return &service{repo: repo, verifier: verifier}
+func NewService(repo repository.ContactRepository, verifier emailverify.Verifier, campaignRepo ...repository.CampaignRepository) Service {
+	s := &service{repo: repo, verifier: verifier}
+	if len(campaignRepo) > 0 {
+		s.campaignRepo = campaignRepo[0]
+	}
+	return s
+}
+
+const launchVerificationBatch = 100
+
+func (s *service) VerifyCampaign(ctx context.Context, campaignID uuid.UUID) (*models.CampaignVerificationSummary, *errx.Error) {
+	contacts, xerr := s.repo.ListCampaignContactsForVerification(ctx, campaignID)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	pending := make([]models.Contact, 0, launchVerificationBatch)
+	for i := range contacts {
+		if contacts[i].VerificationCheckedAt == nil && len(pending) < launchVerificationBatch {
+			pending = append(pending, contacts[i])
+		}
+	}
+	jobs := make(chan models.Contact)
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for contact := range jobs {
+				if ctx.Err() != nil {
+					continue
+				}
+				result := s.verifier.Verify(ctx, contact.Email)
+				_ = s.repo.UpdateContactVerification(ctx, contact.ID, result)
+			}
+		}()
+	}
+	for i := range pending {
+		jobs <- pending[i]
+	}
+	close(jobs)
+	wg.Wait()
+
+	contacts, xerr = s.repo.ListCampaignContactsForVerification(ctx, campaignID)
+	if xerr != nil {
+		return nil, xerr
+	}
+	summary := &models.CampaignVerificationSummary{Total: len(contacts)}
+	projectedHardBounces := 0
+	for i := range contacts {
+		contact := contacts[i]
+		invalid := false
+		switch contact.VerificationStatus {
+		case string(emailverify.StatusValid):
+			summary.Valid++
+		case string(emailverify.StatusRisky):
+			summary.Risky++
+		case string(emailverify.StatusInvalid):
+			summary.Invalid++
+			invalid = true
+		default:
+			summary.Unknown++
+		}
+		if contact.IsCatchAll {
+			summary.CatchAll++
+		}
+		if contact.VerificationCheckedAt == nil {
+			summary.Pending++
+		}
+		disposable := signuprisk.ClassifyAddress(contact.Email).Disposable
+		if disposable {
+			summary.Disposable++
+		}
+		if invalid || disposable {
+			projectedHardBounces++
+		}
+	}
+	if summary.Total > 0 {
+		summary.ProjectedHardBounceRate = float64(projectedHardBounces) / float64(summary.Total)
+	}
+	status := "passed"
+	if summary.Pending > 0 {
+		status = "pending"
+	} else if summary.ProjectedHardBounceRate > 0.05 {
+		status = "blocked"
+	} else if summary.ProjectedHardBounceRate >= 0.02 || summary.Risky > 0 {
+		status = "warning"
+	}
+	if s.campaignRepo != nil {
+		if err := s.campaignRepo.UpdateVerificationStatus(ctx, campaignID, status, summary); err != nil {
+			return nil, errx.InternalError()
+		}
+	}
+	return summary, nil
 }
 
 func (s *service) VerifyAddress(ctx context.Context, email string) emailverify.Result {

--- a/internal/app/orgrisk/service.go
+++ b/internal/app/orgrisk/service.go
@@ -1,0 +1,121 @@
+package orgrisk
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/app/audit"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+const restrictedColdCap = 10
+
+type Service interface {
+	Get(ctx context.Context, organizationID uuid.UUID) (*models.OrganizationRisk, error)
+	RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, score int, reason string, evidence map[string]any) error
+	EffectiveCap(ctx context.Context, organizationID uuid.UUID, current int) int
+	WarmupPool(ctx context.Context, organizationID uuid.UUID, current string) string
+	SendingSuspended(ctx context.Context, organizationID uuid.UUID) bool
+	EvaluateCorrelations(ctx context.Context) error
+}
+
+type service struct {
+	repo  repository.OrgRiskRepository
+	audit audit.AuditService
+}
+
+func NewService(repo repository.OrgRiskRepository, auditService audit.AuditService) Service {
+	return &service{repo: repo, audit: auditService}
+}
+
+func (s *service) Get(ctx context.Context, organizationID uuid.UUID) (*models.OrganizationRisk, error) {
+	return s.repo.Get(ctx, organizationID)
+}
+
+func (s *service) RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, score int, reason string, evidence map[string]any) error {
+	before, after, err := s.repo.RecordSignal(ctx, organizationID, key, models.OrganizationRiskSignal{
+		Score:      score,
+		Reason:     reason,
+		Evidence:   evidence,
+		ObservedAt: time.Now().UTC(),
+	})
+	if err != nil {
+		return err
+	}
+	if before.State != after.State && s.audit != nil {
+		s.audit.LogAction(ctx, organizationID, uuid.Nil, models.AuditActionSystemUpdate, models.AuditEntityOrgRisk, &organizationID, "", "", map[string]string{
+			"risk_state": string(before.State) + " -> " + string(after.State),
+			"risk_score": strconv.Itoa(before.Score) + " -> " + strconv.Itoa(after.Score),
+		}, map[string]string{"reason": after.Reason})
+	}
+	return nil
+}
+
+func (s *service) EffectiveCap(ctx context.Context, organizationID uuid.UUID, current int) int {
+	risk, err := s.repo.Get(ctx, organizationID)
+	if err != nil || risk == nil {
+		return current
+	}
+	switch risk.State {
+	case models.OrganizationRiskSuspended:
+		return 0
+	case models.OrganizationRiskRestricted:
+		return min(current, restrictedColdCap)
+	default:
+		return current
+	}
+}
+
+func (s *service) WarmupPool(ctx context.Context, organizationID uuid.UUID, current string) string {
+	risk, err := s.repo.Get(ctx, organizationID)
+	if err == nil && risk != nil && (risk.State == models.OrganizationRiskRestricted || risk.State == models.OrganizationRiskSuspended) {
+		return "free"
+	}
+	return current
+}
+
+func (s *service) SendingSuspended(ctx context.Context, organizationID uuid.UUID) bool {
+	risk, err := s.repo.Get(ctx, organizationID)
+	return err == nil && risk != nil && risk.Has(models.BanScopeSend)
+}
+
+func (s *service) EvaluateCorrelations(ctx context.Context) error {
+	findings, err := s.repo.ListCorrelationFindings(ctx)
+	if err != nil {
+		return err
+	}
+	for _, finding := range findings {
+		if err := s.RecordSignal(ctx, finding.OrganizationID, finding.Key, finding.Score, finding.Reason, finding.Evidence); err != nil {
+			log.Warn().Err(err).Str("organization_id", finding.OrganizationID.String()).Str("signal", finding.Key).Msg("could not record organization correlation risk")
+		}
+	}
+	return nil
+}
+
+func StartCorrelationSweep(ctx context.Context, service Service, interval time.Duration) {
+	if service == nil {
+		return
+	}
+	go func() {
+		run := func() {
+			if err := service.EvaluateCorrelations(ctx); err != nil {
+				log.Warn().Err(err).Msg("organization risk correlation sweep failed")
+			}
+		}
+		run()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				run()
+			}
+		}
+	}()
+}

--- a/internal/app/sequence/handler.go
+++ b/internal/app/sequence/handler.go
@@ -5,14 +5,20 @@ import (
 
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
 )
 
 func (s *sequenceService) Create(ctx context.Context, userID, campaignID string) (*models.Sequence, *errx.Error) {
-	return s.sequenceRepository.Create(ctx, userID, campaignID)
+	sequence, xerr := s.sequenceRepository.Create(ctx, userID, campaignID)
+	return scoreSequence(sequence), xerr
 }
 
 func (s *sequenceService) Get(ctx context.Context, userID, campaignID string) ([]models.Sequence, *errx.Error) {
-	return s.sequenceRepository.Get(ctx, userID, campaignID)
+	sequences, xerr := s.sequenceRepository.Get(ctx, userID, campaignID)
+	for i := range sequences {
+		scoreSequence(&sequences[i])
+	}
+	return sequences, xerr
 }
 
 func (s *sequenceService) Update(ctx context.Context, userID, campaignID, sequenceID string, data *models.UpdateSequence) (*models.Sequence, *errx.Error) {
@@ -20,7 +26,21 @@ func (s *sequenceService) Update(ctx context.Context, userID, campaignID, sequen
 	// and loops) at schedule time in the repository's finder; the repository also
 	// validates branch shape before persisting. No cross-step write validation is
 	// needed here — the canvas only ever points a branch at a real step or stop.
-	return s.sequenceRepository.Update(ctx, userID, campaignID, sequenceID, data)
+	sequence, xerr := s.sequenceRepository.Update(ctx, userID, campaignID, sequenceID, data)
+	return scoreSequence(sequence), xerr
+}
+
+func scoreSequence(sequence *models.Sequence) *models.Sequence {
+	if sequence == nil || sequence.Kind != "email" {
+		return sequence
+	}
+	score := warmlint.Score(sequence.Subject, sequence.BodyHTML, sequence.BodyPlain)
+	issues := make([]models.ContentSafetyIssue, len(score.Issues))
+	for i := range score.Issues {
+		issues[i] = models.ContentSafetyIssue(score.Issues[i])
+	}
+	sequence.ContentScore = &models.ContentSafetyScore{Score: score.Score, Issues: issues, Hard: score.Hard}
+	return sequence
 }
 
 // UpdateLayout persists only step canvas coordinates (drag-to-stick). Cosmetic

--- a/internal/app/stripe/service.go
+++ b/internal/app/stripe/service.go
@@ -19,6 +19,7 @@ import (
 	balancetxn "github.com/stripe/stripe-go/v76/customerbalancetransaction"
 	"github.com/stripe/stripe-go/v76/invoice"
 	"github.com/stripe/stripe-go/v76/paymentintent"
+	"github.com/stripe/stripe-go/v76/paymentmethod"
 	"github.com/stripe/stripe-go/v76/price"
 	"github.com/stripe/stripe-go/v76/subscription"
 	"github.com/stripe/stripe-go/v76/webhook"
@@ -826,6 +827,7 @@ func (s *stripeService) handleCheckoutCompleted(ctx context.Context, event *stri
 			StripeCustomerID: customerID,
 			Status:           models.SubscriptionStatusIncomplete,
 		}
+		newSub.PaymentFingerprint = paymentFingerprintForCustomer(customerID)
 
 		if checkoutSession.Subscription != nil {
 			newSub.StripeSubscriptionID = &checkoutSession.Subscription.ID
@@ -843,6 +845,7 @@ func (s *stripeService) handleCheckoutCompleted(ctx context.Context, event *stri
 		if checkoutSession.Subscription != nil {
 			sub.StripeSubscriptionID = &checkoutSession.Subscription.ID
 		}
+		sub.PaymentFingerprint = paymentFingerprintForCustomer(sub.StripeCustomerID)
 		if err := s.subRepo.Update(ctx, sub); err != nil {
 			return errx.New(errx.Internal, "failed to update subscription")
 		}
@@ -869,6 +872,21 @@ func (s *stripeService) handleCheckoutCompleted(ctx context.Context, event *stri
 	}
 
 	return nil
+}
+
+func paymentFingerprintForCustomer(customerID string) string {
+	if customerID == "" {
+		return ""
+	}
+	customerRecord, err := customer.Get(customerID, nil)
+	if err != nil || customerRecord == nil || customerRecord.InvoiceSettings == nil || customerRecord.InvoiceSettings.DefaultPaymentMethod == nil {
+		return ""
+	}
+	method, err := paymentmethod.Get(customerRecord.InvoiceSettings.DefaultPaymentMethod.ID, nil)
+	if err != nil || method == nil || method.Card == nil {
+		return ""
+	}
+	return method.Card.Fingerprint
 }
 
 // handleCheckoutExpired releases a pending discount reservation when its

--- a/internal/app/worker/wmail/admit.go
+++ b/internal/app/worker/wmail/admit.go
@@ -168,6 +168,7 @@ func (w *WMail) storeNew(ctx context.Context, msg *models.EmailMessageData, data
 	}
 
 	w.maybeEmitBounce(msg)
+	w.maybeEmitComplaint(msg)
 
 	// The consumer decodes NEW_EMAIL as JobEventNewEmail{user_id, message}.
 	return w.onEvent(models.JobEventTypeNewEmail, &models.JobEventNewEmail{

--- a/internal/app/worker/wmail/complaint.go
+++ b/internal/app/worker/wmail/complaint.go
@@ -1,0 +1,33 @@
+package wmail
+
+import (
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/fbl"
+)
+
+func (w *WMail) maybeEmitComplaint(msg *models.EmailMessageData) {
+	body := msg.BodyPlain + "\n" + msg.BodyHTML
+	if !fbl.Detect(headerFlagValue(msg.Flags, "Content-Type"), body) {
+		return
+	}
+	report := fbl.Parse(body)
+	if !report.Complaint {
+		return
+	}
+	originalID := report.OriginalMessageID
+	if originalID == "" && len(msg.InReplyTo) > 0 {
+		originalID = msg.InReplyTo[len(msg.InReplyTo)-1]
+	}
+	if strings.Trim(originalID, "<>") == "" {
+		return
+	}
+	_ = w.onEvent(models.JobEventTypeInboundComplaint, &models.JobEventInboundComplaint{
+		UserID:            w.UserID,
+		EmailID:           w.ID,
+		OriginalMessageID: strings.Trim(originalID, "<>"),
+		Recipient:         report.Recipient,
+		FeedbackType:      report.FeedbackType,
+	})
+}

--- a/internal/errx/common.go
+++ b/internal/errx/common.go
@@ -134,12 +134,14 @@ var (
 	ErrEmailReplyRate            = New(BadRequest, "Warmup reply rate must be between 0 and 100.")
 
 	// Campaign
-	ErrCampaignName        = New(BadRequest, "Campaign name length must be between 3 and 50 characters.")
-	ErrCampaignDescription = New(BadRequest, "Campaign description length must be below 300 characters.")
-	ErrCampaignDailyLimit  = New(BadRequest, "Daily limit must be between 3 and 10000000.")
-	ErrCampaignStartDate   = New(BadRequest, "Start date cannot be in the past. Pick today or later, or clear it (null) to start right away.")
-	ErrCampaignEndDate     = New(BadRequest, "End date must be in the future.")
-	ErrCampaignLimit       = New(BadRequest, "You reached your limit for campaigns, please try again later.")
+	ErrCampaignName                = New(BadRequest, "Campaign name length must be between 3 and 50 characters.")
+	ErrCampaignDescription         = New(BadRequest, "Campaign description length must be below 300 characters.")
+	ErrCampaignDailyLimit          = New(BadRequest, "Daily limit must be between 3 and 10000000.")
+	ErrCampaignStartDate           = New(BadRequest, "Start date cannot be in the past. Pick today or later, or clear it (null) to start right away.")
+	ErrCampaignEndDate             = New(BadRequest, "End date must be in the future.")
+	ErrCampaignLimit               = New(BadRequest, "You reached your limit for campaigns, please try again later.")
+	ErrCampaignVerificationPending = NewWithIdentifier(Conflict, "campaign_verification_pending", "Campaign launch is waiting for recipient verification. Try again after verification completes.")
+	ErrCampaignProjectedBounce     = NewWithIdentifier(Unprocessable, "campaign_projected_bounce_rate_high", "Campaign launch blocked because the projected hard-bounce rate is above 5%.")
 
 	// Sequence
 	ErrSequenceName      = New(BadRequest, "Sequence name cannot be longer than 50 characters.")
@@ -152,8 +154,9 @@ var (
 	ErrSequenceWaitAfter = New(BadRequest, fmt.Sprintf("Step wait must be between 0 and %d days.", config.SequenceWaitAfterMax))
 
 	// Contact
-	ErrContactSerialize = New(BadRequest, "Failed to serialize contact.")
-	ErrContactSize      = New(BadRequest, "Contact size cannot be bigger than 10KB.")
+	ErrContactSerialize     = New(BadRequest, "Failed to serialize contact.")
+	ErrContactSize          = New(BadRequest, "Contact size cannot be bigger than 10KB.")
+	ErrContactImportQuality = NewWithIdentifier(Unprocessable, "contact_import_quality_blocked", "Import blocked because more than 25% of addresses are invalid or disposable.")
 
 	// Unibox
 	ErrUniboxLimit = New(BadRequest, fmt.Sprintf("Limit must be between %d and %d.", config.UniboxLimitMin, config.UniboxLimitMax))

--- a/internal/infrastructure/db/migrations/000094_org_risk_and_list_safety.down.sql
+++ b/internal/infrastructure/db/migrations/000094_org_risk_and_list_safety.down.sql
@@ -1,0 +1,38 @@
+-- PostgreSQL cannot remove enum values. Normalize rows before rolling back.
+UPDATE tasks
+SET status = 'completed', completed_at = COALESCE(completed_at, NOW())
+WHERE status IN ('skipped_content_guardrail', 'skipped_org_suspended');
+
+DROP TABLE IF EXISTS contact_import_assessments;
+
+ALTER TABLE campaigns
+    DROP CONSTRAINT IF EXISTS campaigns_verification_status_check,
+    DROP COLUMN IF EXISTS verification_checked_at,
+    DROP COLUMN IF EXISTS verification_summary,
+    DROP COLUMN IF EXISTS verification_status;
+
+ALTER TABLE email_accounts
+    DROP COLUMN IF EXISTS cold_ramp_started_at;
+
+DROP INDEX IF EXISTS idx_subscriptions_payment_fingerprint;
+ALTER TABLE subscriptions
+    DROP COLUMN IF EXISTS payment_fingerprint;
+
+DROP INDEX IF EXISTS idx_users_signup_asn;
+DROP INDEX IF EXISTS idx_users_signup_ip;
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_signup_email_risk_check,
+    DROP COLUMN IF EXISTS signup_asn,
+    DROP COLUMN IF EXISTS signup_email_risk,
+    DROP COLUMN IF EXISTS signup_user_agent,
+    DROP COLUMN IF EXISTS signup_ip;
+
+DROP INDEX IF EXISTS idx_organizations_risk_state;
+ALTER TABLE organizations
+    DROP CONSTRAINT IF EXISTS organizations_risk_score_check,
+    DROP CONSTRAINT IF EXISTS organizations_risk_state_check,
+    DROP COLUMN IF EXISTS risk_evaluated_at,
+    DROP COLUMN IF EXISTS risk_signals,
+    DROP COLUMN IF EXISTS risk_reason,
+    DROP COLUMN IF EXISTS risk_score,
+    DROP COLUMN IF EXISTS risk_state;

--- a/internal/infrastructure/db/migrations/000094_org_risk_and_list_safety.up.sql
+++ b/internal/infrastructure/db/migrations/000094_org_risk_and_list_safety.up.sql
@@ -1,0 +1,83 @@
+ALTER TYPE public.task_status ADD VALUE IF NOT EXISTS 'skipped_content_guardrail';
+ALTER TYPE public.task_status ADD VALUE IF NOT EXISTS 'skipped_org_suspended';
+
+ALTER TABLE organizations
+    ADD COLUMN IF NOT EXISTS risk_state text NOT NULL DEFAULT 'trusted',
+    ADD COLUMN IF NOT EXISTS risk_score integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS risk_reason text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS risk_signals jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS risk_evaluated_at timestamptz;
+
+ALTER TABLE organizations
+    DROP CONSTRAINT IF EXISTS organizations_risk_state_check,
+    ADD CONSTRAINT organizations_risk_state_check
+        CHECK (risk_state IN ('trusted', 'watch', 'restricted', 'suspended')),
+    DROP CONSTRAINT IF EXISTS organizations_risk_score_check,
+    ADD CONSTRAINT organizations_risk_score_check
+        CHECK (risk_score BETWEEN 0 AND 100);
+
+CREATE INDEX IF NOT EXISTS idx_organizations_risk_state
+    ON organizations (risk_state, risk_score DESC)
+    WHERE risk_state <> 'trusted';
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS signup_ip inet,
+    ADD COLUMN IF NOT EXISTS signup_user_agent text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS signup_email_risk integer NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS signup_asn bigint;
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_signup_email_risk_check,
+    ADD CONSTRAINT users_signup_email_risk_check
+        CHECK (signup_email_risk BETWEEN 0 AND 100);
+
+CREATE INDEX IF NOT EXISTS idx_users_signup_ip
+    ON users (signup_ip)
+    WHERE signup_ip IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_users_signup_asn
+    ON users (signup_asn)
+    WHERE signup_asn IS NOT NULL;
+
+ALTER TABLE subscriptions
+    ADD COLUMN IF NOT EXISTS payment_fingerprint text NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_payment_fingerprint
+    ON subscriptions (payment_fingerprint)
+    WHERE payment_fingerprint <> '';
+
+ALTER TABLE email_accounts
+    ADD COLUMN IF NOT EXISTS cold_ramp_started_at timestamptz;
+
+ALTER TABLE campaigns
+    ADD COLUMN IF NOT EXISTS verification_status text NOT NULL DEFAULT 'unknown',
+    ADD COLUMN IF NOT EXISTS verification_summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN IF NOT EXISTS verification_checked_at timestamptz;
+
+ALTER TABLE campaigns
+    DROP CONSTRAINT IF EXISTS campaigns_verification_status_check,
+    ADD CONSTRAINT campaigns_verification_status_check
+        CHECK (verification_status IN ('unknown', 'pending', 'passed', 'warning', 'blocked'));
+
+CREATE TABLE IF NOT EXISTS contact_import_assessments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    filename text NOT NULL DEFAULT '',
+    total_rows integer NOT NULL,
+    invalid_rows integer NOT NULL DEFAULT 0,
+    disposable_rows integer NOT NULL DEFAULT 0,
+    role_rows integer NOT NULL DEFAULT 0,
+    risky_tld_rows integer NOT NULL DEFAULT 0,
+    blocked boolean NOT NULL DEFAULT false,
+    summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at timestamptz NOT NULL DEFAULT NOW(),
+    CHECK (total_rows >= 0),
+    CHECK (invalid_rows >= 0),
+    CHECK (disposable_rows >= 0),
+    CHECK (role_rows >= 0),
+    CHECK (risky_tld_rows >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_contact_import_assessments_org_created
+    ON contact_import_assessments (organization_id, created_at DESC);

--- a/internal/models/advanced_outreach.go
+++ b/internal/models/advanced_outreach.go
@@ -57,6 +57,7 @@ type PreflightValidationSettings struct {
 	CheckABVariantConfigured bool `json:"check_ab_variant_configured"`
 	CheckDailyLimit          bool `json:"check_daily_limit"`
 	CheckScheduleWindow      bool `json:"check_schedule_window"`
+	CheckContentSafety       bool `json:"check_content_safety"`
 }
 
 type DeliverabilityDashboardSettings struct {
@@ -459,6 +460,7 @@ func DefaultAdvancedOutreachSettings() AdvancedOutreachSettings {
 			CheckABVariantConfigured: false,
 			CheckDailyLimit:          true,
 			CheckScheduleWindow:      true,
+			CheckContentSafety:       false,
 		},
 		Dashboard: DeliverabilityDashboardSettings{
 			Enabled:            true,

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -119,6 +119,8 @@ const (
 	// background evaluation that opened or resolved findings. Rides the audit
 	// spine so every teammate's advisor strips and nav badges stay live.
 	AuditEntityAdvisorFinding AuditEntityType = "advisor_finding"
+
+	AuditEntityOrgRisk AuditEntityType = "organization_risk"
 )
 
 // AuditActor is the minimal identity of the member who performed an action,

--- a/internal/models/campaign.go
+++ b/internal/models/campaign.go
@@ -165,6 +165,10 @@ type Campaign struct {
 	GuardrailTrippedAt        *time.Time `json:"guardrail_tripped_at,omitempty"`
 	GuardrailReason           string     `json:"guardrail_reason,omitempty"`
 
+	VerificationStatus    string                      `json:"verification_status"`
+	VerificationSummary   CampaignVerificationSummary `json:"verification_summary"`
+	VerificationCheckedAt *time.Time                  `json:"verification_checked_at,omitempty"`
+
 	// Campaign-scoped tracking-domain override. Honored only when verified;
 	// otherwise falls back to the mailbox/default domain.
 	TrackingDomain           string     `json:"tracking_domain"`

--- a/internal/models/contact.go
+++ b/internal/models/contact.go
@@ -55,6 +55,18 @@ type Contact struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+type CampaignVerificationSummary struct {
+	Total                   int     `json:"total"`
+	Valid                   int     `json:"valid"`
+	Risky                   int     `json:"risky"`
+	Invalid                 int     `json:"invalid"`
+	Unknown                 int     `json:"unknown"`
+	Disposable              int     `json:"disposable"`
+	CatchAll                int     `json:"catch_all"`
+	Pending                 int     `json:"pending"`
+	ProjectedHardBounceRate float64 `json:"projected_hard_bounce_rate"`
+}
+
 // ContactCampaignProgress is a contact's aggregate processing state inside one
 // campaign, derived from campaign_contact_progress (across all of the campaign's
 // steps) plus the contact's subscription flag.

--- a/internal/models/contact_import.go
+++ b/internal/models/contact_import.go
@@ -109,13 +109,24 @@ type ContactImportRowError struct {
 }
 
 type ContactImportResult struct {
-	Total     int       `json:"total"`
-	Imported  int       `json:"imported"`
-	Updated   int       `json:"updated"`
-	Skipped   int       `json:"skipped"`
-	Failed    int       `json:"failed"`
-	StartedAt time.Time `json:"started_at"`
-	EndedAt   time.Time `json:"ended_at"`
+	Total     int                   `json:"total"`
+	Imported  int                   `json:"imported"`
+	Updated   int                   `json:"updated"`
+	Skipped   int                   `json:"skipped"`
+	Failed    int                   `json:"failed"`
+	StartedAt time.Time             `json:"started_at"`
+	EndedAt   time.Time             `json:"ended_at"`
+	Quality   *ContactImportQuality `json:"quality,omitempty"`
 
 	Errors []ContactImportRowError `json:"errors,omitempty"`
+}
+
+type ContactImportQuality struct {
+	AssessmentID    string  `json:"assessment_id,omitempty"`
+	Invalid         int     `json:"invalid"`
+	Disposable      int     `json:"disposable"`
+	Role            int     `json:"role"`
+	RiskyTLD        int     `json:"risky_tld"`
+	BadAddressRatio float64 `json:"bad_address_ratio"`
+	Blocked         bool    `json:"blocked"`
 }

--- a/internal/models/email.go
+++ b/internal/models/email.go
@@ -68,17 +68,18 @@ type Email struct {
 	// cannot stop sending immediately.
 	AuthFailingSince *time.Time `json:"auth_failing_since,omitempty"`
 
-	Warmup          *time.Time `json:"warmup"`
-	WarmupPausedAt  *time.Time `json:"warmup_paused_at"`
-	WarmupBase      int        `json:"warmup_base"`
-	WarmupMax       int        `json:"warmup_max"`
-	WarmupIncrease  int        `json:"warmup_increase"`
-	WarmupReplyRate int        `json:"warmup_reply_rate"`
-	WarmupTag       string     `json:"warmup_tag"`
-	WarmupPoolType  string     `json:"warmup_pool_type"`
-	WarmupStartTime string     `json:"warmup_start_time"`
-	WarmupEndTime   string     `json:"warmup_end_time"`
-	WarmupDays      int        `json:"warmup_days"`
+	Warmup            *time.Time `json:"warmup"`
+	WarmupPausedAt    *time.Time `json:"warmup_paused_at"`
+	WarmupBase        int        `json:"warmup_base"`
+	WarmupMax         int        `json:"warmup_max"`
+	WarmupIncrease    int        `json:"warmup_increase"`
+	WarmupReplyRate   int        `json:"warmup_reply_rate"`
+	WarmupTag         string     `json:"warmup_tag"`
+	WarmupPoolType    string     `json:"warmup_pool_type"`
+	WarmupStartTime   string     `json:"warmup_start_time"`
+	WarmupEndTime     string     `json:"warmup_end_time"`
+	WarmupDays        int        `json:"warmup_days"`
+	ColdRampStartedAt *time.Time `json:"cold_ramp_started_at,omitempty"`
 
 	Timezone string `json:"timezone"`
 

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -18,14 +18,15 @@ type WorkerEvent struct {
 type JobEventType string
 
 const (
-	JobEventTypeNewEmail      JobEventType = "NEW_EMAIL"
-	JobEventTypeInboundBounce JobEventType = "INBOUND_BOUNCE"
-	JobEventTypeRemoveEmail   JobEventType = "REMOVE_EMAIL"
-	JobEventTypeFlagsAdd      JobEventType = "FLAGS_ADD"
-	JobEventTypeFlagsRemove   JobEventType = "FLAGS_REMOVE"
-	JobEventTypeEmailUpdate   JobEventType = "UPDATE_EMAIL"
-	JobEventTypeMailboxUpdate JobEventType = "UPDATE_MAILBOX"
-	JobEventTypeMailboxDelete JobEventType = "DELETE_MAILBOX"
+	JobEventTypeNewEmail         JobEventType = "NEW_EMAIL"
+	JobEventTypeInboundBounce    JobEventType = "INBOUND_BOUNCE"
+	JobEventTypeInboundComplaint JobEventType = "INBOUND_COMPLAINT"
+	JobEventTypeRemoveEmail      JobEventType = "REMOVE_EMAIL"
+	JobEventTypeFlagsAdd         JobEventType = "FLAGS_ADD"
+	JobEventTypeFlagsRemove      JobEventType = "FLAGS_REMOVE"
+	JobEventTypeEmailUpdate      JobEventType = "UPDATE_EMAIL"
+	JobEventTypeMailboxUpdate    JobEventType = "UPDATE_MAILBOX"
+	JobEventTypeMailboxDelete    JobEventType = "DELETE_MAILBOX"
 
 	JobEventTypeTokenUpdate      JobEventType = "TOKEN_UPDATE"
 	JobEventTypeHistoryIDUpdate  JobEventType = "HISTORY_ID_UPDATE"

--- a/internal/models/event_w_complaint.go
+++ b/internal/models/event_w_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "github.com/google/uuid"
+
+type JobEventInboundComplaint struct {
+	UserID            uuid.UUID `json:"user_id"`
+	EmailID           uuid.UUID `json:"email_id"`
+	OriginalMessageID string    `json:"original_message_id"`
+	Recipient         string    `json:"recipient"`
+	FeedbackType      string    `json:"feedback_type"`
+}

--- a/internal/models/org_risk.go
+++ b/internal/models/org_risk.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type OrganizationRiskState string
+
+const (
+	OrganizationRiskTrusted    OrganizationRiskState = "trusted"
+	OrganizationRiskWatch      OrganizationRiskState = "watch"
+	OrganizationRiskRestricted OrganizationRiskState = "restricted"
+	OrganizationRiskSuspended  OrganizationRiskState = "suspended"
+)
+
+// OrganizationRiskSignal is the latest evidence for one stable signal key.
+type OrganizationRiskSignal struct {
+	Score      int            `json:"score"`
+	Reason     string         `json:"reason"`
+	Evidence   map[string]any `json:"evidence,omitempty"`
+	ObservedAt time.Time      `json:"observed_at"`
+}
+
+type OrganizationRisk struct {
+	OrganizationID uuid.UUID                         `json:"organization_id"`
+	State          OrganizationRiskState             `json:"state"`
+	Score          int                               `json:"score"`
+	Reason         string                            `json:"reason"`
+	Signals        map[string]OrganizationRiskSignal `json:"signals"`
+	EvaluatedAt    *time.Time                        `json:"evaluated_at,omitempty"`
+}
+
+func OrganizationRiskStateForScore(score int) OrganizationRiskState {
+	switch {
+	case score >= 80:
+		return OrganizationRiskSuspended
+	case score >= 50:
+		return OrganizationRiskRestricted
+	case score >= 20:
+		return OrganizationRiskWatch
+	default:
+		return OrganizationRiskTrusted
+	}
+}
+
+func (r *OrganizationRisk) Has(scope BanScope) bool {
+	return scope == BanScopeSend && r != nil && r.State == OrganizationRiskSuspended
+}

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -16,6 +16,12 @@ type Organization struct {
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 
+	RiskState       OrganizationRiskState             `json:"risk_state"`
+	RiskScore       int                               `json:"risk_score"`
+	RiskReason      string                            `json:"risk_reason,omitempty"`
+	RiskSignals     map[string]OrganizationRiskSignal `json:"-"`
+	RiskEvaluatedAt *time.Time                        `json:"risk_evaluated_at,omitempty"`
+
 	// Soft-delete window. When DeletionScheduledFor is non-nil the
 	// organization is "pending deletion" and will be hard-deleted at
 	// that timestamp unless cancelled.

--- a/internal/models/sequence.go
+++ b/internal/models/sequence.go
@@ -11,11 +11,12 @@ type Sequence struct {
 	ID   uuid.UUID `json:"id"`
 	Name string    `json:"name"`
 
-	Subject   string `json:"subject"`
-	BodyPlain string `json:"body_plain"`
-	BodyHTML  string `json:"body_html"`
-	BodySync  bool   `json:"body_sync"`
-	BodyCode  bool   `json:"body_code"`
+	Subject      string              `json:"subject"`
+	BodyPlain    string              `json:"body_plain"`
+	BodyHTML     string              `json:"body_html"`
+	BodySync     bool                `json:"body_sync"`
+	BodyCode     bool                `json:"body_code"`
+	ContentScore *ContentSafetyScore `json:"content_score,omitempty"`
 
 	WaitAfter int `json:"wait_after"`
 	Position  int `json:"position"`
@@ -46,6 +47,18 @@ type Sequence struct {
 
 	UpdatedAt time.Time `json:"updated_at"`
 	CreatedAt time.Time `json:"created_at"`
+}
+
+type ContentSafetyIssue struct {
+	Severity string `json:"severity"`
+	Code     string `json:"code"`
+	Message  string `json:"message"`
+}
+
+type ContentSafetyScore struct {
+	Score  int                  `json:"score"`
+	Issues []ContentSafetyIssue `json:"issues"`
+	Hard   bool                 `json:"hard"`
 }
 
 // ActionConfig is the persisted config for a non-email (action/wait) node. Type

--- a/internal/models/subscriptions.go
+++ b/internal/models/subscriptions.go
@@ -120,6 +120,7 @@ type Subscription struct {
 	StripeCustomerID     string  `json:"stripe_customer_id"`
 	StripeSubscriptionID *string `json:"stripe_subscription_id,omitempty"`
 	StripePriceID        *string `json:"stripe_price_id,omitempty"`
+	PaymentFingerprint   string  `json:"-"`
 
 	// Subscription state
 	Status SubscriptionStatus `json:"status"`

--- a/internal/models/token.go
+++ b/internal/models/token.go
@@ -95,5 +95,11 @@ type RegistrationSession struct {
 	ReferralCode string `json:"referral_code,omitempty"`
 	// Invite is the invitation token captured at RegistrationStart, re-checked
 	// and redeemed at confirm so the account lands in the inviting org.
-	Invite string `json:"invite,omitempty"`
+	Invite          string   `json:"invite,omitempty"`
+	SignupIP        string   `json:"signup_ip,omitempty"`
+	SignupUserAgent string   `json:"signup_user_agent,omitempty"`
+	SignupEmailRisk int      `json:"signup_email_risk,omitempty"`
+	SignupASN       *int64   `json:"signup_asn,omitempty"`
+	SignupRiskScore int      `json:"signup_risk_score,omitempty"`
+	SignupSignals   []string `json:"signup_signals,omitempty"`
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -21,6 +21,11 @@ type User struct {
 	MaxOrganizations int  `json:"max_organizations"`
 	FreeTrialUsed    bool `json:"free_trial_used"`
 
+	SignupIP        string `json:"-"`
+	SignupUserAgent string `json:"-"`
+	SignupEmailRisk int    `json:"-"`
+	SignupASN       *int64 `json:"-"`
+
 	// Seconds an instant send is held before it actually leaves, so
 	// the user can still cancel it. Bounds live in config
 	// (UndoSendSecondsMin/Max); default 30.

--- a/internal/pkg/fbl/fbl.go
+++ b/internal/pkg/fbl/fbl.go
@@ -1,0 +1,42 @@
+package fbl
+
+import (
+	"regexp"
+	"strings"
+)
+
+type Report struct {
+	Complaint         bool
+	OriginalMessageID string
+	Recipient         string
+	FeedbackType      string
+}
+
+var (
+	feedbackType = regexp.MustCompile(`(?im)^\s*Feedback-Type:\s*([^\s;]+)`)
+	originalRcpt = regexp.MustCompile(`(?im)^\s*(?:Original-Rcpt-To|Original-Recipient):\s*(?:rfc822;\s*)?<?([^\s<>]+@[^\s<>]+)>?`)
+	messageID    = regexp.MustCompile(`(?im)^\s*(?:Original-Message-ID|Message-ID):\s*<([^>\s]+)>`)
+)
+
+func Detect(contentType, body string) bool {
+	lowerType := strings.ToLower(contentType)
+	if strings.Contains(lowerType, "report-type=feedback-report") || strings.Contains(lowerType, "message/feedback-report") {
+		return true
+	}
+	return feedbackType.MatchString(body)
+}
+
+func Parse(body string) Report {
+	var report Report
+	if match := feedbackType.FindStringSubmatch(body); len(match) > 1 {
+		report.FeedbackType = strings.ToLower(strings.TrimSpace(match[1]))
+		report.Complaint = report.FeedbackType == "abuse" || report.FeedbackType == "fraud"
+	}
+	if match := originalRcpt.FindStringSubmatch(body); len(match) > 1 {
+		report.Recipient = strings.TrimSpace(match[1])
+	}
+	if matches := messageID.FindAllStringSubmatch(body, -1); len(matches) > 0 {
+		report.OriginalMessageID = strings.TrimSpace(matches[len(matches)-1][1])
+	}
+	return report
+}

--- a/internal/pkg/fbl/fbl_test.go
+++ b/internal/pkg/fbl/fbl_test.go
@@ -1,0 +1,14 @@
+package fbl
+
+import "testing"
+
+func TestParseComplaint(t *testing.T) {
+	body := "Feedback-Type: abuse\nOriginal-Rcpt-To: rfc822; victim@example.com\nOriginal-Message-ID: <send-123@example.net>"
+	if !Detect("multipart/report; report-type=feedback-report", body) {
+		t.Fatal("feedback report was not detected")
+	}
+	report := Parse(body)
+	if !report.Complaint || report.Recipient != "victim@example.com" || report.OriginalMessageID != "send-123@example.net" {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+}

--- a/internal/pkg/signuprisk/scorer.go
+++ b/internal/pkg/signuprisk/scorer.go
@@ -1,0 +1,233 @@
+package signuprisk
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/mail"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+type Assessment struct {
+	IP              string
+	UserAgent       string
+	EmailRisk       int
+	ASN             *int64
+	NormalizedEmail string
+	Score           int
+	Signals         []string
+}
+
+type ASNResolver interface {
+	LookupASN(ctx context.Context, ip net.IP) (*int64, error)
+}
+
+type Scorer struct {
+	cache    redis.Cmdable
+	resolver ASNResolver
+}
+
+func New(cache redis.Cmdable, resolver ASNResolver) *Scorer {
+	if resolver == nil {
+		resolver = DNSASNResolver{}
+	}
+	return &Scorer{cache: cache, resolver: resolver}
+}
+
+var disposableDomains = map[string]struct{}{
+	"10minutemail.com": {}, "dispostable.com": {}, "emailondeck.com": {},
+	"fakeinbox.com": {}, "getnada.com": {}, "guerrillamail.com": {},
+	"maildrop.cc": {}, "mailinator.com": {}, "mintemail.com": {},
+	"mohmal.com": {}, "sharklasers.com": {}, "temp-mail.org": {},
+	"tempail.com": {}, "tempmail.com": {}, "throwawaymail.com": {},
+	"trashmail.com": {}, "yopmail.com": {},
+}
+
+var knownHostingASNs = map[int64]struct{}{
+	14061: {}, 14618: {}, 16276: {}, 16509: {}, 20473: {}, 24940: {},
+	31898: {}, 36351: {}, 396982: {}, 45102: {}, 63949: {}, 8075: {},
+}
+
+func (s *Scorer) Assess(ctx context.Context, address, ipAddress, userAgent string) Assessment {
+	assessment := Assessment{
+		IP:              strings.TrimSpace(ipAddress),
+		UserAgent:       strings.TrimSpace(userAgent),
+		NormalizedEmail: NormalizeEmail(address),
+	}
+
+	domain := emailDomain(address)
+	if IsDisposableDomain(domain) {
+		assessment.EmailRisk = 30
+		assessment.Score += 30
+		assessment.Signals = append(assessment.Signals, "disposable_email")
+	} else if looksDisposable(domain) {
+		assessment.EmailRisk = 15
+		assessment.Score += 15
+		assessment.Signals = append(assessment.Signals, "disposable_email_heuristic")
+	}
+
+	ip := net.ParseIP(assessment.IP)
+	if ip != nil && !ip.IsPrivate() && !ip.IsLoopback() && !ip.IsUnspecified() && s.resolver != nil {
+		lookupCtx, cancel := context.WithTimeout(ctx, 750*time.Millisecond)
+		asn, err := s.resolver.LookupASN(lookupCtx, ip)
+		cancel()
+		if err == nil && asn != nil {
+			assessment.ASN = asn
+			if _, risky := knownHostingASNs[*asn]; risky {
+				assessment.Score += 20
+				assessment.Signals = append(assessment.Signals, "datacenter_asn")
+			}
+		}
+	}
+
+	if s.cache != nil && ip != nil {
+		if count := s.increment(ctx, "signup:risk:ip:"+digest(assessment.IP), time.Hour); count >= 5 {
+			assessment.Score += 15
+			assessment.Signals = append(assessment.Signals, "signup_ip_velocity")
+		}
+		if assessment.ASN != nil {
+			if count := s.increment(ctx, "signup:risk:asn:"+strconv.FormatInt(*assessment.ASN, 10), time.Hour); count >= 20 {
+				assessment.Score += 10
+				assessment.Signals = append(assessment.Signals, "signup_asn_velocity")
+			}
+		}
+	}
+	if s.cache != nil && assessment.NormalizedEmail != "" {
+		key := "signup:risk:email-aliases:" + digest(assessment.NormalizedEmail)
+		member := digest(strings.ToLower(strings.TrimSpace(address)))
+		if added, err := s.cache.SAdd(ctx, key, member).Result(); err == nil {
+			if added > 0 {
+				_ = s.cache.Expire(ctx, key, 24*time.Hour).Err()
+			}
+			if count, err := s.cache.SCard(ctx, key).Result(); err == nil && count >= 2 {
+				assessment.Score += 20
+				assessment.Signals = append(assessment.Signals, "normalized_email_reuse")
+			}
+		}
+	}
+
+	assessment.Score = min(assessment.Score, 100)
+	return assessment
+}
+
+func (s *Scorer) increment(ctx context.Context, key string, ttl time.Duration) int64 {
+	count, err := s.cache.Incr(ctx, key).Result()
+	if err != nil {
+		return 0
+	}
+	if count == 1 {
+		_ = s.cache.Expire(ctx, key, ttl).Err()
+	}
+	return count
+}
+
+func NormalizeEmail(address string) string {
+	parsed, err := mail.ParseAddress(strings.TrimSpace(address))
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(address))
+	}
+	parts := strings.SplitN(strings.ToLower(parsed.Address), "@", 2)
+	if len(parts) != 2 {
+		return strings.ToLower(parsed.Address)
+	}
+	local, domain := parts[0], parts[1]
+	if domain == "googlemail.com" {
+		domain = "gmail.com"
+	}
+	if domain == "gmail.com" {
+		local = strings.ReplaceAll(strings.SplitN(local, "+", 2)[0], ".", "")
+	}
+	return local + "@" + domain
+}
+
+func IsDisposableDomain(domain string) bool {
+	_, ok := disposableDomains[strings.ToLower(strings.TrimSpace(domain))]
+	return ok
+}
+
+type AddressQuality struct {
+	Disposable bool
+	Role       bool
+	RiskyTLD   bool
+}
+
+var roleLocalParts = map[string]struct{}{
+	"abuse": {}, "admin": {}, "billing": {}, "contact": {}, "help": {},
+	"info": {}, "office": {}, "sales": {}, "security": {}, "support": {},
+}
+
+var riskyTLDs = map[string]struct{}{
+	"click": {}, "country": {}, "download": {}, "gq": {}, "loan": {},
+	"men": {}, "ml": {}, "party": {}, "review": {}, "science": {}, "stream": {},
+	"tk": {}, "top": {}, "trade": {}, "work": {}, "xyz": {},
+}
+
+func ClassifyAddress(address string) AddressQuality {
+	parsed, err := mail.ParseAddress(strings.TrimSpace(address))
+	if err != nil {
+		return AddressQuality{}
+	}
+	parts := strings.SplitN(strings.ToLower(parsed.Address), "@", 2)
+	if len(parts) != 2 {
+		return AddressQuality{}
+	}
+	local, domain := strings.SplitN(parts[0], "+", 2)[0], parts[1]
+	_, role := roleLocalParts[local]
+	tldParts := strings.Split(domain, ".")
+	_, riskyTLD := riskyTLDs[tldParts[len(tldParts)-1]]
+	return AddressQuality{
+		Disposable: IsDisposableDomain(domain) || looksDisposable(domain),
+		Role:       role,
+		RiskyTLD:   riskyTLD,
+	}
+}
+
+func emailDomain(address string) string {
+	parsed, err := mail.ParseAddress(strings.TrimSpace(address))
+	if err != nil {
+		return ""
+	}
+	parts := strings.SplitN(parsed.Address, "@", 2)
+	if len(parts) != 2 {
+		return ""
+	}
+	return strings.ToLower(parts[1])
+}
+
+func looksDisposable(domain string) bool {
+	return strings.Contains(domain, "tempmail") || strings.Contains(domain, "throwaway") || strings.Contains(domain, "10minute")
+}
+
+func digest(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(sum[:12])
+}
+
+type DNSASNResolver struct{}
+
+func (DNSASNResolver) LookupASN(ctx context.Context, ip net.IP) (*int64, error) {
+	v4 := ip.To4()
+	if v4 == nil {
+		return nil, nil
+	}
+	query := fmt.Sprintf("%d.%d.%d.%d.origin.asn.cymru.com", v4[3], v4[2], v4[1], v4[0])
+	records, err := net.DefaultResolver.LookupTXT(ctx, query)
+	if err != nil || len(records) == 0 {
+		return nil, err
+	}
+	fields := strings.Split(records[0], "|")
+	if len(fields) == 0 {
+		return nil, nil
+	}
+	asn, err := strconv.ParseInt(strings.TrimSpace(fields[0]), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	return &asn, nil
+}

--- a/internal/pkg/signuprisk/scorer_test.go
+++ b/internal/pkg/signuprisk/scorer_test.go
@@ -1,0 +1,19 @@
+package signuprisk
+
+import "testing"
+
+func TestNormalizeEmailCanonicalizesGmailAliases(t *testing.T) {
+	got := NormalizeEmail("User.Name+trial@googlemail.com")
+	if got != "username@gmail.com" {
+		t.Fatalf("NormalizeEmail() = %q", got)
+	}
+}
+
+func TestDisposableDomain(t *testing.T) {
+	if !IsDisposableDomain("mailinator.com") {
+		t.Fatal("expected known disposable domain")
+	}
+	if IsDisposableDomain("example.com") {
+		t.Fatal("ordinary domain classified as disposable")
+	}
+}

--- a/internal/pkg/warmlint/lint.go
+++ b/internal/pkg/warmlint/lint.go
@@ -15,6 +15,7 @@ var (
 	wordToken    = regexp.MustCompile(`[a-z0-9%]+`)
 	linkPattern  = regexp.MustCompile(`https?://`)
 	htmlTag      = regexp.MustCompile(`(?i)<[a-z!/][^>]*>`)
+	imageTag     = regexp.MustCompile(`(?i)<img\b`)
 )
 
 // triggerWords are single-token terms that raise SpamAssassin-style content
@@ -74,6 +75,12 @@ type Issue struct {
 type ScoreResult struct {
 	Score  int     `json:"score"` // 0-100, higher = safer
 	Issues []Issue `json:"issues"`
+	Hard   bool    `json:"hard"`
+}
+
+type ScoreOptions struct {
+	AttachmentCount int
+	ImageCount      int
 }
 
 // Score gives an ADVISORY 0-100 content-safety score (higher = safer) for a
@@ -82,6 +89,10 @@ type ScoreResult struct {
 // the mail that actually reaches prospects and drives complaints. It reuses the
 // same trigger-term and ALL-CAPS heuristics as the warmup lint.
 func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
+	return ScoreWithOptions(subject, bodyHTML, bodyPlain, ScoreOptions{})
+}
+
+func ScoreWithOptions(subject, bodyHTML, bodyPlain string, opts ScoreOptions) ScoreResult {
 	res := ScoreResult{Score: 100, Issues: []Issue{}}
 	deduct := func(n int, severity, code, msg string) {
 		res.Score -= n
@@ -94,6 +105,10 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		body = stripTags(bodyHTML)
 	}
 	combined := subj + "\n" + body
+	images := opts.ImageCount
+	if images == 0 {
+		images = len(imageTag.FindAllString(bodyHTML, -1))
+	}
 
 	if subj == "" {
 		deduct(20, "high", "empty_subject", "Subject is empty.")
@@ -126,10 +141,24 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 	} else if len(body) > 15000 {
 		deduct(10, "warn", "oversized_body", "Body is very large; trim it for deliverability.")
 	}
+	if opts.AttachmentCount > 0 {
+		severity := "warn"
+		deduction := 8
+		if opts.AttachmentCount > 2 {
+			severity = "high"
+			deduction = 18
+		}
+		deduct(deduction, severity, "attachments", fmt.Sprintf("%d attachment(s) increase first-contact filtering risk.", opts.AttachmentCount))
+	}
+	if images > 2 {
+		deduction := min(20, (images-2)*5)
+		deduct(deduction, "warn", "image_heavy", fmt.Sprintf("%d images make the message look promotional.", images))
+	}
 
 	if res.Score < 0 {
 		res.Score = 0
 	}
+	res.Hard = res.Score < 25
 	return res
 }
 

--- a/internal/pkg/warmlint/lint_test.go
+++ b/internal/pkg/warmlint/lint_test.go
@@ -1,0 +1,25 @@
+package warmlint
+
+import "testing"
+
+func TestScoreWithOptionsMarksSevereCampaignContentHard(t *testing.T) {
+	result := ScoreWithOptions(
+		"FREE WINNER URGENT BONUS CASH",
+		"<img><img><img><img><img>",
+		"",
+		ScoreOptions{AttachmentCount: 3},
+	)
+	if !result.Hard {
+		t.Fatalf("ScoreWithOptions() score = %d, want hard result", result.Score)
+	}
+	if result.Score >= 25 {
+		t.Fatalf("ScoreWithOptions() score = %d, want below 25", result.Score)
+	}
+}
+
+func TestScoreWithOptionsKeepsOrdinaryCopyAdvisory(t *testing.T) {
+	result := ScoreWithOptions("Quick question", "", "Would Tuesday work for a short call?", ScoreOptions{})
+	if result.Hard || result.Score != 100 {
+		t.Fatalf("ScoreWithOptions() = %+v, want clean advisory result", result)
+	}
+}

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -49,6 +49,7 @@ type CampaignRepository interface {
 	StartCampaign(ctx context.Context, campaignID uuid.UUID) error
 	StopCampaign(ctx context.Context, campaignID uuid.UUID) error
 	ValidateCampaignReady(ctx context.Context, campaignID uuid.UUID) error
+	UpdateVerificationStatus(ctx context.Context, campaignID uuid.UUID, status string, summary *models.CampaignVerificationSummary) error
 	GetPendingCampaignTasks(ctx context.Context, campaignID uuid.UUID) ([]Task, error)
 	// ListCampaignScheduleCandidates returns active campaigns that have NO pending
 	// task — their self-perpetuating chain died and needs re-seeding. Used by the
@@ -129,7 +130,8 @@ const CAMPAIGN_SELECT = `id, name, description, status,
 		  schedule_windows,
 		  guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
 		  guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days,
-		  guardrail_tripped_at, guardrail_reason`
+		  guardrail_tripped_at, guardrail_reason,
+		  verification_status, verification_summary, verification_checked_at`
 
 func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) error {
 	var dest []any = []any{
@@ -148,6 +150,7 @@ func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) err
 		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
 		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
 		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
+		&campaign.VerificationStatus, &campaign.VerificationSummary, &campaign.VerificationCheckedAt,
 	}
 	dest = append(dest, extra...)
 	return rows.Scan(
@@ -171,6 +174,7 @@ const CAMPAIGN_SELECT_FULL = `
 	c.guardrail_enabled, c.guardrail_bounce_rate_max, c.guardrail_complaint_rate_max,
 	c.guardrail_reply_rate_min, c.guardrail_min_sample, c.guardrail_window_days,
 	c.guardrail_tripped_at, c.guardrail_reason,
+	c.verification_status, c.verification_summary, c.verification_checked_at,
 	COALESCE(array_agg(cet.tag_id) FILTER (WHERE cet.tag_id IS NOT NULL), '{}') AS email_tag_ids,
 	COALESCE(array_agg(cec.folder_id) FILTER (WHERE cec.folder_id IS NOT NULL), '{}') AS email_folder_ids
 `
@@ -1239,6 +1243,7 @@ func (r *campaignRepository) GetByID(ctx context.Context, campaignID uuid.UUID) 
 		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
 		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
 		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
+		&campaign.VerificationStatus, &campaign.VerificationSummary, &campaign.VerificationCheckedAt,
 		&campaign.EmailTags, &campaign.Folders,
 	)
 	if err != nil {
@@ -1394,6 +1399,22 @@ func (r *campaignRepository) StartCampaign(ctx context.Context, campaignID uuid.
 		    guardrail_reason = ''
 		WHERE id = $1`
 	_, err := r.DB.Exec(ctx, query, campaignID)
+	return err
+}
+
+func (r *campaignRepository) UpdateVerificationStatus(ctx context.Context, campaignID uuid.UUID, status string, summary *models.CampaignVerificationSummary) error {
+	payload, err := json.Marshal(summary)
+	if err != nil {
+		return err
+	}
+	_, err = r.DB.Exec(ctx, `
+		UPDATE campaigns
+		SET verification_status = $2,
+		    verification_summary = $3,
+		    verification_checked_at = now(),
+		    updated_at = now()
+		WHERE id = $1
+	`, campaignID, status, payload)
 	return err
 }
 

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -41,6 +41,7 @@ type ContactRepository interface {
 	// the batch scheduler can work them off a cap per tick.
 	UpdateContactVerification(ctx context.Context, contactID uuid.UUID, res emailverify.Result) *errx.Error
 	ListUnverifiedContacts(ctx context.Context, limit int) ([]models.Contact, *errx.Error)
+	ListCampaignContactsForVerification(ctx context.Context, campaignID uuid.UUID) ([]models.Contact, *errx.Error)
 	// SetContactESP caches the recipient ESP/provider resolved from the contact's
 	// domain (control-plane only, no MX dial). Best-effort: a failure should not
 	// block sending.
@@ -486,6 +487,40 @@ func (r *contactRepository) ListUnverifiedContacts(ctx context.Context, limit in
 		return nil, errx.InternalError()
 	}
 	return out, nil
+}
+
+func (r *contactRepository) ListCampaignContactsForVerification(ctx context.Context, campaignID uuid.UUID) ([]models.Contact, *errx.Error) {
+	rows, err := r.DB.Query(ctx, `
+		SELECT c.id, c.email, c.verification_status, c.verification_reason,
+		       c.is_catch_all, c.verification_checked_at
+		FROM campaign_leads cl
+		JOIN contacts c ON c.id = cl.contact_id
+		WHERE cl.campaign_id = $1
+		ORDER BY c.created_at ASC
+	`, campaignID)
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+	contacts := make([]models.Contact, 0)
+	for rows.Next() {
+		var contact models.Contact
+		if err := rows.Scan(
+			&contact.ID,
+			&contact.Email,
+			&contact.VerificationStatus,
+			&contact.VerificationReason,
+			&contact.IsCatchAll,
+			&contact.VerificationCheckedAt,
+		); err != nil {
+			return nil, errx.InternalError()
+		}
+		contacts = append(contacts, contact)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errx.InternalError()
+	}
+	return contacts, nil
 }
 
 func (r *contactRepository) GetByEmailAndOrganization(ctx context.Context, organizationID uuid.UUID, email string) (*models.Contact, *errx.Error) {

--- a/internal/repository/pg_contact_import_assessment.go
+++ b/internal/repository/pg_contact_import_assessment.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type ContactImportAssessmentRepository interface {
+	Create(ctx context.Context, organizationID, userID uuid.UUID, filename string, total int, quality *models.ContactImportQuality) (uuid.UUID, error)
+}
+
+type contactImportAssessmentRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewContactImportAssessmentRepository(db *pgxpool.Pool) ContactImportAssessmentRepository {
+	return &contactImportAssessmentRepository{db: db}
+}
+
+func (r *contactImportAssessmentRepository) Create(ctx context.Context, organizationID, userID uuid.UUID, filename string, total int, quality *models.ContactImportQuality) (uuid.UUID, error) {
+	if quality == nil {
+		return uuid.Nil, nil
+	}
+	summary, err := json.Marshal(quality)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	var id uuid.UUID
+	err = r.db.QueryRow(ctx, `
+		INSERT INTO contact_import_assessments (
+			organization_id, user_id, filename, total_rows, invalid_rows,
+			disposable_rows, role_rows, risky_tld_rows, blocked, summary
+		)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		RETURNING id
+	`, organizationID, userID, filename, total, quality.Invalid, quality.Disposable,
+		quality.Role, quality.RiskyTLD, quality.Blocked, summary).Scan(&id)
+	return id, err
+}

--- a/internal/repository/pg_email.go
+++ b/internal/repository/pg_email.go
@@ -117,6 +117,8 @@ type EmailRepository interface {
 	// domains. It returns the mailboxes that entered the failing state on THIS
 	// call, which is what the sweep notifies on.
 	UpdateDomainAuthState(ctx context.Context, domain, state string, spf, dkim, dmarc bool, dmarcPolicy, reason string, checkedAt time.Time) ([]models.EmailAuthTransition, *errx.Error)
+	StartColdRamp(ctx context.Context, emailAccountID uuid.UUID, startedAt time.Time) error
+	MarkAuthFailure(ctx context.Context, emailAccountID uuid.UUID, reason string, checkedAt time.Time) error
 	Delete(ctx context.Context, userID, emailAccountID string) *errx.Error
 
 	NewOauthAccount(ctx context.Context, userID string, data models.NewOauthAccount) (*models.Email, *errx.Error)
@@ -143,6 +145,28 @@ type EmailRepository interface {
 	// ListActiveAccountsByWorker returns the ids of the active mailboxes
 	// assigned to one worker, for reloading them after that worker restarts.
 	ListActiveAccountsByWorker(ctx context.Context, workerID uuid.UUID) ([]uuid.UUID, error)
+}
+
+func (r *emailRepository) StartColdRamp(ctx context.Context, emailAccountID uuid.UUID, startedAt time.Time) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE email_accounts
+		SET cold_ramp_started_at = COALESCE(cold_ramp_started_at, $2), updated_at = now()
+		WHERE id = $1
+	`, emailAccountID, startedAt.UTC())
+	return err
+}
+
+func (r *emailRepository) MarkAuthFailure(ctx context.Context, emailAccountID uuid.UUID, reason string, checkedAt time.Time) error {
+	_, err := r.DB.Exec(ctx, `
+		UPDATE email_accounts
+		SET auth_state = 'failing',
+		    auth_reason = $2,
+		    auth_checked_at = $3,
+		    auth_failing_since = COALESCE(auth_failing_since, $3),
+		    updated_at = now()
+		WHERE id = $1
+	`, emailAccountID, reason, checkedAt.UTC())
+	return err
 }
 
 type emailRepository struct {
@@ -575,7 +599,7 @@ func (r *emailRepository) Search(ctx context.Context, orgID, search string, curs
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at,
 		 ea.auth_state, ea.auth_spf, ea.auth_dkim, ea.auth_dmarc, ea.auth_dmarc_policy, ea.auth_reason, ea.auth_checked_at, ea.auth_failing_since,
 		 ea.warmup, ea.warmup_paused_at, ea.warmup_base,
-		 ea.warmup_max, ea.warmup_increase, ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.save_to_sent,
+		 ea.warmup_max, ea.warmup_increase, ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.cold_ramp_started_at, ea.save_to_sent,
 		 ea.created_at, ea.updated_at,
 		 COALESCE(
 			array_agg(eat.tag_id) FILTER (WHERE eat.tag_id IS NOT NULL), '{}'
@@ -626,7 +650,7 @@ func (r *emailRepository) Search(ctx context.Context, orgID, search string, curs
 			&i.LastSyncedAt, &i.LastID, &i.CampaignLimit, &i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt,
 			&i.AuthState, &i.AuthSPF, &i.AuthDKIM, &i.AuthDMARC, &i.AuthDMARCPolicy, &i.AuthReason, &i.AuthCheckedAt, &i.AuthFailingSince,
 			&i.Warmup, &i.WarmupPausedAt, &i.WarmupBase, &i.WarmupMax, &i.WarmupIncrease,
-			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.SaveToSent,
+			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.ColdRampStartedAt, &i.SaveToSent,
 			&i.CreatedAt, &i.UpdatedAt, &i.Tags,
 		)
 		if err != nil {
@@ -697,7 +721,7 @@ func (r *emailRepository) Get(ctx context.Context, orgID, emailAccountID string)
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at,
 		 ea.auth_state, ea.auth_spf, ea.auth_dkim, ea.auth_dmarc, ea.auth_dmarc_policy, ea.auth_reason, ea.auth_checked_at, ea.auth_failing_since,
 		 ea.warmup, ea.warmup_paused_at, ea.warmup_base,
-		 ea.warmup_max, ea.warmup_increase, ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.save_to_sent,
+		 ea.warmup_max, ea.warmup_increase, ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.cold_ramp_started_at, ea.save_to_sent,
 		 ea.created_at, ea.updated_at,
 		 COALESCE(array_agg(eat.tag_id) FILTER (WHERE eat.tag_id IS NOT NULL), '{}') AS tags
 		FROM email_accounts ea
@@ -721,7 +745,7 @@ func (r *emailRepository) Get(ctx context.Context, orgID, emailAccountID string)
 		&i.LastSyncedAt, &i.LastID, &i.CampaignLimit, &i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt,
 		&i.AuthState, &i.AuthSPF, &i.AuthDKIM, &i.AuthDMARC, &i.AuthDMARCPolicy, &i.AuthReason, &i.AuthCheckedAt, &i.AuthFailingSince,
 		&i.Warmup, &i.WarmupPausedAt, &i.WarmupBase, &i.WarmupMax, &i.WarmupIncrease,
-		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.SaveToSent,
+		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.ColdRampStartedAt, &i.SaveToSent,
 		&i.CreatedAt, &i.UpdatedAt, &i.Tags,
 	)
 	if err != nil {
@@ -952,7 +976,7 @@ func (r *emailRepository) Update(ctx context.Context, userID, emailAccountID str
 		          COALESCE(last_synced_at, created_at) AS last_synced_at, last_id, campaign_limit, min_wait_time, reply_to, tracking_domain, tracking_domain_verified, tracking_domain_verified_at,
 		          auth_state, auth_spf, auth_dkim, auth_dmarc, auth_dmarc_policy, auth_reason, auth_checked_at, auth_failing_since,
 		          warmup, warmup_paused_at, warmup_base, warmup_max, warmup_increase, warmup_reply_rate, warmup_tag, warmup_pool_type,
-		          warmup_start_time, warmup_end_time, warmup_days, save_to_sent, created_at, updated_at
+		          warmup_start_time, warmup_end_time, warmup_days, cold_ramp_started_at, save_to_sent, created_at, updated_at
 	`, strings.Join(setClauses, ", "))
 
 	var i models.Email
@@ -964,7 +988,7 @@ func (r *emailRepository) Update(ctx context.Context, userID, emailAccountID str
 		// dashboard on every unrelated edit.
 		&i.AuthState, &i.AuthSPF, &i.AuthDKIM, &i.AuthDMARC, &i.AuthDMARCPolicy, &i.AuthReason, &i.AuthCheckedAt, &i.AuthFailingSince,
 		&i.Warmup, &i.WarmupPausedAt, &i.WarmupBase, &i.WarmupMax, &i.WarmupIncrease, &i.WarmupReplyRate, &i.WarmupTag, &i.WarmupPoolType,
-		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.SaveToSent,
+		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.ColdRampStartedAt, &i.SaveToSent,
 		&i.CreatedAt, &i.UpdatedAt,
 	)
 	if err != nil {
@@ -1309,7 +1333,7 @@ func (r *emailRepository) GetByID(ctx context.Context, emailAccountID uuid.UUID)
 		 ea.provider, ea.status, COALESCE(ea.last_synced_at, ea.created_at) AS last_synced_at, ea.last_id, ea.campaign_limit,
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at, ea.warmup, ea.warmup_paused_at, ea.warmup_base,
 		 ea.warmup_max, ea.warmup_increase, ea.warmup_reply_rate, ea.warmup_tag, ea.warmup_pool_type,
-		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone, ea.save_to_sent,
+		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone, ea.cold_ramp_started_at, ea.save_to_sent,
 		 ea.auth_state, ea.auth_failing_since,
 		 ea.created_at, ea.updated_at,
 		 COALESCE(array_agg(eat.tag_id) FILTER (WHERE eat.tag_id IS NOT NULL), '{}') AS tags
@@ -1325,7 +1349,7 @@ func (r *emailRepository) GetByID(ctx context.Context, emailAccountID uuid.UUID)
 		&i.Provider, &i.Status, &i.LastSyncedAt, &i.LastID, &i.CampaignLimit,
 		&i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt, &i.Warmup, &i.WarmupPausedAt, &i.WarmupBase,
 		&i.WarmupMax, &i.WarmupIncrease, &i.WarmupReplyRate, &i.WarmupTag, &i.WarmupPoolType,
-		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone, &i.SaveToSent,
+		&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone, &i.ColdRampStartedAt, &i.SaveToSent,
 		&i.AuthState, &i.AuthFailingSince,
 		&i.CreatedAt, &i.UpdatedAt, &i.Tags,
 	)
@@ -1356,7 +1380,7 @@ func (r *emailRepository) GetByTags(ctx context.Context, scope AccountScope, tag
 		 ea.provider, ea.status, COALESCE(ea.last_synced_at, ea.created_at) AS last_synced_at, ea.last_id, ea.campaign_limit,
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at, ea.warmup, ea.warmup_paused_at, ea.warmup_base,
 		 ea.warmup_max, ea.warmup_increase, ea.warmup_reply_rate, ea.warmup_tag,
-		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone,
+		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone, ea.cold_ramp_started_at,
 		 ea.auth_state, ea.auth_failing_since,
 		 ea.created_at, ea.updated_at
 		FROM email_accounts ea
@@ -1382,7 +1406,7 @@ func (r *emailRepository) GetByTags(ctx context.Context, scope AccountScope, tag
 			&i.Provider, &i.Status, &i.LastSyncedAt, &i.LastID, &i.CampaignLimit,
 			&i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt, &i.Warmup, &i.WarmupPausedAt, &i.WarmupBase,
 			&i.WarmupMax, &i.WarmupIncrease, &i.WarmupReplyRate, &i.WarmupTag,
-			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone,
+			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone, &i.ColdRampStartedAt,
 			&i.AuthState, &i.AuthFailingSince,
 			&i.CreatedAt, &i.UpdatedAt,
 		)
@@ -1411,7 +1435,7 @@ func (r *emailRepository) GetAllActiveInScope(ctx context.Context, scope Account
 		 ea.provider, ea.status, COALESCE(ea.last_synced_at, ea.created_at) AS last_synced_at, ea.last_id, ea.campaign_limit,
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at, ea.warmup, ea.warmup_paused_at, ea.warmup_base,
 		 ea.warmup_max, ea.warmup_increase, ea.warmup_reply_rate, ea.warmup_tag,
-		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone,
+		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone, ea.cold_ramp_started_at,
 		 ea.auth_state, ea.auth_failing_since,
 		 ea.created_at, ea.updated_at
 		FROM email_accounts ea
@@ -1435,7 +1459,7 @@ func (r *emailRepository) GetAllActiveInScope(ctx context.Context, scope Account
 			&i.Provider, &i.Status, &i.LastSyncedAt, &i.LastID, &i.CampaignLimit,
 			&i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt, &i.Warmup, &i.WarmupPausedAt, &i.WarmupBase,
 			&i.WarmupMax, &i.WarmupIncrease, &i.WarmupReplyRate, &i.WarmupTag,
-			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone,
+			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone, &i.ColdRampStartedAt,
 			&i.AuthState, &i.AuthFailingSince,
 			&i.CreatedAt, &i.UpdatedAt,
 		)
@@ -1476,7 +1500,7 @@ func (r *emailRepository) GetByCampaignSenders(ctx context.Context, scope Accoun
 		 ea.provider, ea.status, COALESCE(ea.last_synced_at, ea.created_at) AS last_synced_at, ea.last_id, ea.campaign_limit,
 		 ea.min_wait_time, ea.reply_to, ea.tracking_domain, ea.tracking_domain_verified, ea.tracking_domain_verified_at, ea.warmup, ea.warmup_paused_at, ea.warmup_base,
 		 ea.warmup_max, ea.warmup_increase, ea.warmup_reply_rate, ea.warmup_tag,
-		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone,
+		 ea.warmup_start_time, ea.warmup_end_time, ea.warmup_days, ea.timezone, ea.cold_ramp_started_at,
 		 ea.auth_state, ea.auth_failing_since,
 		 ea.created_at, ea.updated_at,
 		 cs.weight, cs.rotation_position, cs.last_sent_at
@@ -1505,7 +1529,7 @@ func (r *emailRepository) GetByCampaignSenders(ctx context.Context, scope Accoun
 			&i.Provider, &i.Status, &i.LastSyncedAt, &i.LastID, &i.CampaignLimit,
 			&i.MinWaitTime, &i.ReplyTo, &i.TrackingDomain, &i.TrackingDomainVerified, &i.TrackingDomainVerifiedAt, &i.Warmup, &i.WarmupPausedAt, &i.WarmupBase,
 			&i.WarmupMax, &i.WarmupIncrease, &i.WarmupReplyRate, &i.WarmupTag,
-			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone,
+			&i.WarmupStartTime, &i.WarmupEndTime, &i.WarmupDays, &i.Timezone, &i.ColdRampStartedAt,
 			&i.AuthState, &i.AuthFailingSince,
 			&i.CreatedAt, &i.UpdatedAt,
 			&sender.Weight, &sender.RotationPosition, &sender.LastSentAt,

--- a/internal/repository/pg_org_risk.go
+++ b/internal/repository/pg_org_risk.go
@@ -1,0 +1,231 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type OrgRiskFinding struct {
+	OrganizationID uuid.UUID
+	Key            string
+	Score          int
+	Reason         string
+	Evidence       map[string]any
+}
+
+type OrgRiskRepository interface {
+	Get(ctx context.Context, organizationID uuid.UUID) (*models.OrganizationRisk, error)
+	RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, signal models.OrganizationRiskSignal) (*models.OrganizationRisk, *models.OrganizationRisk, error)
+	ListCorrelationFindings(ctx context.Context) ([]OrgRiskFinding, error)
+}
+
+type orgRiskRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewOrgRiskRepository(db *pgxpool.Pool) OrgRiskRepository {
+	return &orgRiskRepository{db: db}
+}
+
+func (r *orgRiskRepository) Get(ctx context.Context, organizationID uuid.UUID) (*models.OrganizationRisk, error) {
+	var risk models.OrganizationRisk
+	err := r.db.QueryRow(ctx, `
+		SELECT id, risk_state, risk_score, risk_reason, risk_signals, risk_evaluated_at
+		FROM organizations
+		WHERE id = $1
+	`, organizationID).Scan(
+		&risk.OrganizationID,
+		&risk.State,
+		&risk.Score,
+		&risk.Reason,
+		&risk.Signals,
+		&risk.EvaluatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	return &risk, err
+}
+
+func (r *orgRiskRepository) RecordSignal(ctx context.Context, organizationID uuid.UUID, key string, signal models.OrganizationRiskSignal) (*models.OrganizationRisk, *models.OrganizationRisk, error) {
+	tx, err := r.db.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	before := &models.OrganizationRisk{OrganizationID: organizationID}
+	var raw []byte
+	err = tx.QueryRow(ctx, `
+		SELECT risk_state, risk_score, risk_reason, risk_signals, risk_evaluated_at
+		FROM organizations
+		WHERE id = $1
+		FOR UPDATE
+	`, organizationID).Scan(&before.State, &before.Score, &before.Reason, &raw, &before.EvaluatedAt)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(raw) > 0 {
+		if err := json.Unmarshal(raw, &before.Signals); err != nil {
+			return nil, nil, fmt.Errorf("decode organization risk signals: %w", err)
+		}
+	}
+	if before.Signals == nil {
+		before.Signals = map[string]models.OrganizationRiskSignal{}
+	}
+
+	signal.Score = max(0, min(signal.Score, 100))
+	if signal.ObservedAt.IsZero() {
+		signal.ObservedAt = time.Now().UTC()
+	}
+	after := &models.OrganizationRisk{
+		OrganizationID: organizationID,
+		Signals:        make(map[string]models.OrganizationRiskSignal, len(before.Signals)+1),
+	}
+	for name, current := range before.Signals {
+		after.Signals[name] = current
+	}
+	after.Signals[key] = signal
+	for _, current := range after.Signals {
+		after.Score += current.Score
+	}
+	after.Score = min(after.Score, 100)
+	after.State = models.OrganizationRiskStateForScore(after.Score)
+	after.Reason = signal.Reason
+	evaluatedAt := time.Now().UTC()
+	after.EvaluatedAt = &evaluatedAt
+
+	encoded, err := json.Marshal(after.Signals)
+	if err != nil {
+		return nil, nil, err
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE organizations
+		SET risk_state = $2,
+		    risk_score = $3,
+		    risk_reason = $4,
+		    risk_signals = $5,
+		    risk_evaluated_at = $6,
+		    updated_at = now()
+		WHERE id = $1
+	`, organizationID, after.State, after.Score, after.Reason, encoded, evaluatedAt)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, nil, err
+	}
+	return before, after, nil
+}
+
+func (r *orgRiskRepository) ListCorrelationFindings(ctx context.Context) ([]OrgRiskFinding, error) {
+	findings := make([]OrgRiskFinding, 0)
+	queries := []struct {
+		key    string
+		score  int
+		reason string
+		query  string
+	}{
+		{
+			key:    "shared_signup_ip",
+			score:  25,
+			reason: "Multiple organizations share a signup IP address",
+			query: `
+				SELECT o.id, host(u.signup_ip), count(*) OVER (PARTITION BY u.signup_ip)
+				FROM organizations o
+				JOIN users u ON u.id = o.owner_user_id
+				WHERE u.signup_ip IS NOT NULL
+				  AND u.created_at >= now() - interval '30 days'
+				  AND (SELECT count(DISTINCT o2.id) FROM organizations o2 JOIN users u2 ON u2.id = o2.owner_user_id WHERE u2.signup_ip = u.signup_ip) >= 3
+			`,
+		},
+		{
+			key:    "shared_signup_asn",
+			score:  15,
+			reason: "Signup velocity is concentrated in one network",
+			query: `
+				SELECT o.id, u.signup_asn::text, count(*) OVER (PARTITION BY u.signup_asn)
+				FROM organizations o
+				JOIN users u ON u.id = o.owner_user_id
+				WHERE u.signup_asn IS NOT NULL
+				  AND u.created_at >= now() - interval '7 days'
+				  AND (SELECT count(DISTINCT o2.id) FROM organizations o2 JOIN users u2 ON u2.id = o2.owner_user_id WHERE u2.signup_asn = u.signup_asn AND u2.created_at >= now() - interval '7 days') >= 5
+			`,
+		},
+		{
+			key:    "shared_payment_fingerprint",
+			score:  35,
+			reason: "Multiple organizations share a payment fingerprint",
+			query: `
+				SELECT s.organization_id, s.payment_fingerprint, count(*) OVER (PARTITION BY s.payment_fingerprint)
+				FROM subscriptions s
+				WHERE s.organization_id IS NOT NULL
+				  AND s.payment_fingerprint <> ''
+				  AND (SELECT count(DISTINCT s2.organization_id) FROM subscriptions s2 WHERE s2.payment_fingerprint = s.payment_fingerprint) >= 2
+			`,
+		},
+		{
+			key:    "snowshoe_domains",
+			score:  30,
+			reason: "Many fresh domains are sending just below mailbox caps",
+			query: `
+				WITH recent AS (
+					SELECT ea.organization_id,
+					       split_part(lower(ea.email), '@', 2) AS domain,
+					       count(t.id) AS sends
+					FROM email_accounts ea
+					LEFT JOIN tasks t ON t.email_account_id = ea.id
+					  AND t.task_type = 'campaign'
+					  AND t.status = 'completed'
+					  AND t.completed_at >= now() - interval '7 days'
+					WHERE ea.organization_id IS NOT NULL
+					  AND ea.created_at >= now() - interval '30 days'
+					GROUP BY ea.organization_id, domain
+				), flagged AS (
+					SELECT organization_id, count(*) AS domains, sum(sends) AS sends
+					FROM recent
+					WHERE sends BETWEEN 5 AND 49
+					GROUP BY organization_id
+					HAVING count(*) >= 5
+				)
+				SELECT organization_id, domains::text, sends FROM flagged
+			`,
+		},
+	}
+
+	for _, q := range queries {
+		rows, err := r.db.Query(ctx, q.query)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var orgID uuid.UUID
+			var value string
+			var count int
+			if err := rows.Scan(&orgID, &value, &count); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			findings = append(findings, OrgRiskFinding{
+				OrganizationID: orgID,
+				Key:            q.key,
+				Score:          q.score,
+				Reason:         q.reason,
+				Evidence:       map[string]any{"value": value, "cluster_size": count},
+			})
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		rows.Close()
+	}
+	return findings, nil
+}

--- a/internal/repository/pg_organization.go
+++ b/internal/repository/pg_organization.go
@@ -144,7 +144,8 @@ func (r *organizationRepository) GetByID(ctx context.Context, id uuid.UUID) (*mo
 		       deletion_scheduled_at, deletion_scheduled_for,
 		       presence_show_online, presence_show_activity,
 		       product_description, icp_notes, voice_profile, inbox_agent_enabled,
-		       assistant_shared_history
+		       assistant_shared_history,
+		       risk_state, risk_score, risk_reason, risk_signals, risk_evaluated_at
 		FROM organizations WHERE id = $1
 	`
 	return r.scanOrganization(ctx, query, id)
@@ -157,7 +158,8 @@ func (r *organizationRepository) GetBySlug(ctx context.Context, slug string) (*m
 		       deletion_scheduled_at, deletion_scheduled_for,
 		       presence_show_online, presence_show_activity,
 		       product_description, icp_notes, voice_profile, inbox_agent_enabled,
-		       assistant_shared_history
+		       assistant_shared_history,
+		       risk_state, risk_score, risk_reason, risk_signals, risk_evaluated_at
 		FROM organizations WHERE slug = $1
 	`
 	return r.scanOrganization(ctx, query, slug)
@@ -166,7 +168,7 @@ func (r *organizationRepository) GetBySlug(ctx context.Context, slug string) (*m
 func (r *organizationRepository) scanOrganization(ctx context.Context, query string, args ...interface{}) (*models.Organization, error) {
 	row := r.db.QueryRow(ctx, query, args...)
 	var org models.Organization
-	err := row.Scan(&org.ID, &org.Name, &org.Slug, &org.AvatarURL, &org.OwnerUserID, &org.CreatedAt, &org.UpdatedAt, &org.DeletionScheduledAt, &org.DeletionScheduledFor, &org.PresenceShowOnline, &org.PresenceShowActivity, &org.ProductDescription, &org.ICPNotes, &org.VoiceProfile, &org.InboxAgentEnabled, &org.AssistantSharedHistory)
+	err := row.Scan(&org.ID, &org.Name, &org.Slug, &org.AvatarURL, &org.OwnerUserID, &org.CreatedAt, &org.UpdatedAt, &org.DeletionScheduledAt, &org.DeletionScheduledFor, &org.PresenceShowOnline, &org.PresenceShowActivity, &org.ProductDescription, &org.ICPNotes, &org.VoiceProfile, &org.InboxAgentEnabled, &org.AssistantSharedHistory, &org.RiskState, &org.RiskScore, &org.RiskReason, &org.RiskSignals, &org.RiskEvaluatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}
@@ -212,7 +214,8 @@ func (r *organizationRepository) GetUserOrganizations(ctx context.Context, userI
 			om.id, om.organization_id, om.user_id, om.role, om.permissions,
 			om.invited_by, om.invited_at, om.accepted_at,
 			o.id, o.name, o.slug, o.avatar_url, o.owner_user_id, o.created_at, o.updated_at,
-			o.deletion_scheduled_at, o.deletion_scheduled_for
+			o.deletion_scheduled_at, o.deletion_scheduled_for,
+			o.risk_state, o.risk_score, o.risk_reason, o.risk_signals, o.risk_evaluated_at
 		FROM organization_members om
 		JOIN organizations o ON o.id = om.organization_id
 		WHERE om.user_id = $1
@@ -233,6 +236,7 @@ func (r *organizationRepository) GetUserOrganizations(ctx context.Context, userI
 			&m.InvitedBy, &m.InvitedAt, &m.AcceptedAt,
 			&org.ID, &org.Name, &org.Slug, &org.AvatarURL, &org.OwnerUserID, &org.CreatedAt, &org.UpdatedAt,
 			&org.DeletionScheduledAt, &org.DeletionScheduledFor,
+			&org.RiskState, &org.RiskScore, &org.RiskReason, &org.RiskSignals, &org.RiskEvaluatedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -250,7 +254,8 @@ func (r *organizationRepository) GetUserDefaultOrganization(ctx context.Context,
 		       deletion_scheduled_at, deletion_scheduled_for,
 		       presence_show_online, presence_show_activity,
 		       product_description, icp_notes, voice_profile, inbox_agent_enabled,
-		       assistant_shared_history
+		       assistant_shared_history,
+		       risk_state, risk_score, risk_reason, risk_signals, risk_evaluated_at
 		FROM organizations WHERE owner_user_id = $1
 		ORDER BY created_at ASC LIMIT 1
 	`

--- a/internal/repository/pg_subscription.go
+++ b/internal/repository/pg_subscription.go
@@ -17,7 +17,7 @@ import (
 // order. With `SELECT *`, the trailing NULL free-trial timestamps land in the
 // non-nullable created_at/updated_at scan slots and pgx fails with
 // "cannot scan NULL into *time.Time", 500-ing every subscription read.
-const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at`
+const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, payment_fingerprint, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at`
 
 type SubscriptionRepository interface {
 	Create(ctx context.Context, sub *models.Subscription) error
@@ -51,19 +51,19 @@ func (r *subscriptionRepository) Create(ctx context.Context, sub *models.Subscri
 	query := `
 		INSERT INTO subscriptions (
 			id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id,
-			stripe_price_id, status, current_period_start, current_period_end,
+			stripe_price_id, payment_fingerprint, status, current_period_start, current_period_end,
 			cancel_at_period_end, canceled_at, trial_start, trial_end,
 			free_trial_started_at, free_trial_ends_at,
 			is_enterprise, created_at, updated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19
+			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20
 		)
 	`
 
 	now := time.Now()
 	_, err := r.db.Exec(ctx, query,
 		sub.ID, sub.UserID, sub.OrganizationID, sub.PlanID, sub.StripeCustomerID, sub.StripeSubscriptionID,
-		sub.StripePriceID, sub.Status, sub.CurrentPeriodStart, sub.CurrentPeriodEnd,
+		sub.StripePriceID, sub.PaymentFingerprint, sub.Status, sub.CurrentPeriodStart, sub.CurrentPeriodEnd,
 		sub.CancelAtPeriodEnd, sub.CanceledAt, sub.TrialStart, sub.TrialEnd,
 		sub.FreeTrialStartedAt, sub.FreeTrialEndsAt,
 		sub.IsEnterprise, now, now,
@@ -79,23 +79,24 @@ func (r *subscriptionRepository) Update(ctx context.Context, sub *models.Subscri
 			stripe_customer_id = $4,
 			stripe_subscription_id = $5,
 			stripe_price_id = $6,
-			status = $7,
-			current_period_start = $8,
-			current_period_end = $9,
-			cancel_at_period_end = $10,
-			canceled_at = $11,
-			trial_start = $12,
-			trial_end = $13,
-			free_trial_started_at = $14,
-			free_trial_ends_at = $15,
-			is_enterprise = $16,
-			updated_at = $17
+			payment_fingerprint = $7,
+			status = $8,
+			current_period_start = $9,
+			current_period_end = $10,
+			cancel_at_period_end = $11,
+			canceled_at = $12,
+			trial_start = $13,
+			trial_end = $14,
+			free_trial_started_at = $15,
+			free_trial_ends_at = $16,
+			is_enterprise = $17,
+			updated_at = $18
 		WHERE id = $1
 	`
 
 	_, err := r.db.Exec(ctx, query,
 		sub.ID, sub.OrganizationID, sub.PlanID, sub.StripeCustomerID, sub.StripeSubscriptionID,
-		sub.StripePriceID, sub.Status, sub.CurrentPeriodStart, sub.CurrentPeriodEnd,
+		sub.StripePriceID, sub.PaymentFingerprint, sub.Status, sub.CurrentPeriodStart, sub.CurrentPeriodEnd,
 		sub.CancelAtPeriodEnd, sub.CanceledAt, sub.TrialStart, sub.TrialEnd,
 		sub.FreeTrialStartedAt, sub.FreeTrialEndsAt,
 		sub.IsEnterprise, time.Now(),
@@ -129,7 +130,7 @@ func (r *subscriptionRepository) scanSubscription(ctx context.Context, query str
 	var sub models.Subscription
 	err := row.Scan(
 		&sub.ID, &sub.UserID, &sub.OrganizationID, &sub.PlanID, &sub.StripeCustomerID, &sub.StripeSubscriptionID,
-		&sub.StripePriceID, &sub.Status, &sub.CurrentPeriodStart, &sub.CurrentPeriodEnd,
+		&sub.StripePriceID, &sub.PaymentFingerprint, &sub.Status, &sub.CurrentPeriodStart, &sub.CurrentPeriodEnd,
 		&sub.CancelAtPeriodEnd, &sub.CanceledAt, &sub.TrialStart, &sub.TrialEnd,
 		&sub.FreeTrialStartedAt, &sub.FreeTrialEndsAt,
 		&sub.IsEnterprise, &sub.CreatedAt, &sub.UpdatedAt,
@@ -147,7 +148,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 	query := `
 		SELECT
 			s.id, s.user_id, s.organization_id, s.plan_id, s.stripe_customer_id, s.stripe_subscription_id,
-			s.stripe_price_id, s.status, s.current_period_start, s.current_period_end,
+			s.stripe_price_id, s.payment_fingerprint, s.status, s.current_period_start, s.current_period_end,
 			s.cancel_at_period_end, s.canceled_at, s.trial_start, s.trial_end,
 			s.free_trial_started_at, s.free_trial_ends_at,
 			s.is_enterprise, s.created_at, s.updated_at,
@@ -168,7 +169,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 
 	err := row.Scan(
 		&result.ID, &result.UserID, &result.OrganizationID, &result.PlanID, &result.StripeCustomerID, &result.StripeSubscriptionID,
-		&result.StripePriceID, &result.Status, &result.CurrentPeriodStart, &result.CurrentPeriodEnd,
+		&result.StripePriceID, &result.PaymentFingerprint, &result.Status, &result.CurrentPeriodStart, &result.CurrentPeriodEnd,
 		&result.CancelAtPeriodEnd, &result.CanceledAt, &result.TrialStart, &result.TrialEnd,
 		&result.FreeTrialStartedAt, &result.FreeTrialEndsAt,
 		&result.IsEnterprise, &result.CreatedAt, &result.UpdatedAt,

--- a/internal/repository/pg_user.go
+++ b/internal/repository/pg_user.go
@@ -43,6 +43,8 @@ type UserRepository interface {
 	// CountUsers is the operator-facing count, for boot diagnostics and the
 	// CLI. IsEmpty stays the hot-path check.
 	CountUsers(ctx context.Context) (int, error)
+
+	SetSignupMetadata(ctx context.Context, userID uuid.UUID, ip, userAgent string, emailRisk int, asn *int64) error
 }
 
 type userRepository struct {
@@ -119,6 +121,7 @@ func (r *userRepository) getUser(ctx context.Context, key string, value any) (*m
 	q := fmt.Sprintf(
 		`SELECT u.id, u.email, u.first_name, u.last_name, u.avatar_url, u.referral_source, u.onboarding_completed_at,
 		   u.max_organizations, u.free_trial_used, u.admin_permissions,
+		   COALESCE(host(u.signup_ip), ''), u.signup_user_agent, u.signup_email_risk, u.signup_asn,
 		   u.deletion_scheduled_at, u.deletion_scheduled_for, u.undo_send_seconds,
 		   u.updated_at, u.created_at,
 		   COALESCE(array_agg(ur.role_id) FILTER (WHERE ur.role_id IS NOT NULL), '{}') AS role_ids
@@ -140,6 +143,7 @@ func (r *userRepository) getUser(ctx context.Context, key string, value any) (*m
 		params...,
 	).Scan(&u.ID, &u.Email, &u.FirstName, &u.LastName, &u.AvatarURL, &u.ReferralSource, &u.OnboardingCompletedAt,
 		&u.MaxOrganizations, &u.FreeTrialUsed, &adminPerm,
+		&u.SignupIP, &u.SignupUserAgent, &u.SignupEmailRisk, &u.SignupASN,
 		&u.DeletionScheduledAt, &u.DeletionScheduledFor, &u.UndoSendSeconds,
 		&u.UpdatedAt, &u.CreatedAt, &u.Roles)
 	if err != nil {
@@ -214,6 +218,19 @@ func (r *userRepository) CountUsers(ctx context.Context) (int, error) {
 	var n int
 	err := r.DB.QueryRow(ctx, q).Scan(&n)
 	return n, err
+}
+
+func (r *userRepository) SetSignupMetadata(ctx context.Context, userID uuid.UUID, ip, userAgent string, emailRisk int, asn *int64) error {
+	const q = `
+		UPDATE users
+		SET signup_ip = NULLIF($2, '')::inet,
+		    signup_user_agent = LEFT($3, 1024),
+		    signup_email_risk = LEAST(100, GREATEST(0, $4)),
+		    signup_asn = $5,
+		    updated_at = NOW()
+		WHERE id = $1`
+	_, err := r.DB.Exec(ctx, q, userID, ip, userAgent, emailRisk, asn)
+	return err
 }
 
 func (r *userRepository) GetUndoSendSeconds(ctx context.Context, userID uuid.UUID) (int, error) {

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -65,6 +65,11 @@ type WarmupStatistic struct {
 	TargetVolume   int
 }
 
+type ProviderPlacement struct {
+	Placements int
+	Sends      int
+}
+
 // WarmupReplyCandidate describes a previously sent warmup message that can be replied to.
 type WarmupReplyCandidate struct {
 	MessageID         string
@@ -110,6 +115,8 @@ type WarmupRepository interface {
 	CountUserComplaintsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountSpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
+	RecentPlacementSignal(ctx context.Context, accountID uuid.UUID, since time.Time) (placements, sends int, err error)
+	SenderPlacementByProvider(ctx context.Context, accountID uuid.UUID, since time.Time) (map[string]ProviderPlacement, error)
 	CountDeliverabilityEventsByAccount(ctx context.Context, accountID uuid.UUID, eventType string, since time.Time) (int, error)
 	CountDeliveredByAccount(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 
@@ -149,6 +156,7 @@ type WarmupRepository interface {
 	// Partner diversity support
 	GetPoolParticipantDomains(ctx context.Context, poolType string, excludeBlocked bool) (map[uuid.UUID]string, error)
 	GetPoolParticipantEmails(ctx context.Context, poolType string, excludeBlocked bool) (map[uuid.UUID]string, error)
+	GetPoolParticipantProviders(ctx context.Context, poolType string, excludeBlocked bool) (map[uuid.UUID]string, error)
 	CountEligibleRecipients(ctx context.Context, poolType string, excludeAccountID uuid.UUID) (int, error)
 	GetRecentPartnerDomainCounts(ctx context.Context, accountID uuid.UUID, since time.Time) (map[string]int, error)
 
@@ -596,6 +604,52 @@ func (r *warmupRepository) SumWarmupSentSince(ctx context.Context, accountID uui
 	var total int
 	err := r.db.QueryRow(ctx, query, accountID, since).Scan(&total)
 	return total, err
+}
+
+func (r *warmupRepository) RecentPlacementSignal(ctx context.Context, accountID uuid.UUID, since time.Time) (int, int, error) {
+	placements, err := r.CountSpamPlacementsSince(ctx, accountID, since)
+	if err != nil {
+		return 0, 0, err
+	}
+	sends, err := r.SumWarmupSentSince(ctx, accountID, since)
+	return placements, sends, err
+}
+
+func (r *warmupRepository) SenderPlacementByProvider(ctx context.Context, accountID uuid.UUID, since time.Time) (map[string]ProviderPlacement, error) {
+	query := `
+		WITH sends AS (
+			SELECT COALESCE(NULLIF(lower(ea.provider), ''), 'unknown') AS provider, COUNT(*)::int AS total
+			FROM warmup_tokens wt
+			JOIN email_accounts ea ON ea.id = wt.recipient_account_id
+			WHERE wt.sender_account_id = $1 AND wt.created_at >= $2
+			GROUP BY provider
+		), placements AS (
+			SELECT COALESCE(NULLIF(lower(recipient_provider), ''), 'unknown') AS provider, COUNT(*)::int AS total
+			FROM warmup_spam_reports
+			WHERE reported_account_id = $1
+			  AND report_type = 'spam_placement'
+			  AND created_at >= $2
+			GROUP BY provider
+		)
+		SELECT COALESCE(s.provider, p.provider), COALESCE(p.total, 0), COALESCE(s.total, 0)
+		FROM sends s
+		FULL OUTER JOIN placements p ON p.provider = s.provider
+	`
+	rows, err := r.db.Query(ctx, query, accountID, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]ProviderPlacement{}
+	for rows.Next() {
+		var provider string
+		var signal ProviderPlacement
+		if err := rows.Scan(&provider, &signal.Placements, &signal.Sends); err != nil {
+			return nil, err
+		}
+		out[provider] = signal
+	}
+	return out, rows.Err()
 }
 
 // CountDeliverabilityEventsByAccount counts deliverability events (bounce, complaint, etc.)
@@ -1097,6 +1151,36 @@ func (r *warmupRepository) GetPoolParticipantEmails(ctx context.Context, poolTyp
 			return nil, err
 		}
 		out[id] = email
+	}
+	return out, rows.Err()
+}
+
+func (r *warmupRepository) GetPoolParticipantProviders(ctx context.Context, poolType string, excludeBlocked bool) (map[uuid.UUID]string, error) {
+	query := `
+		SELECT wpp.email_account_id, COALESCE(NULLIF(lower(ea.provider), ''), 'unknown')
+		FROM warmup_pool_participants wpp
+		JOIN warmup_pools wp ON wpp.pool_id = wp.id
+		JOIN email_accounts ea ON ea.id = wpp.email_account_id
+		WHERE wp.pool_type = $1
+		  AND ea.status = 'active'
+	`
+	if excludeBlocked {
+		query += " AND wpp.health_state IN ('healthy', 'watch', 'throttled')"
+	}
+	query += " AND wpp.participant_role IN ('sender_receiver', 'recipient_only')"
+	rows, err := r.db.Query(ctx, query, poolType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[uuid.UUID]string{}
+	for rows.Next() {
+		var id uuid.UUID
+		var provider string
+		if err := rows.Scan(&id, &provider); err != nil {
+			return nil, err
+		}
+		out[id] = provider
 	}
 	return out, rows.Err()
 }

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -97,6 +97,9 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	if len(accounts) == 0 {
 		return time.Time{}, nil, uuid.Nil, ErrNoEmailAccounts
 	}
+	if campaign.OrganizationID != nil && s.orgRisk != nil && s.orgRisk.SendingSuspended(ctx, *campaign.OrganizationID) {
+		return time.Now().UTC().Add(24 * time.Hour), nil, accounts[0].ID, ErrCampaignDeferred
+	}
 
 	// STEP 3: Get campaign progress - find next contact/sequence to send.
 	// Honor the new-lead-per-day cap and the prioritize-new-leads ordering.
@@ -235,12 +238,35 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// intervals per day).
 	candidateTime = nextScheduleSlot(candidateTime, windows, campaignTZ)
 
+	orgCap := campaign.DailyLimit
+	if campaign.OrganizationID != nil && s.orgRisk != nil {
+		orgCap = s.orgRisk.EffectiveCap(ctx, *campaign.OrganizationID, orgCap)
+	}
+	coldCeilings := make(map[uuid.UUID]int, len(accounts))
+	for i := range accounts {
+		acct := &accounts[i]
+		if acct.ColdRampStartedAt == nil {
+			startedAt := time.Now().UTC()
+			if err := s.emailRepo.StartColdRamp(ctx, acct.ID, startedAt); err == nil {
+				acct.ColdRampStartedAt = &startedAt
+			}
+		}
+		placements := 0
+		if s.warmupRepo != nil {
+			if recent, _, err := s.warmupRepo.RecentPlacementSignal(ctx, acct.ID, time.Now().Add(-7*24*time.Hour)); err == nil {
+				placements = recent
+			}
+		}
+		coldCeilings[acct.ID] = coldReadinessCeiling(*acct, time.Now().UTC(), placements)
+	}
+
 	// effectiveCap is the per-mailbox cold cap for THIS campaign, after the ramp
 	// clamp. It is min(per-mailbox cold cap, campaign daily limit) further min()'d
 	// with the day's ramp ceiling. Applied via min() only — it can never RAISE a
 	// mailbox above its cold cap (the mailbox-first safety invariant).
 	effectiveCap := func(acct models.Email) int {
-		lim := min(acct.CampaignLimit, campaign.DailyLimit)
+		lim := min(acct.CampaignLimit, orgCap)
+		lim = min(lim, coldCeilings[acct.ID])
 		if campaign.RampEnabled {
 			lim = min(lim, campaignRampCeiling(true, campaign.RampStart, campaign.RampIncrement, campaign.RampCeiling, campaign.RampLevel))
 		}
@@ -618,6 +644,28 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 
 	// STEP 15: Randomise the sub-minute component so sends never land on :00.
 	return finalSlot(candidateTime), nextPair, account.ID, nil
+}
+
+func coldReadinessCeiling(account models.Email, now time.Time, placements int) int {
+	initial := min(10, account.CampaignLimit)
+	if account.Warmup != nil {
+		daysWarming := max(0, int(now.Sub(*account.Warmup).Hours()/24))
+		warmupVolume := min(account.WarmupBase+daysWarming*account.WarmupIncrease, account.WarmupMax)
+		initial = min(account.CampaignLimit, max(10, warmupVolume))
+	}
+	daysCold := 0
+	if account.ColdRampStartedAt != nil {
+		start := account.ColdRampStartedAt.UTC()
+		today := now.UTC()
+		startDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, time.UTC)
+		todayDay := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+		daysCold = max(0, int(todayDay.Sub(startDay)/(24*time.Hour)))
+	}
+	ceiling := min(account.CampaignLimit, initial+5*daysCold)
+	if placements > 0 {
+		ceiling = max(1, int(float64(ceiling)*0.75+0.5))
+	}
+	return ceiling
 }
 
 // deferToNextDay pushes a candidate time to the next valid campaign day within

--- a/internal/scheduler/cold_readiness_test.go
+++ b/internal/scheduler/cold_readiness_test.go
@@ -1,0 +1,35 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestColdReadinessCeilingGraduatesFivePerDay(t *testing.T) {
+	now := time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+	warmupStarted := now.Add(-30 * 24 * time.Hour)
+	coldStarted := now.Add(-2 * 24 * time.Hour)
+	account := models.Email{
+		CampaignLimit:     50,
+		Warmup:            &warmupStarted,
+		WarmupBase:        10,
+		WarmupIncrease:    1,
+		WarmupMax:         40,
+		ColdRampStartedAt: &coldStarted,
+	}
+	if got := coldReadinessCeiling(account, now, 0); got != 50 {
+		t.Fatalf("coldReadinessCeiling() = %d, want 50", got)
+	}
+	if got := coldReadinessCeiling(account, now, 1); got != 38 {
+		t.Fatalf("placement ceiling = %d, want 38", got)
+	}
+}
+
+func TestColdReadinessCeilingStartsFreshMailboxLow(t *testing.T) {
+	account := models.Email{CampaignLimit: 50}
+	if got := coldReadinessCeiling(account, time.Now(), 0); got != 10 {
+		t.Fatalf("coldReadinessCeiling() = %d, want 10", got)
+	}
+}

--- a/internal/scheduler/errors.go
+++ b/internal/scheduler/errors.go
@@ -49,7 +49,7 @@ var (
 
 	// ErrCampaignDeferred is returned when there IS a valid contact to send but
 	// no eligible mailbox right now — ESP-strict has no same-provider mailbox
-	// under budget, or the daily new-lead cap is reached. The caller must
+	// under budget, the organization is suspended, or the daily new-lead cap is reached. The caller must
 	// reschedule at the returned (defer) time WITHOUT sending. The returned pair
 	// is always nil on this path so it can never be mistaken for a sendable
 	// contact; the returned accountID is a nominal pool mailbox for the wakeup

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -42,6 +42,12 @@ type schedulerService struct {
 	// Optional/nil-safe: without it the persisted auth state stays
 	// observe-only and never blocks a send.
 	domainAuth DomainAuthPolicy
+	orgRisk    OrgRiskPolicy
+}
+
+type OrgRiskPolicy interface {
+	EffectiveCap(ctx context.Context, organizationID uuid.UUID, current int) int
+	SendingSuspended(ctx context.Context, organizationID uuid.UUID) bool
 }
 
 // DomainAuthPolicy resolves whether the sending-domain authentication gate is
@@ -85,6 +91,14 @@ func (s *schedulerService) WireDomainAuth(p DomainAuthPolicy) {
 // authentication gate after construction.
 type DomainAuthAware interface {
 	WireDomainAuth(p DomainAuthPolicy)
+}
+
+func (s *schedulerService) WireOrgRisk(p OrgRiskPolicy) {
+	s.orgRisk = p
+}
+
+type OrgRiskAware interface {
+	WireOrgRisk(p OrgRiskPolicy)
 }
 
 // NewSchedulerService creates a new scheduler service

--- a/internal/scheduler/warmup_scheduler.go
+++ b/internal/scheduler/warmup_scheduler.go
@@ -45,6 +45,17 @@ func adjustmentFor(state models.WarmupHealthState) healthAdjustment {
 	}
 }
 
+func softRampAdjust(target, placements, sends int) int {
+	if placements <= 0 || target <= 1 {
+		return target
+	}
+	adjusted := int(float64(target)*0.75 + 0.5)
+	if sends > 0 && placements*10 >= sends {
+		adjusted = int(float64(target)*0.70 + 0.5)
+	}
+	return max(1, adjusted)
+}
+
 func warmupPoolTypeForAccount(account *models.Email) string {
 	if account != nil && account.WarmupPoolType != "" {
 		return account.WarmupPoolType
@@ -215,6 +226,15 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		}
 	}
 
+	healthState := s.resolveHealthState(ctx, accountID)
+	// Healthy mailboxes brake for three days on an early placement signal.
+	if healthState == models.WarmupHealthHealthy && s.warmupRepo != nil {
+		placements, sends, err := s.warmupRepo.RecentPlacementSignal(ctx, accountID, time.Now().Add(-72*time.Hour))
+		if err == nil {
+			targetVolume = softRampAdjust(targetVolume, placements, sends)
+		}
+	}
+
 	// STEP 2.1: Cap per-mailbox volume to actual recipient capacity. The
 	// sender should not send multiple warmup messages to the same recipient
 	// in a single day just to hit an arbitrary target; that creates obvious
@@ -237,7 +257,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 	// run at reduced volume and wider spacing until the health sweep clears
 	// them back to healthy. We never zero out volume — even degraded mailboxes
 	// keep a small heartbeat so the sweep has fresh sample data to evaluate.
-	adj := adjustmentFor(s.resolveHealthState(ctx, accountID))
+	adj := adjustmentFor(healthState)
 	if adj.volumeMultiplier < 1.0 {
 		floor := 1
 		if activelyWarming {

--- a/internal/scheduler/warmup_soft_ramp_test.go
+++ b/internal/scheduler/warmup_soft_ramp_test.go
@@ -1,0 +1,15 @@
+package scheduler
+
+import "testing"
+
+func TestSoftRampAdjust(t *testing.T) {
+	if got := softRampAdjust(40, 1, 100); got != 30 {
+		t.Fatalf("softRampAdjust() = %d, want 30", got)
+	}
+	if got := softRampAdjust(40, 0, 100); got != 40 {
+		t.Fatalf("clean softRampAdjust() = %d, want 40", got)
+	}
+	if got := softRampAdjust(2, 1, 2); got < 1 {
+		t.Fatalf("softRampAdjust() lost safety floor: %d", got)
+	}
+}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -15,6 +15,7 @@ import (
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
 	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/scheduler"
 	"github.com/warmbly/warmbly/internal/tasks/proto"
@@ -478,6 +479,29 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			}
 			executionStatus = "failed"
 			return errx.InternalError()
+		}
+	}
+
+	contentScore := warmlint.ScoreWithOptions(subject, bodyHTML, bodyPlain, warmlint.ScoreOptions{AttachmentCount: len(attachmentRefs)})
+	if len(contentScore.Issues) > 0 && s.campaignLogRepo != nil {
+		_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+			CampaignID: campaign.ID,
+			EventType:  "content_warning",
+			Message:    "Campaign content triggered deliverability warnings",
+			Metadata: map[string]interface{}{
+				"score":       contentScore.Score,
+				"issues":      contentScore.Issues,
+				"sequence_id": sequence.ID.String(),
+			},
+		})
+	}
+	if contentScore.Hard && s.advanced != nil {
+		enabled, xerr := s.advanced.ContentSafetyEnabled(ctx, orgID, campaign.ID)
+		if xerr == nil && enabled {
+			_ = s.campaignRepo.UpdateStatus(ctx, campaign.ID, "paused_guardrail")
+			_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_content_guardrail")
+			executionStatus = "completed"
+			return nil
 		}
 	}
 

--- a/internal/tasks/email_task.go
+++ b/internal/tasks/email_task.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/tasks/proto"
 )
 
@@ -127,6 +128,11 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 		log.Error().Str("task_id", taskID.String()).Str("email_account_id", account.ID.String()).
 			Msg("warmup blocked: mailbox has no organization, entitlement and pool policy cannot be checked")
 		_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_no_warmup_access")
+		executionStatus = "completed"
+		return nil
+	}
+	if s.orgRisk != nil && s.orgRisk.SendingSuspended(ctx, *account.OrganizationID) {
+		_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_org_suspended")
 		executionStatus = "completed"
 		return nil
 	}
@@ -480,6 +486,14 @@ func (s *tasksService) selectWarmupPartner(ctx context.Context, account Email) (
 		// Diversity weighting is best-effort. Fall back to uniform on lookup error.
 		domainsByID = nil
 	}
+	providersByID, err := s.warmupRepo.GetPoolParticipantProviders(ctx, poolType, true)
+	if err != nil {
+		providersByID = nil
+	}
+	providerPlacement, err := s.warmupRepo.SenderPlacementByProvider(ctx, account.ID, time.Now().Add(-7*24*time.Hour))
+	if err != nil {
+		providerPlacement = nil
+	}
 
 	// Load customer routing rules (premium pool only — free pool ignores
 	// rules since trial mailboxes don't need provider-shape preferences).
@@ -557,7 +571,7 @@ func (s *tasksService) selectWarmupPartner(ctx context.Context, account Email) (
 	// CanParticipate re-evaluates and forces just-unblocked mailboxes into
 	// probation, matching the CLAUDE.md re-entry policy on the recipient surface.
 	for attempts := 0; attempts < 5 && len(availablePartners) > 0; attempts++ {
-		partnerID := pickWeightedPartner(availablePartners, domainsByID, domainCounts, routingRules, account.Email, emailsByID)
+		partnerID := pickWeightedPartner(availablePartners, domainsByID, domainCounts, routingRules, account.Email, emailsByID, providersByID, providerPlacement)
 
 		if s.warmupHealth != nil {
 			if ok, _, _ := s.warmupHealth.CanParticipate(ctx, partnerID, poolType); !ok {
@@ -603,11 +617,13 @@ func pickWeightedPartner(
 	rules []models.WarmupRoutingRule,
 	senderEmail string,
 	emailsByID map[uuid.UUID]string,
+	providersByID map[uuid.UUID]string,
+	providerPlacement map[string]repository.ProviderPlacement,
 ) uuid.UUID {
 	if len(candidates) == 1 {
 		return candidates[0]
 	}
-	if len(domainsByID) == 0 && len(rules) == 0 {
+	if len(domainsByID) == 0 && len(rules) == 0 && len(providerPlacement) == 0 {
 		return candidates[rand.Intn(len(candidates))]
 	}
 
@@ -623,6 +639,9 @@ func pickWeightedPartner(
 			if recipientEmail, ok := emailsByID[id]; ok {
 				w *= routingMultiplier(rules, senderEmail, recipientEmail)
 			}
+		}
+		if provider, ok := providersByID[id]; ok {
+			w *= providerPlacementMultiplier(providerPlacement[provider])
 		}
 
 		weights[i] = w
@@ -646,6 +665,14 @@ func pickWeightedPartner(
 	return candidates[len(candidates)-1]
 }
 
+func providerPlacementMultiplier(signal repository.ProviderPlacement) float64 {
+	if signal.Placements <= 0 || signal.Sends <= 0 {
+		return 1
+	}
+	rate := float64(signal.Placements) / float64(signal.Sends)
+	return 1 / (1 + 8*rate)
+}
+
 // routingMultiplier returns the weight multiplier from the first matching
 // rule in priority order (lowest priority value wins). 1.0 when no rule
 // matches — neutral, so unmatched pairs neither preferred nor penalized.
@@ -662,21 +689,25 @@ func (s *tasksService) resolveWarmupPoolType(ctx context.Context, account *Email
 	if account == nil {
 		return "premium"
 	}
-	if account.WarmupPoolType != "" {
-		return account.WarmupPoolType
-	}
+	current := account.WarmupPoolType
 	// No organization means no entitlement to check, so the mailbox gets the
 	// lower-trust pool rather than defaulting into the paid one.
 	if account.OrganizationID == nil {
 		return "free"
 	}
-	if s.featureGate != nil {
+	if current == "" && s.featureGate != nil {
 		isPaid, xerr := s.featureGate.IsPaidOrganization(ctx, *account.OrganizationID)
 		if xerr == nil && !isPaid {
-			return "free"
+			current = "free"
 		}
 	}
-	return "premium"
+	if current == "" {
+		current = "premium"
+	}
+	if s.orgRisk != nil {
+		return s.orgRisk.WarmupPool(ctx, *account.OrganizationID, current)
+	}
+	return current
 }
 
 func (s *tasksService) scheduleWarmupRecovery(ctx context.Context, accountID uuid.UUID, poolType string) {

--- a/internal/tasks/partner_selection_test.go
+++ b/internal/tasks/partner_selection_test.go
@@ -6,12 +6,13 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
 )
 
 func TestPickWeightedPartner_FallsBackToUniformWithoutDomains(t *testing.T) {
 	a := uuid.New()
 	b := uuid.New()
-	got := pickWeightedPartner([]uuid.UUID{a, b}, nil, nil, nil, "", nil)
+	got := pickWeightedPartner([]uuid.UUID{a, b}, nil, nil, nil, "", nil, nil, nil)
 	if got != a && got != b {
 		t.Errorf("expected a or b, got %v", got)
 	}
@@ -32,7 +33,7 @@ func TestPickWeightedPartner_PrefersUnderRepresentedDomain(t *testing.T) {
 	freshHits := 0
 	iterations := 2000
 	for i := 0; i < iterations; i++ {
-		picked := pickWeightedPartner([]uuid.UUID{saturatedID, freshID}, domainsByID, domainCounts, nil, "", nil)
+		picked := pickWeightedPartner([]uuid.UUID{saturatedID, freshID}, domainsByID, domainCounts, nil, "", nil, nil, nil)
 		if picked == freshID {
 			freshHits++
 		}
@@ -47,9 +48,38 @@ func TestPickWeightedPartner_PrefersUnderRepresentedDomain(t *testing.T) {
 
 func TestPickWeightedPartner_SingleCandidateReturnsIt(t *testing.T) {
 	id := uuid.New()
-	got := pickWeightedPartner([]uuid.UUID{id}, map[uuid.UUID]string{id: "x.com"}, map[string]int{"x.com": 5}, nil, "", nil)
+	got := pickWeightedPartner([]uuid.UUID{id}, map[uuid.UUID]string{id: "x.com"}, map[string]int{"x.com": 5}, nil, "", nil, nil, nil)
 	if got != id {
 		t.Errorf("single candidate should be returned; got %v", got)
+	}
+}
+
+func TestPickWeightedPartner_DownweightsProviderWithPoorPlacement(t *testing.T) {
+	healthyID := uuid.New()
+	poorID := uuid.New()
+	providers := map[uuid.UUID]string{
+		healthyID: "google",
+		poorID:    "microsoft",
+	}
+	placement := map[string]repository.ProviderPlacement{
+		"google":    {Sends: 100, Placements: 0},
+		"microsoft": {Sends: 100, Placements: 30},
+	}
+
+	healthyHits := 0
+	const iterations = 2000
+	for range iterations {
+		picked := pickWeightedPartner(
+			[]uuid.UUID{healthyID, poorID},
+			nil, nil, nil, "", nil, providers, placement,
+		)
+		if picked == healthyID {
+			healthyHits++
+		}
+	}
+
+	if healthyHits < int(float64(iterations)*0.7) {
+		t.Errorf("healthy provider should dominate selection; got %d/%d", healthyHits, iterations)
 	}
 }
 
@@ -82,7 +112,7 @@ func TestPickWeightedPartner_RoutingRulePrefersProviderMatch(t *testing.T) {
 	for i := 0; i < iterations; i++ {
 		picked := pickWeightedPartner(
 			[]uuid.UUID{googleRecipient, microsoftRecipient},
-			domainsByID, nil, rules, "sender@gmail.com", emailsByID,
+			domainsByID, nil, rules, "sender@gmail.com", emailsByID, nil, nil,
 		)
 		if picked == googleRecipient {
 			googleHits++
@@ -120,7 +150,7 @@ func TestPickWeightedPartner_RoutingRuleZeroWeightExcludes(t *testing.T) {
 	for i := 0; i < 500; i++ {
 		picked := pickWeightedPartner(
 			[]uuid.UUID{allowedID, blockedID},
-			domainsByID, nil, rules, "sender@whatever.io", emailsByID,
+			domainsByID, nil, rules, "sender@whatever.io", emailsByID, nil, nil,
 		)
 		if picked == blockedID {
 			t.Fatalf("weight=0 rule should exclude blocked partner")

--- a/internal/tasks/service.go
+++ b/internal/tasks/service.go
@@ -79,6 +79,7 @@ type TasksService interface {
 	// stops warmup sends from a domain that has been failing SPF/DMARC past
 	// the operator's grace window. Nil leaves the state observe-only.
 	SetDomainAuthPolicy(p DomainAuthPolicy)
+	SetOrgRiskPolicy(p OrgRiskPolicy)
 }
 
 // AIToolSource yields the read-only web tools (search_web, fetch_url) a
@@ -144,6 +145,12 @@ type tasksService struct {
 	// Optional/nil-safe: without it the persisted auth state stays
 	// observe-only and no warmup send is ever blocked.
 	domainAuth DomainAuthPolicy
+	orgRisk    OrgRiskPolicy
+}
+
+type OrgRiskPolicy interface {
+	WarmupPool(ctx context.Context, organizationID uuid.UUID, current string) string
+	SendingSuspended(ctx context.Context, organizationID uuid.UUID) bool
 }
 
 // DomainAuthPolicy resolves whether the sending-domain authentication gate is
@@ -152,6 +159,10 @@ type tasksService struct {
 // instancesettings.Service satisfies it.
 type DomainAuthPolicy interface {
 	DomainAuth(ctx context.Context) (enforce bool, grace time.Duration)
+}
+
+func (s *tasksService) SetOrgRiskPolicy(p OrgRiskPolicy) {
+	s.orgRisk = p
 }
 
 // warmupSettingsCache is a tiny TTL cache over the generation settings.

--- a/web/src/components/app/campaigns/ContentScore.tsx
+++ b/web/src/components/app/campaigns/ContentScore.tsx
@@ -1,8 +1,6 @@
-// Advisory campaign-template content check. A "Check content" button POSTs the
-// current subject + body to /templates/score and renders a 0-100 score (higher
-// = safer) plus a list of non-blocking issues. Purely advisory — it never
-// blocks saving or sending, it just surfaces deliverability hints.
+// Live template check; severe findings can stop the pre-send guardrail.
 
+import { useEffect } from "react";
 import { ShieldCheckIcon, AlertTriangleIcon, AlertCircleIcon } from "lucide-react";
 import useScoreTemplate from "@/lib/api/hooks/app/campaigns/useScoreTemplate";
 import type { TemplateScoreIssue } from "@/lib/api/models/app/campaigns/TemplateScore";
@@ -42,8 +40,13 @@ export default function ContentScore({
     const score = useScoreTemplate();
     const data = score.data;
 
-    const run = () =>
-        score.mutate({ subject, body_html: bodyHtml, body_plain: bodyPlain });
+    const run = () => score.mutate({ subject, body_html: bodyHtml, body_plain: bodyPlain });
+
+    useEffect(() => {
+        const timer = setTimeout(run, 500);
+        return () => clearTimeout(timer);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [subject, bodyHtml, bodyPlain]);
 
     const tone = data ? scoreTone(data.score) : null;
 
@@ -52,7 +55,9 @@ export default function ContentScore({
             <div className="flex items-center justify-between gap-3 px-3 py-2.5">
                 <div className="min-w-0">
                     <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Content check</div>
-                    <p className="mt-0.5 text-[11px] text-slate-400 leading-relaxed">Advisory deliverability score — never blocks sending.</p>
+                    <p className="mt-0.5 text-[11px] text-slate-400 leading-relaxed">
+                        Checked automatically. Preflight can pause severe findings.
+                    </p>
                 </div>
                 <button
                     type="button"

--- a/web/src/components/app/contacts/ImportWizard.tsx
+++ b/web/src/components/app/contacts/ImportWizard.tsx
@@ -701,6 +701,23 @@ export function ResultStep({ result, filename }: { result: ImportResult; filenam
                 <StatCard label="Failed"    value={result.failed}   accent={result.failed > 0 ? "red" : "slate"} />
             </div>
 
+            {result.quality && (
+                <div className="rounded-md border border-slate-200 bg-slate-50/40 p-3">
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-slate-500 font-medium">
+                            List quality
+                        </span>
+                        <span className="text-[11px] text-slate-600 tabular-nums">
+                            {(result.quality.bad_address_ratio * 100).toFixed(1)}% invalid or disposable
+                        </span>
+                    </div>
+                    <p className="mt-1.5 text-[11px] text-slate-500 leading-snug">
+                        {result.quality.invalid} invalid, {result.quality.disposable} disposable, {result.quality.role} role-based, and{" "}
+                        {result.quality.risky_tld} risky-domain addresses detected.
+                    </p>
+                </div>
+            )}
+
             {result.errors && result.errors.length > 0 && (
                 <div className="rounded-md border border-slate-200 overflow-hidden">
                     <div className="px-3 h-9 border-b border-slate-200 bg-slate-50/60 flex items-center gap-2">

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -323,6 +323,7 @@ export function useRealtimeEvents() {
           webhook: [['webhooks'], ['integrations', 'connections']],
           template: [['templates']],
           organization: [['organizations']],
+          organization_risk: [['organizations'], ['emails'], ['campaigns']],
           organization_member: [['organizations'], ['organizations', 'members']],
           invitation: [['organizations', 'invitations']],
           team: [['teams']],

--- a/web/src/lib/api/client/app/campaigns/scoreTemplate.ts
+++ b/web/src/lib/api/client/app/campaigns/scoreTemplate.ts
@@ -2,8 +2,7 @@ import type TemplateScore from "@/lib/api/models/app/campaigns/TemplateScore";
 import type { ScoreTemplateRequest } from "@/lib/api/models/app/campaigns/TemplateScore";
 import Request from "../../Request";
 
-// Advisory content score for a campaign template. Never blocks — returns a
-// 0-100 score (higher = safer) plus a list of non-blocking issues.
+// Returns the live score and whether the pre-send guardrail considers it hard.
 export default async function scoreTemplate(
     body: ScoreTemplateRequest,
 ): Promise<TemplateScore> {

--- a/web/src/lib/api/client/app/contacts/importContacts.ts
+++ b/web/src/lib/api/client/app/contacts/importContacts.ts
@@ -51,6 +51,15 @@ export interface ImportRowError {
     reason: string;
 }
 
+export interface ImportQuality {
+    assessment_id?: string;
+    invalid: number;
+    disposable: number;
+    role: number;
+    risky_tld: number;
+    bad_address_ratio: number;
+}
+
 export interface ImportResult {
     total: number;
     imported: number;
@@ -59,6 +68,7 @@ export interface ImportResult {
     failed: number;
     started_at: string;
     ended_at: string;
+    quality?: ImportQuality;
     errors?: ImportRowError[];
 }
 

--- a/web/src/lib/api/models/app/campaigns/Campaign.ts
+++ b/web/src/lib/api/models/app/campaigns/Campaign.ts
@@ -74,6 +74,20 @@ export default interface Campaign {
     guardrail_tripped_at?: string | null;
     guardrail_reason?: string;
 
+    verification_status?: 'unknown' | 'pending' | 'passed' | 'warning' | 'blocked';
+    verification_summary?: {
+        total: number;
+        valid: number;
+        risky: number;
+        invalid: number;
+        unknown: number;
+        disposable: number;
+        catch_all: number;
+        pending: number;
+        projected_hard_bounce_rate: number;
+    };
+    verification_checked_at?: string | null;
+
     // Campaign-scoped tracking-domain override (honored only when verified).
     tracking_domain: string;
     tracking_domain_verified: boolean;
@@ -106,4 +120,3 @@ export interface CampaignSenderInput {
     weight?: number;
     enabled?: boolean;
 }
-

--- a/web/src/lib/api/models/app/campaigns/TemplateScore.ts
+++ b/web/src/lib/api/models/app/campaigns/TemplateScore.ts
@@ -1,6 +1,4 @@
-// Result of POST /templates/score — an advisory content-quality score for a
-// campaign template. Higher score = safer; issues are non-blocking hints to
-// improve deliverability (the score never prevents saving or sending).
+// Live content score; a hard result can stop the pre-send guardrail.
 export interface TemplateScoreIssue {
     severity: "warn" | "high";
     code: string;
@@ -10,6 +8,7 @@ export interface TemplateScoreIssue {
 export default interface TemplateScore {
     score: number;
     issues: TemplateScoreIssue[];
+    hard: boolean;
 }
 
 // Body for POST /templates/score.
@@ -17,4 +16,6 @@ export interface ScoreTemplateRequest {
     subject: string;
     body_html: string;
     body_plain: string;
+    attachment_count?: number;
+    image_count?: number;
 }

--- a/web/src/lib/api/models/app/campaigns/sequences/Sequence.ts
+++ b/web/src/lib/api/models/app/campaigns/sequences/Sequence.ts
@@ -1,6 +1,18 @@
 import type { SequenceConditions } from "./Branching";
 import type { SequenceAction } from "./Action";
 
+export interface SequenceContentScoreIssue {
+    severity: "warn" | "high";
+    code: string;
+    message: string;
+}
+
+export interface SequenceContentScore {
+    score: number;
+    issues: SequenceContentScoreIssue[];
+    hard: boolean;
+}
+
 export default interface Sequence {
     id: string;
     name: string;
@@ -11,6 +23,7 @@ export default interface Sequence {
     body_html: string;
     body_sync: boolean;
     body_code: boolean;
+    content_score?: SequenceContentScore;
 
     wait_after: number;
 


### PR DESCRIPTION
## Summary

- connect SMTP rejects, authentication failures, DSNs, and ARF complaints to the existing deliverability and suppression pipeline
- add organization risk states with signup, import, mailbox, payment, and nightly correlation signals
- close warmup placement feedback, provider-aware routing, and gradual warmup-to-cold graduation
- add campaign content scoring, import quality assessment, and persisted launch verification with stable API errors
- expose additive campaign and sequence safety fields, realtime invalidation, dashboard list-quality feedback, and synchronized docs

## Local verification

- `make fmt`
- `make lint`
- `pnpm typecheck` and `pnpm lint` in `web/`
- `pnpm types:check` and `pnpm lint` in `docs/`

Closes #139
Closes #140
Closes #141
Closes #142
Closes #143
Closes #144
Closes #145
Closes #146
Closes #147
Closes #148