### PR TITLE
fix: stop double-counting invalid warmup token attempts, and log the health evaluation failure that was being discarded (#195)

### DIFF
--- a/internal/app/warmup/service.go
+++ b/internal/app/warmup/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
@@ -481,7 +482,19 @@ func (s *service) ApplyInvalidTokenAttempt(ctx context.Context, accountID uuid.U
 			return nil, errx.InternalError()
 		}
 	}
-	return s.evaluateAndPersistAnyPool(ctx, accountID)
+	// The attempt and its score are already persisted, so a failed evaluation
+	// must not be reported as a failure of the whole call: the caller's
+	// degraded path records both a second time, which doubles every count the
+	// band then reads. Surface it instead and hand back the participant as it
+	// stands.
+	health, err := s.evaluateAndPersistAnyPool(ctx, accountID)
+	if err != nil {
+		log.Error().
+			Str("email_account_id", accountID.String()).
+			Msg("warmup: invalid-token health evaluation failed; the attempt is recorded but no band was applied")
+		return s.getParticipantForAnyPool(ctx, accountID)
+	}
+	return health, nil
 }
 
 func (s *service) ApplyRateLimitExceeded(ctx context.Context, accountID uuid.UUID, reason string) (*models.WarmupParticipantHealth, *errx.Error) {


### PR DESCRIPTION
Fixes #195.

`ApplyInvalidTokenAttempt` persists the attempt and its spam score before it evaluates, so returning an error when only the evaluation failed made the caller's degraded path in `applyInvalidWarmupAttempt` record both a second time. Every attempt was therefore counted twice, and the band that reads those counts never ran at all.

The evaluation failure is now non-fatal: it is logged and the participant is handed back as it stands, so the caller's fallback is reached only when the recording itself failed, which is what that path documents itself as being for.

The log matters as much as the fix. The error was discarded entirely, which is why an evaluation that never fires went unnoticed. On a live install a mailbox reached 36 invalid-token attempts in 24h against `invalidTokenBlockThreshold = 3`, with `last_health_evaluated_at` frozen at the last manual reset and `health_state` still `healthy`. I could not identify which repository call fails, because nothing records it; each of the queries `loadMetrics` issues returns fine when run by hand against that same row. With this in place the next occurrence names itself.

Worth noting for sequencing: on that install the counter was being fed almost entirely by messages the platform generated itself, through the paths fixed in #186, #193 (#201) and #194 (#199). With those in, the signal this band reads is a real one again, so making it fire is now the right thing rather than a way to start banning mailboxes on inflated counts.

`gofmt -l`, `go build ./...`, `go vet`, `golangci-lint v1.64.8 ./internal/...` and `internal/app/warmup` tests are clean.
