### PR TITLE
fix: throttle channel joins on the realtime service, and make both clients handle a refused join without storming it

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -500,8 +500,11 @@ BILLING_PROVIDER=none
 # MAX_CONNECTIONS_PER_IP=50
 # MAX_CONNECTIONS_GLOBAL=100000
 
-# Websocket rate limits, per minute.
+# Websocket rate limits, per minute. Handshakes and channel joins have separate
+# budgets, so a reconnect storm cannot spend the budget a client then needs to
+# rejoin its topics with.
 # RATE_LIMIT_WS_MESSAGE=120
+# RATE_LIMIT_WS_CONNECT=30
 # RATE_LIMIT_WS_JOIN=30
 # RATE_LIMIT_WS_EVENT=60
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+      - name: Run tests
+        run: pnpm test:run
+
       - name: Build
         run: pnpm build
 

--- a/admin/package.json
+++ b/admin/package.json
@@ -9,7 +9,9 @@
     "typecheck": "tsc -b",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",
@@ -62,9 +64,11 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
     "globals": "^16.4.0",
+    "jsdom": "^27.4.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
-    "vite": "^7.3.6"
+    "vite": "^7.3.6",
+    "vitest": "^4.1.10"
   }
 }

--- a/admin/pnpm-lock.yaml
+++ b/admin/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       globals:
         specifier: ^16.4.0
         version: 16.5.0
+      jsdom:
+        specifier: ^27.4.0
+        version: 27.4.0
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
@@ -170,8 +173,23 @@ importers:
       vite:
         specifier: ^7.3.6
         version: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.11(@types/node@24.12.4)(jsdom@27.4.0)(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0))
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -255,6 +273,42 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.1':
+    resolution: {integrity: sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9':
+    resolution: {integrity: sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -449,6 +503,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -1166,6 +1229,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1292,6 +1358,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1377,6 +1449,35 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1391,6 +1492,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
@@ -1404,6 +1509,10 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1422,6 +1531,9 @@ packages:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
@@ -1445,6 +1557,10 @@ packages:
 
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1482,8 +1598,20 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
 
   date-fns@4.3.0:
     resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
@@ -1496,6 +1624,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1522,6 +1653,10 @@ packages:
     resolution: {integrity: sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A==}
     engines: {node: '>=10.13.0'}
 
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -1529,6 +1664,9 @@ packages:
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -1581,6 +1719,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -1604,9 +1743,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1732,9 +1878,21 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1766,6 +1924,9 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1779,6 +1940,15 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1887,6 +2057,10 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1901,6 +2075,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1952,6 +2129,10 @@ packages:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1968,6 +2149,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1975,6 +2159,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2078,6 +2265,10 @@ packages:
     resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2086,6 +2277,10 @@ packages:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -2110,6 +2305,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -2120,6 +2318,12 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -2127,6 +2331,9 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -2138,9 +2345,35 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.11:
+    resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
+
+  tldts@7.4.11:
+    resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2247,14 +2480,99 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2267,6 +2585,26 @@ packages:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2379,6 +2717,30 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.9(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -2503,6 +2865,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3157,6 +3521,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.4':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@standard-schema/utils@0.3.0': {}
 
   '@tailwindcss/node@4.3.0':
@@ -3262,6 +3628,13 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3384,6 +3757,47 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -3395,6 +3809,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -3413,6 +3829,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   asynckit@0.4.0: {}
 
   axios@1.18.1:
@@ -3430,6 +3848,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.32: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   brace-expansion@1.1.15:
     dependencies:
@@ -3456,6 +3878,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001793: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3490,13 +3914,32 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.9(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.5.2
+
   csstype@3.2.3: {}
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
 
   date-fns@4.3.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -3519,9 +3962,13 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  entities@8.0.0: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -3643,7 +4090,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -3745,9 +4198,29 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -3774,6 +4247,8 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   jiti@2.7.0: {}
@@ -3783,6 +4258,34 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@exodus/bytes': 1.15.1
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.21.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -3858,6 +4361,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3871,6 +4376,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
+
+  mdn-data@2.27.1: {}
 
   mime-db@1.52.0: {}
 
@@ -3908,6 +4415,8 @@ snapshots:
 
   node-releases@2.0.46: {}
 
+  obug@2.1.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3929,9 +4438,15 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -4015,6 +4530,8 @@ snapshots:
 
   react@19.2.6: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   rollup@4.60.4:
@@ -4048,6 +4565,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -4062,6 +4583,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   sonner@2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
@@ -4069,11 +4592,17 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
   strip-json-comments@3.1.1: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -4081,10 +4610,30 @@ snapshots:
 
   tapable@2.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@7.4.11: {}
+
+  tldts@7.4.11:
+    dependencies:
+      tldts-core: 7.4.11
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.11
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4156,11 +4705,65 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.32.0
 
+  vitest@4.1.11(@types/node@24.12.4)(jsdom@27.4.0)(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.1
+      vite: 7.3.6(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+      jsdom: 27.4.0
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  ws@8.21.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/admin/src/lib/realtime/socket.test.ts
+++ b/admin/src/lib/realtime/socket.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/api/client", () => ({
+    Request: vi.fn(async () => ({ url: "ws://localhost:4000/socket/websocket", expires_in: 600 })),
+}));
+
+import { startRealtime, stopRealtime, getStatus, onEvent } from "./socket";
+
+const TOPIC = "admin:platform";
+
+interface Frame {
+    topic: string;
+    event: string;
+    payload: Record<string, unknown>;
+    ref?: string;
+    join_ref?: string;
+}
+
+let sent: Frame[];
+let sockets: FakeWS[];
+
+class FakeWS {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    readyState = FakeWS.OPEN;
+    onopen: ((e: unknown) => void) | null = null;
+    onmessage: ((e: { data: string }) => void) | null = null;
+    onclose: ((e: unknown) => void) | null = null;
+    onerror: ((e: unknown) => void) | null = null;
+
+    constructor(public url: string) {
+        sockets.push(this);
+        setTimeout(() => this.onopen?.({}), 0);
+    }
+
+    send(data: string) {
+        const msg = JSON.parse(data) as Frame;
+        sent.push(msg);
+        // Answer heartbeats, or the zombie watchdog closes the socket and
+        // reconnects under every test that runs longer than 25s of fake time.
+        if (msg.topic === "phoenix" && msg.event === "heartbeat") {
+            setTimeout(() => {
+                this.onmessage?.({
+                    data: JSON.stringify({
+                        topic: "phoenix",
+                        event: "phx_reply",
+                        ref: msg.ref,
+                        payload: { status: "ok", response: {} },
+                    }),
+                });
+            }, 0);
+        }
+    }
+
+    close() {
+        if (this.readyState === FakeWS.CLOSED) return;
+        this.readyState = FakeWS.CLOSED;
+        this.onclose?.({ wasClean: true });
+    }
+}
+
+const joins = () => sent.filter((m) => m.event === "phx_join");
+const lastJoin = () => joins()[joins().length - 1];
+
+function deliver(msg: Record<string, unknown>) {
+    sockets[sockets.length - 1]?.onmessage?.({ data: JSON.stringify(msg) });
+}
+
+function refuseJoin(response: Record<string, unknown>) {
+    const join = lastJoin();
+    deliver({
+        topic: TOPIC,
+        event: "phx_reply",
+        ref: join.ref,
+        join_ref: join.join_ref,
+        payload: { status: "error", response },
+    });
+}
+
+function ackJoin() {
+    const join = lastJoin();
+    deliver({
+        topic: TOPIC,
+        event: "phx_reply",
+        ref: join.ref,
+        join_ref: join.join_ref,
+        payload: { status: "ok", response: {} },
+    });
+}
+
+const tick = (ms: number) => vi.advanceTimersByTimeAsync(ms);
+
+beforeEach(async () => {
+    sent = [];
+    sockets = [];
+    vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWS;
+    startRealtime();
+    await tick(10);
+});
+
+afterEach(() => {
+    stopRealtime();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+});
+
+describe("joining the admin channel", () => {
+    it("only reports connected once the channel is joined", async () => {
+        expect(getStatus()).toBe("connecting");
+
+        ackJoin();
+        expect(getStatus()).toBe("connected");
+    });
+
+    it("waits out a throttled join instead of tearing the socket down", async () => {
+        const socketsBefore = sockets.length;
+
+        refuseJoin({ code: 4007, reason: "rate_limited", retry_after_ms: 5000 });
+
+        // Same socket, no reconnect.
+        expect(sockets).toHaveLength(socketsBefore);
+        expect(joins()).toHaveLength(1);
+
+        await tick(4000);
+        expect(joins()).toHaveLength(1);
+
+        await tick(1500);
+        expect(joins()).toHaveLength(2);
+        expect(sockets).toHaveLength(socketsBefore);
+
+        ackJoin();
+        expect(getStatus()).toBe("connected");
+    });
+
+    it("does not storm the server when a join is refused for good", async () => {
+        // A non-admin (or any permanent refusal) used to reconnect on the
+        // 120ms floor forever, because the backoff reset on socket open.
+        for (let i = 0; i < 12; i++) {
+            if (lastJoin()) refuseJoin({ code: 4010, reason: "not_an_admin" });
+            await tick(5000);
+        }
+
+        // With the flat 120ms retry this window would be hundreds of attempts.
+        expect(joins().length).toBeLessThanOrEqual(12);
+        expect(sockets.length).toBeLessThanOrEqual(12);
+    });
+
+    it("gives up on a throttled join rather than retrying forever", async () => {
+        for (let i = 0; i < 20; i++) {
+            if (lastJoin()) refuseJoin({ reason: "rate_limited", retry_after_ms: 1000 });
+            await tick(2000);
+        }
+
+        expect(joins().length).toBeLessThanOrEqual(9);
+        expect(getStatus()).toBe("disconnected");
+    });
+
+    it("clamps an absurd retry hint", async () => {
+        refuseJoin({ reason: "rate_limited", retry_after_ms: 999_999_999 });
+
+        await tick(61_000);
+        expect(joins()).toHaveLength(2);
+    });
+
+    it("backs off further on each channel crash", async () => {
+        ackJoin();
+
+        const delays: number[] = [];
+        for (let i = 0; i < 3; i++) {
+            const before = joins().length;
+            deliver({ topic: TOPIC, event: "phx_error", payload: {} });
+
+            let waited = 0;
+            while (joins().length === before && waited < 90_000) {
+                await tick(100);
+                waited += 100;
+            }
+            delays.push(waited);
+            ackJoin();
+        }
+
+        expect(delays).toEqual([1000, 2000, 5000]);
+    });
+
+    it("starts the backoff over once the channel has been healthy for a while", async () => {
+        ackJoin();
+
+        const measure = async () => {
+            const before = joins().length;
+            deliver({ topic: TOPIC, event: "phx_error", payload: {} });
+            let waited = 0;
+            while (joins().length === before && waited < 90_000) {
+                await tick(100);
+                waited += 100;
+            }
+            return waited;
+        };
+
+        expect(await measure()).toBe(1000);
+        ackJoin();
+
+        await tick(45_000);
+
+        expect(await measure()).toBe(1000);
+    });
+});
+
+describe("event delivery", () => {
+    it("forwards platform events to subscribers", async () => {
+        ackJoin();
+        const seen: Array<[string, Record<string, unknown>]> = [];
+        const off = onEvent((name, payload) => seen.push([name, payload]));
+
+        deliver({ topic: TOPIC, event: "AUDIT_CREATED", payload: { entity_type: "campaign" } });
+
+        expect(seen).toEqual([["AUDIT_CREATED", { entity_type: "campaign" }]]);
+        off();
+    });
+
+    it("never forwards Phoenix internals", async () => {
+        ackJoin();
+        const seen: string[] = [];
+        const off = onEvent((name) => seen.push(name));
+
+        deliver({ topic: TOPIC, event: "presence_diff", payload: {} });
+        deliver({ topic: TOPIC, event: "phx_close", payload: {} });
+
+        expect(seen).toEqual([]);
+        off();
+    });
+});
+
+describe("status reporting", () => {
+    it("stops reporting connected once the socket closes", async () => {
+        ackJoin();
+        expect(getStatus()).toBe("connected");
+
+        sockets[sockets.length - 1].close();
+        await tick(1);
+
+        expect(getStatus()).toBe("disconnected");
+    });
+});

--- a/admin/src/lib/realtime/socket.ts
+++ b/admin/src/lib/realtime/socket.ts
@@ -28,7 +28,18 @@ interface PhoenixMessage {
 const TOPIC = "admin:platform";
 const HEARTBEAT_INTERVAL = 25_000; // under typical 60s idle proxy timeouts
 const HEARTBEAT_TIMEOUT = 8_000; // drop + reconnect if a heartbeat isn't answered
-const REJOIN_DELAY = 1_000; // channel crashed but socket lives: rejoin after a beat
+// Channel crashed, or its join was refused transiently, but the socket lives:
+// rejoin on a backoff. Indexed by consecutive attempt; clamps at the last entry.
+const REJOIN_SCHEDULE = [1_000, 2_000, 5_000, 10_000, 20_000, 30_000];
+const REJOIN_MAX_ATTEMPTS = 8;
+// A channel that has not needed a rejoin for this long starts its backoff over.
+// Resetting it on a successful join instead would make the backoff useless
+// against the case it exists for — a channel that joins, crashes, joins,
+// crashes — because every crash is preceded by a success.
+const REJOIN_RESET_MS = 30_000;
+// Bounds for a server-supplied retry_after_ms, in case it is missing or absurd.
+const JOIN_RETRY_MIN_MS = 1_000;
+const JOIN_RETRY_MAX_MS = 60_000;
 // Retry almost immediately first, then ramp; each delay gets ±25% jitter.
 const RECONNECT_SCHEDULE = [120, 350, 800, 1500, 3000, 5000, 10000];
 
@@ -59,6 +70,8 @@ let status: RealtimeStatus = "disconnected";
 let refCounter = 0;
 let joinRef = "";
 let reconnectAttempt = 0;
+let rejoinAttempt = 0;
+let lastRejoinAt = 0;
 let connecting = false; // guards the async URL fetch window before ws exists
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let rejoinTimer: ReturnType<typeof setTimeout> | null = null;
@@ -157,13 +170,26 @@ function scheduleReconnect() {
     }, delay);
 }
 
-function scheduleRejoin() {
+function scheduleRejoin(delayMs?: number) {
     if (!started || rejoinTimer) return;
+    const now = Date.now();
+    if (now - lastRejoinAt >= REJOIN_RESET_MS) rejoinAttempt = 0;
+    if (rejoinAttempt >= REJOIN_MAX_ATTEMPTS) {
+        // Give up rather than become a join loop of our own; `wake()` (focus or
+        // network back) is the way out.
+        setStatus("disconnected");
+        return;
+    }
+    const base = delayMs ?? REJOIN_SCHEDULE[Math.min(rejoinAttempt, REJOIN_SCHEDULE.length - 1)];
+    // Jitter upward only: retrying early just spends another refusal.
+    const delay = Math.round(base * (1 + Math.random() * 0.25));
+    rejoinAttempt += 1;
+    lastRejoinAt = now;
     rejoinTimer = setTimeout(() => {
         rejoinTimer = null;
         if (ws?.readyState === WebSocket.OPEN) joinChannel();
         else scheduleReconnect();
-    }, REJOIN_DELAY);
+    }, delay);
 }
 
 function handleMessage(raw: string) {
@@ -184,15 +210,39 @@ function handleMessage(raw: string) {
                 heartbeatWatchdog = null;
             }
         } else if (topic === TOPIC && msg.ref === joinRef) {
-            const st = (payload as { status?: string }).status;
-            if (st !== "ok") {
-                // Refused join (likely an expired token URL): reconnect with a
-                // freshly minted URL instead of spinning on the dead socket.
-                try {
-                    ws?.close();
-                } catch {
-                    /* ignore */
-                }
+            const reply = payload as {
+                status?: string;
+                response?: { reason?: string; retry_after_ms?: number };
+            };
+
+            if (reply.status === "ok") {
+                // A joined channel is what "connected" means here. Resetting the
+                // backoff on socket open alone turned a join the server keeps
+                // refusing into an endless ~120ms connect/refuse/close loop.
+                reconnectAttempt = 0;
+                setStatus("connected");
+                return;
+            }
+
+            const response = reply.response ?? {};
+            if (response.reason === "rate_limited") {
+                // Throttled: the socket is fine, so wait out the server's hint
+                // and rejoin instead of tearing the connection down.
+                const hint = Number(response.retry_after_ms);
+                scheduleRejoin(
+                    Number.isFinite(hint)
+                        ? Math.min(Math.max(hint, JOIN_RETRY_MIN_MS), JOIN_RETRY_MAX_MS)
+                        : JOIN_RETRY_MIN_MS,
+                );
+                return;
+            }
+
+            // Anything else is most likely an expired token URL: reconnect with
+            // a freshly minted one instead of spinning on the dead socket.
+            try {
+                ws?.close();
+            } catch {
+                /* ignore */
             }
         }
         return;
@@ -276,8 +326,7 @@ async function connect(): Promise<void> {
 
     socket.onopen = () => {
         if (socket !== ws) return;
-        reconnectAttempt = 0;
-        setStatus("connected");
+        // Stay "connecting" until the channel is actually joined.
         startHeartbeat();
         joinChannel();
     };
@@ -319,6 +368,8 @@ function wake() {
         reconnectTimer = null;
     }
     reconnectAttempt = 0;
+    rejoinAttempt = 0;
+    lastRejoinAt = 0;
     void connect();
 }
 
@@ -327,6 +378,8 @@ export function startRealtime() {
     started = true;
     epoch += 1;
     reconnectAttempt = 0;
+    rejoinAttempt = 0;
+    lastRejoinAt = 0;
     window.addEventListener("online", wake);
     window.addEventListener("focus", wake);
     void connect();

--- a/admin/vitest.config.ts
+++ b/admin/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+export default defineConfig({
+    test: {
+        environment: "jsdom",
+        globals: true,
+        include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    },
+    resolve: {
+        alias: {
+            "@": path.resolve(__dirname, "./src"),
+        },
+    },
+});

--- a/docs/content/docs/api/realtime.mdx
+++ b/docs/content/docs/api/realtime.mdx
@@ -39,7 +39,7 @@ After connecting, join one or more topics with a `phx_join` message:
 | `org:<org_id>` | Organization-wide events | Requires membership; events are filtered by your member permissions |
 | `campaign:<campaign_id>` | One campaign's activity | Requires `view_campaigns` |
 | `account:<account_id>` | One mailbox's sync and warmup events | Requires `manage_emails` |
-| `bulk:<operation_id>` | Progress of one bulk operation | Import/export progress |
+| `bulk:<operation_id>` | Progress of one bulk operation | Import/export progress; only the user who started the operation receives its events |
 
 Events arrive as channel messages whose event name is the event type, for example `EMAIL_SENT`, `EMAIL_OPENED`, `EMAIL_REPLIED`, `EMAIL_RECEIVED`, `AI_DRAFT_READY`, `CAMPAIGN_COMPLETED`, `TASK_PROGRESS`, `ACCOUNT_HEALTH_CHANGED`, `ACCOUNT_SYNC_STATE`, `AUDIT_CREATED`, `AUTOMATION_RUN`, `MEETING_BOOKED`, `NOTIFICATION_CREATED`. Payloads always include `event_type` and a timestamp, plus the relevant ids (`campaign_id`, `contact_id`, `thread_id`, and so on).
 
@@ -290,11 +290,30 @@ The realtime service protects itself against connection spam. All limits are per
 | --- | --- |
 | Concurrent connections | 10 (plan-dependent) |
 | Concurrent connections per IP | 50 |
+| Socket handshakes | 30/minute |
 | Channel joins | 30/minute |
 | Client-sent events (including `presence:update`) | 60/minute |
 | Server-to-client messages | 120/minute |
 
+Handshakes and channel joins draw on separate budgets, so a reconnect storm does not spend the allowance a client then needs to rejoin its topics with. Every limit allows a burst of 1.5x its per-minute figure before refusing.
+
 When a client-sent event is throttled you receive an error reply with `reason: "rate_limited"` and a `retry_after_ms` hint. When outbound delivery is throttled the channel pushes a `rate_limited` message instead of the event.
+
+A `phx_join` over the join budget is refused the same way, with `code: 4007` and its own `retry_after_ms`:
+
+```json
+{
+  "status": "error",
+  "response": {
+    "code": 4007,
+    "reason": "rate_limited",
+    "category": "ws_join",
+    "retry_after_ms": 21400
+  }
+}
+```
+
+The socket stays open, so the right response is to wait out `retry_after_ms` and send the join again, not to reconnect. `retry_after_ms` is the time until the current minute's budget resets, so retrying earlier only spends another refusal. Treat every other refusal reason as final and stop retrying that topic.
 
 Ephemeral [live-collaboration](#live-collaboration) frames (`live:cursor`, `live:node`, `live:select`, `live:patch`) are exempt from the client-event budget above: they are bounded by a separate small per-socket burst limit, and over-budget frames are dropped silently rather than rejected.
 
@@ -303,7 +322,7 @@ Ephemeral [live-collaboration](#live-collaboration) frames (`live:cursor`, `live
 A connection can be refused at two points, and the two surface differently today:
 
 - **Connect-level** (authentication, the realtime permission, the IP allowlist, the rate limit, the connection cap): the WebSocket upgrade is refused at the HTTP layer. The handshake returns an **HTTP 403** carrying the reason, and the client observes a failed upgrade rather than an application close frame.
-- **Post-join** (a `phx_join` that fails after the socket is open, for example a channel you may not see): the join reply comes back with `status: "error"` and a structured error object `{ code, reason }` in its `response`.
+- **Post-join** (a `phx_join` that fails after the socket is open, for example a channel you may not see): the join reply comes back with `status: "error"` and a structured error object `{ code, reason }` in its `response`. `reason` is a stable slug naming the specific refusal (`not_a_member`, `campaign_not_found`, `rate_limited`, ...); `code` is the coarse class to branch on.
 
 Both paths use the same reason codes:
 
@@ -311,9 +330,10 @@ Both paths use the same reason codes:
 | --- | --- | --- |
 | 4003 | Not authenticated (token missing) | Add a valid `token` to the connection URL |
 | 4004 | Authentication failed: token expired, or invalid key | Re-mint the token (or check the key), then reconnect |
-| 4007 | Rate limited | Back off and retry |
+| 4005 | Malformed topic, for example an id that is not a UUID | Fix the topic; retrying will not help |
+| 4007 | Rate limited | Wait out `retry_after_ms`, then retry |
 | 4009 | Connection limit exceeded | Reduce concurrent sockets |
-| 4010 | Permission denied, or IP not allowed | Grant `REALTIME_SUBSCRIBE` (or the realtime scope), or fix the IP allowlist |
+| 4010 | Permission denied, not a member, or no such record | Do not retry this topic |
 
 Because connect-level rejections are an HTTP 403 and not a WebSocket close frame today, a client cannot branch on the connect-level code programmatically: treat any failed upgrade as "re-mint the token if it expired, otherwise back off". Post-join rejections are already machine-readable through `{ code, reason }`. Surfacing connect-level reasons as application close codes too is planned.
 
@@ -328,5 +348,6 @@ The buffer is not an infinite log. It holds roughly the most recent events per o
 - Reuse one connection per process and multiplex channels over it instead of opening one socket per topic.
 - Pass `intents` so you only receive (and pay the message-rate budget for) the events you act on.
 - Reconnect with exponential backoff; the limits above treat reconnect storms the same as connection spam.
+- Back off on rejoins too, and hold one subscription per topic rather than one per component. A client that tears a channel down and rejoins it on every render will exhaust the join budget in seconds.
 - After a reconnect, resume with your last `seq` instead of refetching everything; only fall back to a full REST resync on `resume_failed`.
 - Treat event payloads as invalidation signals (they carry ids, not full state) and refetch the resource over the REST API when you need its current contents.

--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -408,7 +408,8 @@ The Elixir websocket service. Its runtime configuration is read only when the re
 | `MAX_CONNECTIONS_PER_IP` | Concurrent sockets from one address | `50` |
 | `MAX_CONNECTIONS_GLOBAL` | Concurrent sockets on this node | `100000` |
 | `RATE_LIMIT_WS_MESSAGE` | Websocket messages per minute | `120` |
-| `RATE_LIMIT_WS_JOIN` | Channel joins per minute | `30` |
+| `RATE_LIMIT_WS_CONNECT` | Socket handshakes per minute | `30` |
+| `RATE_LIMIT_WS_JOIN` | Channel joins per minute, counted per `phx_join` on an open socket | `30` |
 | `RATE_LIMIT_WS_EVENT` | Client events per minute, which is what bounds presence updates | `60` |
 | `SENTRY_DSN` | Error reporting. An empty string is treated as unset on purpose, because the library rejects `""` hard enough to take the node down | unset |
 

--- a/realtime/config/config.exs
+++ b/realtime/config/config.exs
@@ -25,6 +25,7 @@ config :realtime,
   max_connections_global: String.to_integer(System.get_env("MAX_CONNECTIONS_GLOBAL") || "100000"),
   # Rate limits (per minute)
   rate_limit_ws_message: String.to_integer(System.get_env("RATE_LIMIT_WS_MESSAGE") || "120"),
+  rate_limit_ws_connect: String.to_integer(System.get_env("RATE_LIMIT_WS_CONNECT") || "30"),
   rate_limit_ws_join: String.to_integer(System.get_env("RATE_LIMIT_WS_JOIN") || "30"),
   rate_limit_ws_event: String.to_integer(System.get_env("RATE_LIMIT_WS_EVENT") || "60")
 

--- a/realtime/config/runtime.exs
+++ b/realtime/config/runtime.exs
@@ -55,6 +55,7 @@ if config_env() == :prod do
       String.to_integer(System.get_env("MAX_CONNECTIONS_GLOBAL") || "100000"),
     # Rate limits (per minute)
     rate_limit_ws_message: String.to_integer(System.get_env("RATE_LIMIT_WS_MESSAGE") || "120"),
+    rate_limit_ws_connect: String.to_integer(System.get_env("RATE_LIMIT_WS_CONNECT") || "30"),
     rate_limit_ws_join: String.to_integer(System.get_env("RATE_LIMIT_WS_JOIN") || "30"),
     rate_limit_ws_event: String.to_integer(System.get_env("RATE_LIMIT_WS_EVENT") || "60")
 

--- a/realtime/config/test.exs
+++ b/realtime/config/test.exs
@@ -8,7 +8,14 @@ config :realtime, RealtimeWeb.Endpoint,
 
 config :realtime,
   jwt_secret: "test_jwt_secret",
-  pubsub_enabled: false
+  pubsub_enabled: false,
+  # Count rate-limit hits in memory: the suite must run with no Redis.
+  rate_limit_counter: Realtime.Test.Counter
+
+# No database in the test env: these tests build sockets directly and never
+# reach Auth. One connection keeps the unreachable-Postgres retry noise to a
+# single line instead of five.
+config :realtime, Realtime.Repo, pool_size: 1
 
 config :logger, level: :warning
 

--- a/realtime/lib/realtime/application.ex
+++ b/realtime/lib/realtime/application.ex
@@ -50,7 +50,7 @@ defmodule Realtime.Application do
     )
 
     Logger.info(
-      "Rate limits: message=#{Application.get_env(:realtime, :rate_limit_ws_message, 120)}/min, join=#{Application.get_env(:realtime, :rate_limit_ws_join, 30)}/min, event=#{Application.get_env(:realtime, :rate_limit_ws_event, 60)}/min"
+      "Rate limits: message=#{Application.get_env(:realtime, :rate_limit_ws_message, 120)}/min, connect=#{Application.get_env(:realtime, :rate_limit_ws_connect, 30)}/min, join=#{Application.get_env(:realtime, :rate_limit_ws_join, 30)}/min, event=#{Application.get_env(:realtime, :rate_limit_ws_event, 60)}/min"
     )
 
     Supervisor.start_link(children, opts)

--- a/realtime/lib/realtime/auth.ex
+++ b/realtime/lib/realtime/auth.ex
@@ -118,6 +118,7 @@ defmodule Realtime.Auth do
   def error_code(:ip_not_allowed), do: 4010
   def error_code(:not_a_member), do: 4010
   def error_code(:forbidden), do: 4010
+  def error_code(:invalid_topic), do: 4005
   def error_code(:rate_limited), do: 4007
   def error_code(:limit_exceeded), do: 4009
   def error_code(_), do: 4004
@@ -139,6 +140,7 @@ defmodule Realtime.Auth do
   def error_message(:database_error), do: "Authentication failed"
   def error_message(:permission_denied), do: "Permission denied"
   def error_message(:ip_not_allowed), do: "IP address not allowed"
+  def error_message(:invalid_topic), do: "Invalid channel topic"
   def error_message(:rate_limited), do: "Rate limited"
   def error_message(:limit_exceeded), do: "Connection limit exceeded"
   def error_message(:not_a_member), do: "Not a member of this organization"

--- a/realtime/lib/realtime/rate_limiter.ex
+++ b/realtime/lib/realtime/rate_limiter.ex
@@ -2,10 +2,15 @@ defmodule Realtime.RateLimiter do
   @moduledoc """
   Redis-backed rate limiting with sliding window algorithm.
 
-  Supports three categories:
+  Supports four categories:
   - `ws_message`: Messages sent to client (120/min default)
+  - `ws_connect`: Socket handshakes (30/min default)
   - `ws_join`: Channel join attempts (30/min default)
   - `ws_event`: Client-sent events (60/min default)
+
+  `ws_connect` and `ws_join` are separate buckets on purpose: they used to share
+  one, so a reconnect storm spent the budget a client then needed to rejoin its
+  topics with (and vice versa).
 
   Implements fail-open behavior - if Redis is unavailable,
   rate limiting is bypassed to prevent service disruption.
@@ -17,6 +22,7 @@ defmodule Realtime.RateLimiter do
 
   @categories %{
     ws_message: 120,
+    ws_connect: 30,
     ws_join: 30,
     ws_event: 60
   }
@@ -41,7 +47,7 @@ defmodule Realtime.RateLimiter do
     burst_limit = trunc(limit * @burst_multiplier)
     key = rate_limit_key(user_id, category)
 
-    case Redis.incr_with_ttl(key, @window_seconds) do
+    case counter().incr_with_ttl(key, @window_seconds) do
       nil ->
         # Redis unavailable, fail open
         Logger.debug("Rate limiter: Redis unavailable, allowing request")
@@ -50,10 +56,8 @@ defmodule Realtime.RateLimiter do
       count when count <= burst_limit ->
         {:ok, burst_limit - count}
 
-      count ->
-        # Calculate retry after based on how far over the limit we are
-        retry_after_ms = calculate_retry_after(count, burst_limit)
-        {:error, :rate_limited, retry_after_ms}
+      _count ->
+        {:error, :rate_limited, retry_after_ms()}
     end
   end
 
@@ -101,6 +105,7 @@ defmodule Realtime.RateLimiter do
     config_key =
       case category do
         :ws_message -> :rate_limit_ws_message
+        :ws_connect -> :rate_limit_ws_connect
         :ws_join -> :rate_limit_ws_join
         :ws_event -> :rate_limit_ws_event
         _ -> nil
@@ -124,19 +129,23 @@ defmodule Realtime.RateLimiter do
 
   # Private functions
 
+  # The counter backend is swappable so the limiting logic can be exercised
+  # without a live Redis (tests, and any future in-memory single-node mode).
+  defp counter, do: Application.get_env(:realtime, :rate_limit_counter, Redis)
+
   defp rate_limit_key(user_id, category) do
-    # Use minute-based bucket for sliding window
+    # Fixed window: the bucket is the wall-clock minute.
     minute = div(System.system_time(:second), 60)
     "rl:ws:#{user_id}:#{category}:#{minute}"
   end
 
-  defp calculate_retry_after(current_count, burst_limit) do
-    # Calculate time until the oldest request expires
-    # In a sliding window, we wait until the window shifts
-    overage = current_count - burst_limit
-    base_wait = @window_seconds * 1000
-
-    # Scale wait time based on overage (more overage = longer wait)
-    min(base_wait, div(base_wait, max(1, overage)))
+  # Milliseconds until the current bucket rolls over, which is exactly when
+  # budget is available again. The old version scaled the wait by how far over
+  # the limit the caller was and got it backwards: the worst offender was told
+  # to come back SOONEST (60s/overage), so a client honouring the hint retried
+  # hardest at the moment it was least welcome.
+  defp retry_after_ms do
+    window_ms = @window_seconds * 1000
+    window_ms - rem(System.system_time(:millisecond), window_ms)
   end
 end

--- a/realtime/lib/realtime_web/channels/account_channel.ex
+++ b/realtime/lib/realtime_web/channels/account_channel.ex
@@ -12,9 +12,19 @@ defmodule RealtimeWeb.AccountChannel do
 
   alias Realtime.Auth
   alias Realtime.RateLimiter
+  alias RealtimeWeb.ChannelGuard
 
   @impl true
   def join("account:" <> account_id, _params, socket) do
+    # Throttle before the access lookup: that query is what a rejoin loop turns
+    # into database load.
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} -> {:error, payload}
+      :ok -> authorize_join(account_id, socket)
+    end
+  end
+
+  defp authorize_join(account_id, socket) do
     if valid_uuid?(account_id) do
       user_id = socket.assigns.user_id
 
@@ -32,20 +42,20 @@ defmodule RealtimeWeb.AccountChannel do
           {:ok, socket}
 
         {:error, :not_found} ->
-          {:error, %{reason: "account_not_found"}}
+          ChannelGuard.join_error("account_not_found")
 
         {:error, :forbidden} ->
-          {:error, %{reason: "forbidden"}}
+          ChannelGuard.join_error("forbidden")
 
         {:error, :not_a_member} ->
-          {:error, %{reason: "not_a_member"}}
+          ChannelGuard.join_error("not_a_member")
 
         {:error, reason} ->
           Logger.warning("Failed to join account channel: #{inspect(reason)}")
-          {:error, %{reason: to_string(reason)}}
+          ChannelGuard.join_error(to_string(reason))
       end
     else
-      {:error, %{reason: "invalid_account_id"}}
+      ChannelGuard.join_error("invalid_account_id", :invalid_topic)
     end
   end
 

--- a/realtime/lib/realtime_web/channels/admin_channel.ex
+++ b/realtime/lib/realtime_web/channels/admin_channel.ex
@@ -18,6 +18,7 @@ defmodule RealtimeWeb.AdminChannel do
 
   alias Realtime.Auth
   alias Realtime.RateLimiter
+  alias RealtimeWeb.ChannelGuard
 
   @topic "admin:platform"
 
@@ -28,10 +29,17 @@ defmodule RealtimeWeb.AdminChannel do
 
   @impl true
   def join("admin:platform", _params, socket) do
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} -> {:error, payload}
+      :ok -> authorize_join(socket)
+    end
+  end
+
+  defp authorize_join(socket) do
     user_id = socket.assigns.user_id
 
     if Map.get(socket.assigns, :auth_type) != :jwt do
-      {:error, %{reason: "jwt_required"}}
+      ChannelGuard.join_error("jwt_required")
     else
       case Auth.check_admin(user_id) do
         {:ok, admin} ->
@@ -48,7 +56,7 @@ defmodule RealtimeWeb.AdminChannel do
 
         {:error, reason} ->
           Logger.warning("Admin channel join rejected for #{user_id}: #{inspect(reason)}")
-          {:error, %{reason: "not_an_admin"}}
+          ChannelGuard.join_error("not_an_admin")
       end
     end
   end

--- a/realtime/lib/realtime_web/channels/bulk_channel.ex
+++ b/realtime/lib/realtime_web/channels/bulk_channel.ex
@@ -3,26 +3,45 @@ defmodule RealtimeWeb.BulkChannel do
   Channel for bulk operation events.
 
   Users can subscribe to bulk operation progress (contact imports, bulk updates).
+
+  A bulk operation id is not backed by a table the realtime service can read, so
+  the join itself cannot prove ownership. Delivery is gated instead: an event is
+  pushed only to the socket of the user who owns it (`user_id` on the event
+  body, set by the publisher). Joining someone else's operation id therefore
+  yields an open channel that never receives anything, rather than a live feed of
+  another account's import.
   """
 
   use Phoenix.Channel
 
   require Logger
 
+  alias RealtimeWeb.ChannelGuard
+
   @impl true
   def join("bulk:" <> operation_id, _params, socket) do
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} -> {:error, payload}
+      :ok -> subscribe(operation_id, socket)
+    end
+  end
+
+  defp subscribe(operation_id, socket) do
     if valid_uuid?(operation_id) do
       Logger.debug("User #{socket.assigns.user_id} joined bulk:#{operation_id}")
       Phoenix.PubSub.subscribe(Realtime.PubSub, "bulk:#{operation_id}")
       {:ok, assign(socket, :operation_id, operation_id)}
     else
-      {:error, %{reason: "invalid_operation_id"}}
+      ChannelGuard.join_error("invalid_operation_id", :invalid_topic)
     end
   end
 
   @impl true
   def handle_info({:pubsub_event, event}, socket) do
-    push(socket, event["event_type"], event)
+    if own_event?(event, socket) do
+      push(socket, event["event_type"], event)
+    end
+
     {:noreply, socket}
   end
 
@@ -30,6 +49,15 @@ defmodule RealtimeWeb.BulkChannel do
   def handle_in("ping", _payload, socket) do
     {:reply, {:ok, %{pong: System.system_time(:millisecond)}}, socket}
   end
+
+  @doc false
+  # An event with no owner belongs to nobody and is never delivered here.
+  def own_event?(%{"user_id" => user_id}, socket)
+      when is_binary(user_id) and user_id != "" do
+    user_id == socket.assigns.user_id
+  end
+
+  def own_event?(_event, _socket), do: false
 
   defp valid_uuid?(id) do
     case UUID.info(id) do

--- a/realtime/lib/realtime_web/channels/campaign_channel.ex
+++ b/realtime/lib/realtime_web/channels/campaign_channel.ex
@@ -12,9 +12,19 @@ defmodule RealtimeWeb.CampaignChannel do
 
   alias Realtime.Auth
   alias Realtime.RateLimiter
+  alias RealtimeWeb.ChannelGuard
 
   @impl true
   def join("campaign:" <> campaign_id, _params, socket) do
+    # Throttle before the access lookup: that query is what a rejoin loop turns
+    # into database load.
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} -> {:error, payload}
+      :ok -> authorize_join(campaign_id, socket)
+    end
+  end
+
+  defp authorize_join(campaign_id, socket) do
     if valid_uuid?(campaign_id) do
       user_id = socket.assigns.user_id
 
@@ -32,20 +42,20 @@ defmodule RealtimeWeb.CampaignChannel do
           {:ok, socket}
 
         {:error, :not_found} ->
-          {:error, %{reason: "campaign_not_found"}}
+          ChannelGuard.join_error("campaign_not_found")
 
         {:error, :forbidden} ->
-          {:error, %{reason: "forbidden"}}
+          ChannelGuard.join_error("forbidden")
 
         {:error, :not_a_member} ->
-          {:error, %{reason: "not_a_member"}}
+          ChannelGuard.join_error("not_a_member")
 
         {:error, reason} ->
           Logger.warning("Failed to join campaign channel: #{inspect(reason)}")
-          {:error, %{reason: to_string(reason)}}
+          ChannelGuard.join_error(to_string(reason))
       end
     else
-      {:error, %{reason: "invalid_campaign_id"}}
+      ChannelGuard.join_error("invalid_campaign_id", :invalid_topic)
     end
   end
 

--- a/realtime/lib/realtime_web/channels/channel_guard.ex
+++ b/realtime/lib/realtime_web/channels/channel_guard.ex
@@ -1,0 +1,65 @@
+defmodule RealtimeWeb.ChannelGuard do
+  @moduledoc """
+  The shared gate every channel runs before it does any work in `join/3`.
+
+  Two jobs:
+
+  * Throttle joins. `ws_join` is documented as a per-minute channel-join budget,
+    but it was only ever spent on the socket handshake, so an established socket
+    could issue unlimited `phx_join`s. Each one costs an authorization query, so
+    a client stuck in a rejoin loop turned into a Postgres load generator with
+    nothing in the path to stop it.
+  * Give every join rejection the `{code, reason}` shape the API reference
+    promises, instead of the bare `%{reason: ...}` most channels returned.
+
+  Call `check_join/1` FIRST in `join/3`: refusing before the `Auth` lookup is the
+  point, since that lookup is the expensive part.
+  """
+
+  alias Realtime.Auth
+  alias Realtime.RateLimiter
+
+  require Logger
+
+  @doc """
+  Spend one unit of this user's channel-join budget.
+
+  Returns `:ok`, or `{:error, payload}` ready to be returned straight from
+  `join/3`. Fails open when Redis is down, like every other limiter here.
+  """
+  def check_join(socket) do
+    user_id = socket.assigns.user_id
+    limit = socket.assigns |> Map.get(:rate_limits, %{}) |> Map.get(:limit_ws_join_pm)
+
+    case RateLimiter.check(user_id, :ws_join, limit) do
+      {:ok, _remaining} ->
+        :ok
+
+      {:error, :rate_limited, retry_after_ms} ->
+        Logger.debug("User #{user_id} rate limited on ws_join")
+
+        {:error,
+         %{
+           code: Auth.error_code(:rate_limited),
+           reason: "rate_limited",
+           category: "ws_join",
+           retry_after_ms: retry_after_ms
+         }}
+    end
+  end
+
+  @doc """
+  A join rejection carrying both a numeric `code` and the channel's own reason
+  slug. The slug is passed through verbatim so published reasons like
+  `"campaign_not_found"` keep their meaning for existing clients.
+  """
+  def join_error(slug, code_for \\ :forbidden)
+
+  def join_error(slug, code_for) when is_binary(slug) do
+    {:error, %{code: Auth.error_code(code_for), reason: slug}}
+  end
+
+  def join_error(reason, _code_for) when is_atom(reason) do
+    {:error, %{code: Auth.error_code(reason), reason: Auth.error_message(reason)}}
+  end
+end

--- a/realtime/lib/realtime_web/channels/org_channel.ex
+++ b/realtime/lib/realtime_web/channels/org_channel.ex
@@ -24,6 +24,7 @@ defmodule RealtimeWeb.OrgChannel do
   alias Realtime.Auth
   alias Realtime.Connections
   alias Realtime.RateLimiter
+  alias RealtimeWeb.ChannelGuard
   alias RealtimeWeb.Presence
 
   @presence_actions ~w(viewing editing replying idle)
@@ -41,6 +42,15 @@ defmodule RealtimeWeb.OrgChannel do
 
   @impl true
   def join("org:" <> org_id, params, socket) do
+    # Throttle before the membership lookup: that query is what a rejoin loop
+    # turns into database load.
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} -> {:error, payload}
+      :ok -> authorize_join(org_id, params, socket)
+    end
+  end
+
+  defp authorize_join(org_id, params, socket) do
     user_id = socket.assigns.user_id
 
     case Auth.check_org_membership(user_id, org_id) do
@@ -94,9 +104,7 @@ defmodule RealtimeWeb.OrgChannel do
   # Structured join rejection the client can branch on: a numeric `code`
   # (Auth.error_code/1) plus a human-readable `reason` (Auth.error_message/1),
   # mirroring the socket-level auth error shape.
-  defp join_error(reason) do
-    {:error, %{code: Auth.error_code(reason), reason: Auth.error_message(reason)}}
-  end
+  defp join_error(reason), do: ChannelGuard.join_error(reason)
 
   @impl true
   def handle_info(:after_join, socket) do

--- a/realtime/lib/realtime_web/channels/user_channel.ex
+++ b/realtime/lib/realtime_web/channels/user_channel.ex
@@ -14,16 +14,23 @@ defmodule RealtimeWeb.UserChannel do
 
   alias Realtime.Connections
   alias Realtime.RateLimiter
+  alias RealtimeWeb.ChannelGuard
 
   @impl true
   def join("user:" <> user_id, _params, socket) do
-    # Users can only join their own channel
-    if socket.assigns.user_id == user_id do
-      Logger.debug("User #{user_id} joined user channel")
-      send(self(), :after_join)
-      {:ok, socket}
-    else
-      {:error, %{reason: "unauthorized"}}
+    case ChannelGuard.check_join(socket) do
+      {:error, payload} ->
+        {:error, payload}
+
+      :ok ->
+        # Users can only join their own channel
+        if socket.assigns.user_id == user_id do
+          Logger.debug("User #{user_id} joined user channel")
+          send(self(), :after_join)
+          {:ok, socket}
+        else
+          ChannelGuard.join_error("unauthorized")
+        end
     end
   end
 

--- a/realtime/lib/realtime_web/channels/user_socket.ex
+++ b/realtime/lib/realtime_web/channels/user_socket.ex
@@ -43,8 +43,8 @@ defmodule RealtimeWeb.UserSocket do
 
       {:ok, socket}
     else
-      # The join rate limiter returns a 3-tuple carrying the cooldown; match it
-      # before the generic 2-tuple clause and surface a Retry-After style hint.
+      # The handshake rate limiter returns a 3-tuple carrying the cooldown; match
+      # it before the generic 2-tuple clause and surface a Retry-After style hint.
       {:error, :rate_limited, retry_after_ms} ->
         reject(:rate_limited, retry_after_ms: retry_after_ms)
 
@@ -110,10 +110,14 @@ defmodule RealtimeWeb.UserSocket do
     end
   end
 
+  # Handshake throttle. This spends the `ws_connect` budget, NOT `ws_join`:
+  # channel joins have their own bucket (RealtimeWeb.ChannelGuard) so a
+  # reconnect storm cannot eat the budget a client then needs to rejoin its
+  # topics with.
   defp check_rate_limit(user_id, limits) do
     limit = Map.get(limits, :limit_ws_join_pm, 30)
 
-    case RateLimiter.check(user_id, :ws_join, limit) do
+    case RateLimiter.check(user_id, :ws_connect, limit) do
       {:ok, _remaining} -> :ok
       {:error, :rate_limited, retry_after_ms} -> {:error, :rate_limited, retry_after_ms}
     end

--- a/realtime/mix.exs
+++ b/realtime/mix.exs
@@ -8,9 +8,15 @@ defmodule Realtime.MixProject do
       elixir: "~> 1.18",
       listeners: [Phoenix.CodeReloader],
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps()
     ]
   end
+
+  # test/support holds the in-memory stand-ins (rate-limit counter, channel
+  # case) that let the suite run with no Redis and no Postgres.
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   def application do
     [

--- a/realtime/test/realtime/rate_limiter_test.exs
+++ b/realtime/test/realtime/rate_limiter_test.exs
@@ -1,0 +1,97 @@
+defmodule Realtime.RateLimiterTest do
+  use ExUnit.Case, async: false
+
+  alias Realtime.RateLimiter
+  alias Realtime.Test.Counter
+
+  setup do
+    Counter.reset()
+    :ok
+  end
+
+  describe "check/3" do
+    test "allows up to the burst ceiling, then refuses" do
+      # burst ceiling is 1.5x the limit
+      for n <- 1..15 do
+        assert {:ok, _remaining} = RateLimiter.check("u1", :ws_join, 10), "call #{n} refused"
+      end
+
+      assert {:error, :rate_limited, retry_after_ms} = RateLimiter.check("u1", :ws_join, 10)
+      assert retry_after_ms > 0
+    end
+
+    test "the retry hint points at the next window, and does not shrink as overage grows" do
+      window_ms = 60_000
+
+      for _ <- 1..15, do: RateLimiter.check("u1", :ws_join, 10)
+
+      bucket_before = div(System.system_time(:second), 60)
+      {:error, :rate_limited, first} = RateLimiter.check("u1", :ws_join, 10)
+
+      # 200 more refusals: the hint must still be the time left in this window,
+      # never a shorter wait because the caller misbehaved harder.
+      for _ <- 1..200, do: RateLimiter.check("u1", :ws_join, 10)
+      {:error, :rate_limited, later} = RateLimiter.check("u1", :ws_join, 10)
+      bucket_after = div(System.system_time(:second), 60)
+
+      assert first > 0 and first <= window_ms
+      assert later > 0 and later <= window_ms
+      # Only the clock moved between the two, so the hint may shrink by the
+      # elapsed time and nothing else. (Unless the window itself rolled over
+      # mid-test, in which case the hint legitimately jumps back up.)
+      if bucket_before == bucket_after do
+        assert later <= first
+        assert first - later < 1_000
+      end
+    end
+
+    test "reports the remaining burst allowance" do
+      assert {:ok, 14} = RateLimiter.check("u1", :ws_join, 10)
+      assert {:ok, 13} = RateLimiter.check("u1", :ws_join, 10)
+    end
+
+    test "budgets are per user" do
+      for _ <- 1..15, do: RateLimiter.check("noisy", :ws_join, 10)
+      assert {:error, :rate_limited, _} = RateLimiter.check("noisy", :ws_join, 10)
+
+      assert {:ok, _} = RateLimiter.check("quiet", :ws_join, 10)
+    end
+
+    test "ws_connect and ws_join do not share a bucket" do
+      # A reconnect storm must not spend the budget the client then needs to
+      # rejoin its topics with.
+      for _ <- 1..15, do: RateLimiter.check("u1", :ws_connect, 10)
+      assert {:error, :rate_limited, _} = RateLimiter.check("u1", :ws_connect, 10)
+
+      assert {:ok, _} = RateLimiter.check("u1", :ws_join, 10)
+    end
+
+    test "falls open when the counter backend is unavailable" do
+      Counter.simulate_outage(true)
+
+      for _ <- 1..100 do
+        assert {:ok, _} = RateLimiter.check("u1", :ws_join, 10)
+      end
+    end
+
+    test "uses the configured default when no custom limit is given" do
+      # ws_join defaults to 30/min, so the burst ceiling is 45.
+      for _ <- 1..45, do: assert({:ok, _} = RateLimiter.check("u1", :ws_join))
+      assert {:error, :rate_limited, _} = RateLimiter.check("u1", :ws_join)
+    end
+
+    test "a plan-specific limit overrides the default" do
+      for _ <- 1..3, do: assert({:ok, _} = RateLimiter.check("u1", :ws_join, 2))
+      assert {:error, :rate_limited, _} = RateLimiter.check("u1", :ws_join, 2)
+    end
+  end
+
+  describe "get_limit/1" do
+    test "knows every category" do
+      assert RateLimiter.get_limit(:ws_message) == 120
+      assert RateLimiter.get_limit(:ws_connect) == 30
+      assert RateLimiter.get_limit(:ws_join) == 30
+      assert RateLimiter.get_limit(:ws_event) == 60
+    end
+  end
+end

--- a/realtime/test/realtime_web/channels/bulk_channel_test.exs
+++ b/realtime/test/realtime_web/channels/bulk_channel_test.exs
@@ -1,0 +1,73 @@
+defmodule RealtimeWeb.BulkChannelTest do
+  @moduledoc """
+  A bulk operation id is not backed by a table this service can read, so the join
+  cannot prove ownership and delivery is gated instead. Without that gate any
+  authenticated user could join `bulk:<id>` and watch another account's import.
+  """
+
+  use RealtimeWeb.ChannelCase, async: false
+
+  alias RealtimeWeb.BulkChannel
+
+  defp progress_event(user_id, operation_id) do
+    %{
+      "event_type" => "BULK_PROGRESS",
+      "user_id" => user_id,
+      "operation_id" => operation_id,
+      "processed_items" => 40,
+      "total_items" => 100
+    }
+  end
+
+  defp broadcast(operation_id, event) do
+    Phoenix.PubSub.broadcast(Realtime.PubSub, "bulk:#{operation_id}", {:pubsub_event, event})
+  end
+
+  test "the owner receives their operation's progress" do
+    op = uuid()
+    {:ok, _, _socket} = subscribe_and_join(user_socket("owner"), BulkChannel, "bulk:#{op}")
+
+    broadcast(op, progress_event("owner", op))
+
+    assert_push("BULK_PROGRESS", %{"processed_items" => 40})
+  end
+
+  test "another user joined to the same operation receives nothing" do
+    op = uuid()
+    {:ok, _, _socket} = subscribe_and_join(user_socket("snooper"), BulkChannel, "bulk:#{op}")
+
+    broadcast(op, progress_event("owner", op))
+
+    refute_push("BULK_PROGRESS", _payload, 100)
+  end
+
+  test "an event with no owner is delivered to nobody" do
+    op = uuid()
+    {:ok, _, _socket} = subscribe_and_join(user_socket("owner"), BulkChannel, "bulk:#{op}")
+
+    broadcast(op, %{"event_type" => "BULK_PROGRESS", "operation_id" => op})
+    broadcast(op, %{"event_type" => "BULK_PROGRESS", "operation_id" => op, "user_id" => ""})
+
+    refute_push("BULK_PROGRESS", _payload, 100)
+  end
+
+  test "a malformed operation id is refused with a topic code" do
+    assert {:error, payload} =
+             subscribe_and_join(user_socket("owner"), BulkChannel, "bulk:not-a-uuid")
+
+    assert payload.code == 4005
+    assert payload.reason == "invalid_operation_id"
+  end
+
+  describe "own_event?/2" do
+    test "matches only the owning socket" do
+      socket = user_socket("owner")
+
+      assert BulkChannel.own_event?(%{"user_id" => "owner"}, socket)
+      refute BulkChannel.own_event?(%{"user_id" => "someone-else"}, socket)
+      refute BulkChannel.own_event?(%{"user_id" => ""}, socket)
+      refute BulkChannel.own_event?(%{"user_id" => nil}, socket)
+      refute BulkChannel.own_event?(%{}, socket)
+    end
+  end
+end

--- a/realtime/test/realtime_web/channels/channel_guard_test.exs
+++ b/realtime/test/realtime_web/channels/channel_guard_test.exs
@@ -1,0 +1,38 @@
+defmodule RealtimeWeb.ChannelGuardTest do
+  use RealtimeWeb.ChannelCase, async: false
+
+  alias RealtimeWeb.ChannelGuard
+
+  describe "check_join/1" do
+    test "allows a join under budget" do
+      assert :ok = ChannelGuard.check_join(user_socket("u1"))
+    end
+
+    test "refuses over budget with the documented rate-limit payload" do
+      exhaust_join_budget("u1", 46)
+
+      assert {:error, payload} = ChannelGuard.check_join(user_socket("u1"))
+      assert payload.code == 4007
+      assert payload.reason == "rate_limited"
+      assert payload.category == "ws_join"
+      assert payload.retry_after_ms > 0
+    end
+  end
+
+  describe "join_error/2" do
+    test "keeps a published reason slug and adds a code" do
+      assert {:error, %{code: 4010, reason: "campaign_not_found"}} =
+               ChannelGuard.join_error("campaign_not_found")
+    end
+
+    test "a malformed topic is its own class" do
+      assert {:error, %{code: 4005, reason: "invalid_campaign_id"}} =
+               ChannelGuard.join_error("invalid_campaign_id", :invalid_topic)
+    end
+
+    test "an atom reason renders the human-readable message" do
+      assert {:error, %{code: 4010, reason: "Not a member of this organization"}} =
+               ChannelGuard.join_error(:not_a_member)
+    end
+  end
+end

--- a/realtime/test/realtime_web/channels/join_throttle_test.exs
+++ b/realtime/test/realtime_web/channels/join_throttle_test.exs
@@ -1,0 +1,115 @@
+defmodule RealtimeWeb.JoinThrottleTest do
+  @moduledoc """
+  Every channel spends the `ws_join` budget on each `phx_join`.
+
+  Before this gate existed the budget was only spent on the socket handshake, so
+  an established socket could issue unlimited joins — each one an authorization
+  query — and one client stuck in a rejoin loop was enough to saturate the
+  service.
+  """
+
+  use RealtimeWeb.ChannelCase, async: false
+
+  alias Realtime.Test.Counter
+
+  alias RealtimeWeb.AccountChannel
+  alias RealtimeWeb.AdminChannel
+  alias RealtimeWeb.BulkChannel
+  alias RealtimeWeb.CampaignChannel
+  alias RealtimeWeb.OrgChannel
+  alias RealtimeWeb.UserChannel
+
+  # ws_join defaults to 30/min, burst ceiling 45.
+  @over_budget 46
+
+  defp channels(user_id) do
+    [
+      {UserChannel, "user:#{user_id}"},
+      {OrgChannel, "org:#{uuid()}"},
+      {CampaignChannel, "campaign:#{uuid()}"},
+      {AccountChannel, "account:#{uuid()}"},
+      {BulkChannel, "bulk:#{uuid()}"},
+      {AdminChannel, "admin:platform"}
+    ]
+  end
+
+  test "an over-budget join is refused with a retry hint on every channel" do
+    for {channel, topic} <- channels("u-throttle") do
+      Counter.reset()
+      exhaust_join_budget("u-throttle", @over_budget)
+
+      assert {:error, payload} =
+               subscribe_and_join(user_socket("u-throttle"), channel, topic),
+             "#{inspect(channel)} allowed an over-budget join"
+
+      assert payload.code == 4007
+      assert payload.reason == "rate_limited"
+      assert payload.category == "ws_join"
+      assert payload.retry_after_ms > 0
+    end
+  end
+
+  test "the throttle refuses before the authorization lookup runs" do
+    # Auth would need Postgres, which the suite does not have. Reaching it would
+    # surface as a channel crash rather than a clean refusal, so a clean
+    # {:error, rate_limited} IS the assertion that the guard runs first.
+    exhaust_join_budget("u-order", @over_budget)
+
+    assert {:error, %{reason: "rate_limited"}} =
+             subscribe_and_join(user_socket("u-order"), CampaignChannel, "campaign:#{uuid()}")
+  end
+
+  test "each join spends exactly one unit of the budget" do
+    socket = user_socket("u-count")
+
+    for _ <- 1..3 do
+      {:ok, _, _} = subscribe_and_join(socket, UserChannel, "user:u-count")
+    end
+
+    assert Counter.count(join_key("u-count")) == 3
+  end
+
+  test "a join under budget is allowed" do
+    exhaust_join_budget("u-under", 10)
+
+    assert {:ok, _, _} =
+             subscribe_and_join(user_socket("u-under"), UserChannel, "user:u-under")
+  end
+
+  test "one user's join storm does not refuse another user" do
+    exhaust_join_budget("u-noisy", @over_budget)
+
+    assert {:error, %{reason: "rate_limited"}} =
+             subscribe_and_join(user_socket("u-noisy"), UserChannel, "user:u-noisy")
+
+    assert {:ok, _, _} =
+             subscribe_and_join(user_socket("u-calm"), UserChannel, "user:u-calm")
+  end
+
+  test "joins are allowed when the counter backend is down" do
+    # Fail open: a Redis outage must not take the dashboard's live updates with it.
+    Counter.simulate_outage(true)
+
+    for _ <- 1..50 do
+      assert {:ok, _, _} =
+               subscribe_and_join(user_socket("u-open"), UserChannel, "user:u-open")
+    end
+  end
+
+  test "a plan-specific join limit is honoured" do
+    socket = user_socket("u-plan", %{rate_limits: %{limit_ws_join_pm: 2}})
+
+    # ceiling is 1.5x2 = 3
+    for _ <- 1..3 do
+      assert {:ok, _, _} = subscribe_and_join(socket, UserChannel, "user:u-plan")
+    end
+
+    assert {:error, %{reason: "rate_limited"}} =
+             subscribe_and_join(socket, UserChannel, "user:u-plan")
+  end
+
+  defp join_key(user_id) do
+    minute = div(System.system_time(:second), 60)
+    "rl:ws:#{user_id}:ws_join:#{minute}"
+  end
+end

--- a/realtime/test/support/channel_case.ex
+++ b/realtime/test/support/channel_case.ex
@@ -1,0 +1,50 @@
+defmodule RealtimeWeb.ChannelCase do
+  @moduledoc """
+  Case template for channel tests.
+
+  Builds sockets with `Phoenix.ChannelTest.socket/3`, which skips
+  `UserSocket.connect/3` — so these tests never need a token, a database, or a
+  Redis. Every test starts with a clean rate-limit counter.
+  """
+
+  use ExUnit.CaseTemplate
+
+  import Phoenix.ChannelTest
+
+  @endpoint RealtimeWeb.Endpoint
+
+  using do
+    quote do
+      import Phoenix.ChannelTest
+      import RealtimeWeb.ChannelCase
+
+      @endpoint RealtimeWeb.Endpoint
+    end
+  end
+
+  setup do
+    Realtime.Test.Counter.reset()
+    :ok
+  end
+
+  @doc """
+  A connected socket for `user_id`, as `UserSocket.connect/3` would have left it.
+  """
+  def user_socket(user_id, assigns \\ %{}) do
+    base = %{user_id: user_id, ip_address: "127.0.0.1", auth_type: :jwt, rate_limits: %{}}
+
+    socket(RealtimeWeb.UserSocket, "user_socket:#{user_id}", Map.merge(base, assigns))
+  end
+
+  @doc """
+  Spend `n` units of this user's channel-join budget without joining anything.
+  """
+  def exhaust_join_budget(user_id, n) do
+    Enum.each(1..n, fn _ -> Realtime.RateLimiter.check(user_id, :ws_join) end)
+  end
+
+  @doc """
+  A random v4 UUID, for topics whose id only has to parse.
+  """
+  def uuid, do: UUID.uuid4()
+end

--- a/realtime/test/support/counter.ex
+++ b/realtime/test/support/counter.ex
@@ -1,0 +1,39 @@
+defmodule Realtime.Test.Counter do
+  @moduledoc """
+  In-memory stand-in for the Redis counter behind `Realtime.RateLimiter`.
+
+  Selected via `config :realtime, rate_limit_counter:` so the suite exercises
+  real limiter decisions without a live Redis. `simulate_outage/1` returns nil
+  the way `Realtime.Redis.incr_with_ttl/2` does when Redis is unreachable, which
+  is what the limiter's fail-open path keys on.
+  """
+
+  use Agent
+
+  def start_link(_opts \\ []) do
+    Agent.start_link(fn -> %{counts: %{}, down: false} end, name: __MODULE__)
+  end
+
+  def reset do
+    Agent.update(__MODULE__, fn _ -> %{counts: %{}, down: false} end)
+  end
+
+  def simulate_outage(down?) do
+    Agent.update(__MODULE__, &Map.put(&1, :down, down?))
+  end
+
+  def count(key) do
+    Agent.get(__MODULE__, &get_in(&1, [:counts, key])) || 0
+  end
+
+  def incr_with_ttl(key, _ttl_seconds) do
+    Agent.get_and_update(__MODULE__, fn
+      %{down: true} = state ->
+        {nil, state}
+
+      %{counts: counts} = state ->
+        next = Map.get(counts, key, 0) + 1
+        {next, %{state | counts: Map.put(counts, key, next)}}
+    end)
+  end
+end

--- a/realtime/test/test_helper.exs
+++ b/realtime/test/test_helper.exs
@@ -1,0 +1,3 @@
+{:ok, _} = Realtime.Test.Counter.start_link()
+
+ExUnit.start()

--- a/web/src/hooks/SocketProvider.tsx
+++ b/web/src/hooks/SocketProvider.tsx
@@ -20,6 +20,20 @@ const HEARTBEAT_TIMEOUT = 8000; // drop + reconnect if a heartbeat isn't answere
 // blip is invisible. Indexed by attempt; clamps at the last entry. Each delay
 // gets ±25% jitter so many clients don't reconnect in lockstep after an outage.
 const RECONNECT_SCHEDULE = [120, 350, 800, 1500, 3000, 5000, 10000];
+// Backoff for rejoining ONE channel while the socket stays up: a channel that
+// crashed server-side, or a join the server refused for a transient reason.
+// Indexed by consecutive attempt; clamps at the last entry. Without this a
+// crash-looping channel was rejoined every second forever.
+const CHANNEL_REJOIN_SCHEDULE = [1000, 2000, 5000, 10000, 20000, 30000];
+const CHANNEL_REJOIN_MAX_ATTEMPTS = 8;
+// A topic that has not needed a rejoin for this long starts its backoff over.
+// Resetting on a successful join instead would make the backoff useless against
+// the case it exists for — a channel that joins, crashes, joins, crashes —
+// because every crash is preceded by a success.
+const CHANNEL_REJOIN_RESET_MS = 30000;
+// Bounds for a server-supplied retry_after_ms, in case it is missing or absurd.
+const JOIN_RETRY_MIN_MS = 1000;
+const JOIN_RETRY_MAX_MS = 60000;
 const PHOENIX_EVENTS = {
     JOIN: 'phx_join',
     LEAVE: 'phx_leave',
@@ -74,6 +88,12 @@ export default function SocketProvider({
         });
     }, []);
     const pendingJoinsRef = useRef<Map<string, Record<string, unknown>>>(new Map());
+    // Pending single-channel rejoin, plus how many consecutive attempts it has
+    // taken and when the last one was scheduled. A successful join cancels the
+    // timer; the attempt count decays on its own (CHANNEL_REJOIN_RESET_MS).
+    const rejoinRef = useRef<
+        Map<string, { timer: ReturnType<typeof setTimeout> | null; attempts: number; lastAttemptAt: number }>
+    >(new Map());
     // Topics the app currently wants joined (added by joinChannel, removed by
     // leaveChannel). On reconnect we rejoin exactly these, independent of the
     // per-channel live state — the close handler downgrades joined channels to
@@ -111,6 +131,84 @@ export default function SocketProvider({
         wsRef.current.send(JSON.stringify(msg));
         return true;
     }, []);
+
+    // Drop any pending rejoin for a topic and reset its backoff.
+    const clearRejoin = useCallback((topic: string) => {
+        const pending = rejoinRef.current.get(topic);
+        if (pending?.timer) clearTimeout(pending.timer);
+        rejoinRef.current.delete(topic);
+    }, []);
+
+    // Drop a pending rejoin but keep the backoff position, so a join that
+    // succeeds and immediately crashes again does not start from zero.
+    const cancelRejoinTimer = useCallback((topic: string) => {
+        const pending = rejoinRef.current.get(topic);
+        if (pending?.timer) {
+            clearTimeout(pending.timer);
+            rejoinRef.current.set(topic, { ...pending, timer: null });
+        }
+    }, []);
+
+    const clearAllRejoins = useCallback(() => {
+        rejoinRef.current.forEach((pending) => {
+            if (pending.timer) clearTimeout(pending.timer);
+        });
+        rejoinRef.current.clear();
+    }, []);
+
+    // Rejoin ONE topic later, on a backoff, while the socket stays open. Used
+    // for a channel that crashed server-side and for a join the server refused
+    // transiently (a throttled join carries its own retry_after_ms). Gives up
+    // after CHANNEL_REJOIN_MAX_ATTEMPTS so a permanently unhappy channel cannot
+    // become a slow join loop of its own.
+    const scheduleRejoin = useCallback((topic: string, delayMs?: number) => {
+        if (!desiredTopicsRef.current.has(topic)) return;
+
+        const pending = rejoinRef.current.get(topic);
+        if (pending?.timer) return;
+
+        const now = Date.now();
+        const attempts =
+            pending && now - pending.lastAttemptAt < CHANNEL_REJOIN_RESET_MS ? pending.attempts : 0;
+        if (attempts >= CHANNEL_REJOIN_MAX_ATTEMPTS) return;
+
+        const base =
+            delayMs ??
+            CHANNEL_REJOIN_SCHEDULE[Math.min(attempts, CHANNEL_REJOIN_SCHEDULE.length - 1)];
+        // Jitter upward only: retrying early just spends another refusal.
+        const delay = Math.round(base * (1 + Math.random() * 0.25));
+
+        const timer = setTimeout(() => {
+            const current = rejoinRef.current.get(topic);
+            if (current) rejoinRef.current.set(topic, { ...current, timer: null });
+
+            if (!desiredTopicsRef.current.has(topic)) return;
+            if (wsRef.current?.readyState !== WebSocket.OPEN) return;
+
+            const existing = channelsRef.current.get(topic);
+            if (existing && (existing.state === 'joined' || existing.state === 'joining')) return;
+
+            const params = desiredTopicsRef.current.get(topic) || {};
+            const joinRef = getRef();
+            channelsRef.current.set(topic, {
+                topic,
+                state: 'joining',
+                joinRef,
+                params,
+                handlers: existing?.handlers || new Map(),
+            });
+            markChannelState(topic, 'joining');
+            sendRaw({
+                topic,
+                event: PHOENIX_EVENTS.JOIN,
+                payload: params,
+                ref: joinRef,
+                join_ref: joinRef,
+            });
+        }, delay);
+
+        rejoinRef.current.set(topic, { timer, attempts: attempts + 1, lastAttemptAt: now });
+    }, [getRef, sendRaw, markChannelState]);
 
     // Heartbeat roundtrip tracking. We record send time keyed by ref,
     // and when phx_reply with that ref lands we compute the delta and
@@ -190,11 +288,29 @@ export default function SocketProvider({
         if (event === PHOENIX_EVENTS.REPLY) {
             const channel = channelsRef.current.get(topic);
             if (channel && ref === channel.joinRef) {
-                const status = (payload as { status?: string }).status;
-                if (status === 'ok') {
+                const reply = payload as {
+                    status?: string;
+                    response?: { reason?: string; retry_after_ms?: number };
+                };
+                if (reply.status === 'ok') {
                     channel.state = 'joined';
+                    cancelRejoinTimer(topic);
                 } else {
                     channel.state = 'errored';
+                    // A throttled join is transient and the server says when
+                    // budget is back; retry then. Every other refusal (not a
+                    // member, no such campaign) is final, so stay errored rather
+                    // than hammering a door that will not open.
+                    const response = reply.response ?? {};
+                    if (response.reason === 'rate_limited') {
+                        const hint = Number(response.retry_after_ms);
+                        const delay = Number.isFinite(hint)
+                            ? Math.min(Math.max(hint, JOIN_RETRY_MIN_MS), JOIN_RETRY_MAX_MS)
+                            : JOIN_RETRY_MIN_MS;
+                        scheduleRejoin(topic, delay);
+                    } else {
+                        clearRejoin(topic);
+                    }
                 }
                 markChannelState(topic, channel.state);
             }
@@ -214,30 +330,8 @@ export default function SocketProvider({
             // — no events, no presence — until a full socket reconnect. Only
             // retry a channel that HAD joined, so a genuinely refused join
             // (returns errored) doesn't spin in a loop.
-            if (wasJoined && desiredTopicsRef.current.has(topic)) {
-                setTimeout(() => {
-                    if (!desiredTopicsRef.current.has(topic)) return;
-                    if (wsRef.current?.readyState !== WebSocket.OPEN) return;
-                    const cur = channelsRef.current.get(topic);
-                    if (cur && (cur.state === 'joined' || cur.state === 'joining')) return;
-                    const params = desiredTopicsRef.current.get(topic) || {};
-                    const joinRef = getRef();
-                    channelsRef.current.set(topic, {
-                        topic,
-                        state: 'joining',
-                        joinRef,
-                        params,
-                        handlers: cur?.handlers || new Map(),
-                    });
-                    markChannelState(topic, 'joining');
-                    sendRaw({
-                        topic,
-                        event: PHOENIX_EVENTS.JOIN,
-                        payload: params,
-                        ref: joinRef,
-                        join_ref: joinRef,
-                    });
-                }, 1000);
+            if (wasJoined) {
+                scheduleRejoin(topic);
             }
             return;
         }
@@ -292,7 +386,7 @@ export default function SocketProvider({
                 }
             });
         }
-    }, [setWsLatencyMs, getRef, sendRaw, markChannelState]);
+    }, [setWsLatencyMs, markChannelState, scheduleRejoin, clearRejoin, cancelRejoinTimer]);
 
     // Join channel
     const joinChannel = useCallback((topic: string, params: Record<string, unknown> = {}) => {
@@ -336,6 +430,7 @@ export default function SocketProvider({
     const leaveChannel = useCallback((topic: string) => {
         // No longer want this topic — don't let a reconnect rejoin it.
         desiredTopicsRef.current.delete(topic);
+        clearRejoin(topic);
 
         const channel = channelsRef.current.get(topic);
         if (!channel) return;
@@ -356,7 +451,7 @@ export default function SocketProvider({
         channelsRef.current.delete(topic);
         pendingJoinsRef.current.delete(topic);
         markChannelState(topic, null);
-    }, [getRef, sendRaw, markChannelState]);
+    }, [getRef, sendRaw, markChannelState, clearRejoin]);
 
     // Get channel state
     const getChannelState = useCallback((topic: string): ChannelState => {
@@ -532,6 +627,11 @@ export default function SocketProvider({
                 pendingPingRef.current.clear();
                 onClose?.(ev);
 
+                // A pending per-channel rejoin is now redundant and would
+                // double-join: rejoinChannels covers every desired topic when
+                // the socket comes back.
+                clearAllRejoins();
+
                 // Mark all channels as closed
                 channelsRef.current.forEach((channel) => {
                     if (channel.state === 'joined') {
@@ -584,6 +684,7 @@ export default function SocketProvider({
         rejoinChannels,
         setWsLatencyMs,
         markChannelState,
+        clearAllRejoins,
     ]);
 
     // Mount effect
@@ -645,10 +746,11 @@ export default function SocketProvider({
             if (heartbeatTimeoutRef.current) {
                 clearTimeout(heartbeatTimeoutRef.current);
             }
+            clearAllRejoins();
             stopHeartbeat();
             wsRef.current?.close();
         };
-    }, [connect, stopHeartbeat]);
+    }, [connect, stopHeartbeat, clearAllRejoins]);
 
     // Memoised: an inline object is a new identity on every render, and
     // channelStates re-renders this provider on every join. useChannel's effect

--- a/web/src/hooks/socketChannels.test.tsx
+++ b/web/src/hooks/socketChannels.test.tsx
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act, screen } from '@testing-library/react'
+import React, { useState } from 'react'
+import SocketProvider from './SocketProvider'
+import { useChannel, useChannelEvent } from './context/socket'
+import { installFakeSocket, freezeJitter, type SocketEnv } from './socketTestHarness'
+
+vi.mock('@/lib/api/client/app/socket/getSocket', () => ({
+    default: vi.fn(async () => ({ url: 'ws://localhost:4000/socket/websocket?token=test' })),
+}))
+
+const TOPIC = 'campaign:11111111-1111-1111-1111-111111111111'
+
+let env: SocketEnv
+
+/** Mounts the provider and lets the socket finish opening. */
+async function mount(ui: React.ReactNode) {
+    const result = render(<SocketProvider>{ui}</SocketProvider>)
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(10)
+    })
+    return result
+}
+
+async function tick(ms: number) {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms)
+    })
+}
+
+function Panel({ topic = TOPIC, onEvent }: { topic?: string; onEvent?: () => void }) {
+    const channel = useChannel(topic)
+    useChannelEvent(topic, 'EMAIL_SENT', () => onEvent?.())
+    return <span data-testid="state">{channel.state}</span>
+}
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    freezeJitter(0)
+    env = installFakeSocket()
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+})
+
+describe('channel subscription lifecycle', () => {
+    it('joins once and stays joined across unrelated re-renders', async () => {
+        // Regression: the provider's context value changed identity on every
+        // render, and channelStates re-rendered it on every join, so the effect
+        // that owns the subscription left and rejoined the channel forever.
+        let bump: () => void = () => {}
+        function Harness() {
+            const [, setN] = useState(0)
+            bump = () => setN((n) => n + 1)
+            return <Panel />
+        }
+
+        await mount(<Harness />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        for (let i = 0; i < 10; i++) {
+            await act(async () => {
+                bump()
+            })
+        }
+
+        expect(env.joins(TOPIC)).toHaveLength(1)
+        expect(env.leaves(TOPIC)).toHaveLength(0)
+    })
+
+    it('renders the joined state once the server acks', async () => {
+        await mount(<Panel />)
+        expect(screen.getByTestId('state').textContent).toBe('joining')
+
+        await act(async () => {
+            env.ackJoin(env.lastJoin(TOPIC))
+        })
+
+        expect(screen.getByTestId('state').textContent).toBe('joined')
+    })
+
+    it('leaves the channel when its last holder unmounts', async () => {
+        // The panel goes away (navigating off the campaign), the socket stays.
+        function Wrapper({ show }: { show: boolean }) {
+            return show ? <Panel /> : null
+        }
+
+        const { rerender } = await mount(<Wrapper show />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        await act(async () => {
+            rerender(
+                <SocketProvider>
+                    <Wrapper show={false} />
+                </SocketProvider>
+            )
+        })
+
+        expect(env.leaves(TOPIC)).toHaveLength(1)
+    })
+})
+
+describe('a refused join', () => {
+    it('retries a throttled join when the server says budget is back', async () => {
+        await mount(<Panel />)
+
+        await act(async () => {
+            env.refuseJoin(env.lastJoin(TOPIC), {
+                code: 4007,
+                reason: 'rate_limited',
+                category: 'ws_join',
+                retry_after_ms: 5000,
+            })
+        })
+
+        expect(screen.getByTestId('state').textContent).toBe('errored')
+        expect(env.joins(TOPIC)).toHaveLength(1)
+
+        // Nothing before the hint elapses.
+        await tick(4000)
+        expect(env.joins(TOPIC)).toHaveLength(1)
+
+        await tick(1500)
+        expect(env.joins(TOPIC)).toHaveLength(2)
+
+        await act(async () => {
+            env.ackJoin(env.lastJoin(TOPIC))
+        })
+        expect(screen.getByTestId('state').textContent).toBe('joined')
+    })
+
+    it('never retries a refusal that will not change', async () => {
+        await mount(<Panel />)
+
+        await act(async () => {
+            env.refuseJoin(env.lastJoin(TOPIC), { code: 4010, reason: 'not_a_member' })
+        })
+
+        await tick(120_000)
+
+        expect(env.joins(TOPIC)).toHaveLength(1)
+        expect(screen.getByTestId('state').textContent).toBe('errored')
+    })
+
+    it('gives up on a throttled join rather than retrying forever', async () => {
+        await mount(<Panel />)
+
+        // Refuse every attempt.
+        for (let i = 0; i < 20; i++) {
+            await act(async () => {
+                env.refuseJoin(env.lastJoin(TOPIC), {
+                    reason: 'rate_limited',
+                    retry_after_ms: 1000,
+                })
+            })
+            await tick(2000)
+        }
+
+        expect(env.joins(TOPIC).length).toBeLessThanOrEqual(9)
+    })
+
+    it('clamps an absurd retry hint', async () => {
+        await mount(<Panel />)
+
+        await act(async () => {
+            env.refuseJoin(env.lastJoin(TOPIC), {
+                reason: 'rate_limited',
+                retry_after_ms: 999_999_999,
+            })
+        })
+
+        await tick(61_000)
+        expect(env.joins(TOPIC)).toHaveLength(2)
+    })
+
+    it('treats a missing retry hint as the floor', async () => {
+        await mount(<Panel />)
+
+        await act(async () => {
+            env.refuseJoin(env.lastJoin(TOPIC), { reason: 'rate_limited' })
+        })
+
+        await tick(1200)
+        expect(env.joins(TOPIC)).toHaveLength(2)
+    })
+})
+
+describe('a channel that crashes server-side', () => {
+    /** Crash the channel, then report how long the client waited to rejoin. */
+    async function crashAndMeasureDelay(): Promise<number> {
+        const before = env.joins(TOPIC).length
+        await act(async () => {
+            env.deliver({ topic: TOPIC, event: 'phx_error', payload: {} })
+        })
+
+        let waited = 0
+        while (env.joins(TOPIC).length === before && waited < 90_000) {
+            await tick(100)
+            waited += 100
+        }
+        return waited
+    }
+
+    it('backs off further on each crash instead of retrying once a second', async () => {
+        await mount(<Panel />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        // A crash loop always joins successfully before it crashes again, so a
+        // backoff that reset on a successful join would stay flat at 1s forever.
+        const delays: number[] = []
+        for (let i = 0; i < 3; i++) {
+            delays.push(await crashAndMeasureDelay())
+            env.ackJoin(env.lastJoin(TOPIC))
+            await tick(1)
+        }
+
+        expect(delays).toEqual([1000, 2000, 5000])
+    })
+
+    it('starts the backoff over once the channel has been healthy for a while', async () => {
+        await mount(<Panel />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        expect(await crashAndMeasureDelay()).toBe(1000)
+        env.ackJoin(env.lastJoin(TOPIC))
+
+        // Quiet for well over the reset window.
+        await tick(45_000)
+
+        expect(await crashAndMeasureDelay()).toBe(1000)
+    })
+
+    it('keeps event handlers alive across a rejoin', async () => {
+        const onEvent = vi.fn()
+        await mount(<Panel onEvent={onEvent} />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        await act(async () => {
+            env.deliver({ topic: TOPIC, event: 'phx_error', payload: {} })
+        })
+        await tick(2000)
+
+        await act(async () => {
+            env.ackJoin(env.lastJoin(TOPIC))
+        })
+        await act(async () => {
+            env.pushEvent(TOPIC, 'EMAIL_SENT', {})
+        })
+
+        expect(onEvent).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not rejoin a channel the app has left', async () => {
+        function Wrapper({ show }: { show: boolean }) {
+            return show ? <Panel /> : null
+        }
+
+        const { rerender } = await mount(<Wrapper show />)
+        env.ackJoin(env.lastJoin(TOPIC))
+        await tick(1)
+
+        await act(async () => {
+            env.deliver({ topic: TOPIC, event: 'phx_error', payload: {} })
+            rerender(
+                <SocketProvider>
+                    <Wrapper show={false} />
+                </SocketProvider>
+            )
+        })
+        const joinsAfterLeave = env.joins(TOPIC).length
+
+        await tick(60_000)
+        expect(env.joins(TOPIC)).toHaveLength(joinsAfterLeave)
+    })
+})

--- a/web/src/hooks/socketTestHarness.tsx
+++ b/web/src/hooks/socketTestHarness.tsx
@@ -1,0 +1,138 @@
+import { vi } from 'vitest'
+
+export interface WireMessage {
+    topic: string
+    event: string
+    payload: Record<string, unknown>
+    ref?: string
+    join_ref?: string
+}
+
+export interface FakeSocket {
+    url: string
+    readyState: number
+    onopen: ((e: unknown) => void) | null
+    onmessage: ((e: { data: string }) => void) | null
+    onclose: ((e: unknown) => void) | null
+    onerror: ((e: unknown) => void) | null
+    send(data: string): void
+    close(): void
+}
+
+export interface SocketEnv {
+    /** Every frame the client put on the wire, in order. */
+    sent: WireMessage[]
+    /** Every socket the provider opened. */
+    instances: FakeSocket[]
+    joins(topic?: string): WireMessage[]
+    leaves(topic?: string): WireMessage[]
+    lastJoin(topic: string): WireMessage
+    /** Deliver a server frame on the newest socket. */
+    deliver(msg: Record<string, unknown>): void
+    /** Answer a join with `status: "ok"`. */
+    ackJoin(join: WireMessage, response?: Record<string, unknown>): void
+    /** Answer a join with `status: "error"` and the given response body. */
+    refuseJoin(join: WireMessage, response: Record<string, unknown>): void
+    /** Push a channel event to the client. */
+    pushEvent(topic: string, event: string, payload?: Record<string, unknown>): void
+}
+
+/**
+ * Installs a fake WebSocket and a stubbed `getSocket`, and returns handles for
+ * driving the server side of the conversation.
+ *
+ * Call `vi.mock('@/lib/api/client/app/socket/getSocket', ...)` in the test file
+ * itself — vitest hoists mocks per module, so it cannot live in here.
+ */
+export function installFakeSocket(): SocketEnv {
+    const sent: WireMessage[] = []
+    const instances: FakeSocket[] = []
+
+    class FakeWS implements FakeSocket {
+        static CONNECTING = 0
+        static OPEN = 1
+        static CLOSING = 2
+        static CLOSED = 3
+
+        readyState = 1
+        onopen: ((e: unknown) => void) | null = null
+        onmessage: ((e: { data: string }) => void) | null = null
+        onclose: ((e: unknown) => void) | null = null
+        onerror: ((e: unknown) => void) | null = null
+
+        constructor(public url: string) {
+            instances.push(this)
+            // Opens on the next tick, like a real handshake.
+            setTimeout(() => this.onopen?.({}), 0)
+        }
+
+        send(data: string) {
+            const msg = JSON.parse(data) as WireMessage
+            sent.push(msg)
+            // Answer heartbeats like a live server. Without this the client's
+            // zombie-socket watchdog fires, closes the socket and reconnects,
+            // which rejoins every channel — noise that swamps any test running
+            // longer than one heartbeat interval.
+            if (msg.topic === 'phoenix' && msg.event === 'heartbeat') {
+                setTimeout(() => {
+                    this.onmessage?.({
+                        data: JSON.stringify({
+                            topic: 'phoenix',
+                            event: 'phx_reply',
+                            ref: msg.ref,
+                            payload: { status: 'ok', response: {} },
+                        }),
+                    })
+                }, 0)
+            }
+        }
+
+        close() {
+            this.readyState = FakeWS.CLOSED
+            this.onclose?.({ wasClean: true })
+        }
+    }
+
+    ;(globalThis as unknown as { WebSocket: unknown }).WebSocket = FakeWS
+
+    const socket = () => instances[instances.length - 1]
+
+    const env: SocketEnv = {
+        sent,
+        instances,
+        joins: (topic) =>
+            sent.filter((m) => m.event === 'phx_join' && (!topic || m.topic === topic)),
+        leaves: (topic) =>
+            sent.filter((m) => m.event === 'phx_leave' && (!topic || m.topic === topic)),
+        lastJoin: (topic) => {
+            const all = env.joins(topic)
+            if (all.length === 0) throw new Error(`no phx_join for ${topic}`)
+            return all[all.length - 1]
+        },
+        deliver: (msg) => socket().onmessage?.({ data: JSON.stringify(msg) }),
+        ackJoin: (join, response = {}) =>
+            env.deliver({
+                topic: join.topic,
+                event: 'phx_reply',
+                ref: join.ref,
+                join_ref: join.join_ref,
+                payload: { status: 'ok', response },
+            }),
+        refuseJoin: (join, response) =>
+            env.deliver({
+                topic: join.topic,
+                event: 'phx_reply',
+                ref: join.ref,
+                join_ref: join.join_ref,
+                payload: { status: 'error', response },
+            }),
+        pushEvent: (topic, event, payload = {}) => env.deliver({ topic, event, payload }),
+    }
+
+    return env
+}
+
+/** Freeze the jitter the provider applies to backoff delays. */
+export function freezeJitter(value = 0) {
+    return vi.spyOn(Math, 'random').mockReturnValue(value)
+}


### PR DESCRIPTION
#205 fixed the client that was issuing ~400 channel joins per second. It did not fix the reason one client could take the service down.

`ws_join` is documented as a per-minute channel-join budget, and the API reference has always advertised it. It was only ever spent in `UserSocket.connect/3`, on the handshake. Once a socket was open, `phx_join` was completely unmetered, and each `campaign:` join runs `Auth.check_campaign_access` against Postgres. That is the 939 xact/s in #205.

So: any client, ours or a customer's, can still do this. This PR closes that, then fixes everything the new gate exposes on our own two clients.

## Server (`realtime/`)

**Joins are throttled where they happen.** A shared `RealtimeWeb.ChannelGuard.check_join/1` runs first in every channel's `join/3` — user, org, campaign, account, bulk, admin — deliberately **before** the `Auth` lookup, since refusing after the expensive query would defeat the point. An over-budget join is refused with the shape the docs already describe for throttled client events:

```json
{ "code": 4007, "reason": "rate_limited", "category": "ws_join", "retry_after_ms": 21400 }
```

**Handshakes get their own bucket.** `ws_connect` (30/min, `RATE_LIMIT_WS_CONNECT`) instead of sharing `ws_join`, so a reconnect storm cannot spend the budget a client then needs to rejoin its topics with, and vice versa. No new plan column: connect keeps reading the same per-plan value.

**`retry_after_ms` was backwards.** `calculate_retry_after` returned `60s / overage`, so the further over the limit a caller was, the *sooner* it was told to come back — the worst offender got the shortest wait. Buckets are fixed windows keyed on the wall-clock minute, so the hint is now simply the time until that window rolls over.

**Join rejections carry a code.** The reference documents post-join failures as `{ code, reason }`; only `OrgChannel` actually did that. The other five returned a bare `%{reason: ...}`. They now carry `code` too, with each channel's published reason slug (`campaign_not_found`, `not_a_member`, ...) passed through unchanged so nothing breaks. Added `4005` for a malformed topic, which previously had no honest code.

**`bulk:` was an IDOR.** `BulkChannel.join/3` validated that the operation id parsed as a UUID and subscribed. No ownership check of any kind, so any authenticated user could join `bulk:<id>` and watch another account's import. There is no table this service can read to authorize the join, so delivery is gated instead: an event reaches only the socket whose `user_id` matches the event's. Nothing publishes to this topic today (`PublishBulkProgress` has no callers), so the impact is currently zero — which is exactly why it should be closed now rather than the day someone wires it up.

## Clients

Adding a server-side limiter to clients that mishandle refusals would have made things worse, so both are fixed in the same change.

**`web/`** treated every failed join reply as terminal: the channel went to `errored` and stayed there. A throttled join would have left a campaign page dead until reload. It now distinguishes `rate_limited` (wait out `retry_after_ms`, clamped to 1–60s, and rejoin) from a final refusal (stay errored, stop). The `phx_error` auto-rejoin also moved off its flat 1s retry onto a backoff.

**`admin/`** was worse, and was already broken before this PR: on **any** refused join it closed the socket and reconnected, and `reconnectAttempt` reset to 0 on socket *open*. A permanently refused join — a non-admin opening the panel today — is therefore an endless ~120ms connect/refuse/close loop. With a join limiter in front of it that becomes a throttle-driven storm. Now: the backoff resets on a successful **join**, not on socket open; a throttled join waits and rejoins on the same socket; `getStatus()` reports `connected` only once the channel is actually joined.

**The backoff decays instead of resetting on success.** Worth calling out because the obvious implementation is wrong: a crash loop always joins successfully before it crashes again, so resetting the backoff on a successful join leaves it flat at 1s forever — exactly the case it exists for. Both clients instead reset the attempt count only after `30s` without needing a rejoin.

## Tests

`realtime/` had no test directory at all, though CI already ran `mix test`. It now has one (26 tests) that runs with **no Postgres and no Redis**: the limiter's counter backend is swappable via config and the suite uses an in-memory one, and channel tests build sockets with `Phoenix.ChannelTest.socket/3`, skipping `connect/3`. That the throttle refusal path is testable without a database is itself the proof it runs before `Auth`.

`web/` gains 14 tests over a fake WebSocket, including a regression test for #205 (which hangs the runner on the pre-#205 code — the loop is unbounded, not 400/s). `admin/` had no test runner; it gains vitest, jsdom, 10 tests, and a CI step.

Every behavioral claim above was mutation-checked: each fix was reverted individually and the corresponding test confirmed to fail.

## Deliberately not included

**Channel refcounting.** `leaveChannel` drops the channel entry and every subscriber's handlers with it, so two components holding one topic would fight. I implemented it, then backed it out: `RealtimeManager`'s org effect calls `joinChannel` on every re-run (including every reconnect) with no matching `leaveChannel`, so refcounting would leave the count permanently above zero and an org switch would never actually leave `org:<previous>` — the client would keep receiving the old workspace's events. That is a live data-visibility bug traded for a latent one with no current trigger (only `useCampaignChannel` uses `useChannel`, and nothing holds a topic twice). Balancing that effect first is its own change.

## Verification

`mix format --check-formatted` + `mix test` (26) in `realtime/`; `pnpm typecheck` + `pnpm lint` + `pnpm test:run` in `web/` (39) and `admin/` (10); `pnpm types:check` + `pnpm lint` + `pnpm build` in `docs/`. All clean, no new lint warnings in any tree.
