### PR TITLE
fix: stop the realtime socket rejoining a channel on every render (~400 joins/second from one open campaign page)

### DIFF
--- a/web/src/hooks/SocketProvider.tsx
+++ b/web/src/hooks/SocketProvider.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import type SocketProviderProps from "@/lib/socket/models/SocketProviderProps";
 import getSocket from '@/lib/api/client/app/socket/getSocket';
 import type { AppError } from '@/lib/api/client/normalizeError';
@@ -650,8 +650,13 @@ export default function SocketProvider({
         };
     }, [connect, stopHeartbeat]);
 
-    return (
-        <SocketContext.Provider value={{
+    // Memoised: an inline object is a new identity on every render, and
+    // channelStates re-renders this provider on every join. useChannel's effect
+    // depends on the context value, so the two together tore the channel down
+    // and rejoined it on every render (~400 joins/second on one open campaign
+    // page, enough to saturate the realtime service).
+    const value = useMemo(
+        () => ({
             isConnected,
             reconnectAttempt,
             joinChannel,
@@ -662,7 +667,23 @@ export default function SocketProvider({
             pushToChannel,
             subscribe,
             sendMessage,
-        }}>
+        }),
+        [
+            isConnected,
+            reconnectAttempt,
+            joinChannel,
+            leaveChannel,
+            getChannelState,
+            channelStates,
+            subscribeToChannel,
+            pushToChannel,
+            subscribe,
+            sendMessage,
+        ]
+    );
+
+    return (
+        <SocketContext.Provider value={value}>
             {children}
         </SocketContext.Provider>
     );

--- a/web/src/hooks/context/socket.tsx
+++ b/web/src/hooks/context/socket.tsx
@@ -72,18 +72,27 @@ export const useSocket = (): SocketContextValue => {
 // Hook to join a channel and subscribe to events
 export function useChannel(topic: string, params?: Record<string, unknown>) {
     const socket = useSocket();
+    const { joinChannel, leaveChannel, pushToChannel, channelStates } = socket;
+
+    // Depend on the two stable callbacks, never on the context value itself:
+    // channelStates re-renders the provider on every join, so an effect keyed on
+    // the whole socket left and rejoined the channel on every render.
+    // params is an object literal at its call sites, so key on its value.
+    const paramsKey = params ? JSON.stringify(params) : "";
+    const paramsRef = useRef(params);
+    paramsRef.current = params;
 
     useEffect(() => {
-        socket.joinChannel(topic, params);
+        joinChannel(topic, paramsRef.current);
         return () => {
-            socket.leaveChannel(topic);
+            leaveChannel(topic);
         };
-    }, [socket, topic, params]);
+    }, [joinChannel, leaveChannel, topic, paramsKey]);
 
     return {
-        state: socket.channelStates[topic] ?? "closed",
+        state: channelStates[topic] ?? "closed",
         push: (event: string, payload: Record<string, unknown>) =>
-            socket.pushToChannel(topic, event, payload),
+            pushToChannel(topic, event, payload),
     };
 }
 
@@ -94,7 +103,7 @@ export function useChannelEvent(
     handler: ChannelEventHandler,
     deps: React.DependencyList = []
 ) {
-    const socket = useSocket();
+    const { subscribeToChannel } = useSocket();
     const handlerRef = useRef(handler);
 
     // Update handler ref when it changes
@@ -102,15 +111,17 @@ export function useChannelEvent(
         handlerRef.current = handler;
     }, [handler]);
 
+    // Same reason as useChannel: subscribeToChannel is stable, the context value
+    // is not, so depending on the whole socket resubscribed on every render.
     useEffect(() => {
         const wrappedHandler: ChannelEventHandler = (payload) => {
             handlerRef.current(payload);
         };
 
-        const unsubscribe = socket.subscribeToChannel(topic, event, wrappedHandler);
+        const unsubscribe = subscribeToChannel(topic, event, wrappedHandler);
         return unsubscribe;
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [socket, topic, event, ...deps]);
+    }, [subscribeToChannel, topic, event, ...deps]);
 }
 
 // Convenience hook combining channel join and event subscription


### PR DESCRIPTION
One open campaign detail page issues about **400 channel joins per second**, which saturates the realtime service.

Measured on a self-hosted install with a single user and one browser tab open on a campaign page:

```
23,256  JOINED campaign:<id>   in 60 seconds
     1  JOINED user:<id>
     1  JOINED org:<id>

realtime   94.8% CPU        postgres   53.8% CPU     939 xact/s
load average 3.95 on a 2-core host
```

Closing that one tab:

```
realtime    0.24% CPU       postgres    0.38% CPU       2 xact/s
```

## Cause

`useChannel` owns the subscription in an effect keyed on the whole context value:

```ts
useEffect(() => {
    socket.joinChannel(topic, params);
    return () => { socket.leaveChannel(topic); };
}, [socket, topic, params]);
```

`SocketProvider` passes an inline object literal as that value, so it has a new identity on every render. On its own that was survivable, because nothing in the provider re-rendered on a join. #190 added `channelStates` as React state so a joined channel would stop rendering as "Disconnected" (#189), and that closed the cycle:

join → `channelStates` updates → provider re-renders → new context identity → effect re-runs → **cleanup leaves the channel** → joins again → repeat.

`joinChannel` already early-returns for a topic that is joined or joining, but that guard never helps here: the cleanup leaves first, so every pass starts from `closed`.

`useChannelEvent` has the same dependency (`[socket, topic, event, ...deps]`) and resubscribes on every render for the same reason.

## Fix

Two independent changes, both correct on their own terms:

- the provider's context value is memoised instead of being rebuilt inline;
- `useChannel` and `useChannelEvent` depend on the stable `joinChannel` / `leaveChannel` / `subscribeToChannel` callbacks (all `useCallback` with stable deps already) rather than on the context object, so a `channelStates` update no longer re-runs the effect that owns the subscription.

`params` is also keyed by value now: it is an object literal at the call sites, so it was a new identity on every render too, and would have kept the loop alive on any caller that passes one.

`pnpm typecheck` and `pnpm lint` are clean in `web/` (0 errors; the pre-existing warnings are untouched).
