### PR TITLE
fix: stop banning a warmup recipient for the foldering we ordered, and create the Warmbly folder inside the server's IMAP namespace (#186)

### DIFF
--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -223,6 +223,11 @@ func (s *JobsService) performWarmupActions(ctx context.Context, e *models.JobEve
 	if len(immediate) > 0 {
 		act := base
 		act.Actions = immediate
+		// Mark BEFORE publishing: the move can land, and its removal be
+		// observed, before a marker written afterwards would exist.
+		if hasAction(immediate, "move_to_warmbly") {
+			s.markSelfMove(ctx, e.Message.EmailID, e.Message.MessageID)
+		}
 		s.Publisher.PublishWarmupAction(ctx, *workerID, &act)
 	}
 

--- a/internal/app/consumer/event_remove_email.go
+++ b/internal/app/consumer/event_remove_email.go
@@ -3,6 +3,8 @@ package jobs
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
 )
@@ -18,7 +20,16 @@ import (
 func (s *JobsService) HandleRemoveEmail(ctx context.Context, e *models.JobEventRemoveEmail) error {
 	if s.WarmupRepo != nil {
 		if rec, _ := s.WarmupRepo.GetWarmupReceived(ctx, e.EmailID, e.ID); rec != nil {
-			if s.WarmupService != nil {
+			switch {
+			case s.consumeSelfMove(ctx, e.EmailID, rec.MessageID):
+				// Our own engagement foldered this message. Providers that
+				// report a move as a removal (Graph) would otherwise ban the
+				// recipient for the action we asked it to perform.
+				log.Debug().
+					Str("email_id", e.EmailID.String()).
+					Str("message_id", rec.MessageID).
+					Msg("Warmup message left its folder because we moved it; not tampering")
+			case s.WarmupService != nil:
 				health, _ := s.WarmupService.RecordTampering(ctx, e.EmailID, rec.MessageID, "deletion")
 				s.markRiskBandFromWarmupHealth(ctx, e.EmailID, health)
 			}

--- a/internal/app/consumer/warmup_engagement.go
+++ b/internal/app/consumer/warmup_engagement.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"sync"
@@ -173,4 +174,50 @@ func humanizeFireAt(fireAt time.Time, timezone string) time.Time {
 	}
 	offset := time.Duration(rand.Intn(120))*time.Minute + time.Duration(rand.Intn(60))*time.Second
 	return morning.Add(offset)
+}
+
+// selfMoveTTL bounds how long a pending self-move marker is trusted. The move
+// is published immediately and the provider delta reports it within a sync
+// tick, so this only has to outlive that gap; keeping it short means a real
+// deletion later on is still counted.
+const selfMoveTTL = 30 * time.Minute
+
+func selfMoveKey(accountID uuid.UUID, rfcMessageID string) string {
+	return fmt.Sprintf("warmup:selfmoved:%s:%s", accountID, rfcMessageID)
+}
+
+// markSelfMove records that OUR OWN engagement is about to move this warmup
+// message out of the folder it was delivered to. Graph reports a move as a
+// removal exactly like a delete, so without this the recipient is banned from
+// the pool for foldering the platform itself asked for.
+func (s *JobsService) markSelfMove(ctx context.Context, accountID uuid.UUID, rfcMessageID string) {
+	if s.Cache == nil || rfcMessageID == "" {
+		return
+	}
+	_ = s.Cache.Set(ctx, selfMoveKey(accountID, rfcMessageID), "1", selfMoveTTL).Err()
+}
+
+// consumeSelfMove reports whether this removal is the one our own move caused,
+// clearing the marker so only the FIRST removal is excused and a later real
+// deletion still counts. A cache error answers true on purpose: a permanent
+// warmup ban is not something to hand out on a Redis hiccup.
+func (s *JobsService) consumeSelfMove(ctx context.Context, accountID uuid.UUID, rfcMessageID string) bool {
+	if s.Cache == nil || rfcMessageID == "" {
+		return false
+	}
+	n, err := s.Cache.Del(ctx, selfMoveKey(accountID, rfcMessageID)).Result()
+	if err != nil {
+		return true
+	}
+	return n > 0
+}
+
+// hasAction reports whether the leg contains a given warmup action.
+func hasAction(actions []string, want string) bool {
+	for _, a := range actions {
+		if a == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -54,6 +54,10 @@ type Client struct {
 	// holding mu while warmup actions select under it.
 	selected atomic.Bool
 
+	// nsPrefix caches this connection's personal-namespace prefix (nil until
+	// resolved, "" when the server puts user folders at the root). Guarded by mu.
+	nsPrefix *string
+
 	// BindIP optionally pins outbound TCP to a specific local source address.
 	// When nil, WORKER_BIND_IP is consulted; when still unset, the OS default
 	// route is used.

--- a/internal/client/smtpimap/imap/warmup_actions.go
+++ b/internal/client/smtpimap/imap/warmup_actions.go
@@ -67,11 +67,41 @@ func (c *Client) MoveToFolder(ctx context.Context, sourceMailbox, dstFolder stri
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if err := c.ensureMailboxExists(dstFolder); err != nil {
+	dst := c.qualifyMailboxLocked(dstFolder)
+	if err := c.ensureMailboxExists(dst); err != nil {
 		return err
 	}
 
-	return c.moveUIDLocked(sourceMailbox, dstFolder, uid)
+	return c.moveUIDLocked(sourceMailbox, dst, uid)
+}
+
+// personalPrefixLocked is the prefix this server keeps user folders under. It
+// is "" almost everywhere, but Dovecot is commonly configured with "INBOX.",
+// where creating a folder at the root fails with "nonexistent namespace" and
+// the Warmbly foldering silently never happens. Cached per connection; a
+// server without NAMESPACE keeps the root. mu must be held.
+func (c *Client) personalPrefixLocked() string {
+	if c.nsPrefix != nil {
+		return *c.nsPrefix
+	}
+	prefix := ""
+	if c.client.Caps().Has(imap.CapNamespace) {
+		if data, err := c.client.Namespace().Wait(); err == nil && data != nil && len(data.Personal) > 0 {
+			prefix = data.Personal[0].Prefix
+		}
+	}
+	c.nsPrefix = &prefix
+	return prefix
+}
+
+// qualifyMailboxLocked puts a bare folder name inside the personal namespace,
+// leaving a name that already carries the prefix untouched. mu must be held.
+func (c *Client) qualifyMailboxLocked(name string) string {
+	prefix := c.personalPrefixLocked()
+	if prefix == "" || strings.HasPrefix(name, prefix) {
+		return name
+	}
+	return prefix + name
 }
 
 func (c *Client) moveUID(ctx context.Context, src, dst string, uid uint32) error {


### PR DESCRIPTION
Fixes #186.

Two commits, one per bug in the issue.

**The self-inflicted ban.** `engagementPlan` always appends `move_to_warmbly`; on Graph that move is reported as a removal, `HandleRemoveEmail` counted it as `kind="deletion"`, and `warmupTamperingBlockThreshold = 1` banned the mailbox on its first warmup email. The consumer now marks the message before publishing the leg that carries the move, and consumes that marker in `HandleRemoveEmail`.

The marker is single-use and expires in 30 minutes, so only the removal our own move produces is excused and a later real deletion still counts. It is marked before publishing, because the move can land and be observed before a marker written afterwards would exist. A cache error answers "ours" deliberately: a permanent ban is not worth handing out on a Redis hiccup.

**The Dovecot namespace.** `ensureMailboxExists` created the folder at the root, which Dovecot refuses when its personal namespace is `INBOX.`:

```
create mailbox "Warmbly": imap: NO Client tried to access nonexistent namespace.
(Mailbox name should probably be prefixed with: INBOX.)
```

Every foldering action failed there, silently. The prefix now comes from `NAMESPACE` (cached per connection, gated on `imap.CapNamespace`), and falls back to the root when the server does not advertise it.

Rebased onto current main, so this sits on top of #182. The only overlap was the `Client` struct, where `selected` and `nsPrefix` are independent fields and both are kept.

`gofmt -l`, `go build ./...`, `go vet ./internal/...`, `golangci-lint v1.64.8 ./internal/...` and `scripts/check-migrations.sh` are clean. `internal/client/smtpimap/...` and `internal/app/worker/wmail/...` tests pass, including the ones #182 added.
