### PR TITLE
fix: warmup health evaluation has never run — pgx's ErrNoRows is not sql.ErrNoRows, and UpdateParticipantHealth was never preparable (#195)

### DIFF
--- a/docs/content/docs/guides/mailboxes.mdx
+++ b/docs/content/docs/guides/mailboxes.mdx
@@ -126,6 +126,8 @@ The detail drawer runs a live `SPF`, `DKIM`, and `DMARC` check on your sending d
 
 Underneath, health moves through `healthy`, `watch`, `throttled`, `quarantined`, and `blocked`. These feed warmup pool selection, which only picks healthy mailboxes as partners, so an unhealthy one can be lowered in volume, removed from the pool, or blocked entirely. A blocked mailbox shows the reason and any appeal option on the Warmup tab, and must requalify on a fresh probation sample rather than waiting out the clock.
 
+Health is judged only on what happened while the mailbox was in the pool: signals recorded before it joined are never counted against it.
+
 <Callout type="info" title="Health protects the pool">
   These controls act earlier than the point where providers start penalizing senders. Low complaint rate and low spam placement matter more than maximum throughput.
 </Callout>

--- a/internal/app/warmup/apply_invalid_token_test.go
+++ b/internal/app/warmup/apply_invalid_token_test.go
@@ -1,0 +1,182 @@
+package warmup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Embeds the interface so only the methods this path touches need stubbing; any
+// other call panics loudly rather than silently passing.
+type stubWarmupRepo struct {
+	repository.WarmupRepository
+
+	recordCalls  int
+	scoreCalls   int
+	getHealthErr error
+	metricsErr   error
+	updateErr    error
+	health       *models.WarmupParticipantHealth
+}
+
+func (r *stubWarmupRepo) RecordInvalidTokenAttempt(_ context.Context, _ uuid.UUID, _ string) error {
+	r.recordCalls++
+	return nil
+}
+
+func (r *stubWarmupRepo) IncrementSpamScore(_ context.Context, _ uuid.UUID, _ int) (int, error) {
+	r.scoreCalls++
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) GetParticipantHealth(_ context.Context, _ uuid.UUID, _ string) (*models.WarmupParticipantHealth, error) {
+	if r.getHealthErr != nil {
+		return nil, r.getHealthErr
+	}
+	return r.health, nil
+}
+
+func (r *stubWarmupRepo) UpdateParticipantHealth(_ context.Context, _ uuid.UUID, _ models.WarmupHealthState, _ *time.Time, _ string, _ float64) error {
+	return r.updateErr
+}
+
+func (r *stubWarmupRepo) SumWarmupSentSince(_ context.Context, _ uuid.UUID, _ time.Time) (int, error) {
+	return 0, r.metricsErr
+}
+
+func (r *stubWarmupRepo) CountSpamPlacementsSince(_ context.Context, _ uuid.UUID, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) CountUserComplaintsSince(_ context.Context, _ uuid.UUID, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) CountRecentInvalidAttempts(_ context.Context, _ uuid.UUID, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) GetSpamScore(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) CountDeliverabilityEventsByAccount(_ context.Context, _ uuid.UUID, _ string, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+func (r *stubWarmupRepo) CountDeliveredByAccount(_ context.Context, _ uuid.UUID, _ time.Time) (int, error) {
+	return 0, nil
+}
+
+// The invariant the caller depends on: applyInvalidWarmupAttempt re-records the
+// attempt and the score whenever this returns an error, so once anything has
+// been persisted the call must not report failure. Reporting one is how every
+// attempt came to be counted twice (#195).
+func TestApplyInvalidTokenAttemptNeverReportsFailureAfterRecording(t *testing.T) {
+	cases := []struct {
+		name string
+		repo *stubWarmupRepo
+	}{
+		{
+			// The failure mode that actually happened: the pool probe itself
+			// breaks, so the fallback read breaks with it.
+			name: "pool probe fails",
+			repo: &stubWarmupRepo{getHealthErr: errors.New("connection reset by peer")},
+		},
+		{
+			name: "metrics load fails",
+			repo: &stubWarmupRepo{
+				health:     &models.WarmupParticipantHealth{HealthState: models.WarmupHealthHealthy},
+				metricsErr: errors.New("statement timeout"),
+			},
+		},
+		{
+			name: "persist fails",
+			repo: &stubWarmupRepo{
+				health:    &models.WarmupParticipantHealth{HealthState: models.WarmupHealthHealthy},
+				updateErr: errors.New("deadlock detected"),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := NewService(c.repo).ApplyInvalidTokenAttempt(context.Background(), uuid.New(), "tok", 5)
+
+			if err != nil {
+				t.Fatalf("returned %v after the attempt was persisted; the caller's degraded path will record it again", err)
+			}
+			if c.repo.recordCalls != 1 {
+				t.Fatalf("attempt recorded %d times, want 1", c.repo.recordCalls)
+			}
+			if c.repo.scoreCalls != 1 {
+				t.Fatalf("score incremented %d times, want 1", c.repo.scoreCalls)
+			}
+		})
+	}
+}
+
+// A failure BEFORE anything is persisted must still be reported, so the caller's
+// degraded path can retry the recording. That path is what it documents itself
+// as being for.
+func TestApplyInvalidTokenAttemptReportsAFailedRecording(t *testing.T) {
+	repo := &failingRecordRepo{}
+
+	_, err := NewService(repo).ApplyInvalidTokenAttempt(context.Background(), uuid.New(), "tok", 5)
+	if err == nil {
+		t.Fatal("expected an error so the caller retries the recording")
+	}
+}
+
+type failingRecordRepo struct {
+	repository.WarmupRepository
+}
+
+func (r *failingRecordRepo) RecordInvalidTokenAttempt(_ context.Context, _ uuid.UUID, _ string) error {
+	return errors.New("write failed")
+}
+
+// The evaluation runs whether or not the account is in the first pool probed.
+// Probing "premium" first and treating "not in that pool" as a hard failure is
+// what stopped the band ever firing for a free-pool account.
+func TestEvaluateAnyPoolFallsThroughToTheSecondPool(t *testing.T) {
+	repo := &secondPoolRepo{
+		stubWarmupRepo: stubWarmupRepo{
+			health: &models.WarmupParticipantHealth{HealthState: models.WarmupHealthHealthy},
+		},
+	}
+
+	health, err := NewService(repo).(*service).evaluateAndPersistAnyPool(context.Background(), uuid.New())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if health == nil {
+		t.Fatal("expected the free-pool participant")
+	}
+	if !repo.updated {
+		t.Fatal("the evaluation never persisted a decision")
+	}
+}
+
+type secondPoolRepo struct {
+	stubWarmupRepo
+	updated bool
+}
+
+func (r *secondPoolRepo) GetParticipantHealth(_ context.Context, _ uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error) {
+	if poolType == "premium" {
+		return nil, nil // absent, not broken
+	}
+	return r.health, nil
+}
+
+func (r *secondPoolRepo) UpdateParticipantHealth(_ context.Context, _ uuid.UUID, _ models.WarmupHealthState, _ *time.Time, _ string, _ float64) error {
+	r.updated = true
+	return nil
+}

--- a/internal/app/warmup/health_evaluation_live_test.go
+++ b/internal/app/warmup/health_evaluation_live_test.go
@@ -1,0 +1,233 @@
+package warmup
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Live checks of warmup health evaluation against a real Postgres. Skipped
+// unless WARMBLY_TEST_DB is set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/warmup/ -run Live -v
+//
+// Issue #195: the invalid-token band never fired. GetParticipantHealth compared
+// the driver's not-found error with `err == sql.ErrNoRows`, but the pool is pgx,
+// whose ErrNoRows is a proxy error that wraps sql.ErrNoRows rather than being
+// it. The comparison was therefore always false and "this account is not in
+// this pool" surfaced as a hard error. evaluateAndPersistAnyPool probes
+// "premium" first, so for every free-pool account the very first probe failed
+// and the account's own pool was never reached: no evaluation, ever.
+//
+// The pool probe is pure SQL and the whole failure lives in the driver
+// boundary, so it only reproduces against a real database.
+
+func liveWarmupRepo(t *testing.T) (repository.WarmupRepository, *db.DB) {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+	return repository.NewWarmupRepository(handle.Pool), handle
+}
+
+// freePoolAccount is a mailbox that participates in the free warmup pool and
+// has no premium row, which is the shape every account on a self-hosted install
+// has.
+type freePoolAccount struct {
+	user, org, account uuid.UUID
+}
+
+func newFreePoolAccount(t *testing.T, handle *db.DB) *freePoolAccount {
+	t.Helper()
+	ctx := context.Background()
+	pool := handle.Pool
+
+	f := &freePoolAccount{user: uuid.New(), org: uuid.New(), account: uuid.New()}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'Health', 'Live')`,
+		f.user, "wh-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'Warmup Health Live', $2, $3)`,
+		f.org, "wh-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name,
+	          signature_plain, signature_html, provider, status, campaign_limit, min_wait_time, timezone)
+	      VALUES ($1, $2, $3, $4, 'Health', '', '', 'smtp_imap', 'active', 50, 600, 'UTC')`,
+		f.account, f.user, f.org, "wh-"+f.account.String()[:8]+"@test.local")
+
+	// Free pool only. No premium row, which is the whole point.
+	exec(`INSERT INTO warmup_pool_participants (pool_id, email_account_id)
+	      SELECT id, $1 FROM warmup_pools WHERE pool_type = 'free'`, f.account)
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, s := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM warmup_invalid_token_attempts WHERE email_account_id = $1`, f.account},
+			{`DELETE FROM warmup_pool_participants WHERE email_account_id = $1`, f.account},
+			{`DELETE FROM email_accounts WHERE id = $1`, f.account},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		} {
+			if _, err := pool.Exec(c, s.sql, s.arg); err != nil {
+				t.Errorf("cleanup %q: %v", s.sql, err)
+			}
+		}
+	})
+
+	return f
+}
+
+// The driver-boundary bug itself: "not in this pool" is not an error.
+func TestLiveGetParticipantHealthReportsAbsenceNotFailure(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newFreePoolAccount(t, handle)
+
+	health, err := repo.GetParticipantHealth(context.Background(), f.account, "premium")
+	if err != nil {
+		t.Fatalf("premium probe returned an error for an account that is simply not in that pool: %v", err)
+	}
+	if health != nil {
+		t.Fatal("expected no premium participant")
+	}
+
+	health, err = repo.GetParticipantHealth(context.Background(), f.account, "free")
+	if err != nil {
+		t.Fatalf("free probe: %v", err)
+	}
+	if health == nil {
+		t.Fatal("expected the free participant row")
+	}
+}
+
+// What the absence-as-error bug cost: the band that is supposed to act on
+// invalid tokens never ran for any free-pool account.
+func TestLiveInvalidTokenBandFiresForAFreePoolAccount(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newFreePoolAccount(t, handle)
+	svc := NewService(repo)
+	ctx := context.Background()
+
+	for i := 0; i < invalidTokenBlockThreshold; i++ {
+		if _, err := svc.ApplyInvalidTokenAttempt(ctx, f.account, uuid.NewString(), 0); err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+	}
+
+	attempts, err := repo.CountRecentInvalidAttempts(ctx, f.account, time.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatalf("count attempts: %v", err)
+	}
+	if attempts != invalidTokenBlockThreshold {
+		t.Fatalf("recorded %d attempts, want %d (a second recording means the caller's degraded path ran)",
+			attempts, invalidTokenBlockThreshold)
+	}
+
+	health, err := repo.GetParticipantHealth(ctx, f.account, "free")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if health.LastHealthEvaluatedAt == nil {
+		t.Fatal("last_health_evaluated_at is still null: the evaluation never ran")
+	}
+	if health.HealthState != models.WarmupHealthBlocked {
+		t.Fatalf("health_state is %q after %d invalid attempts, want %q",
+			health.HealthState, attempts, models.WarmupHealthBlocked)
+	}
+}
+
+// EvaluateAllParticipants is the hourly sweep, and the same absence-as-error
+// made it skip every free-pool account without a word.
+func TestLiveSweepEvaluatesAFreePoolAccount(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newFreePoolAccount(t, handle)
+	svc := NewService(repo)
+	ctx := context.Background()
+
+	evaluated, _, xerr := svc.EvaluateAllParticipants(ctx)
+	if xerr != nil {
+		t.Fatalf("sweep: %v", xerr)
+	}
+	if evaluated == 0 {
+		t.Fatal("the sweep evaluated nobody")
+	}
+
+	health, err := repo.GetParticipantHealth(ctx, f.account, "free")
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if health.LastHealthEvaluatedAt == nil {
+		t.Fatal("the sweep skipped this account: last_health_evaluated_at is still null")
+	}
+}
+
+// The cutover floor (migration 000096): a mailbox is not judged on signals from
+// before it was being judged. Without it, the first evaluation after this fix
+// would reach back over everything collected while nothing was watching,
+// including the spurious Junk placements Graph produced before #199 and #201.
+func TestLiveHealthSignalsBeforeTheFloorAreNotCounted(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newFreePoolAccount(t, handle)
+	svc := NewService(repo)
+	ctx := context.Background()
+
+	// Well over the block threshold, but all of it predates the floor.
+	for i := 0; i < invalidTokenBlockThreshold*4; i++ {
+		if _, err := handle.Pool.Exec(ctx,
+			`INSERT INTO warmup_invalid_token_attempts (email_account_id, attempted_token, created_at)
+			 VALUES ($1, $2, NOW() - INTERVAL '2 hours')`,
+			f.account, uuid.NewString()); err != nil {
+			t.Fatalf("backdated attempt: %v", err)
+		}
+	}
+	if _, err := handle.Pool.Exec(ctx,
+		`UPDATE warmup_pool_participants SET health_signals_from = NOW() - INTERVAL '1 hour'
+		 WHERE email_account_id = $1`, f.account); err != nil {
+		t.Fatalf("set floor: %v", err)
+	}
+
+	health, err := svc.(*service).evaluateAndPersistAnyPool(ctx, f.account)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if health.HealthState != models.WarmupHealthHealthy {
+		t.Fatalf("health_state is %q; attempts from before the floor were counted against the mailbox",
+			health.HealthState)
+	}
+
+	// The same volume of attempts after the floor does block it.
+	for i := 0; i < invalidTokenBlockThreshold; i++ {
+		if _, err := svc.ApplyInvalidTokenAttempt(ctx, f.account, uuid.NewString(), 0); err != nil {
+			t.Fatalf("attempt %d: %v", i+1, err)
+		}
+	}
+	health, err = svc.(*service).evaluateAndPersistAnyPool(ctx, f.account)
+	if err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if health.HealthState != models.WarmupHealthBlocked {
+		t.Fatalf("health_state is %q after %d attempts past the floor, want %q",
+			health.HealthState, invalidTokenBlockThreshold, models.WarmupHealthBlocked)
+	}
+}

--- a/internal/app/warmup/service.go
+++ b/internal/app/warmup/service.go
@@ -246,7 +246,7 @@ func (s *service) CanParticipate(ctx context.Context, accountID uuid.UUID, poolT
 		// Block period expired. Instead of snapping back to healthy, enter probation
 		// (throttled state with a 3-day window at reduced volume).
 		wasBlocked := health.HealthState == models.WarmupHealthQuarantined || health.HealthState == models.WarmupHealthBlocked
-		health, xerr := s.evaluateAndPersist(ctx, accountID, poolType)
+		health, xerr := s.evaluateAndPersist(ctx, accountID, poolType, health)
 		if xerr != nil {
 			return false, "", xerr
 		}
@@ -482,17 +482,17 @@ func (s *service) ApplyInvalidTokenAttempt(ctx context.Context, accountID uuid.U
 			return nil, errx.InternalError()
 		}
 	}
-	// The attempt and its score are already persisted, so a failed evaluation
-	// must not be reported as a failure of the whole call: the caller's
-	// degraded path records both a second time, which doubles every count the
-	// band then reads. Surface it instead and hand back the participant as it
-	// stands.
+	// The attempt and its score are already persisted, so nothing from here on
+	// may be reported as a failure of the whole call: the caller's degraded path
+	// re-records both, which doubles every count the band then reads (#195).
+	// The evaluation itself already logs its own cause.
 	health, err := s.evaluateAndPersistAnyPool(ctx, accountID)
 	if err != nil {
-		log.Error().
-			Str("email_account_id", accountID.String()).
-			Msg("warmup: invalid-token health evaluation failed; the attempt is recorded but no band was applied")
-		return s.getParticipantForAnyPool(ctx, accountID)
+		// Best effort: hand back the participant as it stands. If that read
+		// fails too (it runs the same probe that just failed), a nil health is
+		// still the right answer — the caller treats it as "unknown", not as a
+		// reason to record the attempt again.
+		health, _ = s.getParticipantForAnyPool(ctx, accountID)
 	}
 	return health, nil
 }
@@ -509,12 +509,17 @@ func (s *service) evaluateAndPersistAnyPool(ctx context.Context, accountID uuid.
 	for _, poolType := range []string{"premium", "free"} {
 		health, err := s.repo.GetParticipantHealth(ctx, accountID, poolType)
 		if err != nil {
+			log.Error().
+				Err(err).
+				Str("email_account_id", accountID.String()).
+				Str("pool_type", poolType).
+				Msg("warmup: pool membership probe failed; health evaluation skipped")
 			return nil, errx.InternalError()
 		}
 		if health == nil {
 			continue
 		}
-		return s.evaluateAndPersist(ctx, accountID, poolType)
+		return s.evaluateAndPersist(ctx, accountID, poolType, health)
 	}
 	return nil, nil
 }
@@ -523,6 +528,11 @@ func (s *service) getParticipantForAnyPool(ctx context.Context, accountID uuid.U
 	for _, poolType := range []string{"premium", "free"} {
 		health, err := s.repo.GetParticipantHealth(ctx, accountID, poolType)
 		if err != nil {
+			log.Error().
+				Err(err).
+				Str("email_account_id", accountID.String()).
+				Str("pool_type", poolType).
+				Msg("warmup: pool membership probe failed")
 			return nil, errx.InternalError()
 		}
 		if health != nil {
@@ -532,27 +542,45 @@ func (s *service) getParticipantForAnyPool(ctx context.Context, accountID uuid.U
 	return nil, nil
 }
 
-func (s *service) evaluateAndPersist(ctx context.Context, accountID uuid.UUID, poolType string) (*models.WarmupParticipantHealth, *errx.Error) {
-	metrics, err := s.loadMetrics(ctx, accountID)
-	if err != nil {
-		return nil, errx.InternalError()
+func (s *service) evaluateAndPersist(ctx context.Context, accountID uuid.UUID, poolType string, participant *models.WarmupParticipantHealth) (*models.WarmupParticipantHealth, *errx.Error) {
+	// errx.Error carries no cause, so every failure below is logged with the
+	// real error here. Without that the health bands can stop firing entirely
+	// and the only visible symptom is a last_health_evaluated_at that never
+	// moves (issue #195).
+	fail := func(stage string, cause error) *errx.Error {
+		log.Error().
+			Err(cause).
+			Str("email_account_id", accountID.String()).
+			Str("pool_type", poolType).
+			Str("stage", stage).
+			Msg("warmup: health evaluation failed; no band was applied")
+		return errx.InternalError()
 	}
 
-	// Capture the prior state so we can fire a webhook only on real
-	// transitions instead of on every sweep evaluation.
+	// Signals from before this mailbox was being evaluated are not held against
+	// it (see migration 000096).
+	signalsFrom := time.Time{}
 	priorState := models.WarmupHealthState("")
-	if prev, prevErr := s.repo.GetParticipantHealth(ctx, accountID, poolType); prevErr == nil && prev != nil {
-		priorState = prev.HealthState
+	if participant != nil {
+		signalsFrom = participant.HealthSignalsFrom
+		// The prior state is what makes a webhook fire on a real transition
+		// rather than on every sweep.
+		priorState = participant.HealthState
+	}
+
+	metrics, err := s.loadMetrics(ctx, accountID, signalsFrom)
+	if err != nil {
+		return nil, fail("load_metrics", err)
 	}
 
 	decision := evaluateMetrics(metrics, s.now().UTC())
 	if err := s.repo.UpdateParticipantHealth(ctx, accountID, decision.State, decision.BlockedUntil, decision.Reason, decision.Score); err != nil {
-		return nil, errx.InternalError()
+		return nil, fail("persist", err)
 	}
 
 	health, err := s.repo.GetParticipantHealth(ctx, accountID, poolType)
 	if err != nil {
-		return nil, errx.InternalError()
+		return nil, fail("read_back", err)
 	}
 
 	if priorState != "" && health != nil {
@@ -561,34 +589,44 @@ func (s *service) evaluateAndPersist(ctx context.Context, accountID uuid.UUID, p
 	return health, nil
 }
 
-func (s *service) loadMetrics(ctx context.Context, accountID uuid.UUID) (*models.WarmupHealthMetrics, error) {
+// loadMetrics counts the signals behind a health decision. No window reaches
+// further back than signalsFrom, so a mailbox is never judged on a period it was
+// not being judged in.
+func (s *service) loadMetrics(ctx context.Context, accountID uuid.UUID, signalsFrom time.Time) (*models.WarmupHealthMetrics, error) {
 	now := s.now().UTC()
-	sentLast7d, err := s.repo.SumWarmupSentSince(ctx, accountID, now.Add(-7*24*time.Hour))
+	since := func(window time.Duration) time.Time {
+		start := now.Add(-window)
+		if signalsFrom.After(start) {
+			return signalsFrom
+		}
+		return start
+	}
+	sentLast7d, err := s.repo.SumWarmupSentSince(ctx, accountID, since(7*24*time.Hour))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("SumWarmupSentSince: %w", err)
 	}
 
 	// Split the warmup spam signal into placement (provider classifier put
 	// the mail in Junk) vs user complaint (recipient actively flagged it).
 	// These have very different remediation paths so they earn separate
 	// rates instead of one combined ratio.
-	spamPlacementsLast7d, err := s.repo.CountSpamPlacementsSince(ctx, accountID, now.Add(-7*24*time.Hour))
+	spamPlacementsLast7d, err := s.repo.CountSpamPlacementsSince(ctx, accountID, since(7*24*time.Hour))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountSpamPlacementsSince: %w", err)
 	}
-	userComplaintsLast7d, err := s.repo.CountUserComplaintsSince(ctx, accountID, now.Add(-7*24*time.Hour))
+	userComplaintsLast7d, err := s.repo.CountUserComplaintsSince(ctx, accountID, since(7*24*time.Hour))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountUserComplaintsSince: %w", err)
 	}
 
-	invalidAttemptsLast24h, err := s.repo.CountRecentInvalidAttempts(ctx, accountID, now.Add(-24*time.Hour))
+	invalidAttemptsLast24h, err := s.repo.CountRecentInvalidAttempts(ctx, accountID, since(24*time.Hour))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountRecentInvalidAttempts: %w", err)
 	}
 
 	spamScore, err := s.repo.GetSpamScore(ctx, accountID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetSpamScore: %w", err)
 	}
 
 	placementRate := 0.0
@@ -600,18 +638,18 @@ func (s *service) loadMetrics(ctx context.Context, accountID uuid.UUID) (*models
 
 	// Load complaint and bounce counts from deliverability events (last 30 days).
 	// These cover external (non-warmup) sends and remain on a separate axis.
-	since30d := now.Add(-30 * 24 * time.Hour)
+	since30d := since(30 * 24 * time.Hour)
 	complaintsLast30d, err := s.repo.CountDeliverabilityEventsByAccount(ctx, accountID, "complaint", since30d)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountDeliverabilityEventsByAccount(complaint): %w", err)
 	}
 	bouncesLast30d, err := s.repo.CountDeliverabilityEventsByAccount(ctx, accountID, "bounce", since30d)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountDeliverabilityEventsByAccount(bounce): %w", err)
 	}
 	deliveredLast30d, err := s.repo.CountDeliveredByAccount(ctx, accountID, since30d)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("CountDeliveredByAccount: %w", err)
 	}
 
 	complaintRate := 0.0
@@ -811,11 +849,13 @@ func maxFloat(a, b float64) float64 {
 func (s *service) EvaluateAllParticipants(ctx context.Context) (int, int, *errx.Error) {
 	accountIDs, err := s.repo.GetAllParticipantAccountIDs(ctx)
 	if err != nil {
+		log.Error().Err(err).Msg("warmup: health sweep could not list participants")
 		return 0, 0, errx.InternalError()
 	}
 
 	evaluated := 0
 	stateChanges := 0
+	skipped := 0
 
 	for _, accountID := range accountIDs {
 		// Get current state before evaluation
@@ -835,9 +875,12 @@ func (s *service) EvaluateAllParticipants(ctx context.Context) (int, int, *errx.
 			stateBefore = healthBefore.HealthState
 		}
 
-		// Evaluate
+		// Evaluate. evaluateAndPersistAnyPool logs the underlying cause; count
+		// the skip here so the sweep can report how much of the pool it failed
+		// to evaluate instead of quietly reporting only what worked.
 		healthAfter, xerr := s.evaluateAndPersistAnyPool(ctx, accountID)
 		if xerr != nil {
+			skipped++
 			continue
 		}
 		evaluated++
@@ -845,6 +888,14 @@ func (s *service) EvaluateAllParticipants(ctx context.Context) (int, int, *errx.
 		if healthAfter != nil && healthAfter.HealthState != stateBefore {
 			stateChanges++
 		}
+	}
+
+	if skipped > 0 {
+		log.Error().
+			Int("skipped", skipped).
+			Int("evaluated", evaluated).
+			Int("participants", len(accountIDs)).
+			Msg("warmup: health sweep could not evaluate every participant; those accounts keep their last known band")
 	}
 
 	return evaluated, stateChanges, nil

--- a/internal/infrastructure/db/migrations/000096_warmup_health_signal_floor.down.sql
+++ b/internal/infrastructure/db/migrations/000096_warmup_health_signal_floor.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE warmup_pool_participants
+    DROP COLUMN IF EXISTS health_signals_from;

--- a/internal/infrastructure/db/migrations/000096_warmup_health_signal_floor.up.sql
+++ b/internal/infrastructure/db/migrations/000096_warmup_health_signal_floor.up.sql
@@ -1,0 +1,19 @@
+-- The banded warmup health evaluation never ran: UpdateParticipantHealth was
+-- unpreparable and the pool probe treated "not in this pool" as a hard error,
+-- so no mailbox has ever been judged (issue #195). With both fixed, the first
+-- evaluation would otherwise reach back over signals collected while nothing
+-- was watching -- including the spurious Junk placements Microsoft Graph
+-- produced before #199 and #201 -- and could quarantine or block mailboxes for
+-- something the platform did to itself.
+--
+-- This column is the floor. A signal older than it is not counted against the
+-- mailbox. Existing participants are floored at the moment this migration runs;
+-- new participants at the moment they join, which is the honest rule in both
+-- cases (do not judge a mailbox on a period it was not being judged in). The
+-- 30-day evaluation window rolls past the floor on its own, so this stops
+-- mattering roughly a month after deploy without anyone having to do anything.
+ALTER TABLE warmup_pool_participants
+    ADD COLUMN health_signals_from timestamptz NOT NULL DEFAULT now();
+
+COMMENT ON COLUMN warmup_pool_participants.health_signals_from IS
+    'Health signals older than this are not counted against the mailbox. Set to the join time for new participants, and to the #195 fix deploy for pre-existing ones.';

--- a/internal/models/warmup.go
+++ b/internal/models/warmup.go
@@ -82,6 +82,11 @@ type WarmupParticipantHealth struct {
 	LastHealthScore       float64           `json:"last_health_score"`
 	LastHealthReason      *string           `json:"last_health_reason,omitempty"`
 	LastHealthEvaluatedAt *time.Time        `json:"last_health_evaluated_at,omitempty"`
+	// Health signals older than this are not counted against the mailbox: its
+	// join time for a new participant, the #195 fix deploy for one that predates
+	// it. Keeps the first evaluation from judging a mailbox on a period nothing
+	// was evaluating.
+	HealthSignalsFrom time.Time `json:"health_signals_from"`
 }
 
 // WarmupBanStatus is the user-facing view of a mailbox's warmup standing,

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -523,7 +523,7 @@ func (r *campaignProgressRepository) GetResolvedAIVariables(ctx context.Context,
 	`
 	var raw []byte
 	err := r.db.QueryRow(ctx, query, campaignID, contactID, sequenceID).Scan(&raw)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return map[string]string{}, nil
 	}
 	if err != nil {
@@ -567,7 +567,7 @@ func (r *campaignProgressRepository) GetLatestReplyClass(ctx context.Context, co
 	`
 	var class string
 	err := r.db.QueryRow(ctx, query, contactID, campaignID).Scan(&class)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return "", nil
 	}
 	return class, err
@@ -641,7 +641,7 @@ func (r *campaignProgressRepository) GetCampaignProgress(ctx context.Context, ca
 		&progress.EmailsComplained,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return &CampaignProgress{}, nil
 	}
 
@@ -662,7 +662,7 @@ func (r *campaignProgressRepository) GetCampaignRollingRates(ctx context.Context
 	`
 	out := &CampaignRollingRates{}
 	err := r.db.QueryRow(ctx, query, campaignID, since).Scan(&out.Sent, &out.Bounced, &out.Complained)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return &CampaignRollingRates{}, nil
 	}
 	return out, err
@@ -719,7 +719,7 @@ func (r *campaignProgressRepository) GetContactLastSequenceTime(ctx context.Cont
 	var lastTime *time.Time
 	err := r.db.QueryRow(ctx, query, contactID, campaignID).Scan(&lastTime)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -770,7 +770,7 @@ func (r *campaignProgressRepository) GetLatestCampaignSequenceForContact(ctx con
 	`
 	out := &CampaignSequencePair{}
 	if err := r.db.QueryRow(ctx, query, contactID).Scan(&out.CampaignID, &out.SequenceID); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -1698,8 +1698,12 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 	for _, p := range data.Fields {
 		switch p.Type {
 		case models.BulkAddField:
+			// jsonb_build_object is variadic "any", so it gives Postgres nothing
+			// to infer $1/$2 from and the statement is refused before it runs.
+			// to_jsonb($2::text) also matches BulkEditField, which stores the
+			// value as a JSON string rather than a bare literal.
 			b.Queue(`UPDATE contacts
-			         SET custom_fields = custom_fields || jsonb_build_object($1,$2),
+			         SET custom_fields = custom_fields || jsonb_build_object($1::text, to_jsonb($2::text)),
 			             updated_at = NOW()
 			         WHERE organization_id = $3 AND id = ANY($4)`,
 				p.Key, p.Value, orgID, data.Contacts)
@@ -1717,10 +1721,10 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 				p.Key, orgID, data.Contacts)
 		case models.BulkRenameField:
 			b.Queue(`UPDATE contacts
-			         SET custom_fields = (custom_fields - $1) || jsonb_build_object($2, custom_fields->$1),
+			         SET custom_fields = (custom_fields - $1::text) || jsonb_build_object($2::text, custom_fields -> ($1::text)),
 			             updated_at = NOW()
 			         WHERE organization_id = $3 AND id = ANY($4)
-			           AND custom_fields ? $1`,
+			           AND custom_fields ? ($1::text)`,
 				p.Key, p.Value, orgID, data.Contacts)
 		}
 	}

--- a/internal/repository/pg_referral.go
+++ b/internal/repository/pg_referral.go
@@ -294,7 +294,10 @@ func (r *referralRepository) applyAttributionLedger(ctx context.Context, attr *m
 	var balanceAfter int64
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO referral_earnings_ledger (org_id, balance_cents, lifetime_earned_cents, currency)
-		VALUES ($1, $2, GREATEST($2, 0), $3)
+		-- $2 is pinned to bigint: the balance_cents column made Postgres deduce
+		-- bigint while GREATEST($2, 0) against an integer literal deduced
+		-- integer, and the conflict meant this upsert never ran at all.
+		VALUES ($1, $2::bigint, GREATEST($2::bigint, 0), $3)
 		ON CONFLICT (org_id) DO UPDATE SET
 			balance_cents = referral_earnings_ledger.balance_cents + EXCLUDED.balance_cents,
 			lifetime_earned_cents = referral_earnings_ledger.lifetime_earned_cents + GREATEST(EXCLUDED.balance_cents, 0),

--- a/internal/repository/pg_task.go
+++ b/internal/repository/pg_task.go
@@ -281,7 +281,7 @@ func (r *taskRepository) GetTask(ctx context.Context, taskID uuid.UUID) (*Task, 
 		&task.UpdatedAt,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -312,7 +312,7 @@ func (r *taskRepository) GetTaskByMessageID(ctx context.Context, messageID strin
 		&task.CreatedAt,
 		&task.UpdatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	return task, err
@@ -334,7 +334,7 @@ func (r *taskRepository) GetCampaignTask(ctx context.Context, taskID uuid.UUID) 
 		&campaignTask.SequenceID,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -355,7 +355,7 @@ func (r *taskRepository) GetWarmupTask(ctx context.Context, taskID uuid.UUID) (*
 		&warmupTask.TargetAccountID,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -386,7 +386,7 @@ func (r *taskRepository) GetEmailTask(ctx context.Context, taskID uuid.UUID) (*E
 		&emailTask.Encrypted,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -500,7 +500,7 @@ func (r *taskRepository) GetLastEmailTime(ctx context.Context, accountID uuid.UU
 	var lastTime *time.Time
 	err := r.db.QueryRow(ctx, query, accountID).Scan(&lastTime)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 

--- a/internal/repository/pg_template.go
+++ b/internal/repository/pg_template.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -89,7 +90,7 @@ func (r *templateRepository) GetByID(ctx context.Context, orgID, templateID uuid
 		&t.UpdatedAt,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -198,7 +199,7 @@ func (r *templateRepository) Update(ctx context.Context, orgID, templateID uuid.
 		&t.UpdatedAt,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -202,7 +202,7 @@ func (r *warmupRepository) GetPoolByType(ctx context.Context, poolType string) (
 		&pool.CreatedAt,
 	)
 
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 
@@ -378,7 +378,7 @@ func (r *warmupRepository) GetHealthState(ctx context.Context, accountID uuid.UU
 	var state string
 	var blockedUntil *time.Time
 	err := r.db.QueryRow(ctx, query, accountID).Scan(&state, &blockedUntil)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return models.WarmupHealthHealthy, nil, nil
 	}
 	if err != nil {
@@ -487,7 +487,8 @@ func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID u
 			wpp.health_state,
 			wpp.last_health_score,
 			wpp.last_health_reason,
-			wpp.last_health_evaluated_at
+			wpp.last_health_evaluated_at,
+			wpp.health_signals_from
 		FROM warmup_pool_participants wpp
 		JOIN warmup_pools wp ON wp.id = wpp.pool_id
 		WHERE wpp.email_account_id = $1
@@ -510,8 +511,9 @@ func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID u
 		&out.LastHealthScore,
 		&out.LastHealthReason,
 		&out.LastHealthEvaluatedAt,
+		&out.HealthSignalsFrom,
 	); err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, err
@@ -521,25 +523,31 @@ func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID u
 }
 
 func (r *warmupRepository) UpdateParticipantHealth(ctx context.Context, accountID uuid.UUID, state models.WarmupHealthState, blockedUntil *time.Time, reason string, score float64) error {
+	// Every parameter is cast explicitly. Left bare, Postgres deduced $1 as
+	// `character varying` from the health_state assignment and as `text` from the
+	// equality tests, and could not deduce $2 at all from IS NULL / IS DISTINCT
+	// FROM. It refused the whole statement with 42P08, so this UPDATE never ran
+	// for any account in any pool and no warmup health state was ever persisted
+	// (issue #195). Keep the casts.
 	query := `
 		UPDATE warmup_pool_participants
 		SET
-			health_state = $1,
-			blocked_until = $2,
+			health_state = $1::text,
+			blocked_until = $2::timestamptz,
 			blocked_at = CASE
-				WHEN $2 IS NOT NULL AND (blocked_at IS NULL OR blocked_until IS DISTINCT FROM $2) THEN NOW()
-				WHEN $2 IS NULL AND blocked_until IS NOT NULL THEN NULL
+				WHEN $2::timestamptz IS NOT NULL AND (blocked_at IS NULL OR blocked_until IS DISTINCT FROM $2::timestamptz) THEN NOW()
+				WHEN $2::timestamptz IS NULL AND blocked_until IS NOT NULL THEN NULL
 				ELSE blocked_at
 			END,
 			blocked_reason = CASE
-				WHEN $2 IS NOT NULL OR $1 = 'blocked' THEN $3
-				WHEN $1 = 'healthy' THEN NULL
-				ELSE COALESCE($3, blocked_reason)
+				WHEN $2::timestamptz IS NOT NULL OR $1::text = 'blocked' THEN $3::text
+				WHEN $1::text = 'healthy' THEN NULL
+				ELSE COALESCE($3::text, blocked_reason)
 			END,
-			last_health_score = $4,
-			last_health_reason = NULLIF($3, ''),
+			last_health_score = $4::double precision,
+			last_health_reason = NULLIF($3::text, ''),
 			last_health_evaluated_at = NOW()
-		WHERE email_account_id = $5
+		WHERE email_account_id = $5::uuid
 		  AND NOT (blocked_at IS NOT NULL AND blocked_until IS NULL AND health_state = 'blocked')
 	`
 	_, err := r.db.Exec(ctx, query, state, blockedUntil, reason, score, accountID)
@@ -1035,7 +1043,7 @@ func (r *warmupRepository) GetWarmupReceived(ctx context.Context, accountID, int
 	err := r.db.QueryRow(ctx, query, accountID, internalID).Scan(
 		&w.EmailAccountID, &w.InternalID, &w.MessageID, &w.SenderAccountID, &w.CreatedAt,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -1260,7 +1268,7 @@ func (r *warmupRepository) GetLatestReplyCandidate(ctx context.Context, senderAc
 		&candidate.ConversationID,
 		&candidate.ConversationTurn,
 	)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {

--- a/internal/repository/pg_worker_ssh.go
+++ b/internal/repository/pg_worker_ssh.go
@@ -151,15 +151,19 @@ func (r *workerRepository) GetWorkerSSHCredentials(ctx context.Context, id uuid.
 }
 
 func (r *workerRepository) UpdateInstallState(ctx context.Context, id uuid.UUID, state models.WorkerInstallState, lastError string) error {
+	// $2 is pinned to text at every use and cast to the enum only at the
+	// assignment. Left bare, Postgres deduced worker_install_state from the
+	// column and text from the comparisons, refused the statement, and no
+	// install state was ever recorded.
 	_, err := r.db.Exec(ctx, `
 		UPDATE workers
-		SET install_state = $2,
-		    last_error = NULLIF($3, ''),
-		    active = CASE WHEN $2 = 'installed' THEN true
-		                  WHEN $2 IN ('uninstalled', 'error') THEN false
+		SET install_state = ($2::text)::worker_install_state,
+		    last_error = NULLIF($3::text, ''),
+		    active = CASE WHEN $2::text = 'installed' THEN true
+		                  WHEN $2::text IN ('uninstalled', 'error') THEN false
 		                  ELSE active END,
 		    updated_at = NOW()
-		WHERE id = $1
+		WHERE id = $1::uuid
 	`, id, state, lastError)
 	return err
 }

--- a/internal/repository/query_prepare_live_test.go
+++ b/internal/repository/query_prepare_live_test.go
@@ -1,0 +1,150 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Every parameterised statement in this package must be preparable by Postgres.
+// Skipped unless WARMBLY_TEST_DB is set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run TestLiveEveryQueryPrepares -v
+//
+// Issue #195: UpdateParticipantHealth used a bare $1 both as a health_state
+// assignment and in equality tests. Postgres deduced `character varying` from
+// one and `text` from the other, refused the statement with 42P08, and the
+// query never ran — for any account, in any pool, since it was written. Nothing
+// caught it because the error surfaced as a generic internal error at runtime
+// and only on a code path nobody watched.
+//
+// A statement that cannot be prepared can never execute, so this is decidable
+// ahead of time: ask the server. The same sweep found the identical defect in
+// the contacts bulk custom-field writes and in the worker install-state update.
+//
+// Deliberately narrow: only 42P08 fails the test. Other errors are reported but
+// tolerated, because the extractor below is a regex over source and will
+// occasionally pick up a fragment of a statement that is assembled at runtime.
+const indeterminateDatatype = "42P08"
+
+var (
+	// A backtick string literal in Go source.
+	rawLiteral = regexp.MustCompile("`([^`]*)`")
+	// Something that starts like a complete statement.
+	statementStart = regexp.MustCompile(`(?is)^\s*(SELECT|INSERT|UPDATE|DELETE|WITH)\b`)
+	// Placeholders. No placeholders means no parameter to be ambiguous about.
+	hasParam = regexp.MustCompile(`\$\d`)
+	// Assembled with fmt: not a statement, just a template.
+	isTemplate = regexp.MustCompile(`%[sdvqt]`)
+)
+
+type extractedQuery struct {
+	file string
+	line int
+	sql  string
+}
+
+func extractQueries(t *testing.T, dir string) []extractedQuery {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	var out []extractedQuery
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		for _, m := range rawLiteral.FindAllSubmatchIndex(src, -1) {
+			sql := string(src[m[2]:m[3]])
+			if !hasParam.MatchString(sql) ||
+				!statementStart.MatchString(sql) ||
+				isTemplate.MatchString(sql) {
+				continue
+			}
+			out = append(out, extractedQuery{
+				file: name,
+				line: strings.Count(string(src[:m[0]]), "\n") + 1,
+				sql:  sql,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].file != out[j].file {
+			return out[i].file < out[j].file
+		}
+		return out[i].line < out[j].line
+	})
+	return out
+}
+
+func TestLiveEveryQueryPrepares(t *testing.T) {
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+
+	ctx := context.Background()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	queries := extractQueries(t, ".")
+	if len(queries) < 100 {
+		t.Fatalf("only found %d statements to check; the extractor is broken", len(queries))
+	}
+
+	var ambiguous, other []string
+	for i, q := range queries {
+		_, err := conn.Prepare(ctx, fmt.Sprintf("check_%d", i), strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(q.sql), ";")))
+		if err == nil {
+			continue
+		}
+
+		where := fmt.Sprintf("%s:%d", q.file, q.line)
+		var pgErr *pgconn.PgError
+		switch {
+		case errors.As(err, &pgErr) && pgErr.Code == indeterminateDatatype:
+			ambiguous = append(ambiguous, fmt.Sprintf("%s: %s (%s)\n\t\t%s", where, pgErr.Message, pgErr.Detail, oneLine(q.sql)))
+		default:
+			other = append(other, fmt.Sprintf("%s: %v", where, err))
+		}
+	}
+
+	// Informational: a fragment of a runtime-assembled statement lands here, but
+	// so does a genuinely broken query, so keep them visible.
+	if len(other) > 0 {
+		t.Logf("%d statement(s) could not be prepared for other reasons (some are runtime-assembled fragments):\n%s",
+			len(other), strings.Join(other, "\n"))
+	}
+
+	if len(ambiguous) > 0 {
+		t.Fatalf("%d statement(s) have a parameter Postgres cannot type, so they can never execute:\n%s",
+			len(ambiguous), strings.Join(ambiguous, "\n"))
+	}
+
+	t.Logf("checked %d parameterised statements", len(queries))
+}
+
+func oneLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}


### PR DESCRIPTION
Closes #195.

#204 fixed the double-counting. It did not fix what #195 calls "the part that matters most": the health evaluation never runs. This finds out why, and the answer is two independent bugs, neither of which has ever worked since the code was written.

## 1. `pgx.ErrNoRows` is not `sql.ErrNoRows`

`GetParticipantHealth` ends with:

```go
if err == sql.ErrNoRows {
    return nil, nil
}
return nil, err
```

The pool is pgx. `pgx.ErrNoRows` is `newProxyErr(sql.ErrNoRows, "no rows in result set")` (`pgx/v5@v5.9.0/conn.go:107`) — it *wraps* `sql.ErrNoRows`, so `errors.Is` matches but `==` never does. Proven:

```
pgx.ErrNoRows == sql.ErrNoRows           -> false
errors.Is(pgx.ErrNoRows, sql.ErrNoRows)  -> true
type: *pgx.proxyError
```

So "this account is not in this pool" came back as a hard error. `evaluateAndPersistAnyPool` probes `premium` first, so for **every free-pool account the first probe failed and its own pool was never reached**. No evaluation, ever. It also explains the double-counting #204 chased and why the fallback there still re-errored: `getParticipantForAnyPool` runs the same failing probe.

The codebase already agrees this is wrong — 128 sites use `errors.Is`, 19 use `==`. All 19 are fixed.

## 2. `UpdateParticipantHealth` has never been executable

`$1` was used both as `health_state = $1` and as `$1 = 'blocked'`. Postgres, asked to deduce:

```
ERROR:  inconsistent types deduced for parameter $1
DETAIL:  text versus character varying
```

The statement is refused at Parse, so it never ran — not for a free account, not for a premium one, not once. **No warmup health state has ever been persisted.** `$2` was equally undeducible from `IS NULL` / `IS DISTINCT FROM`; it was simply masked behind $1. Every parameter is now cast explicitly.

## The same defect, found everywhere else

A statement that cannot be prepared can never execute, which makes this decidable ahead of time: ask the server. `TestLiveEveryQueryPrepares` extracts every parameterised statement in `internal/repository` and `PREPARE`s it through pgx. It found three more dead queries:

| Where | What was broken |
| --- | --- |
| `pg_contact.go` `BulkAddField` | `jsonb_build_object($1,$2)` is variadic `"any"` — nothing to infer from. Bulk **add custom field** never worked. |
| `pg_contact.go` `BulkRenameField` | Same, plus `custom_fields ? $1`. Bulk **rename custom field** never worked. |
| `pg_worker_ssh.go` `UpdateInstallState` | `text versus worker_install_state`. Worker SSH **install state never persisted**. |
| `pg_referral.go` ledger upsert | `integer versus bigint` from `GREATEST($2, 0)`. **Referral earnings were never credited.** |

The test fails only on 42P08 and reports everything else, because the extractor is a regex over source and will occasionally pick up a fragment of a runtime-assembled statement.

## Diagnosability

`errx.Error` has no cause field and `errx.InternalError()` is a fixed `"Something went wrong."`, so #204's log line could not have named anything even with `.Err()` attached. The logging is now where the real error still exists: `loadMetrics` names the failing repo call, `evaluateAndPersist` logs cause + account + pool + stage, and the hourly sweep reports how many participants it could not evaluate instead of `continue`-ing in silence while reporting only its successes.

This is not theoretical — it is how bug 2 was found. The first log line after fixing bug 1 was `"error":"ERROR: inconsistent types deduced for parameter $1 (SQLSTATE 42P08)","stage":"persist"`.

## The double-count, completed

`ApplyInvalidTokenAttempt` now returns an error only when nothing was persisted, which is the invariant the caller's degraded path actually depends on. #204 stopped short: its fallback re-ran the probe that had just failed and re-raised, and a failed `IncrementSpamScore` still reported failure after the attempt was recorded.

## Not blocking anyone for our own bugs

With the evaluator working, the first sweep would judge mailboxes on history collected while nothing was watching — including the spurious Junk placements Graph produced before #199 and #201, which sit inside the 7-day window until ~Sept 2 and the 30-day window into late September.

Migration `000096` adds `warmup_pool_participants.health_signals_from`, and `loadMetrics` clamps every window to it. Existing participants are floored at the migration; new ones at their join, which is the honest rule in both cases. It expires by itself once the widest window rolls past it, and needs no operator step. `warmup_pool_participants` is `ImportSkip` in `orgtransfer`, so nothing is needed there.

## Tests

- `internal/app/warmup/health_evaluation_live_test.go` — four live tests. All four fail on `main`, including "the sweep evaluated nobody", which is literally what the hourly sweep does today on a database of free-pool accounts.
- `internal/repository/query_prepare_live_test.go` — the prepare sweep.
- `internal/app/warmup/apply_invalid_token_test.go` — the invariant, in all three failure modes, plus the "must still report a failed recording" case.

Each fix was reverted individually and its test confirmed to fail.

## Verification

`gofmt -l` clean, `make lint` clean (incl. `check-migrations`, 96 versions no duplicates), full `go test ./internal/...` green, every `-run Live` test green against the dev Postgres, `docs/` `types:check` + `lint` + `build` clean. `guides/mailboxes.mdx` already described this banded model as working, so the fix makes existing docs true; one sentence was added about the signal floor.
