### PR TITLE
fix: adding a contact to a campaign actually creates the lead and shows it on the Leads tab

### DIFF
--- a/internal/app/contact/import.go
+++ b/internal/app/contact/import.go
@@ -533,7 +533,7 @@ func optString(incoming, fallback string) *string {
 }
 
 // parseLocalCategoryIDs is the import-package twin of pg_contact's
-// parseCategoryIDs. Kept private and small so we don't depend on the
+// parseUUIDList. Kept private and small so we don't depend on the
 // repository package's internals.
 func parseLocalCategoryIDs(raw []string) ([]uuid.UUID, *errx.Error) {
 	if len(raw) == 0 {

--- a/internal/repository/contact_campaign_live_test.go
+++ b/internal/repository/contact_campaign_live_test.go
@@ -1,0 +1,261 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Regression cover for issue #187: adding a contact to a campaign silently did
+// nothing whenever the campaign had been created by a different member of the
+// same organization. Campaign membership was matched on campaigns.user_id, so
+// the INSERT selected no rows, the API answered 200 with the contact's campaign
+// list rendered through the same user filter, and nothing reached the Leads tab.
+//
+// Campaigns are organization assets. Every path below is exercised as the
+// teammate who did NOT create the campaign.
+//
+// Run against the dev stack:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveContactCampaign -v
+
+func liveContactDB(t *testing.T) (*db.DB, *pgxpool.Pool) {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	if err := handle.Ping(context.Background()); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	return handle, handle.Pool
+}
+
+// sharedOrgFixture is one organization with two members: `owner` created the
+// campaign, `mate` is the teammate acting on it.
+type sharedOrgFixture struct {
+	org      uuid.UUID
+	owner    uuid.UUID
+	mate     uuid.UUID
+	campaign uuid.UUID
+	other    uuid.UUID
+	contact  uuid.UUID
+}
+
+func newSharedOrgFixture(t *testing.T, pool *pgxpool.Pool) *sharedOrgFixture {
+	t.Helper()
+	ctx := context.Background()
+	f := &sharedOrgFixture{
+		org:      uuid.New(),
+		owner:    uuid.New(),
+		mate:     uuid.New(),
+		campaign: uuid.New(),
+		other:    uuid.New(),
+		contact:  uuid.New(),
+	}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	for _, u := range []struct {
+		id   uuid.UUID
+		name string
+	}{{f.owner, "Owner"}, {f.mate, "Mate"}} {
+		exec(`INSERT INTO users (id, first_name, last_name, email, password_hash)
+		      VALUES ($1, $2, 'Live', $3, 'x')`,
+			u.id, u.name, "i187-"+u.id.String()[:8]+"@test.local")
+	}
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id)
+	      VALUES ($1, 'Issue 187', $2, $3)`, f.org, "i187-"+f.org.String()[:8], f.owner)
+	exec(`INSERT INTO organization_members (organization_id, user_id, role, accepted_at)
+	      VALUES ($1, $2, 'owner', NOW()), ($1, $3, 'admin', NOW())`, f.org, f.owner, f.mate)
+	// Both campaigns belong to the org but were created by the OWNER.
+	for _, c := range []struct {
+		id   uuid.UUID
+		name string
+	}{{f.campaign, "Agency partnerships"}, {f.other, "RevOps outreach"}} {
+		exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, days, updated_at, created_at)
+		      VALUES ($1, $2, $3, $4, '', 62, NOW(), NOW())`, c.id, f.owner, f.org, c.name)
+	}
+	exec(`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields, updated_at, created_at)
+	      VALUES ($1, $2, $3, $4, 'Carlos', 'Diaz', 'Pied Piper', '', '{}'::jsonb, NOW(), NOW())`,
+		f.contact, f.owner, f.org, "i187-"+f.contact.String()[:8]+"@test.local")
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM campaign_leads WHERE campaign_id IN (SELECT id FROM campaigns WHERE organization_id = $1)`, f.org},
+			{`DELETE FROM campaigns WHERE organization_id = $1`, f.org},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organization_members WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = ANY($1)`, []uuid.UUID{f.owner, f.mate}},
+		} {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+	return f
+}
+
+func campaignNames(t *testing.T, campaigns []models.MiniCampaign) []string {
+	t.Helper()
+	out := make([]string, 0, len(campaigns))
+	for _, c := range campaigns {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+func TestLiveContactCampaignMembershipIsOrganizationWide(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewContactRepostory(handle)
+	ctx := context.Background()
+	mate := f.mate.String()
+
+	// 1. The teammate adds the contact to a campaign they did not create.
+	updated, xerr := repo.Update(ctx, mate, f.contact.String(), f.org, &models.UpdateContact{
+		Campaigns: []string{f.campaign.String()},
+	})
+	if xerr != nil {
+		t.Fatalf("update: %v", xerr)
+	}
+	if got := campaignNames(t, updated.Campaigns); len(got) != 1 || got[0] != "Agency partnerships" {
+		t.Fatalf("response campaigns = %v, want [Agency partnerships]", got)
+	}
+	var leads int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM campaign_leads WHERE campaign_id = $1 AND contact_id = $2`,
+		f.campaign, f.contact).Scan(&leads); err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if leads != 1 {
+		t.Fatalf("campaign_leads rows = %d, want 1 (the add was a silent no-op)", leads)
+	}
+
+	// 2. The campaign Leads tab is this search scoped to the one campaign.
+	res, xerr := repo.Search(ctx, f.org.String(), nil, nil, models.SearchContacts{
+		CampaignIDs: []string{f.campaign.String()},
+	}, 25)
+	if xerr != nil {
+		t.Fatalf("search: %v", xerr)
+	}
+	if len(res.Data) != 1 || res.Data[0].ID != f.contact {
+		t.Fatalf("leads search returned %d rows, want the contact", len(res.Data))
+	}
+
+	// 3. The contact 360 shows the membership to the teammate too.
+	detail, xerr := repo.GetDetail(ctx, f.mate, &f.org, f.contact)
+	if xerr != nil {
+		t.Fatalf("detail: %v", xerr)
+	}
+	if got := campaignNames(t, detail.Campaigns); len(got) != 1 || got[0] != "Agency partnerships" {
+		t.Fatalf("detail campaigns = %v, want [Agency partnerships]", got)
+	}
+
+	// 4. An edit that does not mention campaigns keeps membership and reports it.
+	company := "Pied Piper Inc"
+	updated, xerr = repo.Update(ctx, mate, f.contact.String(), f.org, &models.UpdateContact{Company: &company})
+	if xerr != nil {
+		t.Fatalf("update company: %v", xerr)
+	}
+	if got := campaignNames(t, updated.Campaigns); len(got) != 1 {
+		t.Fatalf("campaigns after unrelated edit = %v, want the membership preserved", got)
+	}
+
+	// 5. The teammate can also move the contact between the owner's campaigns.
+	updated, xerr = repo.Update(ctx, mate, f.contact.String(), f.org, &models.UpdateContact{
+		Campaigns: []string{f.other.String()},
+	})
+	if xerr != nil {
+		t.Fatalf("update swap: %v", xerr)
+	}
+	if got := campaignNames(t, updated.Campaigns); len(got) != 1 || got[0] != "RevOps outreach" {
+		t.Fatalf("campaigns after swap = %v, want [RevOps outreach]", got)
+	}
+}
+
+func TestLiveContactCreatedIntoATeammatesCampaign(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewContactRepostory(handle)
+	ctx := context.Background()
+
+	added, xerr := repo.Add(ctx, f.mate.String(), f.org, []models.AddContact{{
+		FirstName: "New",
+		LastName:  "Lead",
+		Email:     "i187-new-" + f.org.String()[:8] + "@test.local",
+		Campaigns: []string{f.campaign.String()},
+	}})
+	if xerr != nil {
+		t.Fatalf("add: %v", xerr)
+	}
+	if len(added) != 1 {
+		t.Fatalf("added %d contacts, want 1", len(added))
+	}
+	if got := campaignNames(t, added[0].Campaigns); len(got) != 1 || got[0] != "Agency partnerships" {
+		t.Fatalf("new contact campaigns = %v, want [Agency partnerships]", got)
+	}
+
+	var leads int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM campaign_leads WHERE campaign_id = $1 AND contact_id = $2`,
+		f.campaign, added[0].ID).Scan(&leads); err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if leads != 1 {
+		t.Fatalf("campaign_leads rows = %d, want 1 (the new lead never reached the campaign)", leads)
+	}
+}
+
+func TestLiveContactBulkAddToATeammatesCampaign(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewContactRepostory(handle)
+	ctx := context.Background()
+
+	updated, xerr := repo.BulkUpdate(ctx, f.mate.String(), f.org, &models.BulkEditContactsData{
+		Contacts:     []string{f.contact.String()},
+		AddCampaigns: []string{f.campaign.String()},
+	})
+	if xerr != nil {
+		t.Fatalf("bulk update: %v", xerr)
+	}
+	if len(updated) != 1 {
+		t.Fatalf("bulk updated %d contacts, want 1", len(updated))
+	}
+	if got := campaignNames(t, updated[0].Campaigns); len(got) != 1 || got[0] != "Agency partnerships" {
+		t.Fatalf("bulk response campaigns = %v, want [Agency partnerships]", got)
+	}
+
+	var leads int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM campaign_leads WHERE campaign_id = $1 AND contact_id = $2`,
+		f.campaign, f.contact).Scan(&leads); err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if leads != 1 {
+		t.Fatalf("campaign_leads rows = %d, want 1", leads)
+	}
+}

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -83,11 +83,11 @@ func NewContactRepostory(db *db.DB) ContactRepository {
 	}
 }
 
-// parseCategoryIDs accepts string IDs from a JSON body and returns a
+// parseUUIDList accepts string IDs from a JSON body and returns a
 // deduped slice of uuid.UUIDs. Empty strings are skipped silently —
 // they're a normal artifact of clients sending [""] to "clear" a list.
 // A malformed (non-UUID) entry is a client bug worth surfacing as 400.
-func parseCategoryIDs(raw []string) ([]uuid.UUID, *errx.Error) {
+func parseUUIDList(raw []string) ([]uuid.UUID, *errx.Error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
@@ -261,7 +261,8 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 	// Link campaigns. Original code's RETURNING clause referenced a
 	// non-inserted table, which is invalid SQL; resolve by inserting
 	// first, then SELECTing the name back from `campaigns` in a
-	// separate statement. Scoped to the user's own campaigns.
+	// separate statement. Scoped to the organization's campaigns, not the
+	// caller's own: campaigns are org assets (issue #187).
 	for i, cids := range campaignIDs {
 		if len(cids) == 0 {
 			continue
@@ -270,9 +271,9 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			INSERT INTO campaign_leads (contact_id, campaign_id)
 			SELECT $1, c.id
 			FROM   campaigns c
-			WHERE  c.id = ANY($2) AND c.user_id = $3
+			WHERE  c.id = ANY($2) AND c.organization_id = $3
 			ON CONFLICT (campaign_id, contact_id) DO NOTHING
-		`, ncontacts[i].ID, cids, userID); err != nil {
+		`, ncontacts[i].ID, cids, orgID); err != nil {
 			db.CaptureError(err, "", nil, "campaign_leads insert")
 			return nil, errx.InternalError()
 		}
@@ -281,8 +282,8 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			SELECT c.id, c.name
 			FROM   campaigns c
 			JOIN   campaign_leads cl ON cl.campaign_id = c.id
-			WHERE  cl.contact_id = $1 AND c.user_id = $2
-		`, ncontacts[i].ID, userID)
+			WHERE  cl.contact_id = $1 AND c.organization_id = $2
+		`, ncontacts[i].ID, orgID)
 		if err != nil {
 			db.CaptureError(err, "", nil, "campaign_leads select")
 			return nil, errx.InternalError()
@@ -1285,17 +1286,16 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 					SELECT json_agg(json_build_object('id', cam.id, 'name', cam.name))
 					FROM campaign_leads cl2
 					JOIN campaigns cam ON cl2.campaign_id = cam.id
-					WHERE cl2.contact_id = c.id AND cam.user_id = $2
+					WHERE cl2.contact_id = c.id AND cam.organization_id = $2
 				),
 				'[]'::json
 			) AS campaigns
 		FROM contacts c
-		WHERE c.id = $1 AND c.organization_id = $3
+		WHERE c.id = $1 AND c.organization_id = $2
 		`
 
 	params := []any{
 		contactID,
-		userID,
 		orgID,
 	}
 
@@ -1420,111 +1420,99 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		updatedContact = c // No fields updated, use existing contact
 	}
 
-	// Update campaigns if provided
+	// Campaigns are organization assets: scoping membership by the caller made a
+	// teammate's add/remove a silent no-op on campaigns they did not create
+	// (issue #187).
 	if data.Campaigns != nil {
-		// Get current campaign IDs
+		want, perr := parseUUIDList(data.Campaigns)
+		if perr != nil {
+			return nil, perr
+		}
+		wantIDs := make([]string, len(want))
+		for i, id := range want {
+			wantIDs[i] = id.String()
+		}
+
 		currentCampaignIDs := make([]string, len(updatedContact.Campaigns))
 		for i, c := range updatedContact.Campaigns {
 			currentCampaignIDs[i] = c.ID
 		}
 
-		// Compute campaigns to insert and delete
-		toInsert := utils.Difference(data.Campaigns, currentCampaignIDs)
-		toDelete := utils.Difference(currentCampaignIDs, data.Campaigns)
+		toInsert := utils.Difference(wantIDs, currentCampaignIDs)
+		toDelete := utils.Difference(currentCampaignIDs, wantIDs)
 
-		// Delete removed campaigns
-		query = `
-			DELETE FROM campaign_leads
-			WHERE contact_id = $1 AND campaign_id = $2
-		`
-		for _, campaignID := range toDelete {
-			params := []any{
-				contactID,
-				campaignID,
-			}
-			_, err = tx.Exec(
-				ctx,
-				query,
-				params...,
-			)
-			if err != nil {
+		if len(toDelete) > 0 {
+			query = `
+				DELETE FROM campaign_leads cl
+				USING campaigns cam
+				WHERE cl.contact_id = $1
+				  AND cl.campaign_id = cam.id
+				  AND cam.id = ANY($2::uuid[])
+				  AND cam.organization_id = $3
+			`
+			params := []any{contactID, toDelete, orgID}
+			if _, err = tx.Exec(ctx, query, params...); err != nil {
 				db.CaptureError(err, query, params, "exec")
 				return nil, errx.InternalError()
 			}
 		}
 
-		// Insert new campaigns
-		query = `
-			INSERT INTO campaign_leads (contact_id, campaign_id)
-			SELECT $1, id
-			FROM campaigns
-			WHERE id = $2 AND user_id = $3
-			ON CONFLICT (campaign_id, contact_id) DO NOTHING
-		`
-		for _, campaignID := range toInsert {
-			params := []any{
-				contactID,
-				campaignID,
-				userID,
-			}
-			_, err = tx.Exec(
-				ctx,
-				query,
-				params...,
-			)
-			if err != nil {
+		if len(toInsert) > 0 {
+			query = `
+				INSERT INTO campaign_leads (contact_id, campaign_id)
+				SELECT $1, cam.id
+				FROM campaigns cam
+				WHERE cam.id = ANY($2::uuid[]) AND cam.organization_id = $3
+				ON CONFLICT (campaign_id, contact_id) DO NOTHING
+			`
+			params := []any{contactID, toInsert, orgID}
+			if _, err = tx.Exec(ctx, query, params...); err != nil {
 				db.CaptureError(err, query, params, "exec")
 				return nil, errx.InternalError()
 			}
 		}
+	}
 
-		// Fetch updated campaigns
-		var newCampaignsJSON []byte
+	// Always re-read campaigns so the response carries current membership even
+	// when the request touched other fields (a nil slice marshals to `null`,
+	// which the dashboard then caches and reads `.campaigns.map` off).
+	var newCampaignsJSON []byte
+	query = `
+		SELECT COALESCE(
+			(
+				SELECT json_agg(json_build_object('id', cam.id, 'name', cam.name))
+				FROM campaign_leads cl
+				JOIN campaigns cam ON cl.campaign_id = cam.id
+				WHERE cl.contact_id = $1 AND cam.organization_id = $2
+			),
+			'[]'::json
+		)
+	`
 
-		query = `
-			SELECT COALESCE(
-				(
-					SELECT json_agg(json_build_object('id', cam.id, 'name', cam.name))
-					FROM campaign_leads cl
-					JOIN campaigns cam ON cl.campaign_id = cam.id
-					WHERE cl.contact_id =$1 AND cam.user_id = $2
-				),
-				'[]'::json
-			)
-		`
+	params = []any{
+		contactID,
+		orgID,
+	}
 
-		params := []any{
-			contactID,
-			userID,
+	if err = tx.QueryRow(ctx, query, params...).Scan(&newCampaignsJSON); err != nil {
+		db.CaptureError(err, query, params, "queryrow")
+		return nil, errx.InternalError()
+	}
+	updatedContact.Campaigns = make([]models.MiniCampaign, 0)
+	if len(newCampaignsJSON) > 0 {
+		var campaigns []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
 		}
-
-		err = tx.QueryRow(
-			ctx,
-			query,
-			params...,
-		).Scan(&newCampaignsJSON)
-		if err != nil {
-			db.CaptureError(err, query, params, "queryrow")
+		if err := json.Unmarshal(newCampaignsJSON, &campaigns); err != nil {
+			sentry.CaptureException(err)
 			return nil, errx.InternalError()
 		}
-		if len(newCampaignsJSON) > 0 {
-			var campaigns []struct {
-				ID   string `json:"id"`
-				Name string `json:"name"`
-			}
-			if err := json.Unmarshal(newCampaignsJSON, &campaigns); err != nil {
-				sentry.CaptureException(err)
-				return nil, errx.InternalError()
-			}
-			updatedContact.Campaigns = make([]models.MiniCampaign, len(campaigns))
-			for i, c := range campaigns {
-				updatedContact.Campaigns[i] = models.MiniCampaign{
-					ID:   c.ID,
-					Name: c.Name,
-				}
-			}
-		} else {
-			updatedContact.Campaigns = make([]models.MiniCampaign, 0)
+		for _, c := range campaigns {
+			updatedContact.Campaigns = append(updatedContact.Campaigns, models.MiniCampaign{
+				ID:   c.ID,
+				Name: c.Name,
+			})
 		}
 	}
 
@@ -1534,7 +1522,7 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 	// When the absolute form is non-nil it wins; the diff is ignored.
 	categoriesChanged := false
 	if data.Categories != nil {
-		ids, perr := parseCategoryIDs(data.Categories)
+		ids, perr := parseUUIDList(data.Categories)
 		if perr != nil {
 			return nil, perr
 		}
@@ -1558,7 +1546,7 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		categoriesChanged = true
 	} else {
 		if len(data.AddCategories) > 0 {
-			ids, perr := parseCategoryIDs(data.AddCategories)
+			ids, perr := parseUUIDList(data.AddCategories)
 			if perr != nil {
 				return nil, perr
 			}
@@ -1575,7 +1563,7 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 			categoriesChanged = true
 		}
 		if len(data.RemoveCategories) > 0 {
-			ids, perr := parseCategoryIDs(data.RemoveCategories)
+			ids, perr := parseUUIDList(data.RemoveCategories)
 			if perr != nil {
 				return nil, perr
 			}
@@ -2028,11 +2016,14 @@ func (r *contactRepository) GetDetail(ctx context.Context, userID uuid.UUID, org
 	var campaignsJSON, categoriesJSON []byte
 	// Scope the contact row to the org so teammates can open each other's
 	// contacts. Without an org (e.g. an API key with no selected org) fall
-	// back to the legacy user scope. The campaign/category badge subselects
-	// stay user-scoped (categories has no organization_id column).
+	// back to the legacy user scope. Campaigns are org assets, so the badge
+	// subselect follows the same scope (issue #187); the category subselect
+	// stays user-scoped because categories has no organization_id column.
 	rowScope := "c.user_id = $1"
+	campScope := "cam.user_id = $1"
 	if orgID != nil {
 		rowScope = "c.organization_id = $3"
+		campScope = "cam.organization_id = $3"
 	}
 	mainQuery := fmt.Sprintf(`
 		SELECT
@@ -2043,7 +2034,7 @@ func (r *contactRepository) GetDetail(ctx context.Context, userID uuid.UUID, org
 					SELECT json_agg(json_build_object('id', cam.id, 'name', cam.name))
 					FROM   campaign_leads cl
 					JOIN   campaigns cam ON cam.id = cl.campaign_id
-					WHERE  cl.contact_id = c.id AND cam.user_id = $1
+					WHERE  cl.contact_id = c.id AND %s
 				), '[]'::json
 			) AS campaigns,
 			COALESCE(
@@ -2056,7 +2047,7 @@ func (r *contactRepository) GetDetail(ctx context.Context, userID uuid.UUID, org
 			) AS categories
 		FROM contacts c
 		WHERE c.id = $2 AND %s
-	`, rowScope)
+	`, campScope, rowScope)
 	mainArgs := []any{userID, contactID}
 	if orgID != nil {
 		mainArgs = append(mainArgs, *orgID)

--- a/web/src/components/app/contacts/AddFromContactsDialog.tsx
+++ b/web/src/components/app/contacts/AddFromContactsDialog.tsx
@@ -9,7 +9,6 @@
 
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { useQueryClient } from "@tanstack/react-query";
 import {
     AlertCircleIcon,
     CheckIcon,
@@ -46,7 +45,6 @@ function displayName(c: Contact): string {
 }
 
 export default function AddFromContactsDialog({ open, onClose, campaign }: Props) {
-    const queryClient = useQueryClient();
     const bulk = useUpdateContactsBulk();
 
     const [query, setQuery] = React.useState("");
@@ -153,8 +151,6 @@ export default function AddFromContactsDialog({ open, onClose, campaign }: Props
                 remove_campaigns: [],
                 fields: [],
             });
-            // The Leads tab is a contacts search scoped to this campaign.
-            await queryClient.invalidateQueries({ queryKey: ["contacts"] });
             toast.success(`Added ${selected.size} lead${selected.size === 1 ? "" : "s"} to ${campaign.name}`);
             onClose();
         } catch (err) {

--- a/web/src/lib/api/hooks/app/contacts/campaignMembership.test.tsx
+++ b/web/src/lib/api/hooks/app/contacts/campaignMembership.test.tsx
@@ -1,0 +1,171 @@
+// Issue #187: adding a contact to a campaign left the campaign Leads tab showing
+// the old, cached result set. The Leads tab is a ["contacts","list"] search scoped
+// to one campaign, so a contact that has just joined the campaign has no row in it
+// to patch: the query has to refetch. These tests drive the real hooks against a
+// fake API and assert the list ends up holding the new lead.
+
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { QueryClient, QueryClientProvider, type InfiniteData } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type Contact from "@/lib/api/models/app/contacts/Contact";
+import type SearchContacts from "@/lib/api/models/app/contacts/SearchContacts";
+import type SearchContactsResult from "@/lib/api/models/app/contacts/SearchContactsResult";
+
+const searchContacts = vi.fn();
+const updateContactsBulk = vi.fn();
+const updateContact = vi.fn();
+const addContacts = vi.fn();
+
+vi.mock("@/lib/api/client/app/contacts/searchContacts", () => ({
+    default: (...args: unknown[]) => searchContacts(...args),
+}));
+vi.mock("@/lib/api/client/app/contacts/updateContactsBulk", () => ({
+    default: (...args: unknown[]) => updateContactsBulk(...args),
+}));
+vi.mock("@/lib/api/client/app/contacts/updateContact", () => ({
+    default: (...args: unknown[]) => updateContact(...args),
+}));
+vi.mock("@/lib/api/client/app/contacts/addContacts", () => ({
+    default: (...args: unknown[]) => addContacts(...args),
+}));
+
+const useSearchContacts = (await import("./useSearchContacts")).default;
+const useUpdateContactsBulk = (await import("./useUpdateContactsBulk")).default;
+const useUpdateContact = (await import("./useUpdateContact")).default;
+const useAddContacts = (await import("./useAddContacts")).default;
+
+const CAMPAIGN = { id: "camp-1", name: "Agency partnerships" };
+const CONTACT_ID = "contact-1";
+
+function contact(campaigns: { id: string; name: string }[]): Contact {
+    return {
+        id: CONTACT_ID,
+        first_name: "Carlos",
+        last_name: "Diaz",
+        email: "carlos.diaz@piedpiper.test",
+        company: "Pied Piper",
+        phone: "",
+        custom_fields: {},
+        subscribed: true,
+        campaigns,
+        categories: [],
+        updated_at: new Date(),
+        created_at: new Date(),
+    };
+}
+
+function page(data: Contact[]): SearchContactsResult {
+    return { data, pagination: { total: data.length, next_cursor: null, has_more: false } };
+}
+
+// The Leads tab's search: every contact in this one campaign.
+const leadsOptions: SearchContacts = {
+    query: "",
+    filters: [],
+    campaign_ids: [CAMPAIGN.id],
+    sort_by: "created_at",
+    reverse: false,
+};
+
+function wrapper(client: QueryClient) {
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+        return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    };
+}
+
+// Renders the Leads tab search, waits for the first (empty) result, then runs
+// `act` and reports what the list holds once the mutation has settled.
+async function leadsAfter(
+    client: QueryClient,
+    useMutationHook: () => { mutateAsync: (v: never) => Promise<unknown> },
+    payload: unknown,
+) {
+    const leads = renderHook(() => useSearchContacts({ options: leadsOptions }), {
+        wrapper: wrapper(client),
+    });
+    await waitFor(() => expect(leads.result.current.isSuccess).toBe(true));
+    expect(leads.result.current.contacts).toEqual([]);
+
+    const mutation = renderHook(() => useMutationHook(), { wrapper: wrapper(client) });
+    await mutation.result.current.mutateAsync(payload as never);
+
+    await waitFor(() => expect(leads.result.current.contacts).toHaveLength(1));
+    return leads.result.current.contacts;
+}
+
+describe("adding a contact to a campaign refreshes the campaign Leads tab", () => {
+    let client: QueryClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        client = new QueryClient({
+            defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+        });
+        // The lead is not in the campaign on the first read and is on every read
+        // after the mutation, so a stale list is visibly different from a fresh one.
+        let added = false;
+        searchContacts.mockImplementation(async () => page(added ? [contact([CAMPAIGN])] : []));
+        updateContactsBulk.mockImplementation(async () => {
+            added = true;
+            return [contact([CAMPAIGN])];
+        });
+        updateContact.mockImplementation(async () => {
+            added = true;
+            return contact([CAMPAIGN]);
+        });
+        addContacts.mockImplementation(async () => {
+            added = true;
+            return [contact([CAMPAIGN])];
+        });
+    });
+
+    it("bulk edit (All contacts > Edit > Add to campaigns)", async () => {
+        const contacts = await leadsAfter(client, useUpdateContactsBulk, {
+            contacts: [CONTACT_ID],
+            add_campaigns: [CAMPAIGN.id],
+            remove_campaigns: [],
+            fields: [],
+        });
+        expect(contacts?.[0].id).toBe(CONTACT_ID);
+    });
+
+    it("single contact drawer (Details > Campaigns)", async () => {
+        const contacts = await leadsAfter(client, () => useUpdateContact(CONTACT_ID), {
+            campaigns: [CAMPAIGN.id],
+        });
+        expect(contacts?.[0].id).toBe(CONTACT_ID);
+    });
+
+    it("new contact created into the campaign", async () => {
+        const contacts = await leadsAfter(client, useAddContacts, [
+            { email: "carlos.diaz@piedpiper.test", campaigns: [CAMPAIGN.id] },
+        ]);
+        expect(contacts?.[0].id).toBe(CONTACT_ID);
+    });
+
+    it("the bulk mutation only resolves once the lists are fresh", async () => {
+        // AddFromContactsDialog closes and toasts on resolve, so the refetch has to
+        // be awaited by the mutation rather than raced with the dialog closing.
+        const leads = renderHook(() => useSearchContacts({ options: leadsOptions }), {
+            wrapper: wrapper(client),
+        });
+        await waitFor(() => expect(leads.result.current.isSuccess).toBe(true));
+        expect(searchContacts).toHaveBeenCalledTimes(1);
+
+        const mutation = renderHook(() => useUpdateContactsBulk(), { wrapper: wrapper(client) });
+        await mutation.result.current.mutateAsync({
+            contacts: [CONTACT_ID],
+            add_campaigns: [CAMPAIGN.id],
+            remove_campaigns: [],
+            fields: [],
+        });
+
+        // Refetched (not merely marked stale) before the mutation settled.
+        expect(searchContacts).toHaveBeenCalledTimes(2);
+        const cached = client.getQueriesData<InfiniteData<SearchContactsResult>>({
+            queryKey: ["contacts", "list"],
+        });
+        expect(cached.flatMap(([, d]) => d?.pages.flatMap((p) => p.data) ?? [])).toHaveLength(1);
+    });
+});

--- a/web/src/lib/api/hooks/app/contacts/useAddContacts.ts
+++ b/web/src/lib/api/hooks/app/contacts/useAddContacts.ts
@@ -8,9 +8,13 @@ export default function useAddContacts() {
     return useMutation({
         mutationFn: (contacts: AddContact[]) => addContacts(contacts),
         onSuccess: () => {
-            queryClient.invalidateQueries({
-                queryKey: ["contacts", "list"]
-            })
+            // The campaign Leads tab is a ["contacts","list"] search scoped to one
+            // campaign, so a lead created there needs the list refetched, and
+            // ["campaigns"] carries the counts that just moved.
+            return Promise.all([
+                queryClient.invalidateQueries({ queryKey: ["contacts", "list"] }),
+                queryClient.invalidateQueries({ queryKey: ["campaigns"] }),
+            ])
         }
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useContact.ts
+++ b/web/src/lib/api/hooks/app/contacts/useContact.ts
@@ -1,9 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import getContact from "@/lib/api/client/app/contacts/getContact";
 
-// Fetches the hydrated contact 360 payload. Keyed under
-// ["contacts", id] so useUpdateContact's existing cache write keeps
-// the slide-over Overview tab in sync after a save.
+// Fetches the hydrated contact 360 payload. Keyed under the ["contacts"]
+// prefix, so a contact mutation's invalidation keeps the slide-over Overview
+// tab in sync after a save.
 export default function useContact(id: string, enabled = true) {
     return useQuery({
         queryKey: ["contacts", id, "detail"],

--- a/web/src/lib/api/hooks/app/contacts/useDeleteContacts.ts
+++ b/web/src/lib/api/hooks/app/contacts/useDeleteContacts.ts
@@ -1,6 +1,5 @@
 import deleteContacts from "@/lib/api/client/app/contacts/deleteContacts";
-import type SearchContactsResult from "@/lib/api/models/app/contacts/SearchContactsResult";
-import { useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function useDeleteContacts() {
     const queryClient = useQueryClient();
@@ -8,32 +7,18 @@ export default function useDeleteContacts() {
     return useMutation({
         mutationFn: (contact_ids: string[]) => deleteContacts(contact_ids),
         onSuccess: (_, contact_ids) => {
-            const allLists = queryClient.getQueriesData<InfiniteData<SearchContactsResult>>({
-                queryKey: ["campaigns", "list"],
-            });
-
-            for (const [key, oldData] of allLists) {
-                if (!oldData) continue;
-
-                queryClient.setQueryData(key, {
-                    ...oldData,
-                    pages: oldData.pages.map((page) => ({
-                        ...page,
-                        data: page.data.filter((c) => !contact_ids.includes(c.id)),
-                    })),
-                });
-            }
-
             contact_ids.forEach(id => {
                 queryClient.invalidateQueries({
                     queryKey: ["contacts", id]
                 });
             });
             // The contacts table reads ["contacts","list",...]; refresh it so the
-            // deleted rows disappear without a manual reload.
-            queryClient.invalidateQueries({
-                queryKey: ["contacts", "list"]
-            });
+            // deleted rows disappear without a manual reload. ["campaigns"] carries
+            // the lead counts the deleted contacts were part of.
+            return Promise.all([
+                queryClient.invalidateQueries({ queryKey: ["contacts", "list"] }),
+                queryClient.invalidateQueries({ queryKey: ["campaigns"] }),
+            ]);
         }
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useUpdateContact.ts
+++ b/web/src/lib/api/hooks/app/contacts/useUpdateContact.ts
@@ -1,5 +1,4 @@
 import updateContact from "@/lib/api/client/app/contacts/updateContact";
-import type Contact from "@/lib/api/models/app/contacts/Contact";
 import type ContactUpdate from "@/lib/api/models/app/contacts/ContactUpdate";
 import type SearchContactsResult from "@/lib/api/models/app/contacts/SearchContactsResult";
 import { useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
@@ -26,10 +25,13 @@ export default function useUpdateContact(id: string) {
                 });
             }
 
-            queryClient.setQueryData<Contact>(
-                ["contacts", id],
-                data
-            );
+            // Patching rewrites rows a list already holds; campaign membership
+            // decides which lists hold the contact at all (the Leads tab is this
+            // search scoped to one campaign), so they must refetch (issue #187).
+            return Promise.all([
+                queryClient.invalidateQueries({ queryKey: ["contacts"] }),
+                queryClient.invalidateQueries({ queryKey: ["campaigns"] }),
+            ]);
         }
     })
 }

--- a/web/src/lib/api/hooks/app/contacts/useUpdateContactsBulk.ts
+++ b/web/src/lib/api/hooks/app/contacts/useUpdateContactsBulk.ts
@@ -1,41 +1,22 @@
 import updateContactsBulk from "@/lib/api/client/app/contacts/updateContactsBulk";
 import type BulkEditContacts from "@/lib/api/models/app/contacts/BulkEditContacts";
-import type SearchContactsResult from "@/lib/api/models/app/contacts/SearchContactsResult";
-import { useMutation, useQueryClient, type InfiniteData } from "@tanstack/react-query";
-import type Contact from "@/lib/api/models/app/contacts/Contact";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 export default function useUpdateContactsBulk() {
     const queryClient = useQueryClient();
 
     return useMutation({
         mutationFn: (options: BulkEditContacts) => updateContactsBulk(options),
-        onSuccess: (data) => {
-            const allLists = queryClient.getQueriesData<InfiniteData<SearchContactsResult>>({
-                queryKey: ["campaigns", "list"],
-            });
-
-            for (const [key, oldData] of allLists) {
-                if (!oldData) continue;
-
-                queryClient.setQueryData(key, {
-                    ...oldData,
-                    pages: oldData.pages.map((page) => ({
-                        ...page,
-                        data: page.data.map((c) => {
-                            const r = data.find(con => con.id === c.id);
-                            if (!r) return c;
-                            return r;
-                        }),
-                    })),
-                });
-            }
-
-            data.forEach(c => {
-                queryClient.setQueryData<Contact>(
-                    ["contacts", c.id],
-                    c,
-                );
-            })
-        }
-    })
+        // Membership moves rows in and out of result sets, so the campaign Leads
+        // tab (a ["contacts","list"] search scoped to one campaign) has no row to
+        // patch for a contact just added to it. Refetch the whole ["contacts"]
+        // prefix (lists plus the open 360), awaited so callers close on fresh
+        // data (issue #187).
+        onSuccess: () => {
+            return Promise.all([
+                queryClient.invalidateQueries({ queryKey: ["contacts"] }),
+                queryClient.invalidateQueries({ queryKey: ["campaigns"] }),
+            ]);
+        },
+    });
 }


### PR DESCRIPTION
Fixes #187.

Two independent bugs stacked on the same flow. Both reproduced against the dev stack before and after.

## 1. Backend: campaign membership was matched on `campaigns.user_id`

Campaigns are organization assets, but the contact write paths scoped them to the **caller**. When the campaign had been created by a different member of the same org, the `INSERT ... SELECT` matched no rows, so the API returned `200` having done nothing. Reproduced as a teammate (`manager@warmbly.local`) in the seeded demo org, where both campaigns belong to the owner:

```
PATCH /v1/contacts/:id {"campaigns":[<owner's campaign>]}
  -> response campaigns: []      db campaign_leads: unchanged
GET  /v1/contacts/:id
  -> campaigns: []               (the contact WAS in a campaign)
POST /v1/contacts [{campaigns:[...]}]
  -> response campaigns: []      never linked
```

`Update`, `Add` and the `GetDetail` badge subselect now scope on `organization_id`. Alongside that:

- the membership diff runs as one statement per direction instead of a round trip per campaign
- campaign ids are UUID-validated (`400` instead of a `500` on a malformed id), which also normalizes casing so an uppercase id no longer looks like a different campaign
- the response always re-reads membership, so an edit that touches only other fields no longer returns `campaigns: null` for the dashboard to cache and read `.map` off

`BulkUpdate` was already org-scoped and is unchanged.

## 2. Dashboard: the campaign Leads tab never refetched

This is the reporter's follow-up ("it adds the contact but in the campaign lead it is not seen in list, I have to search then it's seen").

The Leads tab is a `["contacts","list"]` search scoped to one campaign, with a 5 minute `staleTime`. `useUpdateContactsBulk` patched rows under `["campaigns","list"]`, a key that holds no contacts, and invalidated nothing. So the cached lead-less result survived, and typing in the search box only appeared to fix it because it produces a new query key.

Membership decides which lists hold a contact at all, so a patch-in-place can never insert the new row. Every contact mutation hook now invalidates `["contacts"]` and `["campaigns"]`, returned from `onSuccess` so `mutateAsync` resolves on fresh data (`AddFromContactsDialog` closes and toasts on resolve). Also removed a dead `setQueryData(["contacts", id])` write, since the contact 360 lives under `["contacts", id, "detail"]`, and the now-redundant manual invalidate in `AddFromContactsDialog`.

## Verification

- **End to end over HTTP as a non-creator teammate**, native backend on an isolated database: add to a teammate's campaign, Leads search shows it, contact 360 shows it, remove works, unrelated edit preserves it, new contact created into it, bulk add. All pass on this branch; the pre-fix equivalents all fail against `main`.
- `internal/repository/contact_campaign_live_test.go`: 3 `TestLiveContact*` cases against real SQL. Two fail on pre-fix code; the third covers `BulkUpdate`, which was already correct, so it passes on both.
- `web/src/lib/api/hooks/app/contacts/campaignMembership.test.tsx`: 4 cases driving the real hooks against a fake API. Three fail on the pre-fix hooks; the fourth covers `useAddContacts`, which already invalidated, so it passes on both.
- `make lint`, `gofmt -l` clean, `go test -race ./...` (54 packages), `pnpm lint`, `pnpm typecheck`, `pnpm test:run`.
- Re-ran every gate plus the full end-to-end pass after rebasing onto #190, whose `CampaignWaker` seam sits on these same add/update/bulk paths.

No migration. No docs change: the docs never described the creator-scoped behavior, so this restores what they already say.

## Out of scope, found while reading the same file

Two adjacent defects deliberately left alone, happy to file them:

1. `Search` binds the categories subquery to the org id (`cat.user_id = $orgID`), so the contacts list never returns categories. Proved against the dev database: the same row returns `[]` with the org id and `["Lead"]` with the user id.
2. `ListSentEmails` and `ListTimeline` filter campaigns by `cam.user_id`, so a contact's activity from a teammate's campaign is invisible on the 360 timeline.
