### PR TITLE
Keep a mailbox in exactly one warmup pool

### DIFF
--- a/docs/content/docs/guides/warmup.mdx
+++ b/docs/content/docs/guides/warmup.mdx
@@ -40,9 +40,11 @@ A pool is the set of mailboxes that warm each other. Your mailbox only exchanges
 | `premium` | Paid organizations' mailboxes. The default for paid accounts, isolated from lower-trust traffic. |
 | `free` | Lower-trust or trial mailboxes, kept separate so free traffic never mixes into premium reputation. |
 
+A mailbox belongs to exactly one pool at a time. When its plan changes the mailbox moves between pools rather than joining a second one, and it takes its warmup standing with it, so a quarantine or block is not cleared by changing tier.
+
 The separation is never crossed silently. Warmbly spreads sends across many partners and recipient domains rather than looping the same two mailboxes, since tight reciprocal pairs are easy for providers to spot. **Pool quality matters more than pool size.**
 
-Turning off outbound warmup does not remove a healthy mailbox from the recipient pool. Disconnecting it, losing warmup-plan access, or entering a quarantined or blocked state does.
+Turning off outbound warmup does not remove a healthy mailbox from the recipient pool. Disconnecting it, losing warmup-plan access, or entering a quarantined or blocked state does. Losing access removes the mailbox from its pool within minutes, whether or not it was still warming.
 
 ## The ramp
 

--- a/internal/app/email/handler.go
+++ b/internal/app/email/handler.go
@@ -287,9 +287,7 @@ func (s *emailService) removeFromAllWarmupPools(ctx context.Context, account *mo
 		return
 	}
 
-	for _, poolType := range []string{"premium", "free"} {
-		_ = s.warmupService.RemovePoolMembership(ctx, account.ID, poolType)
-	}
+	_ = s.warmupService.RemoveFromAllPools(ctx, account.ID)
 }
 
 func (s *emailService) canUseWarmupPool(ctx context.Context, account *models.Email) bool {

--- a/internal/app/warmup/apply_invalid_token_test.go
+++ b/internal/app/warmup/apply_invalid_token_test.go
@@ -42,6 +42,13 @@ func (r *stubWarmupRepo) GetParticipantHealth(_ context.Context, _ uuid.UUID, _ 
 	return r.health, nil
 }
 
+func (r *stubWarmupRepo) GetParticipantHealthForAccount(_ context.Context, _ uuid.UUID) (*models.WarmupParticipantHealth, error) {
+	if r.getHealthErr != nil {
+		return nil, r.getHealthErr
+	}
+	return r.health, nil
+}
+
 func (r *stubWarmupRepo) UpdateParticipantHealth(_ context.Context, _ uuid.UUID, _ models.WarmupHealthState, _ *time.Time, _ string, _ float64) error {
 	return r.updateErr
 }
@@ -142,13 +149,17 @@ func (r *failingRecordRepo) RecordInvalidTokenAttempt(_ context.Context, _ uuid.
 	return errors.New("write failed")
 }
 
-// The evaluation runs whether or not the account is in the first pool probed.
-// Probing "premium" first and treating "not in that pool" as a hard failure is
-// what stopped the band ever firing for a free-pool account.
-func TestEvaluateAnyPoolFallsThroughToTheSecondPool(t *testing.T) {
-	repo := &secondPoolRepo{
+// The evaluation runs on the mailbox's own pool row. Probing "premium" first
+// and treating "not in that pool" as a hard failure is what stopped the band
+// ever firing for a free-pool account (#195); membership is now read per
+// account, which is exact because a mailbox is in exactly one pool (#211).
+func TestEvaluateAnyPoolEvaluatesTheMailboxesOwnPool(t *testing.T) {
+	repo := &ownPoolRepo{
 		stubWarmupRepo: stubWarmupRepo{
-			health: &models.WarmupParticipantHealth{HealthState: models.WarmupHealthHealthy},
+			health: &models.WarmupParticipantHealth{
+				PoolType:    "free",
+				HealthState: models.WarmupHealthHealthy,
+			},
 		},
 	}
 
@@ -162,21 +173,26 @@ func TestEvaluateAnyPoolFallsThroughToTheSecondPool(t *testing.T) {
 	if !repo.updated {
 		t.Fatal("the evaluation never persisted a decision")
 	}
+	if repo.readBackPool != "free" {
+		t.Fatalf("read the decision back from pool %q, want the pool the mailbox is actually in", repo.readBackPool)
+	}
 }
 
-type secondPoolRepo struct {
+type ownPoolRepo struct {
 	stubWarmupRepo
-	updated bool
+	updated      bool
+	readBackPool string
 }
 
-func (r *secondPoolRepo) GetParticipantHealth(_ context.Context, _ uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error) {
-	if poolType == "premium" {
+func (r *ownPoolRepo) GetParticipantHealth(_ context.Context, _ uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error) {
+	r.readBackPool = poolType
+	if poolType != "free" {
 		return nil, nil // absent, not broken
 	}
 	return r.health, nil
 }
 
-func (r *secondPoolRepo) UpdateParticipantHealth(_ context.Context, _ uuid.UUID, _ models.WarmupHealthState, _ *time.Time, _ string, _ float64) error {
+func (r *ownPoolRepo) UpdateParticipantHealth(_ context.Context, _ uuid.UUID, _ models.WarmupHealthState, _ *time.Time, _ string, _ float64) error {
 	r.updated = true
 	return nil
 }

--- a/internal/app/warmup/pool_membership_live_test.go
+++ b/internal/app/warmup/pool_membership_live_test.go
@@ -184,6 +184,37 @@ func TestLiveMovingPoolsCarriesTheMailboxReputation(t *testing.T) {
 	}
 }
 
+// An indefinite block (tampering, appeal only) has no blocked_until at all.
+// It has to survive a pool move as an indefinite block, not become an expiry.
+func TestLiveMovingPoolsKeepsAnIndefiniteBlockIndefinite(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	ctx := context.Background()
+
+	if _, err := handle.Pool.Exec(ctx, `
+		UPDATE warmup_pool_participants
+		SET health_state = 'blocked', blocked_at = NOW(), blocked_until = NULL,
+		    blocked_reason = 'tampering'
+		WHERE email_account_id = $1`, f.account); err != nil {
+		t.Fatalf("block the mailbox: %v", err)
+	}
+
+	if err := repo.MoveToPool(ctx, poolID(t, handle, "free"), f.account, "sender_receiver"); err != nil {
+		t.Fatalf("move to free: %v", err)
+	}
+
+	health, err := repo.GetParticipantHealthForAccount(ctx, f.account)
+	if err != nil || health == nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if health.HealthState != models.WarmupHealthBlocked {
+		t.Fatalf("health %q after the move, want it still blocked", health.HealthState)
+	}
+	if health.BlockedUntil != nil {
+		t.Fatalf("blocked_until %v after the move, want an indefinite block", health.BlockedUntil)
+	}
+}
+
 // The invariant is the database's, not the caller's: a second membership cannot
 // be written even by SQL that asks for one.
 func TestLiveASecondPoolMembershipIsRejected(t *testing.T) {

--- a/internal/app/warmup/pool_membership_live_test.go
+++ b/internal/app/warmup/pool_membership_live_test.go
@@ -1,0 +1,388 @@
+package warmup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Live checks that a mailbox is in exactly one warmup pool, and that changing
+// which one carries its reputation across. Skipped unless WARMBLY_TEST_DB is
+// set:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/warmup/ -run Live -v
+//
+// Issue #211: joining and leaving were both scoped to the pool the mailbox is
+// entitled to RIGHT NOW, so an entitlement change added a row in the new pool
+// and left the old one behind. A downgraded mailbox kept its premium row and
+// went on being offered to paying customers as a warmup partner, and its spam
+// score was counted once per row by the health evaluator.
+//
+// The whole thing lives in SQL — an upsert conflict target, a unique index, an
+// aggregate — so it only reproduces against a real database.
+
+// poolMailbox is a mailbox with a warmup pool membership and a reputation worth
+// losing track of.
+type poolMailbox struct {
+	user, org, account uuid.UUID
+	handle             *db.DB
+}
+
+func newPoolMailbox(t *testing.T, handle *db.DB, poolType string) *poolMailbox {
+	t.Helper()
+	ctx := context.Background()
+	pool := handle.Pool
+
+	var pools int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM warmup_pools`).Scan(&pools); err != nil {
+		t.Fatalf("count pools: %v", err)
+	}
+	if pools == 0 {
+		t.Skip("no warmup pools on this database")
+	}
+
+	f := &poolMailbox{user: uuid.New(), org: uuid.New(), account: uuid.New(), handle: handle}
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'Pool', 'Live')`,
+		f.user, "wp-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'Warmup Pool Live', $2, $3)`,
+		f.org, "wp-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name,
+	          signature_plain, signature_html, provider, status, campaign_limit, min_wait_time, timezone, warmup_pool_type)
+	      VALUES ($1, $2, $3, $4, 'Pool', '', '', 'smtp_imap', 'active', 50, 600, 'UTC', $5)`,
+		f.account, f.user, f.org, "wp-"+f.account.String()[:8]+"@test.local", poolType)
+
+	if poolType != "" {
+		exec(`INSERT INTO warmup_pool_participants (pool_id, email_account_id)
+		      SELECT id, $1 FROM warmup_pools WHERE pool_type = $2::warmup_pool_type`, f.account, poolType)
+	}
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, s := range []string{
+			`DELETE FROM warmup_pool_participants WHERE email_account_id = $1`,
+			`DELETE FROM email_accounts WHERE id = $1`,
+		} {
+			if _, err := pool.Exec(c, s, f.account); err != nil {
+				t.Errorf("cleanup %q: %v", s, err)
+			}
+		}
+		if _, err := pool.Exec(c, `DELETE FROM organizations WHERE id = $1`, f.org); err != nil {
+			t.Errorf("cleanup organizations: %v", err)
+		}
+		if _, err := pool.Exec(c, `DELETE FROM users WHERE id = $1`, f.user); err != nil {
+			t.Errorf("cleanup users: %v", err)
+		}
+	})
+
+	return f
+}
+
+// memberships returns the pool types this mailbox is a participant of.
+func (f *poolMailbox) memberships(t *testing.T) []string {
+	t.Helper()
+	rows, err := f.handle.Pool.Query(context.Background(), `
+		SELECT wp.pool_type::text
+		FROM warmup_pool_participants wpp
+		JOIN warmup_pools wp ON wp.id = wpp.pool_id
+		WHERE wpp.email_account_id = $1
+		ORDER BY 1`, f.account)
+	if err != nil {
+		t.Fatalf("read memberships: %v", err)
+	}
+	defer rows.Close()
+
+	var out []string
+	for rows.Next() {
+		var s string
+		if err := rows.Scan(&s); err != nil {
+			t.Fatalf("scan membership: %v", err)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func poolID(t *testing.T, handle *db.DB, poolType string) uuid.UUID {
+	t.Helper()
+	var id uuid.UUID
+	if err := handle.Pool.QueryRow(context.Background(),
+		`SELECT id FROM warmup_pools WHERE pool_type = $1::warmup_pool_type`, poolType).Scan(&id); err != nil {
+		t.Fatalf("pool %s: %v", poolType, err)
+	}
+	return id
+}
+
+// The bug itself: a mailbox that changes tier moves pools, it does not collect
+// them.
+func TestLiveJoiningTheOtherPoolMovesTheMailboxRatherThanDuplicatingIt(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	ctx := context.Background()
+
+	if err := repo.MoveToPool(ctx, poolID(t, handle, "free"), f.account, "sender_receiver"); err != nil {
+		t.Fatalf("move to free: %v", err)
+	}
+
+	got := f.memberships(t)
+	if len(got) != 1 || got[0] != "free" {
+		t.Fatalf("memberships %v, want exactly [free]; the mailbox is in two pools at once", got)
+	}
+}
+
+// Moving pools must not launder a penalty. A fresh row would start healthy with
+// a zero score, which is how a blocked mailbox could have re-entered the pool it
+// was blocked out of.
+func TestLiveMovingPoolsCarriesTheMailboxReputation(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	ctx := context.Background()
+
+	if _, err := handle.Pool.Exec(ctx, `
+		UPDATE warmup_pool_participants
+		SET spam_score = 47, health_state = 'blocked', blocked_at = NOW(),
+		    blocked_until = NOW() + INTERVAL '30 days', blocked_reason = 'tampering'
+		WHERE email_account_id = $1`, f.account); err != nil {
+		t.Fatalf("stain the mailbox: %v", err)
+	}
+
+	if err := repo.MoveToPool(ctx, poolID(t, handle, "free"), f.account, "recipient_only"); err != nil {
+		t.Fatalf("move to free: %v", err)
+	}
+
+	health, err := repo.GetParticipantHealthForAccount(ctx, f.account)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if health == nil {
+		t.Fatal("the mailbox lost its membership entirely")
+	}
+	if health.PoolType != "free" {
+		t.Fatalf("pool %q, want free", health.PoolType)
+	}
+	if health.HealthState != models.WarmupHealthBlocked {
+		t.Fatalf("health %q after the move, want it still blocked", health.HealthState)
+	}
+	if health.SpamScore != 47 {
+		t.Fatalf("spam score %d after the move, want 47", health.SpamScore)
+	}
+	if health.BlockedUntil == nil {
+		t.Fatal("the block expiry was dropped by the move")
+	}
+}
+
+// The invariant is the database's, not the caller's: a second membership cannot
+// be written even by SQL that asks for one.
+func TestLiveASecondPoolMembershipIsRejected(t *testing.T) {
+	_, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+
+	_, err := handle.Pool.Exec(context.Background(),
+		`INSERT INTO warmup_pool_participants (pool_id, email_account_id) VALUES ($1, $2)`,
+		poolID(t, handle, "free"), f.account)
+	if err == nil {
+		t.Fatal("the database accepted a mailbox into two warmup pools")
+	}
+}
+
+// The score is the mailbox's, not the pool row's. Summing it across memberships
+// counted every increment twice for a dual-member mailbox.
+func TestLiveSpamScoreIsCountedOnce(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	ctx := context.Background()
+
+	after, err := repo.IncrementSpamScore(ctx, f.account, 5)
+	if err != nil {
+		t.Fatalf("increment: %v", err)
+	}
+	if after != 5 {
+		t.Fatalf("increment returned %d, want 5", after)
+	}
+
+	score, err := repo.GetSpamScore(ctx, f.account)
+	if err != nil {
+		t.Fatalf("read score: %v", err)
+	}
+	if score != 5 {
+		t.Fatalf("score %d, want 5", score)
+	}
+}
+
+// The column caps the score at 100. Adding past the cap used to violate the
+// CHECK, and every caller ignores the error, so a noisy mailbox silently kept
+// whatever score it had.
+func TestLiveSpamScoreClampsInsteadOfFailing(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	ctx := context.Background()
+
+	if _, err := handle.Pool.Exec(ctx,
+		`UPDATE warmup_pool_participants SET spam_score = 97 WHERE email_account_id = $1`, f.account); err != nil {
+		t.Fatalf("preload score: %v", err)
+	}
+
+	after, err := repo.IncrementSpamScore(ctx, f.account, 10)
+	if err != nil {
+		t.Fatalf("increment past the ceiling: %v", err)
+	}
+	if after != 100 {
+		t.Fatalf("score %d, want it clamped to 100", after)
+	}
+}
+
+// A late signal about a mailbox that just left warmup is normal, not an error.
+func TestLiveSpamScoreForAMailboxInNoPoolIsNotAFailure(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "")
+	ctx := context.Background()
+
+	after, err := repo.IncrementSpamScore(ctx, f.account, 5)
+	if err != nil {
+		t.Fatalf("increment for a non-participant: %v", err)
+	}
+	if after != 0 {
+		t.Fatalf("score %d, want 0", after)
+	}
+}
+
+// Removal cannot be pool-scoped, because the caller that knows the mailbox is
+// no longer entitled does not know which pool it ended up in.
+func TestLiveLeaveAllPoolsRemovesTheMailboxWhereverItIs(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+
+	if err := repo.LeaveAllPools(context.Background(), f.account); err != nil {
+		t.Fatalf("leave: %v", err)
+	}
+	if got := f.memberships(t); len(got) != 0 {
+		t.Fatalf("memberships %v, want none", got)
+	}
+}
+
+// MoveExistingToPool is the reconciler's tool: it corrects a member's pool and
+// leaves its role alone, and never joins a mailbox that is in no pool.
+func TestLiveMoveExistingOnlyMovesActualMembers(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	ctx := context.Background()
+
+	member := newPoolMailbox(t, handle, "premium")
+	if _, err := handle.Pool.Exec(ctx,
+		`UPDATE warmup_pool_participants SET participant_role = 'recipient_only' WHERE email_account_id = $1`,
+		member.account); err != nil {
+		t.Fatalf("demote: %v", err)
+	}
+
+	moved, err := repo.MoveExistingToPool(ctx, poolID(t, handle, "free"), member.account)
+	if err != nil {
+		t.Fatalf("move member: %v", err)
+	}
+	if !moved {
+		t.Fatal("reported no move for a mailbox that was in the other pool")
+	}
+	if got := member.memberships(t); len(got) != 1 || got[0] != "free" {
+		t.Fatalf("memberships %v, want [free]", got)
+	}
+
+	var role string
+	if err := handle.Pool.QueryRow(ctx,
+		`SELECT participant_role FROM warmup_pool_participants WHERE email_account_id = $1`,
+		member.account).Scan(&role); err != nil {
+		t.Fatalf("read role: %v", err)
+	}
+	if role != "recipient_only" {
+		t.Fatalf("role %q after a move, want the demotion preserved", role)
+	}
+
+	again, err := repo.MoveExistingToPool(ctx, poolID(t, handle, "free"), member.account)
+	if err != nil {
+		t.Fatalf("move again: %v", err)
+	}
+	if again {
+		t.Fatal("reported a move for a mailbox already in that pool")
+	}
+
+	outsider := newPoolMailbox(t, handle, "")
+	moved, err = repo.MoveExistingToPool(ctx, poolID(t, handle, "free"), outsider.account)
+	if err != nil {
+		t.Fatalf("move non-member: %v", err)
+	}
+	if moved {
+		t.Fatal("moved a mailbox that is in no pool")
+	}
+	if got := outsider.memberships(t); len(got) != 0 {
+		t.Fatalf("memberships %v, want the non-member left out of warmup", got)
+	}
+}
+
+// A tier move writes the mailbox's pool type and its pool membership together.
+// Updating only the column is what stranded downgraded mailboxes in the premium
+// pool in the first place.
+func TestLiveChangingTheTierMovesTheMembershipWithIt(t *testing.T) {
+	_, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "premium")
+	workerRepo := repository.NewWorkerRepository(handle.Pool)
+
+	if err := workerRepo.UpdateEmailAccountWarmupPoolType(context.Background(), f.account, "free"); err != nil {
+		t.Fatalf("downgrade: %v", err)
+	}
+
+	if got := f.memberships(t); len(got) != 1 || got[0] != "free" {
+		t.Fatalf("memberships %v, want [free]; the downgraded mailbox is still a premium warmup partner", got)
+	}
+}
+
+// A mailbox in no pool must not be dragged into one by a tier change.
+func TestLiveChangingTheTierDoesNotJoinANonParticipant(t *testing.T) {
+	_, handle := liveWarmupRepo(t)
+	f := newPoolMailbox(t, handle, "")
+	workerRepo := repository.NewWorkerRepository(handle.Pool)
+
+	if err := workerRepo.UpdateEmailAccountWarmupPoolType(context.Background(), f.account, "premium"); err != nil {
+		t.Fatalf("upgrade: %v", err)
+	}
+
+	if got := f.memberships(t); len(got) != 0 {
+		t.Fatalf("memberships %v, want none", got)
+	}
+}
+
+// The account-scoped read finds the row whichever pool it is in, so no caller
+// has to probe the pools in an order and bias toward the first one.
+func TestLiveParticipantHealthIsFoundWithoutNamingThePool(t *testing.T) {
+	repo, handle := liveWarmupRepo(t)
+	ctx := context.Background()
+
+	for _, poolType := range []string{"free", "premium"} {
+		f := newPoolMailbox(t, handle, poolType)
+		health, err := repo.GetParticipantHealthForAccount(ctx, f.account)
+		if err != nil {
+			t.Fatalf("%s: read: %v", poolType, err)
+		}
+		if health == nil || health.PoolType != poolType {
+			t.Fatalf("%s: got %+v, want that pool's row", poolType, health)
+		}
+	}
+
+	outsider := newPoolMailbox(t, handle, "")
+	health, err := repo.GetParticipantHealthForAccount(ctx, outsider.account)
+	if err != nil {
+		t.Fatalf("non-member: %v", err)
+	}
+	if health != nil {
+		t.Fatal("a mailbox in no pool reported a membership")
+	}
+}

--- a/internal/app/warmup/service.go
+++ b/internal/app/warmup/service.go
@@ -69,18 +69,13 @@ const (
 )
 
 type Service interface {
-	// EnsurePoolMembershipWithRole puts the mailbox in exactly one pool: it
-	// joins, or moves an existing membership across, carrying the mailbox's
-	// reputation with it. Membership is never additive, so an entitlement
-	// change cannot leave the mailbox in both pools (issue #211).
+	// EnsurePoolMembershipWithRole puts the mailbox in exactly one pool, moving it (with its
+	// reputation) rather than adding a second membership (issue #211).
 	EnsurePoolMembershipWithRole(ctx context.Context, accountID uuid.UUID, poolType, role string) *errx.Error
-	// MovePoolMembership corrects the pool of a mailbox that is already a
-	// participant, without changing its role and without joining a mailbox
-	// that is in no pool. Reports whether anything moved.
+	// MovePoolMembership corrects an existing member's pool, keeping its role. Reports whether it moved.
 	MovePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) (bool, *errx.Error)
-	// RemoveFromAllPools takes the mailbox out of warmup entirely. Removal is
-	// deliberately not pool-scoped: a caller asking "is this mailbox still
-	// entitled?" knows the answer is no, not which pool it is sitting in.
+	// RemoveFromAllPools takes the mailbox out of warmup; a caller that knows it is not entitled
+	// does not know which pool it is in.
 	RemoveFromAllPools(ctx context.Context, accountID uuid.UUID) *errx.Error
 	CanParticipate(ctx context.Context, accountID uuid.UUID, poolType string) (bool, string, *errx.Error)
 	ApplySpamReport(ctx context.Context, reporterAccountID, reportedAccountID uuid.UUID, messageID, reportType string) (*models.WarmupParticipantHealth, *errx.Error)
@@ -527,10 +522,8 @@ func (s *service) evaluateAndPersistAnyPool(ctx context.Context, accountID uuid.
 	return s.evaluateAndPersist(ctx, accountID, health.PoolType, health)
 }
 
-// getParticipantForAnyPool reads the mailbox's participant row from whichever
-// pool it is in. One query, not one per pool: a mailbox is in at most one pool
-// (migration 000097), so there is nothing to probe in order and no premium bias
-// to get wrong.
+// getParticipantForAnyPool reads the row from whichever pool the mailbox is in: one query, not
+// one per pool, so there is no probe order to bias toward premium.
 func (s *service) getParticipantForAnyPool(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, *errx.Error) {
 	health, err := s.repo.GetParticipantHealthForAccount(ctx, accountID)
 	if err != nil {

--- a/internal/app/warmup/service.go
+++ b/internal/app/warmup/service.go
@@ -69,9 +69,19 @@ const (
 )
 
 type Service interface {
-	EnsurePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) *errx.Error
+	// EnsurePoolMembershipWithRole puts the mailbox in exactly one pool: it
+	// joins, or moves an existing membership across, carrying the mailbox's
+	// reputation with it. Membership is never additive, so an entitlement
+	// change cannot leave the mailbox in both pools (issue #211).
 	EnsurePoolMembershipWithRole(ctx context.Context, accountID uuid.UUID, poolType, role string) *errx.Error
-	RemovePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) *errx.Error
+	// MovePoolMembership corrects the pool of a mailbox that is already a
+	// participant, without changing its role and without joining a mailbox
+	// that is in no pool. Reports whether anything moved.
+	MovePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) (bool, *errx.Error)
+	// RemoveFromAllPools takes the mailbox out of warmup entirely. Removal is
+	// deliberately not pool-scoped: a caller asking "is this mailbox still
+	// entitled?" knows the answer is no, not which pool it is sitting in.
+	RemoveFromAllPools(ctx context.Context, accountID uuid.UUID) *errx.Error
 	CanParticipate(ctx context.Context, accountID uuid.UUID, poolType string) (bool, string, *errx.Error)
 	ApplySpamReport(ctx context.Context, reporterAccountID, reportedAccountID uuid.UUID, messageID, reportType string) (*models.WarmupParticipantHealth, *errx.Error)
 	// RecordSpamPlacement records that a warmup message landed in the
@@ -193,10 +203,6 @@ func (s *service) dispatchHealthEvent(ctx context.Context, accountID uuid.UUID, 
 	}
 }
 
-func (s *service) EnsurePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) *errx.Error {
-	return s.EnsurePoolMembershipWithRole(ctx, accountID, poolType, "sender_receiver")
-}
-
 func (s *service) EnsurePoolMembershipWithRole(ctx context.Context, accountID uuid.UUID, poolType, role string) *errx.Error {
 	if role != "sender_receiver" && role != "recipient_only" {
 		return errx.New(errx.BadRequest, "invalid warmup participant role")
@@ -209,24 +215,29 @@ func (s *service) EnsurePoolMembershipWithRole(ctx context.Context, accountID uu
 	if pool == nil {
 		return errx.New(errx.BadRequest, "warmup pool not found")
 	}
-	if err := s.repo.JoinPool(ctx, pool.ID, accountID); err != nil {
-		return errx.InternalError()
-	}
-	if err := s.repo.SetParticipantRole(ctx, pool.ID, accountID, role); err != nil {
+	if err := s.repo.MoveToPool(ctx, pool.ID, accountID, role); err != nil {
 		return errx.InternalError()
 	}
 	return nil
 }
 
-func (s *service) RemovePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) *errx.Error {
+func (s *service) MovePoolMembership(ctx context.Context, accountID uuid.UUID, poolType string) (bool, *errx.Error) {
 	pool, err := s.repo.GetPoolByType(ctx, poolType)
 	if err != nil {
-		return errx.InternalError()
+		return false, errx.InternalError()
 	}
 	if pool == nil {
-		return nil
+		return false, errx.New(errx.BadRequest, "warmup pool not found")
 	}
-	if err := s.repo.LeavePool(ctx, pool.ID, accountID); err != nil {
+	moved, err := s.repo.MoveExistingToPool(ctx, pool.ID, accountID)
+	if err != nil {
+		return false, errx.InternalError()
+	}
+	return moved, nil
+}
+
+func (s *service) RemoveFromAllPools(ctx context.Context, accountID uuid.UUID) *errx.Error {
+	if err := s.repo.LeaveAllPools(ctx, accountID); err != nil {
 		return errx.InternalError()
 	}
 	return nil
@@ -506,40 +517,30 @@ func (s *service) ApplyRateLimitExceeded(ctx context.Context, accountID uuid.UUI
 }
 
 func (s *service) evaluateAndPersistAnyPool(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, *errx.Error) {
-	for _, poolType := range []string{"premium", "free"} {
-		health, err := s.repo.GetParticipantHealth(ctx, accountID, poolType)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("email_account_id", accountID.String()).
-				Str("pool_type", poolType).
-				Msg("warmup: pool membership probe failed; health evaluation skipped")
-			return nil, errx.InternalError()
-		}
-		if health == nil {
-			continue
-		}
-		return s.evaluateAndPersist(ctx, accountID, poolType, health)
+	health, xerr := s.getParticipantForAnyPool(ctx, accountID)
+	if xerr != nil {
+		return nil, xerr
 	}
-	return nil, nil
+	if health == nil {
+		return nil, nil
+	}
+	return s.evaluateAndPersist(ctx, accountID, health.PoolType, health)
 }
 
+// getParticipantForAnyPool reads the mailbox's participant row from whichever
+// pool it is in. One query, not one per pool: a mailbox is in at most one pool
+// (migration 000097), so there is nothing to probe in order and no premium bias
+// to get wrong.
 func (s *service) getParticipantForAnyPool(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, *errx.Error) {
-	for _, poolType := range []string{"premium", "free"} {
-		health, err := s.repo.GetParticipantHealth(ctx, accountID, poolType)
-		if err != nil {
-			log.Error().
-				Err(err).
-				Str("email_account_id", accountID.String()).
-				Str("pool_type", poolType).
-				Msg("warmup: pool membership probe failed")
-			return nil, errx.InternalError()
-		}
-		if health != nil {
-			return health, nil
-		}
+	health, err := s.repo.GetParticipantHealthForAccount(ctx, accountID)
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("email_account_id", accountID.String()).
+			Msg("warmup: pool membership probe failed")
+		return nil, errx.InternalError()
 	}
-	return nil, nil
+	return health, nil
 }
 
 func (s *service) evaluateAndPersist(ctx context.Context, accountID uuid.UUID, poolType string, participant *models.WarmupParticipantHealth) (*models.WarmupParticipantHealth, *errx.Error) {

--- a/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.down.sql
+++ b/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.down.sql
@@ -1,0 +1,5 @@
+-- Dual membership becomes possible again. The rows merged away on the way up
+-- are gone; nothing can restore them, and nothing should.
+DROP INDEX IF EXISTS warmup_pool_participants_account_key;
+CREATE INDEX IF NOT EXISTS idx_warmup_participants_account
+    ON warmup_pool_participants USING btree (email_account_id);

--- a/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.up.sql
+++ b/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.up.sql
@@ -1,0 +1,89 @@
+-- A mailbox belongs to exactly one warmup pool. Nothing in the product places a
+-- mailbox in two: partner selection resolves one pool type per mailbox, and
+-- every reputation writer on this table (health, spam score, blocking) is
+-- account-scoped, so two rows are two ledgers for one reputation.
+--
+-- They were still reachable (issue #211). Join and removal were both scoped to
+-- the pool the mailbox is entitled to RIGHT NOW, so a mailbox whose entitlement
+-- changed acquired a row in its new pool while the old row was never handed to
+-- any removal. A downgraded mailbox kept its premium row and went on being
+-- offered to paying customers as a warmup partner, and its spam score was
+-- counted once per row by the evaluator.
+--
+-- This migration collapses any dual membership that already exists and makes
+-- the invariant structural.
+
+-- 1. Merge reputation before collapsing. The account-scoped writers keep two
+--    rows in agreement, but a row created AFTER the mailbox earned a penalty
+--    starts clean (healthy, score 0), so collapsing to an arbitrary row could
+--    launder a block. Worst-wins on every column.
+UPDATE warmup_pool_participants t
+SET health_state         = m.health_state,
+    blocked_reason       = m.blocked_reason,
+    last_health_reason   = m.last_health_reason,
+    spam_score           = m.spam_score,
+    joined_at            = m.joined_at,
+    health_signals_from  = m.health_signals_from,
+    blocked_at           = m.blocked_at,
+    blocked_until        = m.blocked_until,
+    last_health_score    = m.last_health_score,
+    participant_role     = m.participant_role
+FROM (
+    SELECT DISTINCT ON (email_account_id)
+        email_account_id,
+        health_state,
+        blocked_reason,
+        last_health_reason,
+        MAX(spam_score)          OVER (PARTITION BY email_account_id) AS spam_score,
+        MIN(joined_at)           OVER (PARTITION BY email_account_id) AS joined_at,
+        MIN(health_signals_from) OVER (PARTITION BY email_account_id) AS health_signals_from,
+        MIN(blocked_at)          OVER (PARTITION BY email_account_id) AS blocked_at,
+        MAX(blocked_until)       OVER (PARTITION BY email_account_id) AS blocked_until,
+        MAX(last_health_score)   OVER (PARTITION BY email_account_id) AS last_health_score,
+        -- 'recipient_only' sorts before 'sender_receiver': the quieter role wins.
+        MIN(participant_role)    OVER (PARTITION BY email_account_id) AS participant_role,
+        COUNT(*)                 OVER (PARTITION BY email_account_id) AS memberships
+    FROM warmup_pool_participants
+    ORDER BY email_account_id,
+             CASE health_state
+                 WHEN 'blocked'     THEN 5
+                 WHEN 'quarantined' THEN 4
+                 WHEN 'throttled'   THEN 3
+                 WHEN 'watch'       THEN 2
+                 ELSE 1
+             END DESC,
+             spam_score DESC
+) m
+WHERE t.email_account_id = m.email_account_id
+  AND m.memberships > 1;
+
+-- 2. Keep the row for the pool the mailbox is entitled to now, dropping the
+--    rest. A mailbox whose entitlement cannot be told apart keeps its free row:
+--    the lower-trust pool is the safe side of the guess.
+DELETE FROM warmup_pool_participants d
+USING (
+    SELECT wpp.pool_id,
+           wpp.email_account_id,
+           ROW_NUMBER() OVER (
+               PARTITION BY wpp.email_account_id
+               ORDER BY (wp.pool_type::text = COALESCE(NULLIF(ea.warmup_pool_type, ''), 'free')) DESC,
+                        wp.pool_type::text ASC
+           ) AS rn
+    FROM warmup_pool_participants wpp
+    JOIN warmup_pools wp ON wp.id = wpp.pool_id
+    JOIN email_accounts ea ON ea.id = wpp.email_account_id
+) k
+WHERE d.pool_id = k.pool_id
+  AND d.email_account_id = k.email_account_id
+  AND k.rn > 1;
+
+-- 3. One pool per mailbox, enforced by the database rather than by every caller
+--    remembering to pass the historical pool type. The unique index also lets
+--    the join become a single upsert that MOVES the row (carrying the mailbox's
+--    reputation with it) instead of adding a second one.
+DROP INDEX IF EXISTS idx_warmup_participants_account;
+CREATE UNIQUE INDEX warmup_pool_participants_account_key
+    ON warmup_pool_participants (email_account_id);
+
+COMMENT ON INDEX warmup_pool_participants_account_key IS
+    'A mailbox is in exactly one warmup pool. Free and premium warmup traffic must not mix, and reputation on this table is per mailbox, not per pool (issue #211).';

--- a/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.up.sql
+++ b/internal/infrastructure/db/migrations/000097_warmup_single_pool_membership.up.sql
@@ -38,7 +38,17 @@ FROM (
         MIN(joined_at)           OVER (PARTITION BY email_account_id) AS joined_at,
         MIN(health_signals_from) OVER (PARTITION BY email_account_id) AS health_signals_from,
         MIN(blocked_at)          OVER (PARTITION BY email_account_id) AS blocked_at,
-        MAX(blocked_until)       OVER (PARTITION BY email_account_id) AS blocked_until,
+        -- A blocked row with no blocked_until is blocked indefinitely (appeal
+        -- only), which is the longest block there is, not a missing value that
+        -- MAX may skip over in favour of a sibling's expiry.
+        CASE
+            WHEN BOOL_OR(
+                health_state = 'blocked'
+                AND blocked_at IS NOT NULL
+                AND blocked_until IS NULL
+            ) OVER (PARTITION BY email_account_id) THEN NULL
+            ELSE MAX(blocked_until) OVER (PARTITION BY email_account_id)
+        END AS blocked_until,
         MAX(last_health_score)   OVER (PARTITION BY email_account_id) AS last_health_score,
         -- 'recipient_only' sorts before 'sender_receiver': the quieter role wins.
         MIN(participant_role)    OVER (PARTITION BY email_account_id) AS participant_role,

--- a/internal/repository/pg_admin.go
+++ b/internal/repository/pg_admin.go
@@ -842,9 +842,9 @@ func (r *adminRepository) GetWorkerEmails(ctx context.Context, workerID uuid.UUI
 		args = append(args, *cursor)
 	}
 
-	// Health lives on warmup_pool_participants; an account can be in more than
-	// one pool, so we pick its WORST state via a CASE rank (same ordering as the
-	// risk rebalancer). risk_band is the mailbox's resolved reputation tier.
+	// Health lives on warmup_pool_participants, one row per mailbox. The CASE
+	// rank keeps the worst state winning if that ever stops being true (same
+	// ordering as the risk rebalancer). risk_band is the resolved tier.
 	query := `
 		SELECT ea.id, ea.email, ea.user_id::uuid, ea.organization_id,
 			ea.status, ea.provider, ea.warmup IS NOT NULL, ea.last_synced_at,

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -96,17 +96,12 @@ type WarmupRepository interface {
 	GetPoolByType(ctx context.Context, poolType string) (*WarmupPool, error)
 	GetPoolParticipants(ctx context.Context, poolType string, excludeBlocked bool) ([]uuid.UUID, error)
 	GetPoolRecipientParticipants(ctx context.Context, poolType string, excludeBlocked bool) ([]uuid.UUID, error)
-	// MoveToPool puts the mailbox in exactly this pool: it joins, or moves an
-	// existing membership over, carrying the mailbox's reputation with it.
-	// One row per mailbox is a database invariant (migration 000097).
+	// MoveToPool joins this pool, or moves an existing membership over.
 	MoveToPool(ctx context.Context, poolID, accountID uuid.UUID, role string) error
-	// MoveExistingToPool moves a mailbox that is already a participant into
-	// this pool without changing its role, and does nothing for a mailbox that
-	// is in no pool. Reports whether a row actually moved.
+	// MoveExistingToPool moves an existing member, keeping its role; a mailbox in no pool stays out.
 	MoveExistingToPool(ctx context.Context, poolID, accountID uuid.UUID) (bool, error)
-	// LeaveAllPools removes the mailbox from warmup entirely. Removal is never
-	// pool-scoped: the caller cannot know which pool a mailbox whose
-	// entitlement just changed is actually sitting in (issue #211).
+	// LeaveAllPools removes the mailbox from warmup. Removal is never pool-scoped: the caller
+	// cannot know which pool a mailbox whose entitlement just changed is sitting in (issue #211).
 	LeaveAllPools(ctx context.Context, accountID uuid.UUID) error
 	BlockFromPool(ctx context.Context, accountID uuid.UUID, reason string) error
 	// GetHealthState returns the account's warmup health state plus its
@@ -117,8 +112,7 @@ type WarmupRepository interface {
 	UnblockFromPool(ctx context.Context, accountID uuid.UUID) error
 	IsInPool(ctx context.Context, accountID uuid.UUID, poolType string) (bool, error)
 	GetParticipantHealth(ctx context.Context, accountID uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error)
-	// GetParticipantHealthForAccount returns the mailbox's participant row
-	// whatever pool it is in, or nil when it is in none.
+	// GetParticipantHealthForAccount returns the participant row whatever pool it is in.
 	GetParticipantHealthForAccount(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, error)
 	UpdateParticipantHealth(ctx context.Context, accountID uuid.UUID, state models.WarmupHealthState, blockedUntil *time.Time, reason string, score float64) error
 	CountSpamReportsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
@@ -317,13 +311,9 @@ func (r *warmupRepository) GetPoolRecipientParticipants(ctx context.Context, poo
 	return accountIDs, rows.Err()
 }
 
-// MoveToPool puts the mailbox in exactly this pool. The unique index on
-// email_account_id (migration 000097) makes the account the conflict target, so
-// a mailbox already in the other pool MOVES rather than gaining a second
-// membership: pool_id and role are overwritten and every reputation column
-// (spam score, health state, block, signal floor) rides along untouched.
-// Joining a pool can therefore never launder a penalty, and a mailbox whose
-// entitlement changed can never sit in two pools at once.
+// MoveToPool conflicts on the account, not the pool (unique index, migration 000097), so a
+// mailbox in the other pool moves and keeps every reputation column: changing pool cannot
+// launder a penalty, and no mailbox can hold two memberships.
 func (r *warmupRepository) MoveToPool(ctx context.Context, poolID, accountID uuid.UUID, role string) error {
 	query := `
 		INSERT INTO warmup_pool_participants (pool_id, email_account_id, joined_at, spam_score, participant_role)
@@ -337,9 +327,8 @@ func (r *warmupRepository) MoveToPool(ctx context.Context, poolID, accountID uui
 	return err
 }
 
-// MoveExistingToPool corrects the pool of a mailbox that is already a
-// participant, leaving its role alone. Used by the reconciler to repair drift
-// without promoting a mailbox that was deliberately demoted to recipient_only.
+// MoveExistingToPool corrects a member's pool and leaves its role alone, so the reconciler
+// cannot promote a mailbox that was deliberately demoted to recipient_only.
 func (r *warmupRepository) MoveExistingToPool(ctx context.Context, poolID, accountID uuid.UUID) (bool, error) {
 	query := `
 		UPDATE warmup_pool_participants
@@ -384,9 +373,8 @@ func (r *warmupRepository) BlockFromPool(ctx context.Context, accountID uuid.UUI
 	return err
 }
 
-// GetHealthState returns the account's current warmup health state and its
-// blocked_until, without the caller having to name a pool. A mailbox has one
-// participant row; the ordering keeps the worst state winning regardless.
+// GetHealthState returns the account's warmup health state and blocked_until without the
+// caller naming a pool. The ordering keeps the worst state winning.
 func (r *warmupRepository) GetHealthState(ctx context.Context, accountID uuid.UUID) (models.WarmupHealthState, *time.Time, error) {
 	query := `
 		SELECT health_state, blocked_until
@@ -487,9 +475,8 @@ func (r *warmupRepository) RecordSpamReport(ctx context.Context, report *SpamRep
 	return cmd.RowsAffected() > 0, nil
 }
 
-// GetSpamScore retrieves the spam score for an account. MAX, not SUM: the
-// score is the mailbox's, not the pool row's, and every writer of it is
-// account-scoped. Summing counted it once per membership (issue #211).
+// GetSpamScore reads the account's spam score. MAX, not SUM: the score is the mailbox's and
+// every writer of it is account-scoped, so summing counted it once per membership (issue #211).
 func (r *warmupRepository) GetSpamScore(ctx context.Context, accountID uuid.UUID) (int, error) {
 	query := `
 		SELECT COALESCE(MAX(spam_score), 0)
@@ -502,8 +489,7 @@ func (r *warmupRepository) GetSpamScore(ctx context.Context, accountID uuid.UUID
 	return score, err
 }
 
-// participantHealthSelect is the participant row every health read returns.
-// The two readers below differ only in whether the pool is pinned.
+// participantHealthSelect: the two readers below differ only in whether the pool is pinned.
 const participantHealthSelect = `
 		SELECT
 			wpp.pool_id,
@@ -523,10 +509,8 @@ const participantHealthSelect = `
 		JOIN warmup_pools wp ON wp.id = wpp.pool_id
 		WHERE wpp.email_account_id = $1`
 
-// GetParticipantHealthForAccount returns the mailbox's participant row from
-// whichever pool it is in. A mailbox is in at most one (migration 000097), so
-// this replaces probing the pools in turn and biasing toward whichever was
-// probed first.
+// GetParticipantHealthForAccount returns the participant row from whichever pool the mailbox
+// is in. Exact because a mailbox is in at most one (migration 000097).
 func (r *warmupRepository) GetParticipantHealthForAccount(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, error) {
 	return r.scanParticipantHealth(r.db.QueryRow(ctx, participantHealthSelect, accountID))
 }
@@ -691,11 +675,9 @@ func (r *warmupRepository) CountDeliveredByAccount(ctx context.Context, accountI
 	return count, err
 }
 
-// IncrementSpamScore increments the spam score for an account. Clamped to the
-// column's CHECK ceiling, or an already-noisy mailbox would fail the constraint
-// and silently keep its old score. A mailbox in no pool has no score to raise,
-// which is not an error: late signals about a mailbox that just left warmup are
-// normal.
+// IncrementSpamScore raises the account's spam score, clamped to the column's CHECK ceiling
+// (past it the UPDATE failed and every caller ignores that error). A mailbox in no pool has no
+// score to raise, which is normal for a late signal, not a failure.
 func (r *warmupRepository) IncrementSpamScore(ctx context.Context, accountID uuid.UUID, amount int) (int, error) {
 	query := `
 		UPDATE warmup_pool_participants

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -96,18 +96,30 @@ type WarmupRepository interface {
 	GetPoolByType(ctx context.Context, poolType string) (*WarmupPool, error)
 	GetPoolParticipants(ctx context.Context, poolType string, excludeBlocked bool) ([]uuid.UUID, error)
 	GetPoolRecipientParticipants(ctx context.Context, poolType string, excludeBlocked bool) ([]uuid.UUID, error)
-	JoinPool(ctx context.Context, poolID, accountID uuid.UUID) error
-	SetParticipantRole(ctx context.Context, poolID, accountID uuid.UUID, role string) error
-	LeavePool(ctx context.Context, poolID, accountID uuid.UUID) error
+	// MoveToPool puts the mailbox in exactly this pool: it joins, or moves an
+	// existing membership over, carrying the mailbox's reputation with it.
+	// One row per mailbox is a database invariant (migration 000097).
+	MoveToPool(ctx context.Context, poolID, accountID uuid.UUID, role string) error
+	// MoveExistingToPool moves a mailbox that is already a participant into
+	// this pool without changing its role, and does nothing for a mailbox that
+	// is in no pool. Reports whether a row actually moved.
+	MoveExistingToPool(ctx context.Context, poolID, accountID uuid.UUID) (bool, error)
+	// LeaveAllPools removes the mailbox from warmup entirely. Removal is never
+	// pool-scoped: the caller cannot know which pool a mailbox whose
+	// entitlement just changed is actually sitting in (issue #211).
+	LeaveAllPools(ctx context.Context, accountID uuid.UUID) error
 	BlockFromPool(ctx context.Context, accountID uuid.UUID, reason string) error
-	// GetHealthState returns the WORST current warmup health state across the
-	// account's pool memberships plus its blocked_until, so non-warmup callers
-	// (e.g. the campaign scheduler) can gate cold sends on warmup health without
-	// needing a pool type. Returns ("healthy", nil) when the account is in no pool.
+	// GetHealthState returns the account's warmup health state plus its
+	// blocked_until, so non-warmup callers (e.g. the campaign scheduler) can
+	// gate cold sends on warmup health without needing a pool type. Returns
+	// ("healthy", nil) when the account is in no pool.
 	GetHealthState(ctx context.Context, accountID uuid.UUID) (models.WarmupHealthState, *time.Time, error)
 	UnblockFromPool(ctx context.Context, accountID uuid.UUID) error
 	IsInPool(ctx context.Context, accountID uuid.UUID, poolType string) (bool, error)
 	GetParticipantHealth(ctx context.Context, accountID uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error)
+	// GetParticipantHealthForAccount returns the mailbox's participant row
+	// whatever pool it is in, or nil when it is in none.
+	GetParticipantHealthForAccount(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, error)
 	UpdateParticipantHealth(ctx context.Context, accountID uuid.UUID, state models.WarmupHealthState, blockedUntil *time.Time, reason string, score float64) error
 	CountSpamReportsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountUserComplaintsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
@@ -305,37 +317,52 @@ func (r *warmupRepository) GetPoolRecipientParticipants(ctx context.Context, poo
 	return accountIDs, rows.Err()
 }
 
-// JoinPool adds an account to a warmup pool
-func (r *warmupRepository) JoinPool(ctx context.Context, poolID, accountID uuid.UUID) error {
+// MoveToPool puts the mailbox in exactly this pool. The unique index on
+// email_account_id (migration 000097) makes the account the conflict target, so
+// a mailbox already in the other pool MOVES rather than gaining a second
+// membership: pool_id and role are overwritten and every reputation column
+// (spam score, health state, block, signal floor) rides along untouched.
+// Joining a pool can therefore never launder a penalty, and a mailbox whose
+// entitlement changed can never sit in two pools at once.
+func (r *warmupRepository) MoveToPool(ctx context.Context, poolID, accountID uuid.UUID, role string) error {
 	query := `
 		INSERT INTO warmup_pool_participants (pool_id, email_account_id, joined_at, spam_score, participant_role)
-		VALUES ($1, $2, NOW(), 0, 'sender_receiver')
-		ON CONFLICT (pool_id, email_account_id) DO UPDATE
-		SET joined_at = warmup_pool_participants.joined_at
+		VALUES ($1::uuid, $2::uuid, NOW(), 0, $3::text)
+		ON CONFLICT (email_account_id) DO UPDATE
+		SET pool_id = EXCLUDED.pool_id,
+		    participant_role = EXCLUDED.participant_role
 	`
 
-	_, err := r.db.Exec(ctx, query, poolID, accountID)
+	_, err := r.db.Exec(ctx, query, poolID, accountID, role)
 	return err
 }
 
-func (r *warmupRepository) SetParticipantRole(ctx context.Context, poolID, accountID uuid.UUID, role string) error {
+// MoveExistingToPool corrects the pool of a mailbox that is already a
+// participant, leaving its role alone. Used by the reconciler to repair drift
+// without promoting a mailbox that was deliberately demoted to recipient_only.
+func (r *warmupRepository) MoveExistingToPool(ctx context.Context, poolID, accountID uuid.UUID) (bool, error) {
 	query := `
 		UPDATE warmup_pool_participants
-		SET participant_role = $1
-		WHERE pool_id = $2 AND email_account_id = $3
+		SET pool_id = $1::uuid
+		WHERE email_account_id = $2::uuid
+		  AND pool_id <> $1::uuid
 	`
-	_, err := r.db.Exec(ctx, query, role, poolID, accountID)
-	return err
+
+	cmd, err := r.db.Exec(ctx, query, poolID, accountID)
+	if err != nil {
+		return false, err
+	}
+	return cmd.RowsAffected() > 0, nil
 }
 
-// LeavePool removes an account from a warmup pool
-func (r *warmupRepository) LeavePool(ctx context.Context, poolID, accountID uuid.UUID) error {
+// LeaveAllPools removes the mailbox from warmup entirely.
+func (r *warmupRepository) LeaveAllPools(ctx context.Context, accountID uuid.UUID) error {
 	query := `
 		DELETE FROM warmup_pool_participants
-		WHERE pool_id = $1 AND email_account_id = $2
+		WHERE email_account_id = $1
 	`
 
-	_, err := r.db.Exec(ctx, query, poolID, accountID)
+	_, err := r.db.Exec(ctx, query, accountID)
 	return err
 }
 
@@ -357,9 +384,9 @@ func (r *warmupRepository) BlockFromPool(ctx context.Context, accountID uuid.UUI
 	return err
 }
 
-// GetHealthState returns the worst current health state across the account's
-// pool memberships and that row's blocked_until. Worst-wins so a mailbox that's
-// blocked in any pool is treated as blocked for cold-send gating.
+// GetHealthState returns the account's current warmup health state and its
+// blocked_until, without the caller having to name a pool. A mailbox has one
+// participant row; the ordering keeps the worst state winning regardless.
 func (r *warmupRepository) GetHealthState(ctx context.Context, accountID uuid.UUID) (models.WarmupHealthState, *time.Time, error) {
 	query := `
 		SELECT health_state, blocked_until
@@ -460,10 +487,12 @@ func (r *warmupRepository) RecordSpamReport(ctx context.Context, report *SpamRep
 	return cmd.RowsAffected() > 0, nil
 }
 
-// GetSpamScore retrieves the spam score for an account
+// GetSpamScore retrieves the spam score for an account. MAX, not SUM: the
+// score is the mailbox's, not the pool row's, and every writer of it is
+// account-scoped. Summing counted it once per membership (issue #211).
 func (r *warmupRepository) GetSpamScore(ctx context.Context, accountID uuid.UUID) (int, error) {
 	query := `
-		SELECT COALESCE(SUM(spam_score), 0)
+		SELECT COALESCE(MAX(spam_score), 0)
 		FROM warmup_pool_participants
 		WHERE email_account_id = $1
 	`
@@ -473,8 +502,9 @@ func (r *warmupRepository) GetSpamScore(ctx context.Context, accountID uuid.UUID
 	return score, err
 }
 
-func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error) {
-	query := `
+// participantHealthSelect is the participant row every health read returns.
+// The two readers below differ only in whether the pool is pinned.
+const participantHealthSelect = `
 		SELECT
 			wpp.pool_id,
 			wp.pool_type,
@@ -491,14 +521,29 @@ func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID u
 			wpp.health_signals_from
 		FROM warmup_pool_participants wpp
 		JOIN warmup_pools wp ON wp.id = wpp.pool_id
-		WHERE wpp.email_account_id = $1
+		WHERE wpp.email_account_id = $1`
+
+// GetParticipantHealthForAccount returns the mailbox's participant row from
+// whichever pool it is in. A mailbox is in at most one (migration 000097), so
+// this replaces probing the pools in turn and biasing toward whichever was
+// probed first.
+func (r *warmupRepository) GetParticipantHealthForAccount(ctx context.Context, accountID uuid.UUID) (*models.WarmupParticipantHealth, error) {
+	return r.scanParticipantHealth(r.db.QueryRow(ctx, participantHealthSelect, accountID))
+}
+
+func (r *warmupRepository) GetParticipantHealth(ctx context.Context, accountID uuid.UUID, poolType string) (*models.WarmupParticipantHealth, error) {
+	query := participantHealthSelect + `
 		  AND wp.pool_type = $2
 		LIMIT 1
 	`
 
+	return r.scanParticipantHealth(r.db.QueryRow(ctx, query, accountID, poolType))
+}
+
+func (r *warmupRepository) scanParticipantHealth(row pgx.Row) (*models.WarmupParticipantHealth, error) {
 	var out models.WarmupParticipantHealth
 	var state string
-	if err := r.db.QueryRow(ctx, query, accountID, poolType).Scan(
+	if err := row.Scan(
 		&out.PoolID,
 		&out.PoolType,
 		&out.EmailAccountID,
@@ -646,17 +691,24 @@ func (r *warmupRepository) CountDeliveredByAccount(ctx context.Context, accountI
 	return count, err
 }
 
-// IncrementSpamScore increments the spam score for an account
+// IncrementSpamScore increments the spam score for an account. Clamped to the
+// column's CHECK ceiling, or an already-noisy mailbox would fail the constraint
+// and silently keep its old score. A mailbox in no pool has no score to raise,
+// which is not an error: late signals about a mailbox that just left warmup are
+// normal.
 func (r *warmupRepository) IncrementSpamScore(ctx context.Context, accountID uuid.UUID, amount int) (int, error) {
 	query := `
 		UPDATE warmup_pool_participants
-		SET spam_score = spam_score + $1
+		SET spam_score = LEAST(100, GREATEST(0, spam_score + $1))
 		WHERE email_account_id = $2
 		RETURNING spam_score
 	`
 
 	var newScore int
 	err := r.db.QueryRow(ctx, query, amount, accountID).Scan(&newScore)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
 	return newScore, err
 }
 

--- a/internal/repository/pg_worker.go
+++ b/internal/repository/pg_worker.go
@@ -493,13 +493,9 @@ func (r *workerRepository) ClearEmailAccountWorker(ctx context.Context, emailAcc
 	return err
 }
 
-// UpdateEmailAccountWarmupPoolType updates the warmup pool type for an email
-// account and moves its warmup pool membership to match, in one transaction.
-// The column and the warmup_pool_participants row record the same fact, and a
-// tier move that updated only the column left the mailbox sitting in the pool
-// it used to belong to: a downgraded mailbox went on being handed to paying
-// customers as a warmup partner (issue #211). A mailbox that is in no pool
-// stays in none; joining is the warmup task's job, not this one's.
+// UpdateEmailAccountWarmupPoolType writes the tier and moves the mailbox's pool membership to
+// match in one transaction: they record the same fact, and updating only the column left
+// downgraded mailboxes in the premium pool (issue #211). A mailbox in no pool stays in none.
 func (r *workerRepository) UpdateEmailAccountWarmupPoolType(ctx context.Context, emailAccountID uuid.UUID, poolType string) error {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {

--- a/internal/repository/pg_worker.go
+++ b/internal/repository/pg_worker.go
@@ -493,11 +493,38 @@ func (r *workerRepository) ClearEmailAccountWorker(ctx context.Context, emailAcc
 	return err
 }
 
-// UpdateEmailAccountWarmupPoolType updates the warmup pool type for an email account
+// UpdateEmailAccountWarmupPoolType updates the warmup pool type for an email
+// account and moves its warmup pool membership to match, in one transaction.
+// The column and the warmup_pool_participants row record the same fact, and a
+// tier move that updated only the column left the mailbox sitting in the pool
+// it used to belong to: a downgraded mailbox went on being handed to paying
+// customers as a warmup partner (issue #211). A mailbox that is in no pool
+// stays in none; joining is the warmup task's job, not this one's.
 func (r *workerRepository) UpdateEmailAccountWarmupPoolType(ctx context.Context, emailAccountID uuid.UUID, poolType string) error {
-	query := `UPDATE email_accounts SET warmup_pool_type = $1, updated_at = NOW() WHERE id = $2`
-	_, err := r.db.Exec(ctx, query, poolType, emailAccountID)
-	return err
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE email_accounts SET warmup_pool_type = $1, updated_at = NOW() WHERE id = $2`,
+		poolType, emailAccountID); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE warmup_pool_participants wpp
+		SET pool_id = wp.id
+		FROM warmup_pools wp
+		WHERE wp.pool_type = $1::warmup_pool_type
+		  AND wpp.email_account_id = $2::uuid
+		  AND wpp.pool_id <> wp.id`,
+		poolType, emailAccountID); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }
 
 // GetEmailAccountWorkerInfo retrieves worker info for an email account

--- a/internal/repository/pg_worker_risk.go
+++ b/internal/repository/pg_worker_risk.go
@@ -153,8 +153,8 @@ func (r *workerRepository) ListRiskCandidates(ctx context.Context, limit int) ([
 	if limit <= 0 {
 		limit = 500
 	}
-	// Health lives on warmup_pool_participants; an account can be in more
-	// than one pool, so we pick its WORST state via a CASE rank.
+	// Health lives on warmup_pool_participants, one row per mailbox. The CASE
+	// rank keeps the worst state winning if that ever stops being true.
 	rows, err := r.db.Query(ctx, `
 		SELECT
 			ea.id,

--- a/internal/tasks/email_task.go
+++ b/internal/tasks/email_task.go
@@ -90,14 +90,19 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 	if account.Status != "active" || (!activelyWarming && !inCampaign) {
 		if s.warmupHealth != nil {
 			if account.Status == "active" && account.OrganizationID != nil && s.featureGate != nil {
-				canWarmup, _ := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
-				if canWarmup {
+				canWarmup, xerr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
+				switch {
+				case xerr != nil:
+					// Entitlement unknown. Leave the membership as it is: an
+					// unreadable subscription is not evidence of anything, and
+					// evicting on it would empty the pool during a blip.
+				case canWarmup:
 					_ = s.warmupHealth.EnsurePoolMembershipWithRole(ctx, account.ID, s.resolveWarmupPoolType(ctx, account), "recipient_only")
-				} else {
-					_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, s.resolveWarmupPoolType(ctx, account))
+				default:
+					_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 				}
 			} else {
-				_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, s.resolveWarmupPoolType(ctx, account))
+				_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 			}
 		}
 		_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "cancelled")
@@ -118,10 +123,7 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 	// warming rather than warming as if it were entitled.
 	if account.OrganizationID == nil {
 		if s.warmupHealth != nil {
-			// Both pools: without an org there is no reliable way to tell which
-			// one this mailbox was placed in.
-			_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, "free")
-			_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, "premium")
+			_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 		}
 		sentry.CaptureException(fmt.Errorf("email account %s reached warmup with no organization", account.ID))
 		log.Error().Str("task_id", taskID.String()).Str("email_account_id", account.ID.String()).
@@ -133,10 +135,12 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 
 	// STEP 3.5: Check if organization can use warmup (only paid orgs)
 	if s.featureGate != nil {
-		canWarmup, _ := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
+		canWarmup, entitlementErr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 		if !canWarmup {
-			if s.warmupHealth != nil {
-				_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, s.resolveWarmupPoolType(ctx, account))
+			// Only a definite "not entitled" removes the mailbox from warmup.
+			// The send is skipped either way.
+			if s.warmupHealth != nil && entitlementErr == nil {
+				_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 			}
 			// Organization cannot use warmup - skip this task
 			s.taskRepo.UpdateTaskStatus(ctx, taskID, "skipped_no_warmup_access")

--- a/internal/tasks/email_task.go
+++ b/internal/tasks/email_task.go
@@ -93,9 +93,7 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 				canWarmup, xerr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 				switch {
 				case xerr != nil:
-					// Entitlement unknown. Leave the membership as it is: an
-					// unreadable subscription is not evidence of anything, and
-					// evicting on it would empty the pool during a blip.
+					// Entitlement unknown: leave the membership alone rather than let a blip evict.
 				case canWarmup:
 					_ = s.warmupHealth.EnsurePoolMembershipWithRole(ctx, account.ID, s.resolveWarmupPoolType(ctx, account), "recipient_only")
 				default:
@@ -137,8 +135,7 @@ func (s *tasksService) HandleEmailTask(task *proto.ProcessTask) *errx.Error {
 	if s.featureGate != nil {
 		canWarmup, entitlementErr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 		if !canWarmup {
-			// Only a definite "not entitled" removes the mailbox from warmup.
-			// The send is skipped either way.
+			// Only a definite "not entitled" evicts; the send is skipped either way.
 			if s.warmupHealth != nil && entitlementErr == nil {
 				_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 			}

--- a/internal/tasks/warmup_pool_reconcile_test.go
+++ b/internal/tasks/warmup_pool_reconcile_test.go
@@ -1,0 +1,257 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/feature"
+	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Stubs embed their interface, so any call this pass is not supposed to make
+// panics instead of quietly passing.
+
+type poolReconcileWarmupRepo struct {
+	repository.WarmupRepository
+	participants []uuid.UUID
+	listErr      error
+}
+
+func (r *poolReconcileWarmupRepo) GetAllParticipantAccountIDs(_ context.Context) ([]uuid.UUID, error) {
+	return r.participants, r.listErr
+}
+
+type poolReconcileEmailRepo struct {
+	repository.EmailRepository
+	accounts map[uuid.UUID]*models.Email
+}
+
+func (r *poolReconcileEmailRepo) GetByID(_ context.Context, id uuid.UUID) (*models.Email, *errx.Error) {
+	return r.accounts[id], nil
+}
+
+type poolReconcileGate struct {
+	feature.FeatureGateService
+	entitled map[uuid.UUID]bool
+	fail     bool
+	calls    int
+}
+
+func (g *poolReconcileGate) CanUseWarmup(_ context.Context, orgID uuid.UUID) (bool, *errx.Error) {
+	g.calls++
+	if g.fail {
+		return false, errx.InternalError()
+	}
+	return g.entitled[orgID], nil
+}
+
+type poolReconcileWarmup struct {
+	warmupapp.Service
+	moved   map[uuid.UUID]string
+	removed map[uuid.UUID]bool
+	// inPool is where each mailbox currently sits, so MovePoolMembership can
+	// report honestly whether it had anything to move.
+	inPool map[uuid.UUID]string
+}
+
+func (w *poolReconcileWarmup) MovePoolMembership(_ context.Context, accountID uuid.UUID, poolType string) (bool, *errx.Error) {
+	if w.inPool[accountID] == poolType {
+		return false, nil
+	}
+	w.inPool[accountID] = poolType
+	w.moved[accountID] = poolType
+	return true, nil
+}
+
+func (w *poolReconcileWarmup) RemoveFromAllPools(_ context.Context, accountID uuid.UUID) *errx.Error {
+	w.removed[accountID] = true
+	delete(w.inPool, accountID)
+	return nil
+}
+
+type poolReconcileFixture struct {
+	svc     *tasksService
+	gate    *poolReconcileGate
+	warmup  *poolReconcileWarmup
+	emails  *poolReconcileEmailRepo
+	orgPaid uuid.UUID
+	orgFree uuid.UUID
+}
+
+func newPoolReconcileFixture() *poolReconcileFixture {
+	f := &poolReconcileFixture{
+		orgPaid: uuid.New(),
+		orgFree: uuid.New(),
+	}
+	f.gate = &poolReconcileGate{entitled: map[uuid.UUID]bool{}}
+	f.warmup = &poolReconcileWarmup{
+		moved:   map[uuid.UUID]string{},
+		removed: map[uuid.UUID]bool{},
+		inPool:  map[uuid.UUID]string{},
+	}
+	f.emails = &poolReconcileEmailRepo{accounts: map[uuid.UUID]*models.Email{}}
+	f.gate.entitled[f.orgPaid] = true
+	f.gate.entitled[f.orgFree] = false
+	return f
+}
+
+// mailbox registers an account and the pool its participant row is currently in.
+func (f *poolReconcileFixture) mailbox(orgID uuid.UUID, poolType, sittingIn string) uuid.UUID {
+	id := uuid.New()
+	org := orgID
+	f.emails.accounts[id] = &models.Email{
+		ID:             id,
+		OrganizationID: &org,
+		Status:         "active",
+		WarmupPoolType: poolType,
+	}
+	f.warmup.inPool[id] = sittingIn
+	return id
+}
+
+func (f *poolReconcileFixture) run(t *testing.T) (int, int) {
+	t.Helper()
+	participants := make([]uuid.UUID, 0, len(f.warmup.inPool))
+	for id := range f.warmup.inPool {
+		participants = append(participants, id)
+	}
+	f.svc = &tasksService{
+		warmupRepo:   &poolReconcileWarmupRepo{participants: participants},
+		emailRepo:    f.emails,
+		featureGate:  f.gate,
+		warmupHealth: f.warmup,
+	}
+	moved, removed, err := f.svc.ReconcileWarmupPoolMembership(context.Background())
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	return moved, removed
+}
+
+// The headline defect: a downgraded mailbox keeps its premium row, so paying
+// customers go on being handed a mailbox with no paid entitlement as a warmup
+// partner. Nothing revisits it, because a mailbox that stopped warming is not a
+// schedule candidate.
+func TestPoolReconcileEvictsAMailboxThatLostItsEntitlement(t *testing.T) {
+	f := newPoolReconcileFixture()
+	downgraded := f.mailbox(f.orgFree, "free", "premium")
+
+	_, removed := f.run(t)
+
+	if removed != 1 {
+		t.Fatalf("removed %d mailboxes, want 1", removed)
+	}
+	if !f.warmup.removed[downgraded] {
+		t.Fatal("the downgraded mailbox is still in a warmup pool")
+	}
+	if _, still := f.warmup.inPool[downgraded]; still {
+		t.Fatal("membership survived the eviction")
+	}
+}
+
+// An entitled mailbox whose tier moved is corrected rather than evicted.
+func TestPoolReconcileMovesAnEntitledMailboxToItsOwnPool(t *testing.T) {
+	f := newPoolReconcileFixture()
+	upgraded := f.mailbox(f.orgPaid, "premium", "free")
+
+	moved, removed := f.run(t)
+
+	if moved != 1 || removed != 0 {
+		t.Fatalf("moved %d removed %d, want 1 and 0", moved, removed)
+	}
+	if f.warmup.moved[upgraded] != "premium" {
+		t.Fatalf("moved to %q, want premium", f.warmup.moved[upgraded])
+	}
+}
+
+// Steady state costs nothing: a mailbox already in the right pool is left alone.
+func TestPoolReconcileLeavesASettledMailboxAlone(t *testing.T) {
+	f := newPoolReconcileFixture()
+	f.mailbox(f.orgPaid, "premium", "premium")
+
+	moved, removed := f.run(t)
+
+	if moved != 0 || removed != 0 {
+		t.Fatalf("moved %d removed %d, want 0 and 0", moved, removed)
+	}
+}
+
+// An unreadable subscription is not evidence that a mailbox lost warmup. If a
+// blip could evict, one bad minute would empty the pool.
+func TestPoolReconcileLeavesMembershipAloneWhenEntitlementCannotBeRead(t *testing.T) {
+	f := newPoolReconcileFixture()
+	mailbox := f.mailbox(f.orgPaid, "premium", "free")
+	f.gate.fail = true
+
+	moved, removed := f.run(t)
+
+	if moved != 0 || removed != 0 {
+		t.Fatalf("moved %d removed %d, want the mailbox untouched", moved, removed)
+	}
+	if f.warmup.removed[mailbox] {
+		t.Fatal("evicted a mailbox on an entitlement lookup failure")
+	}
+}
+
+// A participant row whose mailbox is gone, suspended, or has no workspace has
+// nothing left to check an entitlement against, so it leaves the shared pool.
+func TestPoolReconcileEvictsMailboxesItCannotVouchFor(t *testing.T) {
+	for _, c := range []struct {
+		name    string
+		account func(id uuid.UUID) *models.Email
+	}{
+		{"deleted", func(uuid.UUID) *models.Email { return nil }},
+		{"inactive", func(id uuid.UUID) *models.Email {
+			org := uuid.New()
+			return &models.Email{ID: id, OrganizationID: &org, Status: "inactive", WarmupPoolType: "premium"}
+		}},
+		{"no workspace", func(id uuid.UUID) *models.Email {
+			return &models.Email{ID: id, Status: "active", WarmupPoolType: "premium"}
+		}},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			f := newPoolReconcileFixture()
+			id := f.mailbox(f.orgPaid, "premium", "premium")
+			f.emails.accounts[id] = c.account(id)
+
+			_, removed := f.run(t)
+
+			if removed != 1 || !f.warmup.removed[id] {
+				t.Fatalf("removed %d, want the mailbox out of the pool", removed)
+			}
+		})
+	}
+}
+
+// One subscription lookup per workspace, not per mailbox.
+func TestPoolReconcileAsksAboutEachOrganizationOnce(t *testing.T) {
+	f := newPoolReconcileFixture()
+	for i := 0; i < 5; i++ {
+		f.mailbox(f.orgPaid, "premium", "premium")
+	}
+
+	f.run(t)
+
+	if f.gate.calls != 1 {
+		t.Fatalf("asked about the same organization %d times, want 1", f.gate.calls)
+	}
+}
+
+// A listing failure is reported, not swallowed into a silent no-op pass.
+func TestPoolReconcileReportsAListingFailure(t *testing.T) {
+	svc := &tasksService{
+		warmupRepo:   &poolReconcileWarmupRepo{listErr: errors.New("connection reset by peer")},
+		emailRepo:    &poolReconcileEmailRepo{},
+		warmupHealth: &poolReconcileWarmup{},
+	}
+
+	if _, _, err := svc.ReconcileWarmupPoolMembership(context.Background()); err == nil {
+		t.Fatal("expected the listing failure to surface")
+	}
+}

--- a/internal/tasks/warmup_reconciler.go
+++ b/internal/tasks/warmup_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 )
 
@@ -38,10 +39,12 @@ func (s *tasksService) ReconcileWarmupSchedules(ctx context.Context, limit int) 
 			continue
 		}
 		if s.featureGate != nil {
-			canWarmup, _ := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
+			canWarmup, xerr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 			if !canWarmup {
-				if s.warmupHealth != nil {
-					_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, s.resolveWarmupPoolType(ctx, account))
+				// Only a definite "not entitled" evicts; an unreadable
+				// subscription leaves the membership alone.
+				if s.warmupHealth != nil && xerr == nil {
+					_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 				}
 				continue
 			}
@@ -86,9 +89,97 @@ func (s *tasksService) reconcileOnce(ctx context.Context) {
 	seeded, err := s.ReconcileWarmupSchedules(rctx, warmupReconcileBatch)
 	if err != nil {
 		log.Warn().Err(err).Msg("warmup reconcile pass failed")
-		return
-	}
-	if seeded > 0 {
+	} else if seeded > 0 {
 		log.Info().Int("seeded", seeded).Msg("warmup reconcile seeded chains")
 	}
+
+	moved, removed, err := s.ReconcileWarmupPoolMembership(rctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("warmup pool membership reconcile pass failed")
+		return
+	}
+	if moved > 0 || removed > 0 {
+		log.Info().Int("moved", moved).Int("removed", removed).Msg("warmup pool membership reconciled")
+	}
+}
+
+// ReconcileWarmupPoolMembership walks every warmup pool participant and makes
+// its membership agree with the mailbox's entitlement: a mailbox that may no
+// longer warm leaves warmup, and one whose tier changed is moved to the pool
+// that tier belongs to.
+//
+// The warmup task fixes membership too, but only for mailboxes it still runs
+// for. A mailbox that stops warming (warmup switched off, campaign finished,
+// subscription lapsed) has no chain and is not a schedule candidate, so nothing
+// would ever revisit it and its row would sit in the pool forever (issue #211).
+// This is the pass that ends that.
+//
+// Roles are left alone: a mailbox demoted to recipient_only (failing domain
+// auth, say) must not be quietly promoted back by a sweep that knows nothing
+// about why it was demoted.
+func (s *tasksService) ReconcileWarmupPoolMembership(ctx context.Context) (moved int, removed int, err error) {
+	if s.warmupRepo == nil || s.warmupHealth == nil {
+		return 0, 0, nil
+	}
+
+	ids, err := s.warmupRepo.GetAllParticipantAccountIDs(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	// One subscription lookup per organization, not per mailbox: a workspace
+	// with fifty inboxes is one question asked fifty times otherwise.
+	entitled := map[uuid.UUID]bool{}
+
+	for _, id := range ids {
+		account, xerr := s.emailRepo.GetByID(ctx, id)
+		if xerr != nil {
+			continue
+		}
+		if account == nil || account.Status != "active" || account.OrganizationID == nil {
+			// No mailbox, no active mailbox, or no workspace to check an
+			// entitlement against: it does not belong in a shared pool.
+			if xerr := s.warmupHealth.RemoveFromAllPools(ctx, id); xerr == nil {
+				removed++
+			}
+			continue
+		}
+
+		if s.featureGate != nil {
+			ok, cached := entitled[*account.OrganizationID]
+			if !cached {
+				canWarmup, xerr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
+				if xerr != nil {
+					// Entitlement unknown: leave this mailbox exactly as it is.
+					continue
+				}
+				ok = canWarmup
+				entitled[*account.OrganizationID] = ok
+			}
+			if !ok {
+				if xerr := s.warmupHealth.RemoveFromAllPools(ctx, account.ID); xerr == nil {
+					removed++
+					log.Info().
+						Str("email_account_id", account.ID.String()).
+						Msg("warmup reconcile: mailbox left warmup, organization is no longer entitled")
+				}
+				continue
+			}
+		}
+
+		poolType := s.resolveWarmupPoolType(ctx, account)
+		didMove, xerr := s.warmupHealth.MovePoolMembership(ctx, account.ID, poolType)
+		if xerr != nil {
+			continue
+		}
+		if didMove {
+			moved++
+			log.Info().
+				Str("email_account_id", account.ID.String()).
+				Str("pool_type", poolType).
+				Msg("warmup reconcile: mailbox moved to the pool its tier belongs to")
+		}
+	}
+
+	return moved, removed, nil
 }

--- a/internal/tasks/warmup_reconciler.go
+++ b/internal/tasks/warmup_reconciler.go
@@ -41,8 +41,7 @@ func (s *tasksService) ReconcileWarmupSchedules(ctx context.Context, limit int) 
 		if s.featureGate != nil {
 			canWarmup, xerr := s.featureGate.CanUseWarmup(ctx, *account.OrganizationID)
 			if !canWarmup {
-				// Only a definite "not entitled" evicts; an unreadable
-				// subscription leaves the membership alone.
+				// Only a definite "not entitled" evicts.
 				if s.warmupHealth != nil && xerr == nil {
 					_ = s.warmupHealth.RemoveFromAllPools(ctx, account.ID)
 				}
@@ -103,20 +102,11 @@ func (s *tasksService) reconcileOnce(ctx context.Context) {
 	}
 }
 
-// ReconcileWarmupPoolMembership walks every warmup pool participant and makes
-// its membership agree with the mailbox's entitlement: a mailbox that may no
-// longer warm leaves warmup, and one whose tier changed is moved to the pool
-// that tier belongs to.
-//
-// The warmup task fixes membership too, but only for mailboxes it still runs
-// for. A mailbox that stops warming (warmup switched off, campaign finished,
-// subscription lapsed) has no chain and is not a schedule candidate, so nothing
-// would ever revisit it and its row would sit in the pool forever (issue #211).
-// This is the pass that ends that.
-//
-// Roles are left alone: a mailbox demoted to recipient_only (failing domain
-// auth, say) must not be quietly promoted back by a sweep that knows nothing
-// about why it was demoted.
+// ReconcileWarmupPoolMembership makes every participant's membership agree with its
+// entitlement: no longer entitled leaves warmup, changed tier moves pool. The warmup task does
+// this too, but only for mailboxes it still runs for, and one that stopped warming has no chain
+// and is not a schedule candidate, so nothing else would ever revisit it (issue #211).
+// Roles are left alone so a domain-auth demotion is not quietly promoted back.
 func (s *tasksService) ReconcileWarmupPoolMembership(ctx context.Context) (moved int, removed int, err error) {
 	if s.warmupRepo == nil || s.warmupHealth == nil {
 		return 0, 0, nil
@@ -127,8 +117,7 @@ func (s *tasksService) ReconcileWarmupPoolMembership(ctx context.Context) (moved
 		return 0, 0, err
 	}
 
-	// One subscription lookup per organization, not per mailbox: a workspace
-	// with fifty inboxes is one question asked fifty times otherwise.
+	// One subscription lookup per organization, not per mailbox.
 	entitled := map[uuid.UUID]bool{}
 
 	for _, id := range ids {
@@ -137,8 +126,7 @@ func (s *tasksService) ReconcileWarmupPoolMembership(ctx context.Context) (moved
 			continue
 		}
 		if account == nil || account.Status != "active" || account.OrganizationID == nil {
-			// No mailbox, no active mailbox, or no workspace to check an
-			// entitlement against: it does not belong in a shared pool.
+			// Nothing left to check an entitlement against, so it does not belong in a shared pool.
 			if xerr := s.warmupHealth.RemoveFromAllPools(ctx, id); xerr == nil {
 				removed++
 			}


### PR DESCRIPTION
Closes #211.

## The defect

Both the join and the removal were scoped to the pool the mailbox is entitled to **right now**, so nothing was ever handed the pool it used to be in:

```go
_ = s.warmupHealth.EnsurePoolMembershipWithRole(ctx, account.ID, s.resolveWarmupPoolType(ctx, account), role)
_ = s.warmupHealth.RemovePoolMembership(ctx, account.ID, s.resolveWarmupPoolType(ctx, account))
```

A paying org's mailbox is in `premium`. The org downgrades, `resolveWarmupPoolType` starts answering `free`, and the only removal that ever runs targets `free` and removes nothing. The premium row survives, so `GetPoolParticipants("premium")` keeps handing a mailbox with no paid entitlement to paying customers as a warmup partner. Upgrade is the mirror. And because `GetSpamScore` was `SUM(spam_score)` over the account's rows while every writer of that score is account-scoped, a dual member had each increment counted twice by the health evaluator.

There is a second half the issue did not name. Membership was only ever corrected by the warmup task, and a mailbox that stopped warming (warmup switched off, campaign finished, subscription lapsed) has no chain and is not a schedule candidate. Nothing would revisit it even after the join/leave fix, so the stale row would sit in the pool forever.

## The fix

**Membership is a move, not an addition.** `MoveToPool` is a single upsert with the account as the conflict target:

```sql
INSERT INTO warmup_pool_participants (pool_id, email_account_id, joined_at, spam_score, participant_role)
VALUES ($1::uuid, $2::uuid, NOW(), 0, $3::text)
ON CONFLICT (email_account_id) DO UPDATE
SET pool_id = EXCLUDED.pool_id,
    participant_role = EXCLUDED.participant_role
```

Only `pool_id` and the role are overwritten, so spam score, health state, block and the `health_signals_from` floor ride along untouched. That matters: a fresh row starts healthy with a zero score, so a naive "delete then insert" would have let a blocked mailbox launder its penalty by changing tier.

**Migration 000097** makes it structural. It merges any dual membership worst-wins first (worst health state, max spam score, earliest join and signal floor, `recipient_only` beating `sender_receiver`), keeps the row for the pool the mailbox is entitled to now (tie-breaking to `free`, the lower-trust side), then adds `UNIQUE (email_account_id)` and drops the plain index it supersedes.

**Removal is never pool-scoped.** `RemoveFromAllPools` replaces every wrongly-scoped removal and the two hand-rolled `for _, poolType := range []string{"premium", "free"}` loops. A caller that knows the mailbox is no longer entitled does not know which pool it is sitting in, and now does not have to.

**A tier change moves the row with the column.** `UpdateEmailAccountWarmupPoolType` writes `email_accounts.warmup_pool_type` and moves the participant row in one transaction. They record the same fact, and the worker tier migrations (`MigrateOrgToFreeWorkers` and friends) were updating only the column. A mailbox in no pool stays in none.

**A reconcile pass closes the gap.** `ReconcileWarmupPoolMembership` runs inside the existing 10-minute warmup sweep, walks every participant, evicts the ones whose workspace lost warmup access or whose mailbox is no longer active, and moves the rest to the pool their tier belongs to. Roles are deliberately left alone so a mailbox demoted to `recipient_only` for failing domain auth is not quietly promoted back by a sweep that knows nothing about why. One subscription lookup per organization, not per mailbox.

**An unreadable subscription is not evidence.** Every eviction path previously did `canWarmup, _ := CanUseWarmup(...)`, so a transient failure read as "not entitled" and removed the mailbox. Only a definite answer evicts now; the send is still skipped either way.

**Spam score arithmetic.** `GetSpamScore` takes `MAX` rather than `SUM`. `IncrementSpamScore` clamps to the column's `0..100` CHECK (past 100 it violated the constraint, and every caller ignores that error, so a noisy mailbox silently kept its old score) and treats "mailbox is in no pool" as 0 rather than an error, which is what a late signal about a mailbox that just left warmup looks like.

Also folded in: the premium-then-free probe in the warmup service becomes one account-scoped read, which is exact now that a mailbox is in one pool and drops the bias toward whichever pool was probed first.

## Verification

Live tests need a migrated database:

```
WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
  go test ./internal/app/warmup/ -run Live -v
```

- **Migration**, against a scratch DB seeded with real dual memberships: the downgraded mailbox survived in `free` still blocked, score 62, original join date and demoted role intact; the upgraded one survived in `premium` with the worst of its two states. Down and up round-trip, and a fresh database migrates 1 to 97 in a single pass.
- **15 live tests** (`internal/app/warmup/pool_membership_live_test.go`) over the move, the reputation carry, the unique index, the score arithmetic, the tier move and the account-scoped read. Verified they bite: dropping the index fails two of them immediately.
- **8 unit tests** (`internal/tasks/warmup_pool_reconcile_test.go`) over the reconcile pass, including the "do not evict on a lookup failure" rule and the per-org caching.
- **End to end**: booted the real backend against a migrated scratch database holding a drifted mailbox and an inactive one. It logged `moved=1 removed=1`, the database matched, and a second boot was silent.
- `gofmt`, `make lint`, `make check-migrations`, docs `types:check` and `lint`, and the full Go suite are clean.

Docs: `guides/warmup.mdx` now states that a mailbox is in exactly one pool, that a plan change moves it and carries its standing (so a quarantine is not cleared by changing tier), and that losing access removes it within minutes whether or not it was still warming.

## Adjacent, not fixed here

Nothing outside the sandbox seed ever creates the `warmup_pools` rows. No migration seeds them and the app only joins existing pools, so on a real install `EnsurePoolMembershipWithRole` returns "warmup pool not found" and warmup never works until someone inserts them by hand. Separate defect, and it needs a decision about pinning pool UUIDs in a migration.
