### PR TITLE
fix: campaign stuck at "Queued / Not started" with nothing sending (#189)

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1176,6 +1176,13 @@ func main() {
 			aware.WireDomainAuth(instanceSettings)
 		}
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
+		// Attaching a lead to a running campaign has to wake that campaign's
+		// parked send chain, or the lead sits queued until the chain's next
+		// tick. Wired here because contactService is built before the scheduler
+		// and Cloud Tasks client exist.
+		if contactService != nil {
+			contactService.SetCampaignWaker(campaignService)
+		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
 		// uniboxService is constructed here (rather than alongside the

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -85,6 +85,10 @@ Campaigns send only inside the **weekly sending windows** you define, in the cam
 
 Within a window Warmbly spreads the day's emails evenly, adds random jitter, and rounds to natural send times so nothing arrives in obvious bursts. A mailbox with its own timezone is also kept inside its local business hours (`8am` to `8pm`).
 
+The spread covers every mailbox on the campaign, not one at a time: the day's remaining capacity across the whole sending pool is paced across the hours left in the window. Adding a second healthy mailbox roughly doubles how fast a campaign works through its leads, while each mailbox still stays inside its own daily cap, hourly ceiling and minimum gap.
+
+When nothing is due (every lead is inside a step's wait, for example), the campaign re-checks itself at least every `15` minutes rather than sleeping until the next step falls due. Leads added to a running campaign start sending straight away, without waiting for the next step or a restart.
+
 Optional **campaign dates** bound when it may send. Leave both blank to run open-ended. Picking today as the start date means "start now", and clearing a start date on a running campaign removes the wait entirely. Schedule changes on an active campaign take effect immediately: the next send is recomputed on save, so a campaign waiting on a future start date starts sending as soon as you clear or shorten it.
 
 ## Start and stop

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -282,6 +282,69 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 	return nil
 }
 
+// WakeCampaigns implements the interface comment on CampaignService: after
+// leads are attached to a campaign, pull its parked wakeup forward if the
+// campaign can now act sooner than where it sits.
+//
+// It only ever moves a wakeup EARLIER, and only when the parked one is beyond
+// the deferral horizon, so a campaign already ticking on its send pacing is left
+// alone. Everything here is best effort: the reconciler and the capped deferral
+// horizon are the backstops, so a failure delays the new leads rather than
+// losing them.
+func (s *campaignService) WakeCampaigns(ctx context.Context, orgID uuid.UUID, campaignIDs []string) {
+	if s.scheduler == nil || s.tasksClient == nil || s.taskRepo == nil {
+		return
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, raw := range campaignIDs {
+		id, perr := uuid.Parse(raw)
+		if perr != nil || seen[id] {
+			continue
+		}
+		seen[id] = true
+
+		campaign, err := s.campaignRepository.GetByID(ctx, id)
+		if err != nil || campaign == nil || campaign.Status != "active" {
+			continue
+		}
+		if campaign.OrganizationID == nil || *campaign.OrganizationID != orgID {
+			continue
+		}
+
+		pending, perr2 := s.campaignRepository.GetPendingCampaignTasks(ctx, id)
+		if perr2 != nil {
+			continue
+		}
+		var parked *time.Time
+		for i := range pending {
+			at := pending[i].ScheduledAt
+			if at != nil && (parked == nil || at.Before(*parked)) {
+				parked = at
+			}
+		}
+		// Already about to wake: leave the chain's own pacing alone.
+		if parked != nil && !parked.After(time.Now().Add(config.CampaignMaxDeferMinutes*time.Minute)) {
+			continue
+		}
+
+		nextTime, _, _, cerr := s.scheduler.CalculateNextCampaignTime(ctx, id)
+		if cerr != nil && !errors.Is(cerr, scheduler.ErrCampaignDeferred) {
+			continue
+		}
+		if errors.Is(cerr, scheduler.ErrCampaignDeferred) {
+			nextTime = scheduler.DeferSlot(nextTime)
+		}
+		if nextTime.IsZero() || (parked != nil && !nextTime.Before(*parked)) {
+			continue
+		}
+
+		for i := range pending {
+			_ = s.taskRepo.DeleteTask(ctx, pending[i].ID)
+		}
+		_ = s.enqueueCampaignWakeup(ctx, id)
+	}
+}
+
 func (s *campaignService) enqueueCampaignWakeup(ctx context.Context, campaignID uuid.UUID) *errx.Error {
 	if s.scheduler == nil || s.tasksClient == nil || s.taskRepo == nil {
 		return nil
@@ -291,6 +354,9 @@ func (s *campaignService) enqueueCampaignWakeup(ctx context.Context, campaignID 
 	// A deferral still yields a usable first-send slot (nextTime) and a nominal
 	// pool mailbox (accountID), so fall through and schedule the first wakeup at
 	// the defer time rather than failing the campaign start.
+	if errors.Is(err, scheduler.ErrCampaignDeferred) {
+		nextTime = scheduler.DeferSlot(nextTime)
+	}
 	if err != nil && !errors.Is(err, scheduler.ErrCampaignDeferred) {
 		switch {
 		// Checked before ErrNoEmailAccounts, which they wrap.

--- a/internal/app/campaign/service.go
+++ b/internal/app/campaign/service.go
@@ -31,6 +31,14 @@ type CampaignService interface {
 	// Logs
 	GetLogs(ctx context.Context, userID, campaignID string, limit int, cursor *string) (*models.CampaignLogsResult, *errx.Error)
 
+	// WakeCampaigns pulls the parked wakeup of each listed active campaign
+	// forward when its next slot is sooner than where it is parked. Called after
+	// leads are attached to a campaign: the chain is one self-perpetuating task,
+	// so without this a campaign that had nothing to do keeps sleeping and the
+	// new leads sit at "Queued / Not started". Best effort and never an error to
+	// the caller — the lead was still added.
+	WakeCampaigns(ctx context.Context, orgID uuid.UUID, campaignIDs []string)
+
 	// Explicit sender pool (feature 1).
 	ListCampaignSenders(ctx context.Context, orgID uuid.UUID, campaignID string) ([]models.CampaignSender, *errx.Error)
 	ReplaceCampaignSenders(ctx context.Context, orgID uuid.UUID, campaignID string, in []models.CampaignSenderInput) ([]models.CampaignSender, *errx.Error)

--- a/internal/app/contact/handler.go
+++ b/internal/app/contact/handler.go
@@ -45,6 +45,11 @@ func (s *contactService) Add(ctx context.Context, userID string, orgID uuid.UUID
 	}
 
 	s.publishContactsReload(ctx, userID, "contacts:add")
+	var attached []string
+	for i := range contacts {
+		attached = append(attached, contacts[i].Campaigns...)
+	}
+	s.wakeCampaigns(ctx, orgID, attached)
 	return created, nil
 }
 
@@ -104,6 +109,7 @@ func (s *contactService) BulkUpdate(ctx context.Context, userID string, orgID uu
 	}
 
 	s.publishContactsReload(ctx, userID, "contacts:bulk_update")
+	s.wakeCampaigns(ctx, orgID, data.AddCampaigns)
 	return updated, nil
 }
 
@@ -114,6 +120,7 @@ func (s *contactService) Update(ctx context.Context, userID, contactID string, o
 	}
 
 	s.publishContactsReload(ctx, userID, "contacts:update:"+contactID)
+	s.wakeCampaigns(ctx, orgID, data.Campaigns)
 	return updated, nil
 }
 

--- a/internal/app/contact/import.go
+++ b/internal/app/contact/import.go
@@ -299,6 +299,8 @@ func (s *contactService) ImportCommit(
 	res.EndedAt = time.Now().UTC()
 	if res.Imported > 0 || res.Updated > 0 {
 		s.publishContactsReload(ctx, userID, "contacts:import")
+		// Covers the Google Sheets sync too: it commits through this path.
+		s.wakeCampaigns(ctx, orgID, opts.CampaignIDs)
 	}
 	return res, nil
 }

--- a/internal/app/contact/service.go
+++ b/internal/app/contact/service.go
@@ -60,6 +60,20 @@ type ContactService interface {
 	// ListTimeline returns a merged, reverse-chronological feed of all
 	// engagement + CRM events for the contact.
 	ListTimeline(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, contactID uuid.UUID, limit int, before *time.Time) (*models.ContactTimelineResult, *errx.Error)
+
+	// SetCampaignWaker wires the campaign service so attaching a lead to a
+	// running campaign wakes that campaign's parked send chain. Optional: with
+	// no waker the leads still send, just not until the chain's next tick.
+	SetCampaignWaker(w CampaignWaker)
+}
+
+// CampaignWaker pulls the parked wakeup of a running campaign forward when
+// leads are attached to it. A campaign is a single self-perpetuating task, so a
+// campaign that had nothing to send is parked and would otherwise not look at
+// these leads until that park fires. Satisfied structurally by
+// campaign.CampaignService, so this package needs no import of it.
+type CampaignWaker interface {
+	WakeCampaigns(ctx context.Context, orgID uuid.UUID, campaignIDs []string)
 }
 
 type contactService struct {
@@ -67,6 +81,7 @@ type contactService struct {
 	subRepo            repository.SubscriptionRepository
 	planRepo           repository.PlanRepository
 	streamingPublisher *pubsub.StreamingPublisher
+	campaignWaker      CampaignWaker
 }
 
 func NewService(
@@ -93,4 +108,17 @@ func (s *contactService) publishContactsReload(ctx context.Context, userID strin
 		return
 	}
 	s.streamingPublisher.PublishContactsReload(ctx, userID, operationID)
+}
+
+func (s *contactService) SetCampaignWaker(w CampaignWaker) { s.campaignWaker = w }
+
+// wakeCampaigns is the single place every lead-attaching path funnels through
+// (add, update, bulk edit, CSV/XLSX import and the Google Sheets sync, which
+// runs through ImportCommit). Best effort: the lead is already stored, and the
+// reconciler plus the capped deferral horizon are the backstops.
+func (s *contactService) wakeCampaigns(ctx context.Context, orgID uuid.UUID, campaignIDs []string) {
+	if s.campaignWaker == nil || len(campaignIDs) == 0 {
+		return
+	}
+	s.campaignWaker.WakeCampaigns(ctx, orgID, campaignIDs)
 }

--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -86,6 +86,35 @@ const (
 	// follow-up early; a task that fired on time always passes.
 	CampaignNotDueGraceSeconds = 60
 
+	// CampaignMaxDeferMinutes bounds how far ahead a DEFERRED campaign tick may
+	// park its successor. A deferral means "nothing is sendable right now", and
+	// the reasons it says that (no lead is due, the new-lead cap is spent, no
+	// same-provider mailbox) all change from outside the chain: leads get
+	// imported, a reply routes a contact onto a live branch, a mailbox comes
+	// back under budget. A campaign is a single self-perpetuating task, so a
+	// park at the literal next-due time (days out for a "wait 3 days" step) is
+	// also the next time anything re-reads that state — which is how a campaign
+	// with freshly imported leads sits at "Queued / Not started" for days.
+	// Re-checking on this horizon costs one scheduling pass per idle campaign
+	// per interval and bounds that staleness. It applies ONLY to deferrals: a
+	// tick that actually sent parks its successor at the paced interval, which
+	// is the send spacing and must not be shortened.
+	CampaignMaxDeferMinutes = 15
+
+	// CampaignStaleParkHours is when the reconciler starts distrusting a parked
+	// wakeup. Even-distribution can only push a successor to the end of the
+	// mailbox's current day, so a pending tick further out than this was parked
+	// by a deferral (including ones written before deferrals were capped) and is
+	// re-checked against the campaign's real next-due time.
+	CampaignStaleParkHours = 24
+
+	// CampaignReparkMarginMinutes is how much earlier the recomputed slot must
+	// be before the reconciler moves a stale park. Slot selection carries
+	// jitter, so without a margin a campaign whose window genuinely is days out
+	// (a Monday-only schedule) would be re-parked a few minutes earlier on every
+	// pass forever.
+	CampaignReparkMarginMinutes = 60
+
 	// CampaignSendReclaimAfterMinutes is how long a reserved-but-unresolved send
 	// (dispatched_at set, no worker result, no sent_at) is left alone before the
 	// reclaimer treats its outcome as lost and walks it back as a failed

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -54,6 +54,13 @@ type CampaignRepository interface {
 	// task — their self-perpetuating chain died and needs re-seeding. Used by the
 	// campaign reconciler.
 	ListCampaignScheduleCandidates(ctx context.Context, limit int) ([]uuid.UUID, error)
+	// ListStaleParkedCampaigns returns active campaigns whose EARLIEST pending
+	// task is parked further ahead than staleAfter, with that task. Even
+	// distribution can only push a successor to the end of the mailbox's current
+	// day, so anything beyond a day was parked by a deferral and may be holding
+	// the campaign asleep past work that has since become due (leads imported, a
+	// reply routing a contact onto a live branch). The reconciler re-checks each.
+	ListStaleParkedCampaigns(ctx context.Context, staleAfter time.Duration, limit int) ([]ParkedCampaignTask, error)
 	CountActiveForOrganization(ctx context.Context, orgID uuid.UUID) (int, error)
 	AccountHasActiveCampaign(ctx context.Context, accountID uuid.UUID) (bool, error)
 	// CountActiveCampaignsForAccount returns how many active campaigns send
@@ -1517,6 +1524,57 @@ func (r *campaignRepository) ListCampaignScheduleCandidates(ctx context.Context,
 		ids = append(ids, id)
 	}
 	return ids, rows.Err()
+}
+
+// ParkedCampaignTask is one active campaign together with the pending wakeup
+// task holding its chain, for the reconciler's stale-park check.
+type ParkedCampaignTask struct {
+	CampaignID  uuid.UUID
+	TaskID      uuid.UUID
+	ScheduledAt time.Time
+}
+
+// ListStaleParkedCampaigns implements the interface comment above. Only the
+// earliest pending task per campaign is returned: that is the one that decides
+// when the chain next wakes.
+func (r *campaignRepository) ListStaleParkedCampaigns(ctx context.Context, staleAfter time.Duration, limit int) ([]ParkedCampaignTask, error) {
+	if limit <= 0 {
+		limit = 500
+	}
+	// The staleness filter sits OUTSIDE the DISTINCT ON, so the inner query
+	// still picks each campaign's earliest pending task: filtering inside would
+	// hide a nearby wakeup and make a later one look like the one holding the
+	// chain.
+	query := `
+		SELECT p.campaign_id, p.id, p.scheduled_at
+		FROM (
+			SELECT DISTINCT ON (ct.campaign_id) ct.campaign_id, t.id, t.scheduled_at
+			FROM campaigns c
+			JOIN campaign_tasks ct ON ct.campaign_id = c.id
+			JOIN tasks t ON t.id = ct.task_id
+			WHERE c.status = 'active'
+			  AND t.status = 'pending'
+			  AND t.scheduled_at IS NOT NULL
+			ORDER BY ct.campaign_id, t.scheduled_at ASC
+		) p
+		WHERE p.scheduled_at > NOW() + $1::interval
+		LIMIT $2`
+
+	rows, err := r.DB.Query(ctx, query, staleAfter.String(), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ParkedCampaignTask
+	for rows.Next() {
+		var p ParkedCampaignTask
+		if err := rows.Scan(&p.CampaignID, &p.TaskID, &p.ScheduledAt); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	return out, rows.Err()
 }
 
 func (r *campaignRepository) CountActiveForOrganization(ctx context.Context, orgID uuid.UUID) (int, error) {

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -464,7 +464,9 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		}
 	}
 
-	// STEP 8.5: Select best account per the campaign's rotation mode.
+	// STEP 8.5: Select best account per the campaign's rotation mode. pool is
+	// the set selection actually ran over, kept for the pacing maths below.
+	pool := candidates
 	selected := selectAccountByRotationMode(campaign.RotationMode, candidates)
 	if selected == nil {
 		// ALL accounts at capacity today — push to next day and recompute with
@@ -500,6 +502,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			}
 		}
 
+		pool = tomorrow
 		selected = selectAccountByRotationMode(campaign.RotationMode, tomorrow)
 		if selected == nil {
 			// ESP-strict with no matching mailbox at all: defer rather than
@@ -540,7 +543,15 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// a behaviour profile that is the mailbox's own rolled workday (lunch
 	// excluded); otherwise it is the span of the campaign's intervals for that
 	// weekday.
-	remainingEmails := selected.RemainingToday
+	// The day's remaining sends belong to the POOL, not to the mailbox this tick
+	// happens to have picked. A campaign is one self-perpetuating task, so this
+	// interval is the campaign's whole send rate: pacing it by the selected
+	// mailbox alone made a campaign with three mailboxes send at one mailbox's
+	// rate and leave the other two idle, however high their caps were. Every
+	// per-mailbox guard still binds afterwards — each mailbox's own daily cap
+	// and hourly ceiling gated it into this set, and the min-gap plus conflict
+	// resolution below space its own sends.
+	remainingEmails := poolRemainingOn(pool, candidateTime)
 	if remainingEmails > 0 {
 		remainingMinutes, ok := remainingSendMinutes(selected, candidateTime, windows, campaignTZ)
 		if ok && remainingMinutes > 0 {
@@ -579,10 +590,18 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		}
 	}
 
-	// STEP 11: Add jitter. Deliberately NOT rounded to a 5-minute grid — a
-	// fleet that only ever sends at :x0/:x5 marks is a detectable pattern.
-	jitter := randomJitter(-20, 20)
-	candidateTime = notBefore(candidateTime.Add(time.Minute * time.Duration(jitter)))
+	// STEP 11: Add jitter, scaled to the placement it is perturbing. A flat
+	// +/-20 minutes is wider than the interval STEP 9 just computed whenever the
+	// pool is pacing tighter than 40 minutes apart, so the negative half landed
+	// the slot in the past, notBefore clamped it to a few seconds from now, and
+	// the day's spread collapsed onto the mailbox min-gap. Half the distance to
+	// the slot, capped at the original 20 minutes, keeps the irregularity
+	// without erasing the pacing. Deliberately NOT rounded to a 5-minute grid —
+	// a fleet that only ever sends at :x0/:x5 marks is a detectable pattern.
+	if spread := min(int(time.Until(candidateTime).Minutes())/2, 20); spread > 0 {
+		candidateTime = candidateTime.Add(time.Minute * time.Duration(randomJitter(-spread, spread)))
+	}
+	candidateTime = notBefore(candidateTime)
 
 	// STEP 12: Check conflicts with other scheduled tasks
 	dateToCheck := candidateTime

--- a/internal/scheduler/errors.go
+++ b/internal/scheduler/errors.go
@@ -3,6 +3,9 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/config"
 )
 
 var (
@@ -56,3 +59,24 @@ var (
 	// task only (the next invocation re-evaluates selection from scratch).
 	ErrCampaignDeferred = errors.New("campaign send deferred - no eligible mailbox for this contact right now")
 )
+
+// DeferSlot is the wakeup time a caller must use after CalculateNextCampaignTime
+// returns ErrCampaignDeferred. The returned instant is the campaign's real
+// next-due moment, which is the honest answer to "when could this send" but the
+// wrong answer to "when should this chain look again": a campaign is one
+// self-perpetuating task, so parking it at a next-due three days out also means
+// nothing re-reads the campaign for three days. Leads imported in the meantime
+// sit at "Queued / Not started" until then.
+//
+// So a deferral is capped at config.CampaignMaxDeferMinutes. Anything sooner is
+// kept as-is, because a near-term defer is already a precise wakeup. Sends are
+// unaffected: a tick that fires early and still has nothing due simply defers
+// again, and a tick that DID send parks its successor at the paced interval,
+// which never goes through here.
+func DeferSlot(at time.Time) time.Time {
+	horizon := time.Now().Add(config.CampaignMaxDeferMinutes * time.Minute)
+	if at.IsZero() || at.After(horizon) {
+		return horizon
+	}
+	return at
+}

--- a/internal/scheduler/helpers.go
+++ b/internal/scheduler/helpers.go
@@ -347,6 +347,33 @@ func remainingSendMinutes(c *AccountCandidate, at time.Time, sw models.ScheduleW
 	return dayEnd - max(currentMinutes, dayStart), true
 }
 
+// poolRemainingOn is how many cold sends the campaign's eligible mailboxes still
+// have between them on the day `at` falls on — the denominator the even-
+// distribution step paces the day across.
+//
+// Only mailboxes actually landing on that day are counted. A behaviour-profiled
+// mailbox whose today is spent has already been walked to a later day by
+// placeWithinBehavior, and counting tomorrow's allowance as if it were available
+// now would pace the campaign faster than the mailboxes that can send today can
+// keep up with. A mailbox that opened BEFORE `at` is available whatever day it
+// opened on, which is what keeps the count right when the whole pass has been
+// pushed to tomorrow because every mailbox was at capacity today.
+func poolRemainingOn(pool []AccountCandidate, at time.Time) int {
+	total := 0
+	for i := range pool {
+		c := &pool[i]
+		if c.RemainingToday <= 0 {
+			continue
+		}
+		if c.Behavior.Enabled && c.BehaviorOpenAt != nil &&
+			c.BehaviorOpenAt.After(at) && !sameLocalDay(*c.BehaviorOpenAt, at, c.Behavior.Loc) {
+			continue
+		}
+		total += c.RemainingToday
+	}
+	return total
+}
+
 // campaignRampCeiling returns the day's effective ramp ceiling. When ramp is
 // disabled it returns the campaign ceiling unchanged (the caller still min()s
 // against the per-mailbox cap). When enabled it returns the already-advanced

--- a/internal/scheduler/pacing_test.go
+++ b/internal/scheduler/pacing_test.go
@@ -1,0 +1,90 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// TestDeferSlotCapsAFarFutureWakeup is issue #189's stall in miniature. A
+// campaign is one self-perpetuating task, so a deferral parked at the literal
+// next-due moment ("wait 3 days") is also the next time anything re-reads the
+// campaign — leads imported meanwhile sit at "Queued / Not started" until then.
+func TestDeferSlotCapsAFarFutureWakeup(t *testing.T) {
+	horizon := config.CampaignMaxDeferMinutes * time.Minute
+
+	for _, tc := range []struct {
+		name   string
+		in     time.Time
+		capped bool
+	}{
+		{"three days out", time.Now().Add(72 * time.Hour), true},
+		{"just past the horizon", time.Now().Add(horizon + 5*time.Minute), true},
+		{"zero (nothing computed)", time.Time{}, true},
+		{"inside the horizon", time.Now().Add(2 * time.Minute), false},
+	} {
+		got := DeferSlot(tc.in)
+		switch {
+		case tc.capped:
+			if got.After(time.Now().Add(horizon + time.Second)) {
+				t.Errorf("%s: parked at %s, past the %s horizon", tc.name, got, horizon)
+			}
+		default:
+			if !got.Equal(tc.in) {
+				t.Errorf("%s: a near-term defer must be kept exactly, got %s want %s", tc.name, got, tc.in)
+			}
+		}
+	}
+}
+
+// TestPoolRemainingCountsEveryMailboxSendingToday: the campaign chain runs one
+// task at a time, so the even-distribution interval is the campaign's whole send
+// rate. Pacing it by the selected mailbox alone made a three-mailbox campaign
+// send at one mailbox's rate and leave the other two idle.
+func TestPoolRemainingCountsEveryMailboxSendingToday(t *testing.T) {
+	now := time.Now()
+	pool := []AccountCandidate{
+		{RemainingToday: 30},
+		{RemainingToday: 30},
+		{RemainingToday: 25},
+	}
+	if got := poolRemainingOn(pool, now); got != 85 {
+		t.Fatalf("pool remaining = %d, want 85", got)
+	}
+	if single := poolRemainingOn(pool[:1], now); single != 30 {
+		t.Fatalf("single-mailbox pool = %d, want 30 (unchanged behaviour)", single)
+	}
+}
+
+// TestPoolRemainingSkipsMailboxesWaitingForTomorrow: a mailbox whose today is
+// already spent has been walked to a later day, and counting tomorrow's
+// allowance as if it were available now would pace the campaign faster than the
+// mailboxes that can actually send today can keep up with.
+func TestPoolRemainingSkipsMailboxesWaitingForTomorrow(t *testing.T) {
+	now := time.Now()
+	tomorrow := now.Add(24 * time.Hour)
+
+	b := behavior.NewStandalone(models.DefaultSendingBehavior(uuid.New()), time.UTC)
+	b.Enabled = true
+
+	pool := []AccountCandidate{
+		{RemainingToday: 30, Behavior: b, BehaviorOpenAt: &now},
+		{RemainingToday: 40, Behavior: b, BehaviorOpenAt: &tomorrow},
+	}
+	if got := poolRemainingOn(pool, now); got != 30 {
+		t.Fatalf("pool remaining = %d, want 30 (only the mailbox open today)", got)
+	}
+
+	// The whole pass pushed to tomorrow because every mailbox was at capacity
+	// today: both mailboxes are open by then and both must be counted, or the
+	// pacing step is skipped entirely and tomorrow's sends bunch at the window
+	// start.
+	if got := poolRemainingOn(pool, tomorrow.Add(time.Hour)); got != 70 {
+		t.Fatalf("pool remaining tomorrow = %d, want 70 (both mailboxes open by then)", got)
+	}
+}

--- a/internal/tasks/campaign_reconciler.go
+++ b/internal/tasks/campaign_reconciler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
+	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/scheduler"
 )
 
@@ -38,6 +39,15 @@ func (s *tasksService) ReconcileCampaignSchedules(ctx context.Context, limit int
 		log.Info().Int64("cancelled", n).Msg("campaign reconcile: cancelled overdue pending tasks")
 	}
 
+	// A chain can also be alive but asleep: a deferral parked its wakeup at the
+	// campaign's next-due moment, which for a "wait 3 days" step is three days
+	// out, and nothing re-reads the campaign until then. Leads imported in the
+	// meantime sit at "Queued / Not started". Deferrals are capped now, so this
+	// only sees parks written before that or by a schedule that genuinely is
+	// days out — and it moves one only when the campaign's own next slot is
+	// meaningfully sooner.
+	s.repark(ctx, limit)
+
 	ids, err := s.campaignRepo.ListCampaignScheduleCandidates(ctx, limit)
 	if err != nil {
 		return 0, err
@@ -57,7 +67,9 @@ func (s *tasksService) ReconcileCampaignSchedules(ctx context.Context, limit int
 		switch {
 		case cerr == nil, errors.Is(cerr, scheduler.ErrCampaignDeferred):
 			schedAt := nextTime
-			if schedAt.IsZero() {
+			if errors.Is(cerr, scheduler.ErrCampaignDeferred) {
+				schedAt = scheduler.DeferSlot(schedAt)
+			} else if schedAt.IsZero() {
 				schedAt = time.Now().UTC().Add(1 * time.Minute)
 			}
 			if err := s.createCampaignTask(ctx, id, accountID, schedAt); err != nil {
@@ -78,6 +90,67 @@ func (s *tasksService) ReconcileCampaignSchedules(ctx context.Context, limit int
 		}
 	}
 	return seeded, nil
+}
+
+// repark pulls a stale parked wakeup forward. For each active campaign whose
+// earliest pending task sits further ahead than config.CampaignStaleParkHours,
+// it recomputes the campaign's next slot; when that slot is at least
+// config.CampaignReparkMarginMinutes earlier than the parked one, the parked
+// task is cancelled and the chain re-seeded at the sooner slot.
+//
+// The margin is what keeps this from fighting legitimate schedules. A campaign
+// that only sends on Mondays recomputes to next Monday too, within jitter of
+// where it is already parked, so nothing moves. A campaign parked three days out
+// with leads that became due an hour ago recomputes to now and moves.
+func (s *tasksService) repark(ctx context.Context, limit int) {
+	parked, err := s.campaignRepo.ListStaleParkedCampaigns(ctx, config.CampaignStaleParkHours*time.Hour, limit)
+	if err != nil {
+		log.Warn().Err(err).Msg("campaign reconcile: stale-park scan failed")
+		return
+	}
+
+	for _, p := range parked {
+		nextTime, _, accountID, cerr := s.scheduler.CalculateNextCampaignTime(ctx, p.CampaignID)
+		if cerr != nil && !errors.Is(cerr, scheduler.ErrCampaignDeferred) {
+			// Anything else (completed, no mailbox, a DB blip) is the re-seed
+			// loop's business, not this one's; leave the park alone.
+			continue
+		}
+		if errors.Is(cerr, scheduler.ErrCampaignDeferred) {
+			nextTime = scheduler.DeferSlot(nextTime)
+		}
+		if nextTime.IsZero() || !nextTime.Before(p.ScheduledAt.Add(-config.CampaignReparkMarginMinutes*time.Minute)) {
+			continue
+		}
+
+		// Cancel EVERY pending task on the campaign first: createCampaignTask
+		// no-ops while any is left, so cancelling only the earliest would move
+		// the chain's wakeup to a later one instead of forward.
+		pending, perr := s.campaignRepo.GetPendingCampaignTasks(ctx, p.CampaignID)
+		if perr != nil {
+			continue
+		}
+		cancelled := true
+		for i := range pending {
+			if err := s.taskRepo.UpdateTaskStatus(ctx, pending[i].ID, "cancelled"); err != nil {
+				log.Warn().Err(err).Str("campaign_id", p.CampaignID.String()).Msg("campaign reconcile: could not cancel a stale park")
+				cancelled = false
+				break
+			}
+		}
+		if !cancelled {
+			continue
+		}
+		if err := s.createCampaignTask(ctx, p.CampaignID, accountID, nextTime); err != nil {
+			log.Warn().Err(err).Str("campaign_id", p.CampaignID.String()).Msg("campaign reconcile: re-park failed")
+			continue
+		}
+		log.Info().
+			Str("campaign_id", p.CampaignID.String()).
+			Time("was", p.ScheduledAt).
+			Time("now", nextTime).
+			Msg("campaign reconcile: pulled a stale wakeup forward")
+	}
 }
 
 // StartCampaignReconciler runs ReconcileCampaignSchedules on an interval until

--- a/internal/tasks/campaign_stall_live_test.go
+++ b/internal/tasks/campaign_stall_live_test.go
@@ -1,0 +1,179 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+// processTask is the payload the dispatcher hands a handler.
+func processTask(id uuid.UUID) *proto.ProcessTask {
+	return &proto.ProcessTask{TaskId: id.String()}
+}
+
+// Live checks for issue #189: a campaign that shows ACTIVE with every lead at
+// "Queued / Not started" and nothing sending.
+//
+// The chain is a single self-perpetuating task. A tick that finds nothing due
+// (every lead mid-wait) used to park its successor at the literal next-due
+// moment, which for a "wait 3 days" step is three days out — and since that
+// parked task is also the next time anything re-reads the campaign, leads
+// imported in between were invisible until it fired.
+
+// addLead attaches one more brand-new lead, the "Import" / "Add lead" action
+// from the campaign's Leads tab.
+func (f *campaignSendFixture) addLead(t *testing.T) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	ctx := context.Background()
+	if _, err := f.pool.Exec(ctx, `INSERT INTO contacts (id, user_id, organization_id, email,
+	        first_name, last_name, company, phone, custom_fields, created_at)
+	    VALUES ($1, $2, $3, $4, 'Late', 'Lead', '', '', '{}', NOW() + interval '1 second')`,
+		id, f.user, f.org, "late-"+id.String()[:8]+"@test.local"); err != nil {
+		t.Fatalf("add lead: %v", err)
+	}
+	if _, err := f.pool.Exec(ctx,
+		`INSERT INTO campaign_leads (campaign_id, contact_id, position) VALUES ($1, $2, 1)`,
+		f.campaign, id); err != nil {
+		t.Fatalf("link lead: %v", err)
+	}
+	return id
+}
+
+// addWaitingFollowUp gives the campaign a second step gated behind a long wait
+// and routes step 1 into it, then stamps the original lead's step 1 as sent —
+// the state in which nothing is due for days.
+func (f *campaignSendFixture) addWaitingFollowUp(t *testing.T, waitDays int) {
+	t.Helper()
+	ctx := context.Background()
+	step2 := uuid.New()
+	if _, err := f.pool.Exec(ctx, `INSERT INTO sequences (id, campaign_id, organization_id, name,
+	        subject, body_plain, body_html, wait_after, position, kind)
+	    VALUES ($1, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', $4, 1, 'email')`,
+		step2, f.campaign, f.org, waitDays); err != nil {
+		t.Fatalf("add step 2: %v", err)
+	}
+	if _, err := f.pool.Exec(ctx, `UPDATE sequences
+	    SET conditions = jsonb_build_object('branches', jsonb_build_array(
+	        jsonb_build_object('branch_id', 'else', 'target_step_id', $1::text)))
+	    WHERE id = $2`, step2.String(), f.step); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+	if _, err := f.pool.Exec(ctx, `INSERT INTO campaign_contact_progress
+	    (campaign_id, contact_id, sequence_id, sent_at) VALUES ($1, $2, $3, NOW())`,
+		f.campaign, f.contact, f.step); err != nil {
+		t.Fatalf("stamp step 1: %v", err)
+	}
+}
+
+// parkedWakeup is the campaign's earliest pending task: when the chain next
+// wakes, and the task the next tick will run.
+func (f *campaignSendFixture) parkedWakeup(t *testing.T) (uuid.UUID, time.Time) {
+	t.Helper()
+	var id uuid.UUID
+	var at time.Time
+	if err := f.pool.QueryRow(context.Background(), `
+		SELECT t.id, t.scheduled_at FROM tasks t
+		JOIN campaign_tasks ct ON ct.task_id = t.id
+		WHERE ct.campaign_id = $1 AND t.status = 'pending'
+		ORDER BY t.scheduled_at ASC LIMIT 1`, f.campaign).Scan(&id, &at); err != nil {
+		t.Fatalf("no pending wakeup for the campaign: %v", err)
+	}
+	return id, at
+}
+
+// TestLiveDeferredTickDoesNotParkTheCampaignForDays runs a real tick on a
+// campaign whose only lead is three days into a follow-up wait, and asserts the
+// successor wakes inside the defer horizon rather than in three days.
+func TestLiveDeferredTickDoesNotParkTheCampaignForDays(t *testing.T) {
+	handle := liveCampaignDB(t)
+	sender := &recordingSender{}
+	svc := liveCampaignService(t, handle, sender)
+	f := newCampaignSendFixture(t, handle.Pool)
+	f.addWaitingFollowUp(t, 3)
+
+	taskID := f.queueTick(t, svc.taskRepo)
+	if xerr := svc.HandleCampaignTask(processTask(taskID)); xerr != nil {
+		t.Fatalf("tick: %v", xerr)
+	}
+	if sender.count() != 0 {
+		t.Fatalf("a deferred tick must not send, sent %d", sender.count())
+	}
+
+	_, at := f.parkedWakeup(t)
+	horizon := time.Now().Add(config.CampaignMaxDeferMinutes*time.Minute + time.Minute)
+	if at.After(horizon) {
+		t.Fatalf("campaign parked until %s (%s away); nothing would re-read it before then",
+			at.UTC().Format(time.RFC3339), time.Until(at).Round(time.Minute))
+	}
+	t.Logf("deferred tick re-checks in %s", time.Until(at).Round(time.Second))
+}
+
+// TestLiveLeadAddedToAParkedCampaignSendsOnTheNextTick is the reported symptom
+// end to end: leads land on a campaign that had nothing to do, and the next
+// tick has to pick them up and send.
+func TestLiveLeadAddedToAParkedCampaignSendsOnTheNextTick(t *testing.T) {
+	handle := liveCampaignDB(t)
+	sender := &recordingSender{}
+	svc := liveCampaignService(t, handle, sender)
+	f := newCampaignSendFixture(t, handle.Pool)
+	f.addWaitingFollowUp(t, 3)
+
+	// Tick one: nothing due, so the chain parks.
+	if xerr := svc.HandleCampaignTask(processTask(f.queueTick(t, svc.taskRepo))); xerr != nil {
+		t.Fatalf("first tick: %v", xerr)
+	}
+	next, parked := f.parkedWakeup(t)
+
+	// A lead is imported into the running campaign.
+	f.addLead(t)
+
+	// The parked wakeup fires (capped, so this is minutes away, not days) and
+	// the new lead's first email goes out.
+	if xerr := svc.HandleCampaignTask(processTask(next)); xerr != nil {
+		t.Fatalf("second tick: %v", xerr)
+	}
+	if sender.count() != 1 {
+		t.Fatalf("the imported lead was not sent: sends=%d, chain was parked until %s",
+			sender.count(), parked.UTC().Format(time.RFC3339))
+	}
+}
+
+// TestLiveReconcilerPullsAStaleParkForward covers chains parked before the
+// deferral cap existed: the wakeup sits days out while work is due now, and
+// nothing re-reads the campaign until it fires. The reconciler has to move it.
+func TestLiveReconcilerPullsAStaleParkForward(t *testing.T) {
+	handle := liveCampaignDB(t)
+	svc := liveCampaignService(t, handle, &recordingSender{})
+	f := newCampaignSendFixture(t, handle.Pool)
+
+	// The stale row: a pending wakeup three days out, with a lead due now.
+	stale := uuid.New()
+	at := time.Now().Add(72 * time.Hour)
+	ctx := context.Background()
+	if _, err := f.pool.Exec(ctx, `INSERT INTO tasks (id, task_type, email_account_id, status, message_id, scheduled_at)
+	    VALUES ($1, 'campaign', $2, 'pending', '', $3)`, stale, f.mailbox, at); err != nil {
+		t.Fatalf("park task: %v", err)
+	}
+	if _, err := f.pool.Exec(ctx, `INSERT INTO campaign_tasks (task_id, campaign_id) VALUES ($1, $2)`,
+		stale, f.campaign); err != nil {
+		t.Fatalf("park campaign task: %v", err)
+	}
+
+	if _, err := svc.ReconcileCampaignSchedules(ctx, 500); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	_, moved := f.parkedWakeup(t)
+	if !moved.Before(at.Add(-config.CampaignReparkMarginMinutes * time.Minute)) {
+		t.Fatalf("stale park left at %s; the campaign has a lead due now",
+			moved.UTC().Format(time.RFC3339))
+	}
+	t.Logf("pulled the wakeup from %s forward to %s",
+		at.UTC().Format(time.RFC3339), moved.UTC().Format(time.RFC3339))
+}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -194,10 +194,10 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			// has no same-provider mailbox, or the daily new-lead cap is reached).
 			// Reschedule at the deferred slot WITHOUT sending and WITHOUT touching
 			// progress / daily counters / rotation — mirrors the daily-limit path.
-			scheduledNext := nextTime
-			if scheduledNext.IsZero() {
-				scheduledNext = time.Now().UTC().Add(1 * time.Hour)
-			}
+			// Capped: the next-due moment can be days out, and until this chain
+			// wakes nothing re-reads the campaign, so leads imported meanwhile
+			// would sit queued until then.
+			scheduledNext := scheduler.DeferSlot(nextTime)
 			if cerr := s.createCampaignTask(ctx, campaign.ID, accountID, scheduledNext); cerr != nil {
 				log.Warn().Err(cerr).Str("campaign_id", campaign.ID.String()).Str("task_id", taskID.String()).Msg("Failed to schedule deferred campaign task")
 			}

--- a/web/src/components/app/campaigns/schedule/WeekScheduleGrid.tsx
+++ b/web/src/components/app/campaigns/schedule/WeekScheduleGrid.tsx
@@ -31,7 +31,11 @@ const hourLabel = (h: number) => {
     const h12 = hh % 12 === 0 ? 12 : hh % 12;
     return `${h12}${ampm}`;
 };
+// An interval's end is exclusive and may be 1440 (midnight, end of day), which
+// the plain h<12 test rendered as "12pm" — so a full day read as "12am-12pm"
+// and looked like sending stopped at noon.
 const fmt = (min: number) => {
+    if (min === DAY) return "midnight";
     const h = Math.floor(min / 60);
     const m = min % 60;
     const ampm = h < 12 ? "am" : "pm";

--- a/web/src/components/app/contacts/ContactsTable.tsx
+++ b/web/src/components/app/contacts/ContactsTable.tsx
@@ -55,6 +55,7 @@ import ContactEdit from "./ContactEdit";
 import type { ContactSlideTab } from "./contact-edit/tabs";
 import type MiniCampaign from "@/lib/api/models/app/campaigns/MiniCampaign";
 import type { ContactCampaignProgress, LeadStatus } from "@/lib/api/models/app/contacts/Contact";
+import type { CampaignLeadCounts } from "@/lib/api/models/app/contacts/SearchContactsResult";
 import ContactsEditBulk from "./ContactsEditBulk";
 import { NewContactDialog } from "./NewContactDialog";
 import ExportDialog from "./ExportDialog";
@@ -366,6 +367,7 @@ export default function ContactsTable({
                     contacts={contacts ?? []}
                     total={total}
                     hasMore={!!contactsData.hasNextPage}
+                    serverCounts={contactsData.data?.pages[0]?.lead_counts}
                 />
                 <div className="relative">
                     {tableNode}
@@ -1020,18 +1022,36 @@ function LeadStatusPill({ lead }: { lead?: ContactCampaignProgress | null }) {
 }
 
 // Compact campaign-state strip above the Leads list: a segmented bar + per-state
-// counts derived from the loaded leads, so you can see at a glance how the
-// campaign is processing its leads.
+// counts, so you can see at a glance how the campaign is processing its leads.
+//
+// The numbers come from the server's campaign-wide `lead_counts` whenever it is
+// there. Counting the loaded rows instead made the strip lie on any campaign
+// past one page: a campaign of 57 leads showed "Queued 50, Done 0" purely
+// because those were the 50 rows on screen (issue #189). The loaded-row count
+// stays as the fallback so the strip is never blank on first paint.
 function LeadProgressStrip({
     contacts,
     total,
     hasMore,
+    serverCounts,
 }: {
     contacts: { campaign_lead?: ContactCampaignProgress | null }[];
     total: number;
     hasMore: boolean;
+    serverCounts?: CampaignLeadCounts;
 }) {
     const counts = React.useMemo(() => {
+        if (serverCounts) {
+            return {
+                pending: serverCounts.queued,
+                active: serverCounts.processing,
+                completed: serverCounts.completed,
+                replied: serverCounts.replied,
+                bounced: serverCounts.bounced,
+                failed: serverCounts.failed,
+                unsubscribed: serverCounts.unsubscribed,
+            } satisfies Record<LeadStatus, number>;
+        }
         const c: Record<LeadStatus, number> = {
             pending: 0,
             active: 0,
@@ -1043,10 +1063,12 @@ function LeadProgressStrip({
         };
         for (const ct of contacts) c[ct.campaign_lead?.status ?? "pending"]++;
         return c;
-    }, [contacts]);
+    }, [contacts, serverCounts]);
 
     const loaded = contacts.length;
     if (loaded === 0) return null;
+    // The bar's segments are shares of whatever the counts cover.
+    const barTotal = serverCounts ? Math.max(serverCounts.total, 1) : loaded;
 
     const segs: { key: LeadStatus; color: string }[] = [
         { key: "active", color: "bg-sky-500" },
@@ -1067,7 +1089,7 @@ function LeadProgressStrip({
                             <div
                                 key={s.key}
                                 className={`${s.color} transition-[width] duration-500 ease-out`}
-                                style={{ width: `${(counts[s.key] / loaded) * 100}%` }}
+                                style={{ width: `${(counts[s.key] / barTotal) * 100}%` }}
                             />
                         ) : null,
                     )}

--- a/web/src/hooks/SocketProvider.tsx
+++ b/web/src/hooks/SocketProvider.tsx
@@ -55,6 +55,24 @@ export default function SocketProvider({
     const heartbeatTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const refCounterRef = useRef(0);
     const channelsRef = useRef<Map<string, ChannelInternal>>(new Map());
+    // Reactive mirror of channelsRef's per-channel state. The map itself is a
+    // ref, so a component rendering a channel's state never re-rendered when
+    // that channel actually joined and sat on its first-render value forever
+    // ("Disconnected" on a live campaign, issue #189). Every transition below
+    // goes through markChannelState so the two cannot drift.
+    const [channelStates, setChannelStates] = useState<Record<string, ChannelState>>({});
+    const markChannelState = useCallback((topic: string, state: ChannelState | null) => {
+        setChannelStates((prev) => {
+            if (state === null) {
+                if (!(topic in prev)) return prev;
+                const next = { ...prev };
+                delete next[topic];
+                return next;
+            }
+            if (prev[topic] === state) return prev;
+            return { ...prev, [topic]: state };
+        });
+    }, []);
     const pendingJoinsRef = useRef<Map<string, Record<string, unknown>>>(new Map());
     // Topics the app currently wants joined (added by joinChannel, removed by
     // leaveChannel). On reconnect we rejoin exactly these, independent of the
@@ -178,6 +196,7 @@ export default function SocketProvider({
                 } else {
                     channel.state = 'errored';
                 }
+                markChannelState(topic, channel.state);
             }
             return;
         }
@@ -187,6 +206,7 @@ export default function SocketProvider({
             const wasJoined = channel?.state === 'joined';
             if (channel) {
                 channel.state = 'errored';
+                markChannelState(topic, 'errored');
             }
             // A channel that was live crashed server-side while the socket stays
             // open (e.g. an unhandled message in the channel process). Phoenix's
@@ -209,6 +229,7 @@ export default function SocketProvider({
                         params,
                         handlers: cur?.handlers || new Map(),
                     });
+                    markChannelState(topic, 'joining');
                     sendRaw({
                         topic,
                         event: PHOENIX_EVENTS.JOIN,
@@ -225,6 +246,7 @@ export default function SocketProvider({
             const channel = channelsRef.current.get(topic);
             if (channel) {
                 channel.state = 'closed';
+                markChannelState(topic, 'closed');
             }
             return;
         }
@@ -270,7 +292,7 @@ export default function SocketProvider({
                 }
             });
         }
-    }, [setWsLatencyMs, getRef, sendRaw]);
+    }, [setWsLatencyMs, getRef, sendRaw, markChannelState]);
 
     // Join channel
     const joinChannel = useCallback((topic: string, params: Record<string, unknown> = {}) => {
@@ -293,6 +315,7 @@ export default function SocketProvider({
             handlers: existing?.handlers || new Map(),
         };
         channelsRef.current.set(topic, channel);
+        markChannelState(topic, 'joining');
 
         // If connected, send join immediately
         if (wsRef.current?.readyState === WebSocket.OPEN) {
@@ -307,7 +330,7 @@ export default function SocketProvider({
             // Queue for when connected
             pendingJoinsRef.current.set(topic, params);
         }
-    }, [getRef, sendRaw]);
+    }, [getRef, sendRaw, markChannelState]);
 
     // Leave channel
     const leaveChannel = useCallback((topic: string) => {
@@ -318,6 +341,7 @@ export default function SocketProvider({
         if (!channel) return;
 
         channel.state = 'leaving';
+        markChannelState(topic, 'leaving');
 
         if (wsRef.current?.readyState === WebSocket.OPEN) {
             sendRaw({
@@ -331,7 +355,8 @@ export default function SocketProvider({
 
         channelsRef.current.delete(topic);
         pendingJoinsRef.current.delete(topic);
-    }, [getRef, sendRaw]);
+        markChannelState(topic, null);
+    }, [getRef, sendRaw, markChannelState]);
 
     // Get channel state
     const getChannelState = useCallback((topic: string): ChannelState => {
@@ -441,6 +466,7 @@ export default function SocketProvider({
                 handlers: existing?.handlers || new Map(),
             };
             channelsRef.current.set(topic, channel);
+            markChannelState(topic, 'joining');
             sendRaw({
                 topic,
                 event: PHOENIX_EVENTS.JOIN,
@@ -450,7 +476,7 @@ export default function SocketProvider({
             });
         });
         pendingJoinsRef.current.clear();
-    }, [getRef, sendRaw]);
+    }, [getRef, sendRaw, markChannelState]);
 
     // Connect to WebSocket
     const connect = useCallback(async () => {
@@ -510,6 +536,7 @@ export default function SocketProvider({
                 channelsRef.current.forEach((channel) => {
                     if (channel.state === 'joined') {
                         channel.state = 'closed';
+                        markChannelState(channel.topic, 'closed');
                     }
                 });
 
@@ -556,6 +583,7 @@ export default function SocketProvider({
         stopHeartbeat,
         rejoinChannels,
         setWsLatencyMs,
+        markChannelState,
     ]);
 
     // Mount effect
@@ -629,6 +657,7 @@ export default function SocketProvider({
             joinChannel,
             leaveChannel,
             getChannelState,
+            channelStates,
             subscribeToChannel,
             pushToChannel,
             subscribe,

--- a/web/src/hooks/context/socket.tsx
+++ b/web/src/hooks/context/socket.tsx
@@ -33,6 +33,11 @@ interface SocketContextValue {
     joinChannel: (topic: string, params?: Record<string, unknown>) => void;
     leaveChannel: (topic: string) => void;
     getChannelState: (topic: string) => ChannelState;
+    // Reactive mirror of every channel's state, keyed by topic. getChannelState
+    // reads a ref, so a component that renders it never re-renders when the
+    // channel actually joins — which is how a live campaign's panel sat on
+    // "Disconnected" forever (issue #189). Render from this.
+    channelStates: Record<string, ChannelState>;
 
     // Event handling
     subscribeToChannel: (
@@ -76,7 +81,7 @@ export function useChannel(topic: string, params?: Record<string, unknown>) {
     }, [socket, topic, params]);
 
     return {
-        state: socket.getChannelState(topic),
+        state: socket.channelStates[topic] ?? "closed",
         push: (event: string, payload: Record<string, unknown>) =>
             socket.pushToChannel(topic, event, payload),
     };

--- a/web/src/lib/api/models/app/contacts/SearchContactsResult.ts
+++ b/web/src/lib/api/models/app/contacts/SearchContactsResult.ts
@@ -18,8 +18,24 @@ export interface ContactsCounts {
     categories: ContactCategoryCount[];
 }
 
+// Per-status lead totals for one campaign's Leads view. Returned on the first
+// page when the search targets exactly one campaign, and independent of the
+// request's lead_status filter, so every chip shows the campaign's real total
+// rather than a count over the rows that happen to be loaded.
+export interface CampaignLeadCounts {
+    total: number;
+    queued: number;
+    processing: number;
+    completed: number;
+    replied: number;
+    bounced: number;
+    failed: number;
+    unsubscribed: number;
+}
+
 export default interface SearchContactsResult {
     data: Contact[];
     pagination: Pagination;
     counts?: ContactsCounts;
+    lead_counts?: CampaignLeadCounts;
 }


### PR DESCRIPTION
Closes #189.

## What the reporter saw

Four screenshots, each pointing at a different piece of the same problem:

1. **Leads tab** — campaign `ACTIVE`, 57 leads, every one `QUEUED` / "Not started", nothing sent for 1.5 hours.
2. **Schedule tab** — 7 full-day windows in Asia/Kolkata, labelled `12am` – `12pm`.
3. **Mailbox settings** — workday 06:00–07:00 to 22:00–23:00 UTC, 30–45/day, 5–15/hour, 30–100s gap. Nothing wrong with the settings.
4. **Overview** — one email sent, then nothing; "Live activity" showing `Active` next to a grey `Disconnected`.

## Root cause

A campaign is a single self-perpetuating task. A tick that finds nothing due parked its successor at the campaign's literal next-due moment — three days out for a `wait 3 days` step. That parked task is *also* the next time anything re-reads the campaign, so leads imported afterwards were invisible until it fired. `ReconcileCampaignSchedules` never noticed, because it only re-seeds campaigns with **no** pending task.

Confirmed against a live database rather than inferred: both active sandbox campaigns had 6 unsent, un-suppressed, due-now leads while their only pending tick sat at `2026-08-26 14:00` and `2026-08-27 14:18`, with `now` at `2026-08-25 13:26`. Calling `CalculateNextCampaignTime` directly returned a sendable pair at `now+38s`.

## Changes

**The stall**

- Deferral parks are capped at `config.CampaignMaxDeferMinutes` (15 min) through `scheduler.DeferSlot`, applied at all three enqueue sites. Only deferrals: a tick that actually sent still parks its successor at the paced interval, so send spacing is unchanged.
- The reconciler re-checks any active campaign parked beyond `CampaignStaleParkHours` (24 h) and pulls its wakeup forward when the campaign's real next slot is `CampaignReparkMarginMinutes` (1 h) sooner. This heals chains parked before the cap existed; the margin keeps it from fighting a genuinely-days-out schedule (a Monday-only campaign recomputes to next Monday and nothing moves).
- Attaching leads to a running campaign wakes it immediately, through one `CampaignWaker` seam in the contact service — so add / update / bulk edit / CSV-XLSX import / Google Sheets sync are all covered by one call site. It only ever moves a wakeup earlier.

**Throughput**

- Even distribution now paces across the whole sender pool (`poolRemainingOn`) instead of the one mailbox the tick happened to pick. The chain runs one task at a time, so that interval *is* the campaign's send rate: a three-mailbox campaign was sending at one mailbox's rate with the other two idle. Measured against live Postgres with the reporter's profile: 1 mailbox ≈ 12–19 min/send, 3 mailboxes ≈ 2.5–4 min. Every per-mailbox guard still binds — each mailbox's own daily cap and hourly ceiling gated it into the set, and the min-gap plus conflict resolution space its own sends.
- The flat ±20 minute jitter was wider than the interval it was perturbing whenever the pool paced tighter than 40 minutes apart, so the negative half landed the slot in the past, `notBefore` clamped it to a few seconds from now, and the day's spread collapsed onto the mailbox min-gap. Repeated live runs produced slots of 9s / 23s / 48s where ~14 min was intended. It is now scaled to half the distance to the slot, capped at the original 20 minutes.

**Dashboard**

- A window ending at 1440 renders `midnight`, not `12pm` — a full day read as "12am–12pm" and looked like sending stopped at noon.
- The campaign lead strip uses the server's campaign-wide `lead_counts` (already returned by the search endpoint, previously ignored) instead of counting the 50 loaded rows. That is why a 57-lead campaign showed "Queued 50, Done 0".
- Channel state moves out of a `useRef` into React state. `getChannelState` read the ref during render, so nothing re-rendered when the channel actually joined and the panel sat on its first-paint value — a live campaign reading `Disconnected` forever.

## Verification

- `make lint` (including `check-migrations`), `gofmt -l` clean, full `go test ./...`
- Every `-run Live` suite against dev Postgres, including three new regressions in `internal/tasks/campaign_stall_live_test.go`: a deferred tick does not park the campaign for days, a lead added to a parked campaign sends on the next tick, and the reconciler pulls a stale park forward. The last one also healed the two genuinely-stuck sandbox campaigns when it ran.
- Unit coverage for the defer cap and pool pacing in `internal/scheduler/pacing_test.go`.
- `pnpm typecheck` and `pnpm lint` in `web/` and `docs/`, no new warnings.
- End-to-end simulation of the reporter's exact configuration (Asia/Kolkata full-day windows, three UTC mailboxes on their profile, 57 leads, 4 steps) driving the real tick loop: 8 sends over 12 ticks with 1–12 minute gaps, versus zero before.

`docs/content/docs/guides/campaigns.mdx` updated for the pool-wide pacing, the re-check horizon, and leads added to a running campaign.