### PR TITLE
fix: Graph rescues a message from Junk that was never in Junk, undoing the Warmbly foldering and re-ingesting the message

### DIFF
--- a/internal/client/msgraph/actions.go
+++ b/internal/client/msgraph/actions.go
@@ -35,9 +35,59 @@ func (c *Client) AddFlag(ctx context.Context, messageID string) error {
 // RemoveFromSpam rescues a message out of Junk Email back into the Inbox.
 // Graph has no stable v1.0 "not junk" action (markAsNotJunk is retired), so the
 // move is the reliable primitive. Returns the message's new id (move is a
-// copy+delete, so the id changes).
+// copy+delete, so the id changes), or "" when the message was not in Junk and
+// nothing was moved.
+//
+// The Junk check is the point: engagementPlan runs move_to_warmbly first, so by
+// the time this runs the message is usually in the untracked Warmbly folder.
+// Moving it unconditionally would undo that foldering and drop it back into the
+// tracked Inbox under a new id, where live sync reads it as new mail. The IMAP
+// path guards the same way with IsSpamMailbox.
 func (c *Client) RemoveFromSpam(ctx context.Context, messageID string) (string, error) {
+	junkID, err := c.wellKnownFolderID(ctx, FolderJunk)
+	if err != nil {
+		return "", err
+	}
+	parentID, err := c.messageParentFolder(ctx, messageID)
+	if err != nil {
+		return "", err
+	}
+	if parentID != junkID {
+		return "", nil
+	}
 	return c.move(ctx, messageID, FolderInbox)
+}
+
+// wellKnownFolderID resolves a well-known folder name to the opaque id Graph
+// reports as a message's parentFolderId. The two are not interchangeable: the
+// name is accepted in a path, but never returned. Cached for the mailbox's life.
+func (c *Client) wellKnownFolderID(ctx context.Context, name string) (string, error) {
+	c.mu.Lock()
+	if id, ok := c.folderIDs[name]; ok {
+		c.mu.Unlock()
+		return id, nil
+	}
+	c.mu.Unlock()
+
+	var folder struct {
+		ID string `json:"id"`
+	}
+	if err := c.doJSON(ctx, "GET", graphBase+"/me/mailFolders/"+url.PathEscape(name)+"?$select=id", nil, &folder); err != nil {
+		return "", err
+	}
+	c.cacheFolder(name, folder.ID)
+	return folder.ID, nil
+}
+
+// messageParentFolder returns the id of the folder a message currently sits in.
+func (c *Client) messageParentFolder(ctx context.Context, messageID string) (string, error) {
+	var msg struct {
+		ParentFolderID string `json:"parentFolderId"`
+	}
+	if err := c.doJSON(ctx, "GET", c.messageURL(messageID)+"?$select=parentFolderId", nil, &msg); err != nil {
+		return "", err
+	}
+	return msg.ParentFolderID, nil
 }
 
 // MoveToFolder moves the message into a named folder, creating it if needed.

--- a/internal/client/msgraph/spam_rescue_test.go
+++ b/internal/client/msgraph/spam_rescue_test.go
@@ -1,0 +1,102 @@
+package msgraph
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// stubRT answers Graph calls from a canned table and records what was asked.
+type stubRT struct {
+	body  map[string]string // match on URL fragment -> JSON response
+	calls []string
+}
+
+func (s *stubRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	s.calls = append(s.calls, req.Method+" "+req.URL.Path)
+	for frag, body := range s.body {
+		if strings.Contains(req.URL.String(), frag) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       io.NopCloser(strings.NewReader(body)),
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+			}, nil
+		}
+	}
+	return &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+}
+
+func newStubClient(rt *stubRT) *Client {
+	return &Client{hc: &http.Client{Transport: rt}, folderIDs: map[string]string{}}
+}
+
+func (s *stubRT) moved() bool {
+	for _, c := range s.calls {
+		if strings.HasSuffix(c, "/move") {
+			return true
+		}
+	}
+	return false
+}
+
+// A message sitting in Junk is what the rescue exists for: it must move.
+func TestRemoveFromSpamMovesAMessageThatIsInJunk(t *testing.T) {
+	rt := &stubRT{body: map[string]string{
+		"/mailFolders/junkemail": `{"id":"JUNK_ID"}`,
+		"parentFolderId":         `{"parentFolderId":"JUNK_ID"}`,
+		"/move":                  `{"id":"NEW_ID"}`,
+	}}
+	newID, err := newStubClient(rt).RemoveFromSpam(context.Background(), "MSG")
+	if err != nil {
+		t.Fatalf("RemoveFromSpam: %v", err)
+	}
+	if !rt.moved() {
+		t.Error("a message in Junk must be moved to the Inbox")
+	}
+	if newID != "NEW_ID" {
+		t.Errorf("new id = %q, want NEW_ID", newID)
+	}
+}
+
+// The regression: engagementPlan folders into Warmbly first, so the rescue
+// usually runs against a message that is no longer in Junk. Moving it then
+// undoes the foldering and re-admits it to the tracked Inbox under a new id.
+func TestRemoveFromSpamLeavesAMessageThatIsNotInJunk(t *testing.T) {
+	rt := &stubRT{body: map[string]string{
+		"/mailFolders/junkemail": `{"id":"JUNK_ID"}`,
+		"parentFolderId":         `{"parentFolderId":"WARMBLY_ID"}`,
+		"/move":                  `{"id":"NEW_ID"}`,
+	}}
+	newID, err := newStubClient(rt).RemoveFromSpam(context.Background(), "MSG")
+	if err != nil {
+		t.Fatalf("RemoveFromSpam: %v", err)
+	}
+	if rt.moved() {
+		t.Error("a message outside Junk must not be moved: that undoes the Warmbly foldering")
+	}
+	if newID != "" {
+		t.Errorf("new id = %q, want empty (nothing moved)", newID)
+	}
+}
+
+// The well-known folder id is resolved once and cached, not re-fetched per call.
+func TestWellKnownFolderIDIsCached(t *testing.T) {
+	rt := &stubRT{body: map[string]string{"/mailFolders/junkemail": `{"id":"JUNK_ID"}`}}
+	c := newStubClient(rt)
+	for i := 0; i < 3; i++ {
+		if _, err := c.wellKnownFolderID(context.Background(), FolderJunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n := 0
+	for _, call := range rt.calls {
+		if strings.Contains(call, "junkemail") {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("junk folder resolved %d times, want 1 (cached)", n)
+	}
+}


### PR DESCRIPTION
Found while reviewing #198. Related to #194, whose first symptom this causes.

## The bug

`msgraph.RemoveFromSpam` moves unconditionally:

```go
func (c *Client) RemoveFromSpam(ctx context.Context, messageID string) (string, error) {
	return c.move(ctx, messageID, FolderInbox)
}
```

The IMAP path guards the same action (`if !imap.IsSpamMailbox(sourceBox.Name, sourceBox.Attrs) { continue }`), and `engagementPlan` says the guard is expected: "spam-rescue ... fires at the configured rate but only actually executes when the message really landed in spam (the worker guards this)". On Graph nothing guards it.

`engagementPlan` always appends `move_to_warmbly` first, then `remove_from_spam` at `SpamRescueRate` (default **85**), and `splitEngagementLegs` puts both in the same immediate leg, executed in order. So on Graph, for ~85% of warmup mail:

1. `move_to_warmbly` — Inbox to the **Warmbly** folder, which `ensureFolder` creates as a top-level folder
2. `remove_from_spam` — Warmbly back to **Inbox**, unconditionally

Two consequences:

**The foldering is undone.** The message ends in the Inbox, not in Warmbly. The organisational signal the folder exists for is discarded most of the time.

**The message is re-ingested as new mail.** `TrackedFolders` is `[inbox, junkemail, sentitems]`, so Warmbly is not followed. While the message sits there it is invisible to sync. Moving it back into the Inbox gives it a new id in a tracked folder, and `onGraphMessageSeen` dedupes on the Graph provider id, so it misses the map and is stored and emitted as `NEW_EMAIL`. Its warmup token was consumed on first delivery, so it is then recorded as an invalid-token attempt worth +5 spam score.

That last part is #194's first symptom. Worth noting the mechanism there is not quite right: `move_to_warmbly` alone cannot cause it, because it moves the message *out* of every tracked folder. It is this second move dragging it back in that does.

## The fix

Resolve the Junk folder's id once per connection and only move when the message is actually there. `RemoveFromSpam` returns `""` when it does not move, which the worker already handles (`if newID != "" { msgID = newID }`).

The well-known name and the opaque `parentFolderId` are not interchangeable, which is why the folder id has to be resolved rather than compared to `"junkemail"` directly.

Graph-only. Gmail applies a label and its ids are stable, and IMAP already guards.

## Tests

`TestRemoveFromSpamMovesAMessageThatIsInJunk`, `TestRemoveFromSpamLeavesAMessageThatIsNotInJunk`, `TestWellKnownFolderIDIsCached`, against a stub `http.Client` transport.

Verified the regression test actually catches the bug: with the guard reverted, `TestRemoveFromSpamLeavesAMessageThatIsNotInJunk` fails; with it restored, it passes.

`make fmt`, `make lint` (including `check-migrations`) and the tests for `internal/client/...`, `internal/app/worker/...` and `internal/app/consumer/...` are clean. No migration.

This does not close #194: the Message-ID dedupe and the Sent Items half are still worth doing, and @joaoppa offered to take that one.