### PR TITLE
feat: make a 1,000-row contact import with spaced custom-field names actually land, and report a bad mapping once instead of once per row

### DIFF
--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -70,11 +70,18 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 |--------|------|----------------|
 | POST | `/contacts/search` | `READ_CONTACTS` |
 | GET | `/contacts/custom-fields` | `READ_CONTACTS` |
+| GET | `/contacts/lookup` | `READ_CONTACTS` |
 | POST | `/contacts` | `WRITE_CONTACTS` |
 | DELETE | `/contacts` | `BULK_CONTACTS` |
 | PATCH | `/contacts` | `BULK_CONTACTS` |
+| GET | `/contacts/:id` | `READ_CONTACTS` |
 | PATCH | `/contacts/:id` | `WRITE_CONTACTS` |
 | DELETE | `/contacts/:id` | `WRITE_CONTACTS` |
+| GET | `/contacts/:id/emails` | `READ_CONTACTS` |
+| GET | `/contacts/:id/timeline` | `READ_CONTACTS` |
+| POST | `/contacts/export` | `READ_CONTACTS` |
+| POST | `/contacts/import/preview` | `WRITE_CONTACTS` |
+| POST | `/contacts/import/commit` | `BULK_CONTACTS` |
 | GET | `/contacts/:id/notes` | `READ_CONTACTS` |
 | POST | `/contacts/:id/notes` | `WRITE_CONTACTS` |
 | PATCH | `/contacts/:id/notes/:noteId` | `WRITE_CONTACTS` |
@@ -87,7 +94,26 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 
 `GET /contacts/custom-fields` lists the distinct custom-field keys used across your contacts (frequency-ranked), for building personalization pickers. It returns a flat string array under `data`, capped at 200 keys.
 
+The import pair is two steps over the same file: preview parses it and suggests a column mapping, commit applies the mapping you chose. Commit takes the stricter `BULK_CONTACTS` scope because one call writes up to 50,000 rows. A mapping problem, an unusable custom-field name or no `email` column, is a `400` on the whole request; see [contacts](/api/reference/contacts/).
+
 AI contact research charges credits (2 per run, billable even when it finds nothing) and only saves cited findings. See the [AI contact research](/guides/ai-contact-research/) guide. The batch endpoint accepts up to 500 contact ids and drains in the background.
+
+### Lead sync
+
+Saved Google Sheets sources that upsert contacts on demand. Gated under the contact write scope because a sync ultimately writes contacts. Nothing syncs on a timer: a source only runs when `/lead-sync/sources/:id/sync` is called.
+
+| Method | Path | API Permission |
+|--------|------|----------------|
+| GET | `/lead-sync/google/connection` | `WRITE_CONTACTS` |
+| POST | `/lead-sync/google/spreadsheet` | `WRITE_CONTACTS` |
+| POST | `/lead-sync/google/preview` | `WRITE_CONTACTS` |
+| GET | `/lead-sync/sources`, `/lead-sync/sources/:id` | `WRITE_CONTACTS` |
+| POST | `/lead-sync/sources` | `WRITE_CONTACTS` |
+| PATCH | `/lead-sync/sources/:id` | `WRITE_CONTACTS` |
+| DELETE | `/lead-sync/sources/:id` | `WRITE_CONTACTS` |
+| POST | `/lead-sync/sources/:id/sync` | `WRITE_CONTACTS` |
+
+A source's `column_mapping` is validated when the source is written, not on its next sync, so a mapping with no `email` column or an unusable custom-field name is a `400` on create or update. See [integrations](/api/reference/integrations/).
 
 ### Unibox
 

--- a/docs/content/docs/api/reference/contacts.mdx
+++ b/docs/content/docs/api/reference/contacts.mdx
@@ -143,6 +143,9 @@ A JSON array of contact objects (at least one, up to the per-request maximum; an
 | `campaigns` | string[] | No | Campaign IDs to add the contact to. |
 | `categories` | string[] | No | Category IDs to assign. |
 | `custom_fields` | object | No | String key/value custom fields. Keys may use letters, numbers, underscores, spaces, and dashes. |
+| `subscribed` | boolean | No | Marketing-consent flag. Omit it to let a new contact default to subscribed and an existing one keep whatever it already had. |
+
+An address you already have is matched (lowercased) and enriched rather than duplicated: fields you send replace what is stored, fields you omit or send empty are left alone, and `custom_fields` is merged key by key. Use `PATCH /contacts/:id` to clear a value.
 
 ```json
 [
@@ -383,7 +386,7 @@ Send `multipart/form-data` with a `file` field and an `options` field containing
 }
 ```
 
-Imports are capped at 50,000 rows. `errors` carries at most the first 1,000 failed rows; when more rows failed, `errors_truncated` is `true` and `failed` still holds the real count.
+Imports are capped at 50,000 rows. `errors` carries at most the first 1,000 entries; past that `errors_truncated` is `true` and the counters, not the list, are the real totals. Every row lands in exactly one of `imported`, `updated`, `skipped`, or `failed`, so those four always sum to `total`.
 
 A custom-field name may use letters, numbers, underscores, spaces, and dashes (`Company Mobile`, `first-name`, `plan_tier`). Anything else is a `400` on the whole request, raised before any row is written, along with a mapping that names no `email` column or a `custom` column with no `custom_key`. Per-row `errors` are reserved for problems with the data itself.
 

--- a/docs/content/docs/api/reference/contacts.mdx
+++ b/docs/content/docs/api/reference/contacts.mdx
@@ -142,7 +142,7 @@ A JSON array of contact objects (at least one, up to the per-request maximum; an
 | `phone` | string | No | Phone number. |
 | `campaigns` | string[] | No | Campaign IDs to add the contact to. |
 | `categories` | string[] | No | Category IDs to assign. |
-| `custom_fields` | object | No | Arbitrary string key/value custom fields. |
+| `custom_fields` | object | No | String key/value custom fields. Keys may use letters, numbers, underscores, spaces, and dashes. |
 
 ```json
 [
@@ -345,7 +345,7 @@ Send `multipart/form-data` with a `file` field and an `options` field containing
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
-| `mapping` | array | Yes | Column mappings: `{ "index", "target", "custom_key" }`. `target` is `ignore`, `email`, `first_name`, `last_name`, `company`, `phone`, `subscribed`, `categories`, or `custom:<key>`. |
+| `mapping` | array | Yes | Column mappings: `{ "index", "target", "custom_key" }`. `target` is `ignore`, `email`, `first_name`, `last_name`, `company`, `phone`, `subscribed`, `categories`, or `custom` with the name in `custom_key`. `custom:<key>` is still accepted as the older spelling. Exactly one column must map to `email`. |
 | `dedup` | string | Yes | `skip`, `update`, or `create_duplicate` for rows whose email matches an existing contact. |
 | `has_header` | boolean | Yes | Whether the first row is a header. |
 | `category_ids` | string[] | No | Categories to assign to imported contacts. |
@@ -357,7 +357,7 @@ Send `multipart/form-data` with a `file` field and an `options` field containing
   "mapping": [
     { "index": 0, "target": "email" },
     { "index": 1, "target": "first_name" },
-    { "index": 3, "target": "custom:company_size", "custom_key": "company_size" }
+    { "index": 3, "target": "custom", "custom_key": "Company Mobile" }
   ],
   "dedup": "update",
   "has_header": true,
@@ -383,7 +383,9 @@ Send `multipart/form-data` with a `file` field and an `options` field containing
 }
 ```
 
-Imports are capped at 50,000 rows.
+Imports are capped at 50,000 rows. `errors` carries at most the first 1,000 failed rows; when more rows failed, `errors_truncated` is `true` and `failed` still holds the real count.
+
+A custom-field name may use letters, numbers, underscores, spaces, and dashes (`Company Mobile`, `first-name`, `plan_tier`). Anything else is a `400` on the whole request, raised before any row is written, along with a mapping that names no `email` column or a `custom` column with no `custom_key`. Per-row `errors` are reserved for problems with the data itself.
 
 ## Look up a contact by email
 

--- a/docs/content/docs/api/reference/integrations.mdx
+++ b/docs/content/docs/api/reference/integrations.mdx
@@ -1117,7 +1117,7 @@ Auth: **Scope** `WRITE_CONTACTS` · **Org permission** `manage_contacts`.
 | `sheet_title` | string | No | Spreadsheet title (for display). |
 | `tab_title` | string | No | Tab to read. |
 | `has_header` | boolean | No | Whether the first row is a header. |
-| `column_mapping` | array | Yes | Column-to-target mappings (same shape as contact import). |
+| `column_mapping` | array | Yes | Column-to-target mappings ([same shape as contact import](/api/reference/contacts/)). Validated on save, not on the next sync: a mapping with no `email` column, or a custom field whose name Warmbly cannot use, is a `400` here. |
 | `dedup` | string | No | Collision strategy: `skip`, `update`, or `create_duplicate`. |
 | `target_campaign_id` | uuid | No | Enrol new/updated leads into this campaign on each sync. |
 | `category_ids` | string[] | No | Categories to assign to synced leads. |

--- a/docs/content/docs/guides/contacts-crm.mdx
+++ b/docs/content/docs/guides/contacts-crm.mdx
@@ -17,15 +17,19 @@ You must map at least one column to **Email**.
 | --- | --- |
 | Email | Required, and used to dedupe |
 | First name, Last name, Company, Phone | Standard identity fields |
-| Subscribed | A truthy value marks the contact subscribed |
-| Categories | Existing category names to apply |
+| Subscribed | `yes`, `true`, `1`, `subscribed` and their opposites (`no`, `false`, `0`, `unsubscribed`). Applies to new contacts and to existing ones you update; a value the importer cannot read fails only that row |
+| Categories | Category names, separated by commas or semicolons. Names you do not have yet are created, up to 100 new names per import |
 | Custom field | Anything else; you name it |
 
 <Callout type="info" title="Duplicates match on lowercased email">
 `Dana@Acme.com` and `dana@acme.com` are the same contact. Choose **Skip existing** (leave untouched), **Update existing** (merge new values in), or **Create duplicates** (force a new one, falling back to update if a uniqueness rule blocks it).
+
+Skipping still adds the contact to the campaign and categories the import targets: it leaves their fields alone, it does not leave them out of the list. If the same address appears twice in one file it becomes one contact, and the extra rows count as skipped.
 </Callout>
 
-Rows with a missing or invalid email are reported with a line number and reason rather than imported.
+Rows with a missing or invalid email are reported with a line number and reason rather than imported. A blank cell never erases a value you already have, so re-importing a partial export enriches contacts instead of wiping them.
+
+Problems with the mapping itself, an unnamed custom field or a name Warmbly cannot use, are reported once before anything is written, so a single typo can never fail every row.
 
 **From Google Sheets**, a sheet is a reusable **sync source** rather than a one-time upload. Connect it once (Warmbly reads only the tab you choose and never writes back), paste the spreadsheet ID from the URL between `/d/` and `/edit`, pick the tab, map columns, then set duplicate handling, a label, and optionally a campaign to enroll into and categories to apply. **Nothing syncs automatically**: press **Sync now**, or save and sync immediately.
 
@@ -36,6 +40,8 @@ Saved sources live in your Sync sources list to re-run, edit, or remove. Each sy
 For anything beyond identity: industry, plan tier, account owner. Create them by mapping a column to "Use as custom field" during import, or on a contact's Details tab.
 
 They feed personalization, which is the main reason to get imports right.
+
+Field names may use letters, numbers, underscores, spaces, and dashes: `industry`, `account_owner`, `Company Mobile`, `first-name`. Other characters (`/`, `#`, `(`, `)`) are rejected because there would be no way to merge that field into an email. When you map a column to a custom field the wizard fills the name in from the column header and flags it inline if it cannot be used.
 
 <Callout type="info" title="Field names with spaces work too">
 Simple names (letters, numbers, underscores) use a dot: `{{.industry}}`, `{{.account_owner}}`. Names with spaces or dashes work the same way, written exactly as named:

--- a/internal/app/contact/handler.go
+++ b/internal/app/contact/handler.go
@@ -2,6 +2,7 @@ package contact
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -13,30 +14,46 @@ import (
 	"github.com/warmbly/warmbly/internal/utils/validate"
 )
 
+// checkContactLimit enforces the plan's contact ceiling for a batch about to
+// be created. Callers that write in chunks (the importer) must ask once for
+// the whole batch, or a rejected chunk turns one plan problem into one error
+// per row.
+//
+// This path reads the plan directly instead of going through the feature
+// gate, so it never saw the self-host short-circuit: every self-hosted org
+// was capped at the seeded Free Trial plan's 100 contacts even though
+// BILLING_PROVIDER=none unlocks every other limit.
+func (s *contactService) checkContactLimit(ctx context.Context, userID string, adding int) *errx.Error {
+	if config.SelfHosted() || s.subRepo == nil || s.planRepo == nil || adding <= 0 {
+		return nil
+	}
+	uid, parseErr := uuid.Parse(userID)
+	if parseErr != nil {
+		return nil
+	}
+	sub, err := s.subRepo.GetByUserID(ctx, uid)
+	if err != nil || sub == nil {
+		return nil
+	}
+	plan, err := s.planRepo.GetByID(ctx, sub.PlanID)
+	if err != nil || plan == nil || plan.MaxContacts <= 0 {
+		return nil
+	}
+	currentCount, xerr := s.contactRepository.GetContactCount(ctx, userID)
+	if xerr != nil {
+		return nil
+	}
+	if currentCount+adding > int(plan.MaxContacts) {
+		return errx.New(errx.Forbidden, fmt.Sprintf(
+			"adding %d contacts would put you over your plan's limit of %d (you have %d)",
+			adding, plan.MaxContacts, currentCount))
+	}
+	return nil
+}
+
 func (s *contactService) Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error) {
-	// Enforce contact limit if subscription repos are available.
-	//
-	// This path reads the plan directly instead of going through the feature
-	// gate, so it never saw the self-host short-circuit: every self-hosted org
-	// was capped at the seeded Free Trial plan's 100 contacts even though
-	// BILLING_PROVIDER=none unlocks every other limit.
-	if !config.SelfHosted() && s.subRepo != nil && s.planRepo != nil {
-		uid, parseErr := uuid.Parse(userID)
-		if parseErr == nil {
-			sub, err := s.subRepo.GetByUserID(ctx, uid)
-			if err == nil && sub != nil {
-				plan, err := s.planRepo.GetByID(ctx, sub.PlanID)
-				if err == nil && plan != nil && plan.MaxContacts > 0 {
-					currentCount, xerr := s.contactRepository.GetContactCount(ctx, userID)
-					if xerr == nil {
-						newTotal := currentCount + len(contacts)
-						if newTotal > int(plan.MaxContacts) {
-							return nil, errx.New(errx.Forbidden, "contact limit reached for your plan")
-						}
-					}
-				}
-			}
-		}
+	if xerr := s.checkContactLimit(ctx, userID, len(contacts)); xerr != nil {
+		return nil, xerr
 	}
 
 	created, xerr := s.contactRepository.Add(ctx, userID, orgID, contacts)

--- a/internal/app/contact/import.go
+++ b/internal/app/contact/import.go
@@ -3,7 +3,6 @@ package contact
 import (
 	"context"
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -62,6 +61,88 @@ func (s *contactService) ImportPreview(ctx context.Context, r io.Reader, filenam
 	}, nil
 }
 
+// importColumn is one validated mapping entry: exactly one destination
+// for one column index. Building these up front means a bad mapping is a
+// single actionable 400 instead of the same message repeated once per row.
+type importColumn struct {
+	index     int
+	target    models.ContactImportColumnTarget
+	customKey string
+}
+
+// resolveMapping validates the client's column mapping once, before any
+// row is touched. It returns the columns that actually go somewhere.
+func resolveMapping(mapping []models.ContactImportColumnMapping) ([]importColumn, *errx.Error) {
+	out := make([]importColumn, 0, len(mapping))
+	hasEmail := false
+	for _, m := range mapping {
+		if m.Index < 0 {
+			return nil, errx.New(errx.BadRequest,
+				fmt.Sprintf("column index %d is out of range", m.Index))
+		}
+		target := m.Target
+		key := strings.TrimSpace(m.CustomKey)
+		// "custom:<key>" is the legacy spelling of {target:"custom",
+		// custom_key:"<key>"}; an explicit custom_key still wins.
+		if rest, ok := strings.CutPrefix(string(target), string(models.ContactImportTargetCustom)+":"); ok {
+			target = models.ContactImportTargetCustom
+			if key == "" {
+				key = strings.TrimSpace(rest)
+			}
+		}
+
+		switch target {
+		case models.ContactImportTargetIgnore, "":
+			continue
+		case models.ContactImportTargetEmail:
+			hasEmail = true
+		case models.ContactImportTargetFirstName,
+			models.ContactImportTargetLastName,
+			models.ContactImportTargetCompany,
+			models.ContactImportTargetPhone,
+			models.ContactImportTargetSubscribed,
+			models.ContactImportTargetCategories:
+		case models.ContactImportTargetCustom:
+		default:
+			// An unrecognised target with a custom key is how older clients
+			// spelled a custom field; anything else is a client bug.
+			if key == "" {
+				return nil, errx.New(errx.BadRequest,
+					"unknown target "+strconv.Quote(string(m.Target))+" for column "+strconv.Itoa(m.Index+1))
+			}
+			target = models.ContactImportTargetCustom
+		}
+
+		if target == models.ContactImportTargetCustom {
+			key = utils.NormalizeJSONKey(key)
+			if key == "" {
+				return nil, errx.New(errx.BadRequest,
+					fmt.Sprintf("column %d is mapped to a custom field but has no name", m.Index+1))
+			}
+			if !utils.IsValidJSONKey(key) {
+				return nil, errx.New(errx.BadRequest,
+					"invalid custom field name "+strconv.Quote(key)+": "+utils.JSONKeyRules)
+			}
+		}
+
+		out = append(out, importColumn{index: m.Index, target: target, customKey: key})
+	}
+	if !hasEmail {
+		return nil, errx.New(errx.BadRequest, "map one column to Email before importing")
+	}
+	return out, nil
+}
+
+// ValidateImportMapping exposes resolveMapping's verdict without running an
+// import, so a saved mapping can be rejected at save time.
+func (s *contactService) ValidateImportMapping(mapping []models.ContactImportColumnMapping) *errx.Error {
+	if len(mapping) == 0 {
+		return errx.New(errx.BadRequest, "no column mapping provided")
+	}
+	_, xerr := resolveMapping(mapping)
+	return xerr
+}
+
 // ImportCommit re-parses the file and writes the upsert. We don't share
 // state with ImportPreview on purpose — keeping the path stateless
 // makes the commit safe to retry without an opaque "session id".
@@ -102,10 +183,24 @@ func (s *contactService) ImportCommit(
 		subscribedDefault = *opts.SubscribedDefault
 	}
 
-	// Validate category IDs are well-formed UUIDs. Ownership scoping
-	// happens later inside the repo (the INSERT joins against
-	// categories.user_id) so we don't need to round-trip the DB here.
-	catIDs, xerr := parseLocalCategoryIDs(opts.CategoryIDs)
+	// The mapping is validated once, up front: a mistyped custom-field name
+	// is one 400 the user can act on, not the same row error 50,000 times.
+	columns, xerr := resolveMapping(opts.Mapping)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	// Validate the category and campaign IDs up front. Ownership scoping
+	// happens later inside the repo (the INSERTs join against
+	// categories.user_id / campaigns.organization_id) so we don't need to
+	// round-trip the DB here, but they do have to be well-formed UUIDs: a
+	// blank one reaches Postgres as `'' = ANY($1::uuid[])` and fails the
+	// statement, which used to surface as every row failing to link.
+	globalCatIDs, xerr := parseIDList(opts.CategoryIDs)
+	if xerr != nil {
+		return nil, xerr
+	}
+	globalCampaignIDs, xerr := parseIDList(opts.CampaignIDs)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -134,19 +229,27 @@ func (s *contactService) ImportCommit(
 	// Build the parsed contacts up front so we can pre-check
 	// collisions in one DB round trip instead of N.
 	type pendingRow struct {
-		line    int
-		raw     []string
-		contact models.AddContact
-		ok      bool
-		errMsg  string
+		line       int
+		raw        []string
+		contact    models.AddContact
+		categories []string // category titles read from the file
+		ok         bool
+		// dupInFile marks a row whose address an earlier row already claimed.
+		// Not an error: it counts as skipped and its data was merged.
+		dupInFile bool
+		errMsg    string
 	}
 
 	parsed := make([]pendingRow, 0, len(data))
+	// firstByEmail points at the first pending row that claimed an address, so
+	// a file that lists the same person twice produces one contact instead of
+	// two upserts of the same row counted as two imports.
+	firstByEmail := make(map[string]int, len(data))
 	for i, row := range data {
 		line := i + dataStart + 1 // 1-based for "open in Excel and jump"
 		p := pendingRow{line: line, raw: row}
 
-		contact, err := buildAddContact(row, opts.Mapping, subscribedDefault, opts.CampaignIDs, opts.CategoryIDs)
+		contact, cats, err := buildAddContact(row, columns, globalCampaignIDs, globalCatIDs)
 		if err != "" {
 			p.errMsg = err
 			parsed = append(parsed, p)
@@ -159,9 +262,47 @@ func (s *contactService) ImportCommit(
 			continue
 		}
 		contact.Email = strings.ToLower(contact.Email)
+
+		if prev, dup := firstByEmail[contact.Email]; dup {
+			// Same address twice in one file. "skip" keeps the first row;
+			// the other strategies merge the later row onto it so no data
+			// from the file is silently dropped.
+			if dedup != models.ContactImportDedupSkip {
+				mergeAddContact(&parsed[prev].contact, contact)
+				parsed[prev].categories = appendUnique(parsed[prev].categories, cats...)
+			}
+			p.contact = contact
+			p.dupInFile = true
+			parsed = append(parsed, p)
+			continue
+		}
+		firstByEmail[contact.Email] = len(parsed)
+
 		p.contact = contact
+		p.categories = cats
 		p.ok = true
 		parsed = append(parsed, p)
+	}
+
+	// Resolve every category title the file mentions in one round trip,
+	// creating the ones the user doesn't have yet.
+	titleToID := map[string]uuid.UUID{}
+	var allTitles []string
+	for i := range parsed {
+		allTitles = append(allTitles, parsed[i].categories...)
+	}
+	if len(allTitles) > 0 {
+		titleToID, xerr = s.contactRepository.ResolveCategoryNames(ctx, uid, allTitles)
+		if xerr != nil {
+			return nil, xerr
+		}
+		for i := range parsed {
+			for _, title := range parsed[i].categories {
+				if id, ok := titleToID[strings.ToLower(strings.TrimSpace(title))]; ok {
+					parsed[i].contact.Categories = appendUnique(parsed[i].contact.Categories, id.String())
+				}
+			}
+		}
 	}
 
 	// Pre-check existing emails in one shot so we can route rows to
@@ -182,6 +323,21 @@ func (s *contactService) ImportCommit(
 		StartedAt: startedAt,
 		Errors:    make([]models.ContactImportRowError, 0),
 	}
+	// warn records a row-level note without counting the row as failed, so
+	// Total always equals imported + updated + skipped + failed.
+	warn := func(line int, addr string, values []string, reason string) {
+		if len(res.Errors) >= models.MaxContactImportReportedErrors {
+			res.ErrorsTruncated = true
+			return
+		}
+		res.Errors = append(res.Errors, models.ContactImportRowError{
+			Line: line, Email: addr, Values: values, Reason: reason,
+		})
+	}
+	fail := func(line int, addr string, values []string, reason string) {
+		res.Failed++
+		warn(line, addr, values, reason)
+	}
 
 	// Bucket rows by target action. We send fresh inserts through
 	// contactRepository.Add in batches and fall back to per-row
@@ -190,22 +346,41 @@ func (s *contactService) ImportCommit(
 	toInsert := make([]models.AddContact, 0, len(parsed))
 	toInsertLines := make([]int, 0, len(parsed))
 	toUpdate := make([]pendingRow, 0)
+	// Existing contacts the file listed but did not change. They still have
+	// to join the campaign / categories this import targets: "skip" means
+	// "don't touch their fields", not "leave them out of the list".
+	skippedLinks := make([]linkTarget, 0)
 
 	for _, p := range parsed {
 		if !p.ok {
-			res.Failed++
-			res.Errors = append(res.Errors, models.ContactImportRowError{
-				Line: p.line, Email: p.contact.Email, Values: p.raw, Reason: p.errMsg,
-			})
+			if p.dupInFile {
+				res.Skipped++
+				continue
+			}
+			fail(p.line, p.contact.Email, p.raw, p.errMsg)
 			continue
 		}
-		_, dup := existing[p.contact.Email]
+		ex, dup := existing[p.contact.Email]
 		switch {
 		case !dup:
+			// SubscribedDefault is what a NEW contact inherits. An update must
+			// never touch the flag, or re-importing a list would resubscribe
+			// everyone who had opted out.
+			if p.contact.Subscribed == nil {
+				sub := subscribedDefault
+				p.contact.Subscribed = &sub
+			}
 			toInsert = append(toInsert, p.contact)
 			toInsertLines = append(toInsertLines, p.line)
 		case dedup == models.ContactImportDedupSkip:
 			res.Skipped++
+			skippedLinks = append(skippedLinks, linkTarget{
+				line:       p.line,
+				email:      p.contact.Email,
+				contactID:  ex.ID.String(),
+				campaigns:  p.contact.Campaigns,
+				categories: p.contact.Categories,
+			})
 		case dedup == models.ContactImportDedupUpdate:
 			toUpdate = append(toUpdate, p)
 		case dedup == models.ContactImportDedupCreateDuplicate:
@@ -216,6 +391,13 @@ func (s *contactService) ImportCommit(
 			// behaviour than failing the whole batch.
 			toUpdate = append(toUpdate, p)
 		}
+	}
+
+	// Ask about the plan ceiling once for the whole batch. Per chunk it would
+	// report the same plan problem 500 times, which is what the row-level
+	// error list is explicitly not for.
+	if xerr := s.checkContactLimit(ctx, userID, len(toInsert)); xerr != nil {
+		return nil, xerr
 	}
 
 	// Insert in chunks so a 50k row import doesn't blow up a single
@@ -231,12 +413,7 @@ func (s *contactService) ImportCommit(
 			// Per-row reasons are easier to act on than a "batch
 			// failed" — record each as failed with the same reason.
 			for i, p := range chunk {
-				res.Failed++
-				res.Errors = append(res.Errors, models.ContactImportRowError{
-					Line:   toInsertLines[start+i],
-					Email:  p.Email,
-					Reason: xerr.Message,
-				})
+				fail(toInsertLines[start+i], p.Email, nil, xerr.Message)
 			}
 			continue
 		}
@@ -249,10 +426,11 @@ func (s *contactService) ImportCommit(
 		idStr := ex.ID.String()
 
 		update := &models.UpdateContact{
-			FirstName: optString(p.contact.FirstName, ex.FirstName),
-			LastName:  optString(p.contact.LastName, ex.LastName),
-			Company:   optString(p.contact.Company, ex.Company),
-			Phone:     optString(p.contact.Phone, ex.Phone),
+			FirstName:  optString(p.contact.FirstName),
+			LastName:   optString(p.contact.LastName),
+			Company:    optString(p.contact.Company),
+			Phone:      optString(p.contact.Phone),
+			Subscribed: p.contact.Subscribed,
 		}
 		if len(p.contact.CustomFields) > 0 {
 			merged := make(map[string]string, len(p.contact.CustomFields))
@@ -261,20 +439,11 @@ func (s *contactService) ImportCommit(
 			}
 			update.CustomFields = &merged
 		}
-		if len(catIDs) > 0 {
-			ids := make([]string, len(catIDs))
-			for i, id := range catIDs {
-				ids[i] = id.String()
-			}
-			update.AddCategories = ids
+		if len(p.contact.Categories) > 0 {
+			update.AddCategories = p.contact.Categories
 		}
 		if _, xerr := s.contactRepository.Update(ctx, userID, idStr, orgID, update); xerr != nil {
-			res.Failed++
-			res.Errors = append(res.Errors, models.ContactImportRowError{
-				Line:   p.line,
-				Email:  p.contact.Email,
-				Reason: xerr.Message,
-			})
+			fail(p.line, p.contact.Email, nil, xerr.Message)
 			continue
 		}
 		res.Updated++
@@ -285,24 +454,127 @@ func (s *contactService) ImportCommit(
 				Contacts:     []string{idStr},
 				AddCampaigns: p.contact.Campaigns,
 			}); xerr != nil {
-				// Non-fatal — the contact was updated, the link
-				// failed. Surface as a row-level warning.
-				res.Errors = append(res.Errors, models.ContactImportRowError{
-					Line:   p.line,
-					Email:  p.contact.Email,
-					Reason: "contact updated but campaign link failed: " + xerr.Message,
-				})
+				// Non-fatal: the contact was updated, only the link failed.
+				// Surface it as a row note, not as a failed row.
+				warn(p.line, p.contact.Email, nil, "contact updated but campaign link failed: "+xerr.Message)
+			}
+		}
+	}
+
+	// One BulkUpdate per distinct (campaigns, categories) set covers every
+	// skipped contact that shares it, so the common case (one campaign, one
+	// category list for the whole file) is a single statement.
+	for _, group := range groupLinks(skippedLinks) {
+		if len(group.campaigns) == 0 && len(group.categories) == 0 {
+			continue
+		}
+		if _, xerr := s.contactRepository.BulkUpdate(ctx, userID, orgID, &models.BulkEditContactsData{
+			Contacts:      group.contactIDs,
+			AddCampaigns:  group.campaigns,
+			AddCategories: group.categories,
+		}); xerr != nil {
+			// The rows that were imported are fine; only these links failed.
+			// Move the affected rows from skipped to failed rather than
+			// discarding the whole result.
+			for _, m := range group.members {
+				res.Skipped--
+				fail(m.line, m.email, nil,
+					"contact already existed but could not be added to the campaign: "+xerr.Message)
 			}
 		}
 	}
 
 	res.EndedAt = time.Now().UTC()
-	if res.Imported > 0 || res.Updated > 0 {
+	if res.Imported > 0 || res.Updated > 0 || len(skippedLinks) > 0 {
 		s.publishContactsReload(ctx, userID, "contacts:import")
 		// Covers the Google Sheets sync too: it commits through this path.
-		s.wakeCampaigns(ctx, orgID, opts.CampaignIDs)
+		s.wakeCampaigns(ctx, orgID, globalCampaignIDs)
 	}
 	return res, nil
+}
+
+// linkTarget is an existing contact that must join the import's campaigns and
+// categories even though its own fields were left alone.
+type linkTarget struct {
+	line       int
+	email      string
+	contactID  string
+	campaigns  []string
+	categories []string
+}
+
+type linkGroup struct {
+	campaigns  []string
+	categories []string
+	contactIDs []string
+	members    []linkTarget
+}
+
+func groupLinks(targets []linkTarget) []linkGroup {
+	byKey := map[string]*linkGroup{}
+	order := make([]string, 0, 1)
+	for _, t := range targets {
+		key := strings.Join(t.campaigns, ",") + "|" + strings.Join(t.categories, ",")
+		g, ok := byKey[key]
+		if !ok {
+			g = &linkGroup{campaigns: t.campaigns, categories: t.categories}
+			byKey[key] = g
+			order = append(order, key)
+		}
+		g.contactIDs = append(g.contactIDs, t.contactID)
+		g.members = append(g.members, t)
+	}
+	out := make([]linkGroup, 0, len(order))
+	for _, key := range order {
+		out = append(out, *byKey[key])
+	}
+	return out
+}
+
+// mergeAddContact folds a later row for the same address onto the first one.
+// Non-empty incoming values win; blanks never erase what an earlier row set.
+func mergeAddContact(dst *models.AddContact, src models.AddContact) {
+	if strings.TrimSpace(src.FirstName) != "" {
+		dst.FirstName = src.FirstName
+	}
+	if strings.TrimSpace(src.LastName) != "" {
+		dst.LastName = src.LastName
+	}
+	if strings.TrimSpace(src.Company) != "" {
+		dst.Company = src.Company
+	}
+	if strings.TrimSpace(src.Phone) != "" {
+		dst.Phone = src.Phone
+	}
+	if src.Subscribed != nil {
+		dst.Subscribed = src.Subscribed
+	}
+	if len(src.CustomFields) > 0 {
+		if dst.CustomFields == nil {
+			dst.CustomFields = map[string]string{}
+		}
+		for k, v := range src.CustomFields {
+			dst.CustomFields[k] = v
+		}
+	}
+	dst.Campaigns = appendUnique(dst.Campaigns, src.Campaigns...)
+	dst.Categories = appendUnique(dst.Categories, src.Categories...)
+}
+
+func appendUnique(dst []string, add ...string) []string {
+	for _, v := range add {
+		found := false
+		for _, have := range dst {
+			if have == v {
+				found = true
+				break
+			}
+		}
+		if !found {
+			dst = append(dst, v)
+		}
+	}
+	return dst
 }
 
 // parseSpreadsheet returns rows as a 2-D slice and the detected format.
@@ -434,34 +706,30 @@ func guessTarget(idx int, header string) models.ContactImportColumnMapping {
 	return models.ContactImportColumnMapping{Index: idx, Target: models.ContactImportTargetIgnore}
 }
 
-// buildAddContact applies the column mapping to a single row. Returns
-// either a fully-populated AddContact or a reason string explaining why
-// the row was rejected. We don't bail on the first bad field — we
-// gather everything so the user sees one good error.
+// buildAddContact applies the resolved column mapping to a single row.
+// It returns the contact, the category titles the row named, and a reason
+// string when the row itself is unusable.
 func buildAddContact(
 	row []string,
-	mapping []models.ContactImportColumnMapping,
-	subscribedDefault bool,
+	columns []importColumn,
 	defaultCampaignIDs []string,
 	defaultCategoryIDs []string,
-) (models.AddContact, string) {
+) (models.AddContact, []string, string) {
 	ac := models.AddContact{
 		CustomFields: map[string]string{},
 		Campaigns:    append([]string{}, defaultCampaignIDs...),
 		Categories:   append([]string{}, defaultCategoryIDs...),
 	}
-	subscribedSet := false
-	for _, m := range mapping {
-		if m.Index < 0 || m.Index >= len(row) {
+	var categories []string
+	for _, col := range columns {
+		if col.index >= len(row) {
 			continue
 		}
-		val := strings.TrimSpace(row[m.Index])
+		val := strings.TrimSpace(row[col.index])
 		if val == "" {
 			continue
 		}
-		switch m.Target {
-		case models.ContactImportTargetIgnore:
-			continue
+		switch col.target {
 		case models.ContactImportTargetEmail:
 			ac.Email = val
 		case models.ContactImportTargetFirstName:
@@ -473,38 +741,25 @@ func buildAddContact(
 		case models.ContactImportTargetPhone:
 			ac.Phone = val
 		case models.ContactImportTargetSubscribed:
-			subscribedSet = true
 			b, perr := parseBoolish(val)
 			if perr != "" {
-				return models.AddContact{}, perr
+				return models.AddContact{}, nil, perr
 			}
-			_ = b // not used: we don't have a way to push it into AddContact yet
+			sub := b
+			ac.Subscribed = &sub
 		case models.ContactImportTargetCategories:
-			// Comma-separated list of category names — caller could
-			// also pass IDs but names are friendlier for CSV
-			// round-trips. For now we ignore names from the file
-			// (we'd need a lookup); the bulk category assignment
-			// applied by `opts.CategoryIDs` covers the common case.
-			_ = val
-		default:
-			if strings.HasPrefix(string(m.Target), "custom:") {
-				key := strings.TrimPrefix(string(m.Target), "custom:")
-				if key == "" || !utils.IsValidJSONKey(key) {
-					return models.AddContact{}, "invalid custom field key: " + key
+			// Comma- or semicolon-separated category titles. Resolved to ids
+			// (creating what's missing) once for the whole file by the caller.
+			for _, name := range strings.FieldsFunc(val, func(r rune) bool { return r == ',' || r == ';' }) {
+				if name = strings.TrimSpace(name); name != "" {
+					categories = appendUnique(categories, name)
 				}
-				ac.CustomFields[key] = val
 			}
-			if m.CustomKey != "" {
-				if !utils.IsValidJSONKey(m.CustomKey) {
-					return models.AddContact{}, "invalid custom field key: " + m.CustomKey
-				}
-				ac.CustomFields[m.CustomKey] = val
-			}
+		case models.ContactImportTargetCustom:
+			ac.CustomFields[col.customKey] = val
 		}
 	}
-	_ = subscribedSet // AddContact doesn't carry subscribed; default applies at row creation
-	_ = subscribedDefault
-	return ac, ""
+	return ac, categories, ""
 }
 
 // parseBoolish accepts the strings real CSV exporters emit for boolean
@@ -520,27 +775,27 @@ func parseBoolish(v string) (bool, string) {
 	return false, "could not parse subscribed value: " + v
 }
 
-// optString returns a pointer to `incoming` if non-empty, else `fallback`.
+// optString returns a pointer to `incoming` when it has content, else nil.
 // Used in the update path to avoid blanking a populated field with an
 // empty CSV cell — the importer's job is to enrich, not erase.
-func optString(incoming, fallback string) *string {
+func optString(incoming string) *string {
 	if strings.TrimSpace(incoming) == "" {
 		return nil
 	}
 	v := incoming
-	_ = fallback
 	return &v
 }
 
-// parseLocalCategoryIDs is the import-package twin of pg_contact's
-// parseUUIDList. Kept private and small so we don't depend on the
-// repository package's internals.
-func parseLocalCategoryIDs(raw []string) ([]uuid.UUID, *errx.Error) {
+// parseIDList canonicalises a list of UUID strings from the request: blanks
+// dropped, duplicates removed, malformed rejected. It is the import-package
+// twin of pg_contact's parseUUIDList, kept private and small so we don't
+// depend on the repository package's internals.
+func parseIDList(raw []string) ([]string, *errx.Error) {
 	if len(raw) == 0 {
 		return nil, nil
 	}
 	seen := make(map[uuid.UUID]struct{}, len(raw))
-	out := make([]uuid.UUID, 0, len(raw))
+	out := make([]string, 0, len(raw))
 	for _, s := range raw {
 		s = strings.TrimSpace(s)
 		if s == "" {
@@ -554,9 +809,7 @@ func parseLocalCategoryIDs(raw []string) ([]uuid.UUID, *errx.Error) {
 			continue
 		}
 		seen[id] = struct{}{}
-		out = append(out, id)
+		out = append(out, id.String())
 	}
 	return out, nil
 }
-
-var _ = errors.New

--- a/internal/app/contact/import_live_test.go
+++ b/internal/app/contact/import_live_test.go
@@ -1,0 +1,502 @@
+package contact
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Issue #207: a 1,000-row CSV with 13 columns failed every single row with
+// "invalid custom field key: Company Mobile". Custom-field keys were held to
+// ^[A-Za-z0-9_]+$ even though the campaign template engine has always been
+// able to resolve spaced keys, and a mapping mistake was re-reported once per
+// row instead of once per import.
+//
+// Run against the dev stack:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/contact/ -run LiveImport -v
+
+type importFixture struct {
+	org      uuid.UUID
+	user     uuid.UUID
+	campaign uuid.UUID
+	svc      ContactService
+	repo     repository.ContactRepository
+	pool     *pgxpool.Pool
+}
+
+func newImportFixture(t *testing.T) *importFixture {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	handle, err := db.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+
+	f := &importFixture{
+		org:      uuid.New(),
+		user:     uuid.New(),
+		campaign: uuid.New(),
+		pool:     handle.Pool,
+	}
+	ctx := context.Background()
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := f.pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(70, len(sql))], err)
+		}
+	}
+	exec(`INSERT INTO users (id, first_name, last_name, email, password_hash)
+	      VALUES ($1, 'Import', 'Live', $2, 'x')`, f.user, "i207-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id)
+	      VALUES ($1, 'Issue 207', $2, $3)`, f.org, "i207-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO organization_members (organization_id, user_id, role, accepted_at)
+	      VALUES ($1, $2, 'owner', NOW())`, f.org, f.user)
+	exec(`INSERT INTO campaigns (id, user_id, organization_id, name, description, days, updated_at, created_at)
+	      VALUES ($1, $2, $3, 'Iqonic Agency Mix', '', 62, NOW(), NOW())`, f.campaign, f.user, f.org)
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM campaign_leads WHERE campaign_id IN (SELECT id FROM campaigns WHERE organization_id = $1)`, f.org},
+			{`DELETE FROM campaigns WHERE organization_id = $1`, f.org},
+			{`DELETE FROM contact_categories WHERE contact_id IN (SELECT id FROM contacts WHERE organization_id = $1)`, f.org},
+			{`DELETE FROM contacts WHERE organization_id = $1`, f.org},
+			{`DELETE FROM categories WHERE user_id = $1`, f.user},
+			{`DELETE FROM organization_members WHERE organization_id = $1`, f.org},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		} {
+			if _, err := f.pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+
+	f.repo = repository.NewContactRepostory(handle)
+	// nil sub/plan repos: the plan cap is skipped, which is what we want here.
+	f.svc = NewService(f.repo, nil, nil)
+	return f
+}
+
+func (f *importFixture) newCategory(t *testing.T, title string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO categories (id, user_id, title, color, position) VALUES ($1, $2, $3, '#38bdf8', 0)`,
+		id, f.user, title); err != nil {
+		t.Fatalf("create category: %v", err)
+	}
+	return id
+}
+
+func (f *importFixture) commit(t *testing.T, csv string, opts *models.ContactImportCommit) (*models.ContactImportResult, string) {
+	t.Helper()
+	res, xerr := f.svc.ImportCommit(context.Background(), f.user.String(), f.org,
+		strings.NewReader(csv), "leads.csv", opts)
+	if xerr != nil {
+		return nil, xerr.Message
+	}
+	// Every row lands in exactly one bucket. A count that stops adding up is
+	// how "1,000 failed" hid a mapping bug behind per-row noise.
+	if sum := res.Imported + res.Updated + res.Skipped + res.Failed; sum != res.Total {
+		t.Fatalf("counts do not add up: total=%d imported=%d updated=%d skipped=%d failed=%d",
+			res.Total, res.Imported, res.Updated, res.Skipped, res.Failed)
+	}
+	return res, ""
+}
+
+func col(idx int, target models.ContactImportColumnTarget) models.ContactImportColumnMapping {
+	return models.ContactImportColumnMapping{Index: idx, Target: target}
+}
+
+func customCol(idx int, key string) models.ContactImportColumnMapping {
+	return models.ContactImportColumnMapping{
+		Index: idx, Target: models.ContactImportTargetCustom, CustomKey: key,
+	}
+}
+
+// thirteenColumnCSV mirrors the file in the report: 13 columns, several of
+// them custom fields whose names contain spaces.
+func thirteenColumnCSV(rows int) string {
+	var b strings.Builder
+	b.WriteString("Email,First Name,Last Name,Company,Phone,Company Mobile,Job Title,Seniority Level,Employee Count,Annual Revenue,LinkedIn URL,City,Country\n")
+	for i := 0; i < rows; i++ {
+		fmt.Fprintf(&b,
+			"lead%04d@iqonic.test,Ada%04d,Lovelace,Iqonic %04d,+15550000%03d,+15551110%03d,Head of Growth,VP,250,10M,linkedin-%04d,Berlin,DE\n",
+			i, i, i, i%1000, i%1000, i)
+	}
+	return b.String()
+}
+
+func thirteenColumnMapping() []models.ContactImportColumnMapping {
+	return []models.ContactImportColumnMapping{
+		col(0, models.ContactImportTargetEmail),
+		col(1, models.ContactImportTargetFirstName),
+		col(2, models.ContactImportTargetLastName),
+		col(3, models.ContactImportTargetCompany),
+		col(4, models.ContactImportTargetPhone),
+		customCol(5, "Company Mobile"),
+		customCol(6, "Job Title"),
+		customCol(7, "Seniority Level"),
+		customCol(8, "Employee Count"),
+		customCol(9, "Annual Revenue"),
+		customCol(10, "LinkedIn URL"),
+		customCol(11, "City"),
+		customCol(12, "Country"),
+	}
+}
+
+func TestLiveImportThousandRowsWithSpacedCustomFields(t *testing.T) {
+	f := newImportFixture(t)
+
+	res, msg := f.commit(t, thirteenColumnCSV(1000), &models.ContactImportCommit{
+		Mapping:     thirteenColumnMapping(),
+		Dedup:       models.ContactImportDedupSkip,
+		HasHeader:   true,
+		CampaignIDs: []string{f.campaign.String()},
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Failed != 0 {
+		t.Fatalf("failed=%d (want 0); first errors: %+v", res.Failed, firstN(res.Errors, 3))
+	}
+	if res.Imported != 1000 {
+		t.Fatalf("imported=%d updated=%d skipped=%d (want imported 1000)", res.Imported, res.Updated, res.Skipped)
+	}
+
+	// The spaced key is stored verbatim, so {{.Company Mobile}} resolves.
+	var mobile, title string
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT custom_fields ->> 'Company Mobile', custom_fields ->> 'Job Title'
+		 FROM contacts WHERE organization_id = $1 AND email = 'lead0007@iqonic.test'`,
+		f.org).Scan(&mobile, &title); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if mobile == "" || title != "Head of Growth" {
+		t.Fatalf("custom fields not stored: mobile=%q title=%q", mobile, title)
+	}
+
+	// Every row joined the campaign it was imported into.
+	var leads int
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&leads); err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if leads != 1000 {
+		t.Fatalf("campaign_leads=%d (want 1000)", leads)
+	}
+
+	// A custom field with a space is filterable through the same UI path.
+	found, xerr := f.repo.Search(context.Background(), f.org.String(), nil, nil, models.SearchContacts{
+		CustomFieldFilters: []models.SearchContactsFilter{
+			{Name: "Job Title", Value: "Head of Growth", Type: models.SearchContactsFilterTypeEqual},
+		},
+	}, 5)
+	if xerr != nil {
+		t.Fatalf("search by custom field: %s", xerr.Message)
+	}
+	if len(found.Data) == 0 {
+		t.Fatalf("custom-field filter on a spaced key returned nothing")
+	}
+}
+
+func TestLiveImportRejectsBadMappingOnceNotPerRow(t *testing.T) {
+	f := newImportFixture(t)
+
+	mapping := thirteenColumnMapping()
+	mapping[5] = customCol(5, "Company/Mobile") // a slash is not addressable
+	res, msg := f.commit(t, thirteenColumnCSV(50), &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	})
+	if res != nil {
+		t.Fatalf("expected a 400, got a result with %d errors", len(res.Errors))
+	}
+	if !strings.Contains(msg, "Company/Mobile") || !strings.Contains(msg, "letters") {
+		t.Fatalf("unhelpful message: %q", msg)
+	}
+
+	// An unnamed custom column is rejected the same way.
+	mapping[5] = customCol(5, "   ")
+	if res, msg = f.commit(t, thirteenColumnCSV(5), &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	}); res != nil || !strings.Contains(msg, "no name") {
+		t.Fatalf("unnamed custom column: res=%v msg=%q", res, msg)
+	}
+
+	// So is a mapping with no email column at all.
+	if res, msg = f.commit(t, thirteenColumnCSV(5), &models.ContactImportCommit{
+		Mapping:   []models.ContactImportColumnMapping{col(1, models.ContactImportTargetFirstName)},
+		HasHeader: true,
+	}); res != nil || !strings.Contains(msg, "Email") {
+		t.Fatalf("missing email mapping: res=%v msg=%q", res, msg)
+	}
+}
+
+func TestLiveImportHonoursSubscribedAndCategoriesColumns(t *testing.T) {
+	f := newImportFixture(t)
+	ctx := context.Background()
+
+	csv := "email,subscribed,tags\n" +
+		"a@iqonic.test,yes,Agency; Enterprise\n" +
+		"b@iqonic.test,unsubscribed,Agency\n" +
+		"c@iqonic.test,,Startup\n"
+	res, msg := f.commit(t, csv, &models.ContactImportCommit{
+		Mapping: []models.ContactImportColumnMapping{
+			col(0, models.ContactImportTargetEmail),
+			col(1, models.ContactImportTargetSubscribed),
+			col(2, models.ContactImportTargetCategories),
+		},
+		Dedup:     models.ContactImportDedupSkip,
+		HasHeader: true,
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Imported != 3 || res.Failed != 0 {
+		t.Fatalf("imported=%d failed=%d %+v", res.Imported, res.Failed, res.Errors)
+	}
+
+	subs := map[string]bool{}
+	rows, err := f.pool.Query(ctx, `SELECT email, subscribed FROM contacts WHERE organization_id = $1`, f.org)
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	for rows.Next() {
+		var e string
+		var sub bool
+		if err := rows.Scan(&e, &sub); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		subs[e] = sub
+	}
+	rows.Close()
+	if subs["a@iqonic.test"] != true || subs["b@iqonic.test"] != false || subs["c@iqonic.test"] != true {
+		t.Fatalf("subscribed column ignored: %+v", subs)
+	}
+
+	// Categories named in the file exist and are attached.
+	var linked int
+	if err := f.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM contact_categories cc
+		JOIN categories cat ON cat.id = cc.category_id
+		JOIN contacts c ON c.id = cc.contact_id
+		WHERE c.organization_id = $1 AND cat.title = 'Agency'`, f.org).Scan(&linked); err != nil {
+		t.Fatalf("count categories: %v", err)
+	}
+	if linked != 2 {
+		t.Fatalf("Agency category attached to %d contacts (want 2)", linked)
+	}
+}
+
+func TestLiveImportDeduplicatesWithinTheFileAndLinksSkippedRows(t *testing.T) {
+	f := newImportFixture(t)
+	ctx := context.Background()
+
+	csv := "email,first_name\n" +
+		"dup@iqonic.test,Ada\n" +
+		"dup@iqonic.test,Ada\n" +
+		"other@iqonic.test,Grace\n"
+	mapping := []models.ContactImportColumnMapping{
+		col(0, models.ContactImportTargetEmail),
+		col(1, models.ContactImportTargetFirstName),
+	}
+	res, msg := f.commit(t, csv, &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Imported != 2 || res.Skipped != 1 {
+		t.Fatalf("imported=%d skipped=%d (want 2/1)", res.Imported, res.Skipped)
+	}
+
+	// Re-importing the same people into a campaign must add them as leads
+	// even though "skip existing" leaves their fields alone, and a blank
+	// name column must not erase the name already stored.
+	category := f.newCategory(t, "Re-import")
+	res, msg = f.commit(t, "email,first_name\ndup@iqonic.test,\nother@iqonic.test,\n", &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+		CampaignIDs: []string{f.campaign.String()},
+		CategoryIDs: []string{category.String()},
+	})
+	if msg != "" {
+		t.Fatalf("second import rejected: %s", msg)
+	}
+	if res.Skipped != 2 || res.Imported != 0 {
+		t.Fatalf("second import: imported=%d skipped=%d (want 0/2)", res.Imported, res.Skipped)
+	}
+	var leads int
+	if err := f.pool.QueryRow(ctx, `SELECT COUNT(*) FROM campaign_leads WHERE campaign_id = $1`, f.campaign).Scan(&leads); err != nil {
+		t.Fatalf("count leads: %v", err)
+	}
+	if leads != 2 {
+		t.Fatalf("skipped rows were not added to the campaign: campaign_leads=%d (want 2)", leads)
+	}
+	var name string
+	if err := f.pool.QueryRow(ctx,
+		`SELECT first_name FROM contacts WHERE organization_id = $1 AND email = 'dup@iqonic.test'`,
+		f.org).Scan(&name); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if name != "Ada" {
+		t.Fatalf("blank cell erased the stored name: %q", name)
+	}
+	var tagged int
+	if err := f.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM contact_categories cc
+		JOIN contacts c ON c.id = cc.contact_id
+		WHERE c.organization_id = $1 AND cc.category_id = $2`, f.org, category).Scan(&tagged); err != nil {
+		t.Fatalf("count categories: %v", err)
+	}
+	if tagged != 2 {
+		t.Fatalf("skipped rows did not get the import's categories: %d (want 2)", tagged)
+	}
+}
+
+func TestLiveImportMixedFileCountsEveryRowOnce(t *testing.T) {
+	f := newImportFixture(t)
+
+	mapping := []models.ContactImportColumnMapping{
+		col(0, models.ContactImportTargetEmail),
+		col(1, models.ContactImportTargetFirstName),
+	}
+	if _, msg := f.commit(t, "email,first_name\nseed@iqonic.test,Seed\n", &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	}); msg != "" {
+		t.Fatalf("seed import rejected: %s", msg)
+	}
+
+	// new + already-there + unusable address + the same address twice.
+	res, msg := f.commit(t, "email,first_name\n"+
+		"fresh@iqonic.test,Fresh\n"+
+		"seed@iqonic.test,Seed\n"+
+		"not-an-email,Broken\n"+
+		"twice@iqonic.test,Twice\n"+
+		"twice@iqonic.test,Twice\n", &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Total != 5 || res.Imported != 2 || res.Skipped != 2 || res.Failed != 1 {
+		t.Fatalf("total=%d imported=%d updated=%d skipped=%d failed=%d (want 5/2/0/2/1)",
+			res.Total, res.Imported, res.Updated, res.Skipped, res.Failed)
+	}
+	if len(res.Errors) != 1 || res.Errors[0].Line != 4 {
+		t.Fatalf("expected one error on line 4, got %+v", res.Errors)
+	}
+}
+
+// A blank campaign or category id reaches Postgres as `” = ANY($1::uuid[])`
+// and fails the statement, which showed up as every row failing to link. The
+// request is canonicalised before anything is written.
+func TestLiveImportIgnoresBlankCampaignAndCategoryIDs(t *testing.T) {
+	f := newImportFixture(t)
+
+	mapping := []models.ContactImportColumnMapping{col(0, models.ContactImportTargetEmail)}
+	csv := "email\nblank-ids@iqonic.test\n"
+	if _, msg := f.commit(t, csv, &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+	}); msg != "" {
+		t.Fatalf("seed import rejected: %s", msg)
+	}
+
+	// Second pass: the contact exists, so it goes down the skipped-link path.
+	res, msg := f.commit(t, csv, &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+		CampaignIDs: []string{""}, CategoryIDs: []string{"", " "},
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Failed != 0 || res.Skipped != 1 {
+		t.Fatalf("blank ids broke the import: skipped=%d failed=%d %+v", res.Skipped, res.Failed, res.Errors)
+	}
+
+	// A malformed id is a request error, not a per-row one.
+	if res, msg = f.commit(t, csv, &models.ContactImportCommit{
+		Mapping: mapping, Dedup: models.ContactImportDedupSkip, HasHeader: true,
+		CampaignIDs: []string{"not-a-uuid"},
+	}); res != nil || msg == "" {
+		t.Fatalf("malformed campaign id: res=%v msg=%q", res, msg)
+	}
+}
+
+func TestLiveImportUpdateDoesNotResubscribeOrErase(t *testing.T) {
+	f := newImportFixture(t)
+	ctx := context.Background()
+
+	// Someone who already opted out, with a name and a custom field.
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name, company, phone, custom_fields, subscribed)
+		VALUES (gen_random_uuid(), $1, $2, 'opted-out@iqonic.test', 'Grace', 'Hopper', 'Navy', '', '{"Job Title":"Rear Admiral"}'::jsonb, FALSE)`,
+		f.user, f.org); err != nil {
+		t.Fatalf("seed contact: %v", err)
+	}
+
+	yes := true
+	res, msg := f.commit(t, "email,first_name,company\nopted-out@iqonic.test,,Iqonic\n", &models.ContactImportCommit{
+		Mapping: []models.ContactImportColumnMapping{
+			col(0, models.ContactImportTargetEmail),
+			col(1, models.ContactImportTargetFirstName),
+			col(2, models.ContactImportTargetCompany),
+		},
+		Dedup:             models.ContactImportDedupUpdate,
+		HasHeader:         true,
+		SubscribedDefault: &yes,
+	})
+	if msg != "" {
+		t.Fatalf("import rejected: %s", msg)
+	}
+	if res.Updated != 1 {
+		t.Fatalf("updated=%d (want 1)", res.Updated)
+	}
+
+	var sub bool
+	var first, company, title string
+	if err := f.pool.QueryRow(ctx, `
+		SELECT subscribed, first_name, company, COALESCE(custom_fields ->> 'Job Title', '')
+		FROM contacts WHERE organization_id = $1 AND email = 'opted-out@iqonic.test'`,
+		f.org).Scan(&sub, &first, &company, &title); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	// subscribed_default applies to NEW contacts only.
+	if sub {
+		t.Fatalf("an update resubscribed a contact who had opted out")
+	}
+	if first != "Grace" {
+		t.Fatalf("blank cell erased first_name: %q", first)
+	}
+	if company != "Iqonic" {
+		t.Fatalf("update did not apply: company=%q", company)
+	}
+	if title != "Rear Admiral" {
+		t.Fatalf("update dropped an existing custom field: %q", title)
+	}
+}
+
+func firstN[T any](in []T, n int) []T {
+	if len(in) < n {
+		return in
+	}
+	return in[:n]
+}

--- a/internal/app/contact/import_mapping_test.go
+++ b/internal/app/contact/import_mapping_test.go
@@ -1,0 +1,137 @@
+package contact
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Issue #207: a mistyped custom-field name used to be reported once per row
+// (1,000 identical errors for a 1,000-row file). The mapping is now resolved
+// once, before any row is read.
+
+func mapCol(idx int, target models.ContactImportColumnTarget) models.ContactImportColumnMapping {
+	return models.ContactImportColumnMapping{Index: idx, Target: target}
+}
+
+func TestResolveMapping(t *testing.T) {
+	emailCol := mapCol(0, models.ContactImportTargetEmail)
+
+	t.Run("keeps only the columns that go somewhere", func(t *testing.T) {
+		cols, xerr := resolveMapping([]models.ContactImportColumnMapping{
+			emailCol,
+			mapCol(1, models.ContactImportTargetIgnore),
+			{Index: 2, Target: models.ContactImportTargetCustom, CustomKey: " Company  Mobile "},
+		})
+		if xerr != nil {
+			t.Fatalf("unexpected error: %s", xerr.Message)
+		}
+		if len(cols) != 2 {
+			t.Fatalf("got %d columns, want 2 (%+v)", len(cols), cols)
+		}
+		if cols[1].customKey != "Company Mobile" {
+			t.Fatalf("key not normalized: %q", cols[1].customKey)
+		}
+	})
+
+	t.Run("accepts the legacy custom:<key> target", func(t *testing.T) {
+		cols, xerr := resolveMapping([]models.ContactImportColumnMapping{
+			emailCol, {Index: 1, Target: "custom:plan_tier"},
+		})
+		if xerr != nil {
+			t.Fatalf("unexpected error: %s", xerr.Message)
+		}
+		if cols[1].target != models.ContactImportTargetCustom || cols[1].customKey != "plan_tier" {
+			t.Fatalf("legacy target not resolved: %+v", cols[1])
+		}
+	})
+
+	t.Run("an explicit custom_key wins over the target suffix", func(t *testing.T) {
+		cols, _ := resolveMapping([]models.ContactImportColumnMapping{
+			emailCol, {Index: 1, Target: "custom:old", CustomKey: "new"},
+		})
+		if cols[1].customKey != "new" {
+			t.Fatalf("custom_key ignored: %q", cols[1].customKey)
+		}
+	})
+
+	for name, tc := range map[string]struct {
+		mapping []models.ContactImportColumnMapping
+		wants   string
+	}{
+		"unusable name": {
+			[]models.ContactImportColumnMapping{emailCol, {Index: 5, Target: models.ContactImportTargetCustom, CustomKey: "Company/Mobile"}},
+			"Company/Mobile",
+		},
+		"no name": {
+			[]models.ContactImportColumnMapping{emailCol, {Index: 5, Target: models.ContactImportTargetCustom}},
+			"column 6 is mapped to a custom field but has no name",
+		},
+		"no email": {
+			[]models.ContactImportColumnMapping{mapCol(0, models.ContactImportTargetFirstName)},
+			"Email",
+		},
+		"unknown target": {
+			[]models.ContactImportColumnMapping{emailCol, mapCol(1, "middle_name")},
+			"unknown target",
+		},
+		"negative index": {
+			[]models.ContactImportColumnMapping{{Index: -1, Target: models.ContactImportTargetEmail}},
+			"out of range",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, xerr := resolveMapping(tc.mapping)
+			if xerr == nil {
+				t.Fatalf("expected an error mentioning %q", tc.wants)
+			}
+			if !strings.Contains(xerr.Message, tc.wants) {
+				t.Fatalf("message %q does not mention %q", xerr.Message, tc.wants)
+			}
+		})
+	}
+}
+
+func TestBuildAddContactReadsEveryTarget(t *testing.T) {
+	cols, xerr := resolveMapping([]models.ContactImportColumnMapping{
+		mapCol(0, models.ContactImportTargetEmail),
+		mapCol(1, models.ContactImportTargetFirstName),
+		mapCol(2, models.ContactImportTargetSubscribed),
+		mapCol(3, models.ContactImportTargetCategories),
+		{Index: 4, Target: models.ContactImportTargetCustom, CustomKey: "Company Mobile"},
+	})
+	if xerr != nil {
+		t.Fatalf("resolve: %s", xerr.Message)
+	}
+
+	row := []string{"dana@acme.com", "Dana", "unsubscribed", "Agency; Enterprise , Agency", "+15550000"}
+	ac, cats, reason := buildAddContact(row, cols, nil, nil)
+	if reason != "" {
+		t.Fatalf("row rejected: %s", reason)
+	}
+	if ac.Email != "dana@acme.com" || ac.FirstName != "Dana" {
+		t.Fatalf("identity fields not read: %+v", ac)
+	}
+	if ac.Subscribed == nil || *ac.Subscribed {
+		t.Fatalf("subscribed column not honoured: %v", ac.Subscribed)
+	}
+	if ac.CustomFields["Company Mobile"] != "+15550000" {
+		t.Fatalf("custom field not stored: %+v", ac.CustomFields)
+	}
+	if len(cats) != 2 || cats[0] != "Agency" || cats[1] != "Enterprise" {
+		t.Fatalf("category titles: %+v", cats)
+	}
+
+	// No subscribed column means "leave it to the caller's default", which is
+	// what keeps an update from resubscribing someone who opted out.
+	bare, _, _ := buildAddContact([]string{"x@y.com"}, cols[:1], nil, nil)
+	if bare.Subscribed != nil {
+		t.Fatalf("subscribed was decided without a column: %v", *bare.Subscribed)
+	}
+
+	// A value the importer cannot read fails that row, not the import.
+	if _, _, reason = buildAddContact([]string{"a@b.com", "A", "maybe", "", ""}, cols, nil, nil); reason == "" {
+		t.Fatal("an unreadable subscribed value should fail the row")
+	}
+}

--- a/internal/app/contact/service.go
+++ b/internal/app/contact/service.go
@@ -33,6 +33,12 @@ type ContactService interface {
 	// the columns + first N rows + suggested mapping — no DB writes.
 	ImportPreview(ctx context.Context, file io.Reader, filename string) (*models.ContactImportPreview, *errx.Error)
 
+	// ValidateImportMapping reports whether a column mapping is usable:
+	// exactly the checks ImportCommit runs before it touches a row. Callers
+	// that persist a mapping for later (the Google Sheets sync sources) use
+	// it so a bad mapping is caught when it is saved, not on the next sync.
+	ValidateImportMapping(mapping []models.ContactImportColumnMapping) *errx.Error
+
 	// ImportCommit re-parses the uploaded file with the chosen mapping
 	// and performs the upsert / skip / dedup work. Returns per-row
 	// result counts plus a list of rows that failed (with reasons).

--- a/internal/app/leadsync/service.go
+++ b/internal/app/leadsync/service.go
@@ -145,7 +145,7 @@ func (s *service) Create(ctx context.Context, orgID, userID uuid.UUID, in *model
 	if xerr := validateDedup(in.Dedup); xerr != nil {
 		return nil, xerr
 	}
-	if xerr := validateMappingHasEmail(in.ColumnMapping); xerr != nil {
+	if xerr := s.contacts.ValidateImportMapping(in.ColumnMapping); xerr != nil {
 		return nil, xerr
 	}
 
@@ -221,7 +221,7 @@ func (s *service) Update(ctx context.Context, orgID, id uuid.UUID, in *models.Up
 		if len(*in.ColumnMapping) == 0 {
 			return nil, errx.New(errx.BadRequest, "column_mapping cannot be empty")
 		}
-		if xerr := validateMappingHasEmail(*in.ColumnMapping); xerr != nil {
+		if xerr := s.contacts.ValidateImportMapping(*in.ColumnMapping); xerr != nil {
 			return nil, xerr
 		}
 		src.ColumnMapping = *in.ColumnMapping
@@ -369,17 +369,6 @@ func validateDedup(d models.ContactImportDedupStrategy) *errx.Error {
 		return nil
 	}
 	return errx.New(errx.BadRequest, "unknown dedup strategy: "+string(d))
-}
-
-// validateMappingHasEmail enforces that at least one column maps to the email
-// target — without it ImportCommit would reject every row as "missing email".
-func validateMappingHasEmail(mapping []models.ContactImportColumnMapping) *errx.Error {
-	for _, m := range mapping {
-		if m.Target == models.ContactImportTargetEmail {
-			return nil
-		}
-	}
-	return errx.New(errx.BadRequest, "column_mapping must map one column to 'email'")
 }
 
 // normalizeHeaders trims the header row and synthesises a name for any blank

--- a/internal/errx/common.go
+++ b/internal/errx/common.go
@@ -20,7 +20,6 @@ var (
 	ErrTimezone  = New(BadRequest, "Timezone doesn't exists.")
 	ErrTime      = New(BadRequest, "Invalid time format.")
 	ErrNotEnough = New(BadRequest, "Not enough data to perform this action.")
-	ErrJSONKey   = New(BadRequest, "JSON key can only contain characters and underscore.")
 	ErrLimit     = New(BadRequest, "Limit must be between 10 and 200.")
 
 	// Authorization

--- a/internal/models/contact.go
+++ b/internal/models/contact.go
@@ -321,6 +321,12 @@ type AddContact struct {
 	Categories []string `json:"categories"`
 
 	CustomFields map[string]string `json:"custom_fields"`
+
+	// Subscribed is the marketing-consent flag to store. nil means "don't
+	// decide": a new contact defaults to subscribed, an existing one keeps
+	// whatever it already had. Set explicitly by the importer when the file
+	// carries a subscribed column.
+	Subscribed *bool `json:"subscribed,omitempty"`
 }
 
 type SearchContactsFilterType string

--- a/internal/models/contact_import.go
+++ b/internal/models/contact_import.go
@@ -112,8 +112,8 @@ type ContactImportRowError struct {
 	Reason string   `json:"reason"`
 }
 
-// MaxContactImportReportedErrors caps how many per-row failures travel back
-// in the response. Failed still counts every one; without the cap a 50k-row
+// MaxContactImportReportedErrors caps how many per-row entries travel back in
+// the response. The counters still count every row; without the cap a 50k-row
 // file of bad addresses would echo the whole file back as JSON.
 const MaxContactImportReportedErrors = 1000
 
@@ -126,8 +126,10 @@ type ContactImportResult struct {
 	StartedAt time.Time `json:"started_at"`
 	EndedAt   time.Time `json:"ended_at"`
 
+	// Errors holds per-row failures and per-row notes, capped at
+	// MaxContactImportReportedErrors entries.
 	Errors []ContactImportRowError `json:"errors,omitempty"`
-	// ErrorsTruncated is true when Failed exceeds the reported-error cap, so
-	// the UI can say "showing the first N of M".
+	// ErrorsTruncated is true when that cap was reached, so the UI can say
+	// "showing the first N of M" instead of implying it listed everything.
 	ErrorsTruncated bool `json:"errors_truncated,omitempty"`
 }

--- a/internal/models/contact_import.go
+++ b/internal/models/contact_import.go
@@ -42,6 +42,10 @@ const (
 	ContactImportTargetPhone      ContactImportColumnTarget = "phone"
 	ContactImportTargetSubscribed ContactImportColumnTarget = "subscribed"
 	ContactImportTargetCategories ContactImportColumnTarget = "categories"
+	// ContactImportTargetCustom routes the column into Contact.CustomFields
+	// under ContactImportColumnMapping.CustomKey. "custom:<key>" is accepted
+	// as an equivalent legacy spelling.
+	ContactImportTargetCustom ContactImportColumnTarget = "custom"
 )
 
 // ContactImportColumnMapping says "the column at this index maps to
@@ -108,6 +112,11 @@ type ContactImportRowError struct {
 	Reason string   `json:"reason"`
 }
 
+// MaxContactImportReportedErrors caps how many per-row failures travel back
+// in the response. Failed still counts every one; without the cap a 50k-row
+// file of bad addresses would echo the whole file back as JSON.
+const MaxContactImportReportedErrors = 1000
+
 type ContactImportResult struct {
 	Total     int       `json:"total"`
 	Imported  int       `json:"imported"`
@@ -118,4 +127,7 @@ type ContactImportResult struct {
 	EndedAt   time.Time `json:"ended_at"`
 
 	Errors []ContactImportRowError `json:"errors,omitempty"`
+	// ErrorsTruncated is true when Failed exceeds the reported-error cap, so
+	// the UI can say "showing the first N of M".
+	ErrorsTruncated bool `json:"errors_truncated,omitempty"`
 }

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -47,6 +47,10 @@ type ContactRepository interface {
 	// block sending.
 	SetContactESP(ctx context.Context, contactID uuid.UUID, provider string) error
 	GetByEmailsAndUser(ctx context.Context, userID uuid.UUID, emails []string) (map[string]models.Contact, *errx.Error)
+	// ResolveCategoryNames maps category titles (as typed in an imported file)
+	// to the caller's category IDs, creating the ones that don't exist yet.
+	// Keys of the returned map are the lowercased titles.
+	ResolveCategoryNames(ctx context.Context, userID uuid.UUID, names []string) (map[string]uuid.UUID, *errx.Error)
 	Search(ctx context.Context, userID string, category, cursor *string, filters models.SearchContacts, limit int32) (*models.ContactsResult, *errx.Error)
 	// SearchCounts returns org-wide contact facet totals for the browse
 	// sidebar (independent of any search filters), mirroring campaigns-overview.
@@ -1935,6 +1939,98 @@ func (r *contactRepository) Delete(ctx context.Context, userID string, orgID uui
 // the given list, scoped to a single user. Used by the import path to
 // detect collisions before doing the bulk upsert. The map is keyed by
 // lowercased email so the caller doesn't have to normalize again.
+// MaxImportCategoryNames bounds how many distinct category titles one import
+// may introduce. A column of free text mapped to Categories by mistake would
+// otherwise mint a category per row.
+const MaxImportCategoryNames = 100
+
+func (r *contactRepository) ResolveCategoryNames(ctx context.Context, userID uuid.UUID, names []string) (map[string]uuid.UUID, *errx.Error) {
+	out := make(map[string]uuid.UUID, len(names))
+	wanted := make([]string, 0, len(names))
+	seen := make(map[string]string, len(names)) // lowered -> original casing
+	for _, raw := range names {
+		title := strings.TrimSpace(raw)
+		if title == "" {
+			continue
+		}
+		if len(title) > 50 {
+			return nil, errx.New(errx.BadRequest,
+				"category name "+strconv.Quote(title)+" is longer than 50 characters")
+		}
+		lower := strings.ToLower(title)
+		if _, dup := seen[lower]; dup {
+			continue
+		}
+		seen[lower] = title
+		wanted = append(wanted, lower)
+	}
+	if len(wanted) == 0 {
+		return out, nil
+	}
+	if len(wanted) > MaxImportCategoryNames {
+		return nil, errx.New(errx.BadRequest, fmt.Sprintf(
+			"the categories column has %d distinct values; at most %d can be created in one import",
+			len(wanted), MaxImportCategoryNames))
+	}
+
+	rows, err := r.DB.Query(ctx, `
+		SELECT id, LOWER(title) FROM categories
+		WHERE user_id = $1 AND LOWER(title) = ANY($2::text[])
+	`, userID, wanted)
+	if err != nil {
+		db.CaptureError(err, "", nil, "ResolveCategoryNames query")
+		return nil, errx.InternalError()
+	}
+	for rows.Next() {
+		var id uuid.UUID
+		var lower string
+		if err := rows.Scan(&id, &lower); err != nil {
+			rows.Close()
+			db.CaptureError(err, "", nil, "ResolveCategoryNames scan")
+			return nil, errx.InternalError()
+		}
+		out[lower] = id
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		db.CaptureError(err, "", nil, "ResolveCategoryNames rows")
+		return nil, errx.InternalError()
+	}
+
+	missing := make([]string, 0, len(wanted))
+	for _, lower := range wanted {
+		if _, ok := out[lower]; !ok {
+			missing = append(missing, lower)
+		}
+	}
+	if len(missing) == 0 {
+		return out, nil
+	}
+
+	// Positions continue after whatever the user already has, so the new
+	// categories land at the end of their list instead of colliding.
+	var nextPos int32
+	if err := r.DB.QueryRow(ctx,
+		`SELECT COALESCE(MAX(position), -1) + 1 FROM categories WHERE user_id = $1`,
+		userID).Scan(&nextPos); err != nil {
+		db.CaptureError(err, "", nil, "ResolveCategoryNames position")
+		return nil, errx.InternalError()
+	}
+	for _, lower := range missing {
+		id := uuid.New()
+		if _, err := r.DB.Exec(ctx, `
+			INSERT INTO categories (id, user_id, title, color, position)
+			VALUES ($1, $2, $3, $4, $5)
+		`, id, userID, seen[lower], defaultGroupColor(nextPos), nextPos); err != nil {
+			db.CaptureError(err, "", nil, "ResolveCategoryNames insert")
+			return nil, errx.InternalError()
+		}
+		out[lower] = id
+		nextPos++
+	}
+	return out, nil
+}
+
 func (r *contactRepository) GetByEmailsAndUser(ctx context.Context, userID uuid.UUID, emails []string) (map[string]models.Contact, *errx.Error) {
 	out := make(map[string]models.Contact, len(emails))
 	if len(emails) == 0 {

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -111,6 +112,26 @@ func parseUUIDList(raw []string) ([]uuid.UUID, *errx.Error) {
 	return out, nil
 }
 
+// normalizeCustomFields trims and collapses whitespace in every custom-field
+// key, then rejects the map if any key is still unusable. Keys are user data
+// (CSV headers, API payloads) so " Company Mobile" and "Company Mobile" must
+// land on the same JSONB key instead of splitting the field in two.
+func normalizeCustomFields(in map[string]string) (map[string]string, *errx.Error) {
+	if len(in) == 0 {
+		return map[string]string{}, nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		key := utils.NormalizeJSONKey(k)
+		if !utils.IsValidJSONKey(key) {
+			return nil, errx.New(errx.BadRequest,
+				"invalid custom field name "+strconv.Quote(k)+": "+utils.JSONKeyRules)
+		}
+		out[key] = v
+	}
+	return out, nil
+}
+
 func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error) {
 	// Validate userID up front. The handler should have caught a
 	// malformed JWT subject, but a defensive check here keeps any
@@ -141,11 +162,11 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 		if lead.CustomFields == nil {
 			lead.CustomFields = map[string]string{}
 		}
-		for key := range lead.CustomFields {
-			if !utils.IsValidJSONKey(key) {
-				return nil, errx.ErrJSONKey
-			}
+		fields, xerr := normalizeCustomFields(lead.CustomFields)
+		if xerr != nil {
+			return nil, xerr
 		}
+		lead.CustomFields = fields
 
 		// Approximate size check using JSON payload.
 		data, jerr := json.Marshal(lead)
@@ -613,7 +634,8 @@ func (r *contactRepository) Search(
 	// Custom field filters (JSONB)
 	// -----------------------------
 	for _, f := range filters.CustomFieldFilters {
-		if f.Name == "" || f.Value == "" || !utils.IsValidJSONKey(f.Name) {
+		name := utils.NormalizeJSONKey(f.Name)
+		if name == "" || f.Value == "" || !utils.IsValidJSONKey(name) {
 			continue
 		}
 		var op, val string
@@ -634,9 +656,11 @@ func (r *contactRepository) Search(
 			op = "ILIKE"
 			val = "%" + f.Value + "%"
 		}
-		whereClauses = append(whereClauses, fmt.Sprintf(`c.custom_fields ->> '%s' %s $%d`, f.Name, op, argIndex))
-		args = append(args, val)
-		argIndex++
+		// The key is a bound parameter, never interpolated: custom-field
+		// names are user data and now legitimately contain spaces.
+		whereClauses = append(whereClauses, fmt.Sprintf(`c.custom_fields ->> $%d::text %s $%d`, argIndex, op, argIndex+1))
+		args = append(args, name, val)
+		argIndex += 2
 	}
 
 	// -----------------------------
@@ -1384,17 +1408,16 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		argIndex++
 	}
 	if data.CustomFields != nil {
-		for key := range *data.CustomFields {
-			if !utils.IsValidJSONKey(key) {
-				return nil, errx.ErrJSONKey
-			}
+		incoming, xerr := normalizeCustomFields(*data.CustomFields)
+		if xerr != nil {
+			return nil, xerr
 		}
 		// Merge existing custom_fields with updates
 		mergedFields := make(map[string]string)
 		for k, v := range c.CustomFields {
 			mergedFields[k] = v
 		}
-		for k, v := range *data.CustomFields {
+		for k, v := range incoming {
 			if v == "" {
 				delete(mergedFields, k) // Remove key if value is empty
 			} else {
@@ -1696,6 +1719,21 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 	}
 
 	for _, p := range data.Fields {
+		// Keys arrive from the UI's bulk field editor; normalize + reject the
+		// same way the single-contact writes do so a bulk edit cannot mint a
+		// field name nothing else in the product can address.
+		p.Key = utils.NormalizeJSONKey(p.Key)
+		if !utils.IsValidJSONKey(p.Key) {
+			return nil, errx.New(errx.BadRequest,
+				"invalid custom field name "+strconv.Quote(p.Key)+": "+utils.JSONKeyRules)
+		}
+		if p.Type == models.BulkRenameField {
+			p.Value = utils.NormalizeJSONKey(p.Value)
+			if !utils.IsValidJSONKey(p.Value) {
+				return nil, errx.New(errx.BadRequest,
+					"invalid custom field name "+strconv.Quote(p.Value)+": "+utils.JSONKeyRules)
+			}
+		}
 		switch p.Type {
 		case models.BulkAddField:
 			// jsonb_build_object is variadic "any", so it gives Postgres nothing

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -232,21 +232,29 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 	insertBatch := pgx.Batch{}
 	for _, lead := range normalized {
 		insertBatch.Queue(
+			// $9 and $10 are the same value: a parameter used both as an
+			// INSERT value and inside the DO UPDATE set gives Postgres two
+			// inference sites for one placeholder, so it is passed twice with
+			// explicit casts. NULL means "leave the flag alone".
 			`INSERT INTO contacts (
-			 id, user_id, organization_id, first_name, last_name, email, company, phone, custom_fields
+			 id, user_id, organization_id, first_name, last_name, email, company, phone, custom_fields, subscribed
 			 ) VALUES (
-			  gen_random_uuid(), $1, $2, $3, $4, LOWER($5), $6, $7, $8
+			  gen_random_uuid(), $1, $2, $3, $4, LOWER($5), $6, $7, $8, COALESCE($9::boolean, TRUE)
 			 )
 			 ON CONFLICT (user_id, (LOWER(email))) DO UPDATE SET
 			  organization_id = COALESCE(contacts.organization_id, EXCLUDED.organization_id),
-			  first_name = EXCLUDED.first_name,
-			  last_name = EXCLUDED.last_name,
-			  company = EXCLUDED.company,
-			  phone = EXCLUDED.phone,
+			  -- Enrich, never erase: a blank cell in a re-imported file must
+			  -- not wipe a name we already have.
+			  first_name = COALESCE(NULLIF(EXCLUDED.first_name, ''), contacts.first_name),
+			  last_name = COALESCE(NULLIF(EXCLUDED.last_name, ''), contacts.last_name),
+			  company = COALESCE(NULLIF(EXCLUDED.company, ''), contacts.company),
+			  phone = COALESCE(NULLIF(EXCLUDED.phone, ''), contacts.phone),
 			  custom_fields = contacts.custom_fields || EXCLUDED.custom_fields,
+			  subscribed = COALESCE($10::boolean, contacts.subscribed),
 			  updated_at = NOW()
 			 RETURNING id, first_name, last_name, email, company, phone, custom_fields, subscribed, updated_at, created_at`,
 			userID, orgID, lead.FirstName, lead.LastName, lead.Email, lead.Company, lead.Phone, lead.CustomFields,
+			lead.Subscribed, lead.Subscribed,
 		)
 	}
 

--- a/internal/utils/json.go
+++ b/internal/utils/json.go
@@ -1,18 +1,41 @@
 package utils
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
+// MaxJSONKeyLength caps a custom-field key so one row can't push an
+// unbounded string into the JSONB column.
+const MaxJSONKeyLength = 255
+
+// jsonKeyPattern is the set of custom-field keys the whole product can
+// actually address. A key is either a plain identifier ("role") or
+// identifier segments joined by spaces/dashes ("Company Mobile",
+// "first-name"). That is exactly what the campaign template engine can
+// resolve: tasks.rewriteSpacedFieldRefs turns `{{.Company Mobile}}`
+// into `(index . "Company Mobile")`, so spaced and dashed keys work
+// everywhere a plain one does. Anything outside this set would produce a
+// field the user can never reference in an email.
+var jsonKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_]+(?:[ -]+[A-Za-z0-9_]+)*$`)
+
+// JSONKeyRules is the human-readable version of jsonKeyPattern, for
+// error messages the user has to act on.
+const JSONKeyRules = "use letters, numbers, underscores, spaces or dashes"
+
+// NormalizeJSONKey trims a custom-field key and collapses internal
+// whitespace runs to a single space. CSV headers routinely arrive with a
+// trailing space or a tab, and "Company Mobile" and "Company  Mobile"
+// must not become two different fields.
+func NormalizeJSONKey(key string) string {
+	return strings.Join(strings.Fields(key), " ")
+}
+
+// IsValidJSONKey reports whether key is usable as a contact custom-field
+// key. Callers should NormalizeJSONKey first.
 func IsValidJSONKey(key string) bool {
-	const maxKeyLength = 255
-	if len(key) == 0 || len(key) > maxKeyLength {
+	if len(key) == 0 || len(key) > MaxJSONKeyLength {
 		return false
 	}
-	matched, err := regexp.MatchString(`^[a-zA-Z0-9_]+$`, key)
-	if err != nil {
-		return false
-	}
-	if !matched {
-		return false
-	}
-	return true
+	return jsonKeyPattern.MatchString(key)
 }

--- a/internal/utils/json_test.go
+++ b/internal/utils/json_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import "testing"
+
+// Issue #207: this rule used to be ^[A-Za-z0-9_]+$, so a CSV column called
+// "Company Mobile" failed every row of the import even though the campaign
+// template engine has always been able to resolve a spaced key. The set below
+// is exactly what tasks.rewriteSpacedFieldRefs can address, and the same rule
+// is mirrored in web/src/components/app/contacts/importShared.ts.
+func TestIsValidJSONKey(t *testing.T) {
+	valid := []string{"role", "Job_Title", "Company Mobile", "first-name", "plan tier 2", "a"}
+	for _, k := range valid {
+		if !IsValidJSONKey(k) {
+			t.Errorf("IsValidJSONKey(%q) = false, want true", k)
+		}
+	}
+	invalid := []string{
+		"", " ", "Company/Mobile", "Revenue ($)", "a.b", "тест",
+		" leading", "trailing ", "-dash", "dash-", "a\tb",
+	}
+	for _, k := range invalid {
+		if IsValidJSONKey(k) {
+			t.Errorf("IsValidJSONKey(%q) = true, want false", k)
+		}
+	}
+	long := make([]byte, MaxJSONKeyLength+1)
+	for i := range long {
+		long[i] = 'a'
+	}
+	if IsValidJSONKey(string(long)) {
+		t.Error("an over-length key was accepted")
+	}
+}
+
+func TestNormalizeJSONKey(t *testing.T) {
+	cases := map[string]string{
+		"  Company   Mobile ": "Company Mobile",
+		"Company\tMobile":     "Company Mobile",
+		"role":                "role",
+		"   ":                 "",
+	}
+	for in, want := range cases {
+		if got := NormalizeJSONKey(in); got != want {
+			t.Errorf("NormalizeJSONKey(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// Normalizing is what makes a header with stray whitespace usable.
+	if !IsValidJSONKey(NormalizeJSONKey(" Company  Mobile ")) {
+		t.Error("a normalized header should be a valid key")
+	}
+}

--- a/web/src/app/app/campaigns/campaignTabs.test.tsx
+++ b/web/src/app/app/campaigns/campaignTabs.test.tsx
@@ -1,0 +1,183 @@
+// Issue #207 (second report): clicking a campaign tab changed the URL without
+// changing the page. This mounts the real dashboard shell (RootAppLayout ->
+// AppShell -> RouteBoundary -> Suspense -> Outlet) around the real campaign
+// routes and walks the tab bar, so a regression that leaves the content panel
+// showing the previous tab, or blank, fails here instead of in someone's
+// browser. It also pins the scroll reset: the shell scrolls an inner div, so
+// nothing but AppShell can put a new route back at the top.
+
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// jsdom has no layout, so Element.scrollTo is missing entirely.
+const scrolled: { top: number }[] = [];
+(Element.prototype as unknown as { scrollTo: (o: { top: number }) => void }).scrollTo = function (o) {
+    scrolled.push(o);
+};
+
+// Every request the dashboard bootstrap fires, answered with the smallest
+// shape each consumer needs. `hang` lets a test hold one endpoint open.
+let hang: RegExp | null = null;
+vi.mock("@/lib/api/client/Request", () => ({
+    default: (cfg: { url?: string }) => {
+        const url = String(cfg?.url ?? "");
+        if (hang?.test(url)) return new Promise(() => {});
+        return Promise.resolve(route(url));
+    },
+}));
+vi.mock("@/lib/helper/getToken", () => ({
+    default: () => ({
+        access_token: "a",
+        refresh_token: "r",
+        access_token_expires_at: new Date(Date.now() + 3600e3).toISOString(),
+        refresh_token_expires_at: new Date(Date.now() + 3600e3).toISOString(),
+    }),
+}));
+// The real provider opens a websocket; the channel hooks are what components use.
+vi.mock("@/hooks/SocketProvider", () => ({
+    default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/hooks/context/socket", async (orig) => {
+    const actual = (await orig()) as Record<string, unknown>;
+    return {
+        ...actual,
+        useSocket: () => ({
+            isConnected: false,
+            subscribeToChannel: () => () => {},
+            pushToChannel: () => {},
+            socket: null,
+            status: "closed",
+        }),
+        useChannel: () => ({ state: "closed", push: () => {}, channel: null }),
+        useChannelEvent: () => {},
+        useChannelSubscription: () => {},
+    };
+});
+
+const EMPTY_LIST = { data: [], pagination: { total: 0, next_cursor: null, has_more: false } };
+
+function route(url: string): unknown {
+    if (/^\/campaigns\/[^/?]+$/.test(url)) {
+        return { id: "camp-1", name: "Probe campaign", status: "draft", description: "" };
+    }
+    if (url === "/auth/me" || url === "/me") {
+        return {
+            id: "u1", email: "d@w.com", first_name: "D", last_name: "W",
+            onboarding_completed_at: new Date().toISOString(),
+            tags: [], categories: [], folders: [], roles: [],
+        };
+    }
+    if (url.startsWith("/organization")) return [{ id: "org-1", name: "Org", slug: "org" }];
+    if (url.startsWith("/subscription/credits/")) return { data: [] };
+    if (url.startsWith("/subscription/credits")) {
+        return {
+            monthly_balance: 100, monthly_allowance: 100, purchased_balance: 0,
+            spent_today: 0, spent_week: 0, spent_month: 0,
+        };
+    }
+    if (url.startsWith("/subscription")) return { plan: { name: "Pro" }, status: "active" };
+    if (url.startsWith("/analytics")) return { summary: {}, steps: [], data: [] };
+    if (url.startsWith("/advisor")) return { findings: [], data: [], total: 0 };
+    if (url.includes("/steps")) return [];
+    if (url.includes("connections")) return { connections: [] };
+    return EMPTY_LIST;
+}
+
+const RootAppLayout = (await import("../layout")).default;
+const CampaignLayout = (await import("./[id]/layout")).default;
+const CampaignOverview = (await import("./[id]/page")).default;
+const CampaignLeads = (await import("./[id]/leads/page")).default;
+const CampaignSteps = (await import("./[id]/steps/page")).default;
+
+function mountDashboard() {
+    const router = createMemoryRouter(
+        [
+            {
+                path: "/app",
+                element: <RootAppLayout />,
+                children: [
+                    {
+                        path: "campaigns/:id",
+                        element: <CampaignLayout />,
+                        children: [
+                            { index: true, element: <CampaignOverview /> },
+                            { path: "leads", element: <CampaignLeads /> },
+                            { path: "steps", element: <CampaignSteps /> },
+                        ],
+                    },
+                ],
+            },
+        ],
+        { initialEntries: ["/app/campaigns/camp-1"] },
+    );
+    render(
+        <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+            <RouterProvider router={router} />
+        </QueryClientProvider>,
+    );
+    return router;
+}
+
+async function settle() {
+    await act(async () => {
+        await new Promise((r) => setTimeout(r, 300));
+    });
+}
+
+function clickTab(name: RegExp) {
+    const links = screen.getAllByRole("link", { name });
+    return act(async () => {
+        fireEvent.click(links[links.length - 1]);
+    });
+}
+
+describe("campaign tabs", () => {
+    it("swaps the content panel when the URL changes", async () => {
+        hang = null;
+        const router = mountDashboard();
+        await settle();
+        expect(screen.queryByText("Performance")).toBeTruthy();
+
+        await clickTab(/Leads/i);
+        await settle();
+        expect(router.state.location.pathname).toBe("/app/campaigns/camp-1/leads");
+        // The Overview is gone and the Leads browser is mounted in its place.
+        expect(screen.queryByText("Performance")).toBeNull();
+        expect(screen.queryByPlaceholderText("Search leads…")).toBeTruthy();
+
+        await clickTab(/Overview/i);
+        await settle();
+        expect(router.state.location.pathname).toBe("/app/campaigns/camp-1");
+        expect(screen.queryByPlaceholderText("Search leads…")).toBeNull();
+        expect(screen.queryByText("Performance")).toBeTruthy();
+    });
+
+    it("puts every navigation back at the top of the content panel", async () => {
+        hang = null;
+        mountDashboard();
+        await settle();
+        scrolled.length = 0;
+
+        await clickTab(/Leads/i);
+        await settle();
+        expect(scrolled.some((s) => s.top === 0)).toBe(true);
+    });
+
+    it("shows a loading state instead of an empty panel when a page suspends", async () => {
+        // The Steps tab reads its data with useSuspenseQuery. Navigate while
+        // that request is still open: something has to render, or the panel
+        // sits blank until the user reloads.
+        hang = /\/steps$/;
+        mountDashboard();
+        await settle();
+
+        await clickTab(/Steps/i);
+        await settle();
+        const main = document.querySelector("main");
+        expect(main?.querySelector(".animate-pulse")).toBeTruthy();
+        hang = null;
+    });
+});

--- a/web/src/components/app/contacts/ImportWizard.tsx
+++ b/web/src/components/app/contacts/ImportWizard.tsx
@@ -53,7 +53,16 @@ import {
 import { Label, TextInput } from "@/components/ui/field";
 import CategoryPicker from "./CategoryPicker";
 import { downloadBlob } from "@/lib/api/client/app/contacts/exportContacts";
-import { DEDUP_OPTIONS, STANDARD_TARGETS, describeError } from "./importShared";
+import {
+    CUSTOM_KEY_RULES,
+    DEDUP_OPTIONS,
+    STANDARD_TARGETS,
+    describeError,
+    isCustomTarget,
+    isValidCustomKey,
+    mappingProblem,
+    suggestCustomKey,
+} from "./importShared";
 
 interface Props {
     open: boolean;
@@ -137,9 +146,10 @@ export default function ImportWizard({ open, onClose, lockedCampaign }: Props) {
         }
     }
 
-    function emailIsMapped(): boolean {
-        return mapping.some((m) => m.target === "email");
-    }
+    // Any reason the mapping can't be committed (missing email, an unnamed or
+    // unusable custom-field name). Caught here so a mistyped field name costs
+    // one glance instead of a whole import.
+    const mapProblem = mappingProblem(mapping);
 
     return (
         <AnimatePresence>
@@ -244,16 +254,16 @@ export default function ImportWizard({ open, onClose, lockedCampaign }: Props) {
                                         <ArrowLeftIcon className="w-3 h-3" />
                                         Re-upload
                                     </button>
-                                    {!emailIsMapped() && (
+                                    {mapProblem && (
                                         <span className="text-[11px] text-amber-700 inline-flex items-center gap-1">
-                                            <AlertTriangleIcon className="w-3 h-3" />
-                                            Map a column to Email
+                                            <AlertTriangleIcon className="w-3 h-3 shrink-0" />
+                                            {mapProblem}
                                         </span>
                                     )}
                                     <button
                                         type="button"
                                         onClick={() => setStep("options")}
-                                        disabled={!emailIsMapped()}
+                                        disabled={!!mapProblem}
                                         className="ml-auto h-7 px-3 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
                                     >
                                         Continue
@@ -453,6 +463,30 @@ export function MapStep({
         return mapping.find((m) => m.index === idx) ?? { index: idx, target: "ignore" };
     }
 
+    // Columns we didn't recognise default to Ignore, which means a CRM export
+    // with a dozen extra columns is a dozen dropdowns. Offer the obvious bulk
+    // action for the ones whose header is already a usable field name.
+    // Only with a real header row: without one the columns are synthesised
+    // ("Column 4"), which is a legal field name but never the one you want.
+    const claimable = !hasHeader
+        ? []
+        : preview.columns
+              .map((header, idx) => ({ idx, key: suggestCustomKey(header) }))
+              .filter(({ idx, key }) => key !== "" && getMapping(idx).target === "ignore");
+
+    function claimAllAsCustom() {
+        setMapping((cur) => {
+            const next = [...cur];
+            for (const { idx, key } of claimable) {
+                const at = next.findIndex((m) => m.index === idx);
+                const entry: ImportColumnMapping = { index: idx, target: "custom", custom_key: key };
+                if (at >= 0) next[at] = entry;
+                else next.push(entry);
+            }
+            return next;
+        });
+    }
+
     return (
         <div className="space-y-3">
             <div className="flex items-center gap-2">
@@ -462,6 +496,15 @@ export function MapStep({
                         {preview.format.toUpperCase()} · {preview.total_rows.toLocaleString()} rows · {preview.columns.length} columns
                     </p>
                 </div>
+                {claimable.length > 0 && (
+                    <button
+                        type="button"
+                        onClick={claimAllAsCustom}
+                        className="h-7 px-2.5 rounded-md border border-slate-200 hover:border-slate-300 text-slate-700 hover:text-slate-900 text-[11.5px] font-medium transition-colors shrink-0"
+                    >
+                        Keep {claimable.length} more as custom fields
+                    </button>
+                )}
                 <label className="inline-flex items-center gap-1.5 text-[11.5px] text-slate-700 cursor-pointer">
                     <input
                         type="checkbox"
@@ -499,6 +542,7 @@ export function MapStep({
                                     <td className="px-3 py-2">
                                         <TargetPicker
                                             value={m}
+                                            header={col}
                                             onChange={(next) => updateMapping(idx, next)}
                                         />
                                     </td>
@@ -515,17 +559,20 @@ export function MapStep({
 export function TargetPicker({
     value,
     onChange,
+    header,
 }: {
     value: ImportColumnMapping;
     onChange: (next: ImportColumnMapping) => void;
+    /** The column's header, used to pre-fill the custom-field name. */
+    header?: string;
 }) {
     // Custom-field rows are tagged with target="custom" (sentinel); the
     // user-typed name lives in custom_key. We also accept the legacy
     // "custom:<key>" form in case a saved mapping comes in that shape.
-    const isCustom =
-        value.target === "custom" || value.target.toString().startsWith("custom:");
+    const isCustom = isCustomTarget(value.target.toString());
     const stdLabel = STANDARD_TARGETS.find((t) => t.id === value.target)?.label;
     const customKey = value.custom_key ?? "";
+    const keyInvalid = isCustom && customKey.trim() !== "" && !isValidCustomKey(customKey);
     const label = isCustom
         ? customKey
             ? `Custom: ${customKey}`
@@ -558,7 +605,10 @@ export function TargetPicker({
                             onChange({
                                 index: value.index,
                                 target: "custom",
-                                custom_key: customKey,
+                                // Start from the column header: "Company Mobile"
+                                // is a valid field name, so there is nothing to
+                                // type in the common case.
+                                custom_key: customKey || suggestCustomKey(header ?? ""),
                             })
                         }
                     >
@@ -573,6 +623,8 @@ export function TargetPicker({
                         onChange({ index: value.index, target: "custom", custom_key: v })
                     }
                     placeholder="field name"
+                    invalid={keyInvalid}
+                    title={keyInvalid ? CUSTOM_KEY_RULES : undefined}
                     className="w-24 md:w-32"
                 />
             )}
@@ -708,7 +760,9 @@ export function ResultStep({ result, filename }: { result: ImportResult; filenam
                             Errors
                         </span>
                         <span className="text-[11px] text-slate-500">
-                            {result.errors.length}
+                            {result.errors_truncated
+                                ? `${result.errors.length.toLocaleString()} of ${result.failed.toLocaleString()}`
+                                : result.errors.length.toLocaleString()}
                         </span>
                         <button
                             type="button"

--- a/web/src/components/app/contacts/SheetSyncWizard.tsx
+++ b/web/src/components/app/contacts/SheetSyncWizard.tsx
@@ -30,7 +30,7 @@ import {
 import toast from "react-hot-toast";
 
 import { MapStep, ResultStep } from "./ImportWizard";
-import { DEDUP_OPTIONS, announceResult, describeError } from "./importShared";
+import { DEDUP_OPTIONS, announceResult, describeError, mappingProblem } from "./importShared";
 import CategoryPicker from "./CategoryPicker";
 import { Label, TextInput } from "@/components/ui/field";
 import {
@@ -199,7 +199,9 @@ export default function SheetSyncWizard({ open, onClose, lockedCampaign, onSaved
         }
     }
 
-    const emailMapped = mapping.some((m) => m.target === "email");
+    // Same gate as the file importer: a saved source with an unusable custom
+    // field name is rejected by the API, so catch it on the mapping screen.
+    const mapProblem = mappingProblem(mapping);
 
     async function save(runSync: boolean) {
         if (!connectionId || !meta) return;
@@ -376,16 +378,16 @@ export default function SheetSyncWizard({ open, onClose, lockedCampaign, onSaved
                                         <ArrowLeftIcon className="w-3 h-3" />
                                         Back
                                     </button>
-                                    {!emailMapped && (
+                                    {mapProblem && (
                                         <span className="text-[11px] text-amber-700 inline-flex items-center gap-1">
-                                            <AlertTriangleIcon className="w-3 h-3" />
-                                            Map a column to Email
+                                            <AlertTriangleIcon className="w-3 h-3 shrink-0" />
+                                            {mapProblem}
                                         </span>
                                     )}
                                     <button
                                         type="button"
                                         onClick={() => setStep("options")}
-                                        disabled={!emailMapped}
+                                        disabled={!!mapProblem}
                                         className="ml-auto h-7 px-3 rounded-md bg-slate-900 hover:bg-slate-800 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-50"
                                     >
                                         Continue

--- a/web/src/components/app/contacts/importShared.test.ts
+++ b/web/src/components/app/contacts/importShared.test.ts
@@ -1,0 +1,70 @@
+// Issue #207: a 1,000-row import failed every row with "invalid custom field
+// key: Company Mobile". The client now enforces the same rule the API does, so
+// a name it cannot use is caught on the mapping screen. These cases mirror
+// internal/utils/json.go — if that rule moves, this is where it shows up.
+
+import { describe, it, expect } from "vitest";
+import {
+    isValidCustomKey,
+    mappingProblem,
+    normalizeCustomKey,
+    suggestCustomKey,
+} from "./importShared";
+import type { ImportColumnMapping } from "@/lib/api/client/app/contacts/importContacts";
+
+describe("custom field names", () => {
+    it("accepts what the template engine can resolve", () => {
+        for (const key of ["role", "Job_Title", "Company Mobile", "first-name", "plan tier 2"]) {
+            expect(isValidCustomKey(key)).toBe(true);
+        }
+    });
+
+    it("rejects names nothing could merge into an email", () => {
+        for (const key of ["", "   ", "Company/Mobile", "Revenue ($)", "a.b", "тест"]) {
+            expect(isValidCustomKey(key)).toBe(false);
+        }
+    });
+
+    it("collapses stray whitespace so one column is one field", () => {
+        expect(normalizeCustomKey("  Company   Mobile ")).toBe("Company Mobile");
+        expect(isValidCustomKey("  Company   Mobile ")).toBe(true);
+    });
+
+    it("turns a spreadsheet header into a usable name", () => {
+        expect(suggestCustomKey("Company Mobile")).toBe("Company Mobile");
+        expect(suggestCustomKey("Revenue ($)")).toBe("Revenue");
+        expect(suggestCustomKey("Annual Revenue (USD)")).toBe("Annual Revenue USD");
+        expect(suggestCustomKey("###")).toBe("");
+    });
+});
+
+describe("mappingProblem", () => {
+    const email: ImportColumnMapping = { index: 0, target: "email" };
+
+    it("passes a mapping the API would accept", () => {
+        expect(
+            mappingProblem([email, { index: 5, target: "custom", custom_key: "Company Mobile" }]),
+        ).toBeNull();
+    });
+
+    it("names the column when a custom field has no name", () => {
+        expect(mappingProblem([email, { index: 5, target: "custom", custom_key: "  " }])).toBe(
+            "Column 6 needs a custom field name.",
+        );
+    });
+
+    it("explains an unusable name instead of letting the import fail row by row", () => {
+        const msg = mappingProblem([email, { index: 5, target: "custom", custom_key: "Company/Mobile" }]);
+        expect(msg).toContain("Company/Mobile");
+        expect(msg).toContain("letters");
+    });
+
+    it("still requires an email column", () => {
+        expect(mappingProblem([{ index: 1, target: "first_name" }])).toBe("Map a column to Email.");
+    });
+
+    it("understands the legacy custom:<key> spelling", () => {
+        expect(mappingProblem([email, { index: 2, target: "custom:plan_tier" }])).toBeNull();
+        expect(mappingProblem([email, { index: 2, target: "custom:plan/tier" }])).toContain("plan/tier");
+    });
+});

--- a/web/src/components/app/contacts/importShared.ts
+++ b/web/src/components/app/contacts/importShared.ts
@@ -6,6 +6,7 @@
 
 import toast from "react-hot-toast";
 import type {
+    ImportColumnMapping,
     ImportDedupStrategy,
     ImportResult,
 } from "@/lib/api/client/app/contacts/importContacts";
@@ -60,4 +61,58 @@ export function announceResult(res: ImportResult) {
     } else {
         toast(`Synced with ${res.failed} errors`, { icon: "⚠️" });
     }
+}
+
+// ----- Custom-field names -----------------------------------------
+//
+// Mirrors internal/utils.IsValidJSONKey. A custom field is addressable in
+// campaign copy either as {{.Role}} or, for a spaced/dashed name, through the
+// server-side rewrite to (index . "Company Mobile"). Anything else would make
+// a field the user can store but never merge into an email, so the API rejects
+// it — we catch it here so a mistyped name never costs a whole import.
+const CUSTOM_KEY_RE = /^[A-Za-z0-9_]+(?:[ -]+[A-Za-z0-9_]+)*$/;
+
+export const CUSTOM_KEY_RULES = "Use letters, numbers, underscores, spaces or dashes.";
+
+export function normalizeCustomKey(key: string): string {
+    return key.trim().split(/\s+/).filter(Boolean).join(" ");
+}
+
+export function isValidCustomKey(key: string): boolean {
+    const k = normalizeCustomKey(key);
+    return k.length > 0 && k.length <= 255 && CUSTOM_KEY_RE.test(k);
+}
+
+// suggestCustomKey turns a raw spreadsheet header into a name the API accepts,
+// so picking "Use as custom field" on a "Company Mobile" column just works.
+// Returns "" when nothing usable survives and the user has to type a name.
+export function suggestCustomKey(header: string): string {
+    const cleaned = normalizeCustomKey(header.replace(/[^A-Za-z0-9_ -]+/g, " "))
+        .replace(/^[-\s]+/, "")
+        .replace(/[-\s]+$/, "");
+    return isValidCustomKey(cleaned) ? cleaned : "";
+}
+
+export function isCustomTarget(target: string): boolean {
+    return target === "custom" || target.startsWith("custom:");
+}
+
+// mappingProblem returns the first reason the mapping cannot be committed, or
+// null when it is good to go. Same order of checks as the server so the two
+// never disagree about which column is at fault.
+export function mappingProblem(mapping: ImportColumnMapping[]): string | null {
+    for (const m of mapping) {
+        if (!isCustomTarget(m.target)) continue;
+        const key = m.custom_key ?? (m.target.startsWith("custom:") ? m.target.slice(7) : "");
+        if (normalizeCustomKey(key) === "") {
+            return `Column ${m.index + 1} needs a custom field name.`;
+        }
+        if (!isValidCustomKey(key)) {
+            return `"${key.trim()}" is not a valid field name. ${CUSTOM_KEY_RULES}`;
+        }
+    }
+    if (!mapping.some((m) => m.target === "email")) {
+        return "Map a column to Email.";
+    }
+    return null;
 }

--- a/web/src/components/layout/AppShell.tsx
+++ b/web/src/components/layout/AppShell.tsx
@@ -15,7 +15,7 @@
 // where it meets the chrome's inner corner. Reads as one continuous
 // frame around a clean work surface.
 
-import { useEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Outlet, useLocation } from "react-router-dom";
 import { SkyChrome } from "./SkyChrome";
 import { AppHeader } from "./AppHeader";
@@ -41,6 +41,13 @@ export function AppShell() {
     // The page content's scroll container, anchor for the global cursor layer.
     const scrollRef = useRef<HTMLDivElement>(null);
 
+    // Pages scroll this inner container, not the window, so nothing resets the
+    // offset between routes: navigating from halfway down a long list used to
+    // land mid-page on the next one. Reset before paint so it never flashes.
+    useLayoutEffect(() => {
+        scrollRef.current?.scrollTo({ top: 0, left: 0 });
+    }, [pathname]);
+
     return (
         <div className="fixed inset-0 flex flex-col">
             <SkyChrome />
@@ -64,7 +71,15 @@ export function AppShell() {
                         <GlobalCursorsProvider scrollRef={scrollRef}>
                             <div ref={scrollRef} className="h-full overflow-auto">
                                 <RouteBoundary>
-                                    <Outlet />
+                                    {/* Router navigations run inside a
+                                        transition, so a page that suspends with
+                                        no boundary above it commits an empty
+                                        content area and stays that way until
+                                        the query lands (only a reload fixes
+                                        it). This is that boundary. */}
+                                    <Suspense fallback={<RouteFallback />}>
+                                        <Outlet />
+                                    </Suspense>
                                 </RouteBoundary>
                             </div>
                         </GlobalCursorsProvider>
@@ -76,6 +91,18 @@ export function AppShell() {
             <CommandPalette />
             {/* Right-side AI assistant, persistent across routes. */}
             <AgentPanel />
+        </div>
+    );
+}
+
+// RouteFallback is what a suspending page shows while its data loads. Same
+// hairline chrome as the pages themselves so the panel never goes blank.
+function RouteFallback() {
+    return (
+        <div className="px-5 pt-5 space-y-4" role="status" aria-label="Loading">
+            <div className="h-6 w-56 bg-slate-100 rounded-md animate-pulse" />
+            <div className="h-3 w-40 bg-slate-100 rounded animate-pulse" />
+            <div className="h-56 bg-slate-100 rounded-md animate-pulse" />
         </div>
     );
 }

--- a/web/src/components/ui/field.tsx
+++ b/web/src/components/ui/field.tsx
@@ -27,6 +27,8 @@ export function TextInput({
     className,
     onKeyDown,
     onBlur,
+    invalid,
+    title,
 }: {
     value: string;
     onChange: (v: string) => void;
@@ -42,6 +44,10 @@ export function TextInput({
     // text into something else (a clock value, a number) so the parse happens
     // once the user settles rather than on every keystroke.
     onBlur?: () => void;
+    // Marks the value as rejected: red hairline + aria-invalid for screen
+    // readers. Pair it with `title` (or nearby text) saying what is wrong.
+    invalid?: boolean;
+    title?: string;
 }) {
     return (
         <input
@@ -54,7 +60,14 @@ export function TextInput({
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={onKeyDown}
             onBlur={onBlur}
-            className={cn(base, "min-w-0", className)}
+            aria-invalid={invalid || undefined}
+            title={title}
+            className={cn(
+                base,
+                "min-w-0",
+                invalid && "border-red-300 focus:border-red-400 focus:ring-red-100",
+                className,
+            )}
         />
     );
 }

--- a/web/src/lib/api/client/app/contacts/importContacts.ts
+++ b/web/src/lib/api/client/app/contacts/importContacts.ts
@@ -60,6 +60,9 @@ export interface ImportResult {
     started_at: string;
     ended_at: string;
     errors?: ImportRowError[];
+    // Set when more rows failed than the API reports back; `errors` then holds
+    // the first slice of them and `failed` is the true count.
+    errors_truncated?: boolean;
 }
 
 async function authHeader(): Promise<Record<string, string>> {


### PR DESCRIPTION
Fixes #207.

## 1. Contact import fails with "invalid custom field key: Company Mobile"

`utils.IsValidJSONKey` held custom-field keys to `^[a-zA-Z0-9_]+$`, so a CSV column called `Company Mobile` was refused. The campaign template engine has always supported spaced keys (`tasks.rewriteSpacedFieldRefs` rewrites `{{.Company Mobile}}` into `(index . "Company Mobile")`, and the Contacts guide documents it) — the import validator was the only thing that disagreed. Worse, the check ran per row, so one mistyped mapping became 1,000 identical failures instead of one message.

- keys now allow letters, numbers, `_`, spaces and dashes, exactly the set the template engine can address, and are trimmed + whitespace-collapsed so `" Company  Mobile "` and `"Company Mobile"` are one field
- the mapping is resolved **once**, before any row is read: a bad name, an unnamed custom column, an unknown target or a mapping with no email column is a single `400` carrying `code` and `request_id`
- the wizard mirrors the same rule, pre-fills the field name from the column header, flags a bad one inline and blocks Continue, so it does not reach the API in the first place

Adjacent defects on the same path, fixed here:

| Was | Now |
| --- | --- |
| `Subscribed` column parsed then discarded (`_ = b`) | applied; `subscribed_default` is confined to new contacts, so an update cannot resubscribe someone who opted out |
| `Categories` column read then ignored | resolved to categories, creating missing names (capped at 100 per import) |
| `dedup=skip` + import-into-campaign added nothing to the campaign | skipped rows still join the campaign and categories |
| same address twice in a file → two upserts counted as two imports | one contact, later row merged, extras counted skipped |
| a blank cell erased a stored name on re-import | enrich, never erase |
| plan-limit rejection reported once per row | one message with the numbers |
| custom-field search filter interpolated the key into SQL | bound parameter |
| 50k failed rows echoed the whole file back | first 1,000 plus `errors_truncated` |
| a blank `campaign_ids` entry failed every row's link | ids canonicalised, malformed ones refused up front |

## 2. Campaign Overview → Leads changes the URL but not the page

I could not reproduce this at HEAD. I mounted the real dashboard shell (`RootAppLayout → AppShell → RouteBoundary → Outlet`) around the real campaign routes and walked the tab bar with instant, slow and hanging responses; Overview ↔ Leads ↔ Steps swapped correctly every time. So this PR fixes the two things it could prove, both of which produce that symptom:

- **no `<Suspense>` boundary above the routed outlet.** Router navigations run inside a transition, so any page that suspends without a boundary of its own commits an empty content panel that only a reload recovers. Verified: remove the Steps page's local boundary and the panel goes blank; with the shell boundary it shows a loading state.
- **the shell scrolls an inner div that nothing reset between routes**, so navigating from halfway down one page landed mid-page on the next.

Both are pinned by `campaignTabs.test.tsx`; each assertion fails if the corresponding fix is reverted. If the reporter still sees it on this build, their browser console output at the moment of the click would settle it.

## Verification

End to end against a real backend (scratch database, native API, real multipart): the exact 1,000-row × 13-column file with `Company Mobile` → `imported 1000, failed 0` in 290 ms, all 1,000 joined the campaign, the eight spaced keys appear in the variable picker, filter correctly, and render in campaign copy including inside `{{if eq}}`. Re-import with "skip existing" → 1,000 skipped and 1,000 added to a second campaign. Each bad mapping → one `400`.

Tests: seven `TestLiveImport*` against Postgres, unit tests for the mapping resolver and for the key rule on both sides of the wire, and the campaign tab-navigation test.

`make fmt` clean · `make lint` clean · full Go suite and live Postgres tests pass · `web` typecheck, lint and 51 vitest tests pass · `docs` types:check, lint and a full `pnpm build` pass.

Docs updated in the same change: the Contacts & CRM guide (field-name rules, subscribed and categories behaviour, skip-still-enrols, blank-cell rule) and the contacts + integrations API reference (mapping shape, `errors_truncated`, the request-level `400`s, sheet-sync mappings validated on save).
