### PR TITLE
Redesign the marketing index sections

### DIFF
--- a/site/src/components/BentoGrid.astro
+++ b/site/src/components/BentoGrid.astro
@@ -1,0 +1,607 @@
+---
+/**
+ * "One platform" bento.
+ *
+ * Card anatomy follows the reference set rather than a flat panel: a tinted
+ * plinth carries a faint texture, a back layer of real product UI bleeds off
+ * the card edges and dissolves into a mask fade, and one floating element sits
+ * on top with a heavier shadow. Depth comes from the layering, not from borders.
+ *
+ * Motion is viewport-gated: ambient loops only run while a card is on screen.
+ */
+import Icon from './Icon.astro';
+
+const threads = [
+  { who: 'Jenna Carter', sub: 'Re: quick question on outbound', time: '2m', tag: 'interested', grad: 'from-rose-400 to-amber-400' },
+  { who: 'Aman Patel', sub: 'Re: intro from Maya', time: '14m', tag: 'interested', grad: 'from-sky-400 to-indigo-400' },
+  { who: 'Lina Park', sub: 'Re: pricing tier?', time: '1h', tag: 'question', grad: 'from-emerald-400 to-teal-400' },
+  { who: 'Karim Salah', sub: 'Re: not the right time', time: '3h', tag: 'not now', grad: 'from-violet-400 to-fuchsia-400' },
+];
+
+const tagClass = (t: string) =>
+  t === 'interested' ? 'bg-emerald-50 text-emerald-700 ring-emerald-200'
+  : t === 'question' ? 'bg-sky-50 text-sky-700 ring-sky-200'
+  : 'bg-slate-100 text-slate-500 ring-slate-200';
+
+// Warmup ramp, the repo default: start at 10/day, +1/day, ceiling 40.
+const ramp = [10, 12, 14, 16, 18, 21, 23, 26, 28, 31, 33, 36, 38, 40, 40];
+
+const providers = [
+  { name: 'Gmail', pct: 97 },
+  { name: 'Outlook', pct: 95 },
+  { name: 'Yahoo', pct: 94 },
+];
+---
+
+<section class="container-page py-16 md:py-20">
+  <div class="max-w-3xl">
+    <div class="text-[11px] uppercase tracking-[0.16em] text-[color:var(--brand)] font-semibold mb-4">One platform</div>
+    <h2 class="text-[32px] md:text-[48px] font-semibold tracking-[-0.03em] leading-[1.04] text-heading">
+      Warmup, sending, inbox, engineered together.
+    </h2>
+    <p class="mt-4 text-foreground/75 leading-relaxed max-w-2xl">
+      The signal one part collects is the signal the next part acts on.
+    </p>
+  </div>
+
+  <div class="bento mt-12 grid grid-cols-1 md:grid-cols-12 gap-3">
+    <!-- ── Unified inbox ──────────────────────────────────────────── -->
+    <article class="bento-card md:col-span-7">
+      <div class="bento-stage h-[292px]">
+        <span class="bento-texture bento-dots"></span>
+
+        <!-- Back layer: the thread list, bleeding off the right edge. -->
+        <div class="bento-layer bento-fade-b absolute left-7 right-0 top-7 rounded-tl-[10px] bg-white ring-1 ring-slate-200/70 shadow-[0_10px_30px_-18px_rgb(15_23_42_/_0.25)]">
+          <div class="h-9 pl-4 pr-3 border-b border-slate-200 flex items-center gap-2.5">
+            <span class="text-[9.5px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Inbox</span>
+            <span class="h-3 w-px bg-slate-200"></span>
+            <span class="text-[11.5px] text-slate-600 whitespace-nowrap">12 unread across 8 mailboxes</span>
+          </div>
+          {threads.map((t, i) => (
+            <div class="bento-row flex items-center gap-2.5 pl-4 pr-3 py-2.5 border-b border-slate-200/60" style={`--i:${i}`}>
+              <span class={`w-6 h-6 rounded-full shrink-0 bg-gradient-to-br ${t.grad}`}></span>
+              <div class="min-w-0 flex-1">
+                <div class="text-[12px] font-semibold text-slate-900 truncate">{t.who}</div>
+                <div class="text-[11.5px] text-slate-500 truncate">{t.sub}</div>
+              </div>
+              <span class="text-[10px] font-mono text-slate-400 shrink-0">{t.time}</span>
+              <span class={`shrink-0 px-1.5 py-0.5 rounded text-[9.5px] font-semibold uppercase tracking-[0.06em] ring-1 whitespace-nowrap ${tagClass(t.tag)}`}>{t.tag}</span>
+            </div>
+          ))}
+        </div>
+
+        <!-- Front layer: the thing that just happened. -->
+        <div class="bento-pop absolute left-10 right-10 bottom-5 rounded-[11px] bg-white ring-1 ring-slate-200 shadow-[0_22px_50px_-16px_rgb(15_23_42_/_0.30)] px-3 py-2.5 flex items-center gap-2.5">
+          <span class="w-7 h-7 rounded-full shrink-0 bg-gradient-to-br from-rose-400 to-amber-400"></span>
+          <div class="min-w-0 flex-1">
+            <div class="text-[12px] font-semibold text-slate-900 truncate">Jenna Carter replied</div>
+            <div class="text-[11px] text-slate-500 truncate">"Thursday 10am ET works for me."</div>
+          </div>
+          <span class="hidden sm:inline-flex shrink-0 px-1.5 py-0.5 rounded text-[9.5px] font-semibold uppercase tracking-[0.06em] ring-1 bg-emerald-50 text-emerald-700 ring-emerald-200">interested</span>
+          <span class="shrink-0 inline-flex h-7 px-2.5 items-center rounded-md text-[11.5px] font-medium bg-sky-600 text-white">Reply</span>
+        </div>
+      </div>
+      <div class="bento-copy">
+        <span class="bento-eyebrow"><Icon name="inbox" size={13} />One inbox</span>
+        <h3>Every reply lands in one place</h3>
+        <p>Replies from all of your sending addresses arrive together, already sorted by what the person actually said.</p>
+      </div>
+    </article>
+
+    <!-- ── Warmup ─────────────────────────────────────────────────── -->
+    <article class="bento-card md:col-span-5">
+      <div class="bento-stage h-[292px]">
+        <span class="bento-texture bento-rings"></span>
+
+        <!-- Back layer: the ramp, bleeding off the bottom right. -->
+        <div class="bento-fade-r absolute left-7 right-0 bottom-0 h-[168px] flex items-end gap-[4px] pr-2">
+          {ramp.map((v, i) => (
+            <span
+              class="bento-bar flex-1 rounded-t-[3px] bg-gradient-to-t from-sky-500/90 to-sky-300/90 origin-bottom"
+              style={`height:${(v / 40) * 100}%; --i:${i}`}
+            ></span>
+          ))}
+        </div>
+
+        <!-- Front layer: today's number. -->
+        <div class="bento-pop absolute left-7 top-7 w-[196px] rounded-[11px] bg-white ring-1 ring-slate-200 shadow-[0_22px_50px_-16px_rgb(15_23_42_/_0.30)] p-3.5">
+          <div class="flex items-center justify-between">
+            <span class="text-[9.5px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Warmup</span>
+            <span class="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[9.5px] font-semibold bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200">
+              <span class="bento-live-dot w-1 h-1 rounded-full bg-emerald-500"></span>healthy
+            </span>
+          </div>
+          <div class="mt-2.5 flex items-baseline gap-1.5">
+            <span class="text-[30px] font-light leading-none text-slate-900 tabular-nums">40</span>
+            <span class="text-[11.5px] text-slate-500">/ day</span>
+          </div>
+          <div class="mt-1.5 text-[10.5px] font-mono text-slate-400">up from 10, over 15 days</div>
+        </div>
+      </div>
+      <div class="bento-copy">
+        <span class="bento-eyebrow"><Icon name="flame" size={13} />Runs itself</span>
+        <h3>Mailboxes that warm themselves up</h3>
+        <p>New addresses start slow and build real sending history on their own, so your first campaign is not your first impression.</p>
+      </div>
+    </article>
+
+    <!-- ── Branching ──────────────────────────────────────────────── -->
+    <article class="bento-card md:col-span-4">
+      <div class="bento-stage h-[266px]">
+        <span class="bento-texture bento-canvas"></span>
+
+        <div class="absolute inset-x-4 top-6">
+          <!-- Root -->
+          <div class="bento-node mx-auto w-[74%] rounded-[9px] bg-white ring-1 ring-slate-200 shadow-[0_10px_26px_-14px_rgb(15_23_42_/_0.32)] px-2.5 py-2" style="--i:0">
+            <div class="text-[9px] font-mono uppercase tracking-wider text-slate-400">Step 1</div>
+            <div class="text-[11.5px] font-medium text-slate-900 truncate">Intro email</div>
+          </div>
+
+          <!-- Split -->
+          <!-- Base rails sit under a travelling pulse. The pulse paths carry no
+               non-scaling-stroke: their dash length must stay in user units to
+               match the path length the dashoffset animates over. -->
+          <svg class="bento-edges w-full h-[30px]" viewBox="0 0 300 30" fill="none" preserveAspectRatio="none">
+            <path d="M150 0 V9 Q150 15 140 15 H79 Q69 15 69 21 V30" stroke="#a7f3d0" stroke-width="1.5" vector-effect="non-scaling-stroke" />
+            <path d="M150 0 V9 Q150 15 160 15 H221 Q231 15 231 21 V30" stroke="#e2e8f0" stroke-width="1.5" vector-effect="non-scaling-stroke" />
+            <path class="bento-flow bento-flow-a" d="M150 0 V9 Q150 15 140 15 H79 Q69 15 69 21 V30" stroke="#10b981" stroke-width="2.5" stroke-linecap="round" />
+            <path class="bento-flow bento-flow-b" d="M150 0 V9 Q150 15 160 15 H221 Q231 15 231 21 V30" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round" />
+          </svg>
+
+          <div class="grid grid-cols-2 gap-2.5">
+            <!-- Replied branch -->
+            <div>
+              <div class="bento-branch-label text-emerald-600">replied</div>
+              <div class="bento-node rounded-[9px] bg-emerald-50 ring-1 ring-emerald-200 px-2.5 py-2" style="--i:1">
+                <div class="flex items-center gap-1.5">
+                  <Icon name="check" size={11} strokeWidth={2.5} class="text-emerald-600 shrink-0" />
+                  <span class="text-[11px] font-medium text-emerald-800 truncate">Stop here</span>
+                </div>
+                <div class="mt-0.5 text-[9.5px] text-emerald-700/80 truncate">no more follow-ups</div>
+              </div>
+            </div>
+            <!-- No reply branch -->
+            <div>
+              <div class="bento-branch-label text-slate-400">no reply</div>
+              <div class="bento-node rounded-[9px] bg-white ring-1 ring-slate-200 shadow-[0_8px_20px_-14px_rgb(15_23_42_/_0.3)] px-2.5 py-2" style="--i:2">
+                <div class="flex items-center gap-1.5">
+                  <Icon name="clock" size={11} class="text-slate-400 shrink-0" />
+                  <span class="text-[11px] font-medium text-slate-900 truncate">Wait 3 days</span>
+                </div>
+                <div class="mt-0.5 text-[9.5px] text-slate-500 truncate">business hours</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Tail under the no-reply branch only -->
+          <svg class="bento-edges w-full h-[22px]" viewBox="0 0 300 22" fill="none" preserveAspectRatio="none">
+            <path d="M231 0 V22" stroke="#e2e8f0" stroke-width="1.5" vector-effect="non-scaling-stroke" />
+            <path class="bento-flow bento-flow-c" d="M231 0 V22" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round" />
+          </svg>
+          <div class="grid grid-cols-2 gap-2.5">
+            <span></span>
+            <div class="bento-node rounded-[9px] bg-white ring-1 ring-slate-200 shadow-[0_8px_20px_-14px_rgb(15_23_42_/_0.3)] px-2.5 py-2" style="--i:3">
+              <div class="text-[9px] font-mono uppercase tracking-wider text-slate-400">Step 2</div>
+              <div class="text-[11.5px] font-medium text-slate-900 truncate">Follow-up</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="bento-copy">
+        <span class="bento-eyebrow"><Icon name="workflow" size={13} />Knows when to stop</span>
+        <h3>Follow-ups that end at "yes"</h3>
+        <p>Each step branches on what the person did. Answer once and the rest of the sequence is cancelled automatically.</p>
+      </div>
+    </article>
+
+    <!-- ── Placement ──────────────────────────────────────────────── -->
+    <article class="bento-card md:col-span-4">
+      <div class="bento-stage h-[266px]">
+        <span class="bento-texture bento-rings"></span>
+
+        <!-- Back layer: per-provider detail, dissolving at the bottom. -->
+        <div class="bento-fade-b absolute left-7 right-0 top-7 rounded-tl-[10px] bg-white ring-1 ring-slate-200/70 shadow-[0_10px_30px_-18px_rgb(15_23_42_/_0.25)] pl-3.5 pr-4 py-3">
+          <div class="text-[9.5px] uppercase tracking-[0.14em] text-slate-400 font-semibold">By provider</div>
+          <div class="mt-2.5 space-y-2.5">
+            {providers.map((p, i) => (
+              <div class="bento-meter-row" style={`--i:${i}`}>
+                <div class="flex items-center justify-between text-[11px] mb-1">
+                  <span class="text-slate-600">{p.name}</span>
+                  <span class="font-mono text-slate-400">{p.pct}%</span>
+                </div>
+                <div class="h-1.5 rounded-full bg-slate-100 overflow-hidden">
+                  <span class="bento-meter block h-full rounded-full bg-sky-500" style={`--target:${p.pct}%`}></span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <!-- Front layer: the headline number. -->
+        <div class="bento-pop absolute left-6 right-8 bottom-5 rounded-[11px] bg-white ring-1 ring-slate-200 shadow-[0_22px_50px_-16px_rgb(15_23_42_/_0.30)] px-3.5 py-2.5 flex items-center gap-3">
+          <div>
+            <div class="text-[26px] font-light leading-none text-slate-900 tabular-nums">96%</div>
+            <div class="mt-1 text-[10px] uppercase tracking-[0.12em] text-slate-400 font-semibold">reached the inbox</div>
+          </div>
+          <span class="ml-auto shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[9.5px] font-semibold bg-rose-50 text-rose-700 ring-1 ring-rose-200">
+            1% spam
+          </span>
+        </div>
+      </div>
+      <div class="bento-copy">
+        <span class="bento-eyebrow"><Icon name="chart" size={13} />No guessing</span>
+        <h3>See if you landed in the inbox</h3>
+        <p>We test where your mail actually arrives at each provider, so you find out before your reply rate does.</p>
+      </div>
+    </article>
+
+    <!-- ── Personalization ────────────────────────────────────────── -->
+    <article class="bento-card md:col-span-4">
+      <div class="bento-stage h-[266px]">
+        <span class="bento-texture bento-dots"></span>
+
+        <!-- Back layer: the other copies of this email, stacked behind. -->
+        <div class="bento-ghost absolute left-14 right-3 top-6 h-[54px] rounded-[10px] bg-white/70 ring-1 ring-slate-200/60" style="--i:2"></div>
+        <div class="bento-ghost absolute left-11 right-6 top-9 h-[54px] rounded-[10px] bg-white/85 ring-1 ring-slate-200/70" style="--i:1"></div>
+
+        <!-- Front layer: the one you actually wrote. -->
+        <div class="bento-pop bento-fade-b absolute left-7 right-9 top-12 bottom-0 rounded-t-[11px] bg-white ring-1 ring-slate-200 shadow-[0_22px_50px_-16px_rgb(15_23_42_/_0.30)]">
+          <div class="h-9 px-3.5 border-b border-slate-200 flex items-center gap-2">
+            <span class="text-[9.5px] uppercase tracking-[0.14em] text-slate-400 font-semibold">Compose</span>
+            <span class="ml-auto px-1.5 py-0.5 rounded text-[9.5px] font-semibold uppercase tracking-[0.06em] bg-sky-50 text-sky-700 ring-1 ring-sky-200 whitespace-nowrap">1 of 2,480</span>
+          </div>
+          <!-- Each field cross-fades between the placeholder and a resolved
+               value. inline-grid stacks both in one cell so the box is as wide
+               as the longer string and the paragraph never reflows. -->
+          <div class="px-3.5 py-2.5 text-[11.5px] leading-[1.8] text-slate-700">
+            <p>Hi <span class="bento-tag bento-swap" style="--i:0"><span class="swap-a">{'{{first_name}}'}</span><span class="swap-b">Jenna</span></span>,</p>
+            <p class="mt-1">
+              Saw <span class="bento-tag bento-swap" style="--i:1"><span class="swap-a">{'{{company}}'}</span><span class="swap-b">Northwind</span></span> is hiring across
+              <span class="bento-tag bento-swap" style="--i:2"><span class="swap-a">{'{{team}}'}</span><span class="swap-b">support</span></span>. We keep outreach out of
+              the spam folder for teams that size.
+            </p>
+            <p class="mt-1 text-slate-500">Worth a look?</p>
+          </div>
+        </div>
+      </div>
+      <div class="bento-copy">
+        <span class="bento-eyebrow"><Icon name="spark" size={13} />Sounds human</span>
+        <h3>Written once, personal to everyone</h3>
+        <p>Pull real details from your contact list so each person gets their own version, without writing each one.</p>
+      </div>
+    </article>
+  </div>
+</section>
+
+<style>
+  /* ── Card shell ──────────────────────────────────────────────── */
+  .bento-card {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: 18px;
+    background: linear-gradient(175deg, #fbfcfe 0%, var(--surface-2) 100%);
+    box-shadow: inset 0 0 0 1px var(--border);
+    transition: box-shadow 260ms cubic-bezier(0.22, 1, 0.36, 1),
+                transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .bento-stage {
+    position: relative;
+    overflow: hidden;
+    flex-shrink: 0;
+  }
+
+  /* ── Plinth texture ──────────────────────────────────────────── */
+  /* Faint pattern behind the artifact, masked so it never reaches an edge. */
+  .bento-texture {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    -webkit-mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+    mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+  }
+  .bento-dots {
+    background-image: radial-gradient(circle, rgb(15 23 42 / 0.07) 1px, transparent 1.2px);
+    background-size: 14px 14px;
+  }
+  .bento-rings {
+    background-image: repeating-radial-gradient(
+      circle at 50% 38%, transparent 0 19px, rgb(2 132 199 / 0.07) 19px 20px);
+  }
+  .bento-canvas {
+    background-image:
+      linear-gradient(to right, rgb(15 23 42 / 0.05) 1px, transparent 1px),
+      linear-gradient(to bottom, rgb(15 23 42 / 0.05) 1px, transparent 1px);
+    background-size: 22px 22px;
+  }
+
+  /* ── Edge fades ──────────────────────────────────────────────── */
+  /* Back layers dissolve instead of hard-cropping, the way the references do. */
+  .bento-fade-b {
+    -webkit-mask-image: linear-gradient(to bottom, #000 52%, transparent 94%);
+    mask-image: linear-gradient(to bottom, #000 52%, transparent 94%);
+  }
+  .bento-fade-r {
+    -webkit-mask-image: linear-gradient(to right, #000 62%, transparent 99%);
+    mask-image: linear-gradient(to right, #000 62%, transparent 99%);
+  }
+
+  /* Merge field, the way the composer renders one. */
+  .bento-tag {
+    display: inline-block;
+    padding: 0 3px;
+    border-radius: 3px;
+    background: var(--brand-soft);
+    color: var(--brand-strong);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 10.5px;
+  }
+
+  /* Both strings occupy one grid cell, so the field keeps the width of the
+     longer of the two and swapping never reflows the sentence. */
+  .bento-swap {
+    display: inline-grid;
+    vertical-align: bottom;
+  }
+  .bento-swap > span {
+    grid-area: 1 / 1;
+    text-align: center;
+  }
+  .bento-swap > .swap-b { opacity: 0; }
+
+  .bento-branch-label {
+    margin-bottom: 5px;
+    text-align: center;
+    font-size: 9px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  /* ── Copy block ──────────────────────────────────────────────── */
+  .bento-copy { padding: 20px 24px 24px; }
+  .bento-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--brand);
+    font-size: 10.5px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+  }
+  .bento-copy h3 {
+    margin-top: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    line-height: 1.3;
+    color: var(--heading);
+  }
+  .bento-copy p {
+    margin-top: 6px;
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: color-mix(in oklab, var(--foreground) 70%, transparent);
+  }
+
+  /* ── Reveal ──────────────────────────────────────────────────── */
+  /* Armed only once the inline script confirms JS is alive, so a script
+     failure leaves every card visible instead of blank. */
+  .bento.js-ready .bento-card {
+    opacity: 0;
+    transform: translateY(20px);
+    will-change: opacity, transform;
+  }
+  /* box-shadow is restated because the shorthand would otherwise drop the
+     hover transition inherited from .bento-card. */
+  .bento.js-ready .bento-card.is-in {
+    opacity: 1;
+    transform: none;
+    transition: opacity 700ms cubic-bezier(0.22, 1, 0.36, 1),
+                transform 700ms cubic-bezier(0.22, 1, 0.36, 1),
+                box-shadow 260ms ease;
+  }
+  /* Once the reveal has played out the card drops back to the short hover
+     timing, so the lift is not stuck at the 700ms reveal duration. */
+  .bento.js-ready .bento-card.is-settled {
+    transition: box-shadow 260ms ease,
+                transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  @media (hover: hover) {
+    .bento-card:hover {
+      transform: translateY(-3px);
+      box-shadow: inset 0 0 0 1px var(--border-strong), var(--shadow-md);
+    }
+  }
+
+  /* ── Artifact motion ─────────────────────────────────────────── */
+  /* Gated on .is-live, which the script adds on enter and strips on leave, so
+     nothing animates off screen. Delays key off an inline --i rather than
+     nth-child, which would miscount against non-item siblings. */
+  @media (prefers-reduced-motion: no-preference) {
+    .bento.js-ready .bento-row,
+    .bento.js-ready .bento-meter-row,
+    .bento.js-ready .bento-node,
+    .bento.js-ready .bento-ghost,
+    .bento.js-ready .bento-edges,
+    .bento.js-ready .bento-pop { opacity: 0; }
+
+    /* Rows rise once, then a highlight keeps walking down the list so the
+       inbox reads as still receiving mail. */
+    .is-live .bento-row {
+      animation: bento-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both,
+                 bento-scan 7s ease-in-out infinite;
+      animation-delay: calc(var(--i) * 80ms), calc(var(--i) * 800ms + 1200ms);
+    }
+
+    .is-live .bento-meter-row {
+      animation: bento-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 80ms);
+    }
+
+    /* Flow builds root, then branches, then the tail. */
+    .is-live .bento-node {
+      animation: bento-rise 460ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 150ms);
+    }
+    .is-live .bento-edges { animation: bento-fade 500ms ease-out 260ms both; }
+
+    /* A pulse runs the flow forever: down the replied branch, then the no-reply
+       branch, then on to step 2. --off is the dash travel per path length. */
+    .bento-flow {
+      stroke-dasharray: var(--dash, 12) var(--gap, 120);
+      opacity: 0;
+    }
+    .is-live .bento-flow { animation: bento-flow 5.2s ease-in-out infinite; }
+    .is-live .bento-flow-a { animation-delay: 1.1s; }
+    .is-live .bento-flow-b { animation-delay: 3.1s; }
+    .is-live .bento-flow-c {
+      --dash: 8;
+      --gap: 34;
+      --off: 42;
+      animation-delay: 3.85s;
+    }
+
+    /* Ghost copies fan out behind the composed email. */
+    .is-live .bento-ghost {
+      animation: bento-fan 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 90ms + 260ms);
+    }
+
+    /* The floating layer arrives last, after its backdrop has settled. */
+    .is-live .bento-pop {
+      animation: bento-drop 620ms cubic-bezier(0.34, 1.24, 0.64, 1) 420ms both;
+    }
+
+    /* The ramp rebuilds on a loop: grow left to right, hold, fall away. That
+       cycle is the feature, so it is the one large continuous motion here.
+       It scales rather than animating height, which would force layout on
+       fifteen bars every frame for as long as the card is on screen. */
+    .bento.js-ready .bento-bar { transform: scaleY(0); }
+    .is-live .bento-bar {
+      animation: bento-ramp-cycle 11s cubic-bezier(0.22, 1, 0.36, 1) infinite;
+      animation-delay: calc(var(--i) * 55ms);
+    }
+
+    .bento.js-ready .bento-meter { width: 0; }
+    .is-live .bento-meter {
+      animation: bento-grow 900ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 80ms + 200ms);
+    }
+    /* A light sweep keeps crossing the filled bars. */
+    .bento-meter { position: relative; overflow: hidden; }
+    .is-live .bento-meter::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, transparent, rgb(255 255 255 / 0.7), transparent);
+      animation: bento-sweep 4.2s ease-in-out infinite;
+      animation-delay: calc(var(--i) * 280ms + 1200ms);
+    }
+
+    /* Merge fields resolve to a real value and back, one after another. */
+    .is-live .swap-a { animation: bento-swap-out 8s ease-in-out infinite; }
+    .is-live .swap-b { animation: bento-swap-in 8s ease-in-out infinite; }
+    .is-live .swap-a,
+    .is-live .swap-b { animation-delay: calc(var(--i) * 900ms + 1400ms); }
+
+    .is-live .bento-live-dot { animation: bento-pulse 2.4s ease-in-out infinite; }
+  }
+
+  @keyframes bento-rise {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes bento-drop {
+    from { opacity: 0; transform: translateY(16px) scale(0.97); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes bento-fan {
+    from { opacity: 0; transform: translate(-10px, 8px); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes bento-fade { from { opacity: 0; } to { opacity: 1; } }
+  @keyframes bento-grow { from { width: 0; } to { width: var(--target); } }
+  @keyframes bento-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+
+  @keyframes bento-ramp-cycle {
+    0%        { transform: scaleY(0); }
+    14%       { transform: scaleY(1); }
+    84%       { transform: scaleY(1); }
+    100%      { transform: scaleY(0); }
+  }
+  /* A brief sky wash passes over one row at a time. */
+  @keyframes bento-scan {
+    0%, 10%, 100% { background-color: rgb(240 249 255 / 0); }
+    3%            { background-color: rgb(240 249 255 / 1); }
+  }
+  @keyframes bento-flow {
+    0%        { stroke-dashoffset: var(--off, 132); opacity: 0; }
+    6%        { opacity: 1; }
+    38%       { stroke-dashoffset: 0; opacity: 1; }
+    46%, 100% { stroke-dashoffset: 0; opacity: 0; }
+  }
+  @keyframes bento-sweep {
+    0%        { transform: translateX(-130%); }
+    55%, 100% { transform: translateX(260%); }
+  }
+  @keyframes bento-swap-out {
+    0%, 34%, 92%, 100% { opacity: 1; }
+    42%, 84%           { opacity: 0; }
+  }
+  @keyframes bento-swap-in {
+    0%, 34%, 92%, 100% { opacity: 0; }
+    42%, 84%           { opacity: 1; }
+  }
+
+  /* Reduced motion keeps every artifact in its resolved end state. The flow
+     pulses are hidden outright: their opacity: 0 lives in the no-preference
+     block, so without this they would sit on the rails as static dashes. */
+  @media (prefers-reduced-motion: reduce) {
+    .bento-flow { opacity: 0; }
+    .bento-meter { width: var(--target); }
+    .bento.js-ready .bento-card {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+    .bento-card { transition: none; }
+  }
+</style>
+
+<script is:inline>
+  // Arm the reveal only when JS is running, before first paint of the section.
+  document.querySelectorAll('.bento').forEach((el) => el.classList.add('js-ready'));
+</script>
+
+<script>
+  import { inView } from 'motion';
+
+  const cards = document.querySelectorAll<HTMLElement>('.bento-card');
+
+  // Reveal once, staggered by DOM order.
+  cards.forEach((card, i) => {
+    inView(card, () => {
+      setTimeout(() => {
+        card.classList.add('is-in');
+        card.addEventListener(
+          'transitionend',
+          () => card.classList.add('is-settled'),
+          { once: true },
+        );
+      }, i * 70);
+    }, { amount: 0.15 });
+  });
+
+  // Ambient artifact motion runs only while the card is on screen. Replaying
+  // on re-entry is deliberate: the flow rebuilds when you scroll back.
+  cards.forEach((card) => {
+    inView(card, () => {
+      card.classList.add('is-live');
+      return () => card.classList.remove('is-live');
+    }, { amount: 0.3 });
+  });
+</script>

--- a/site/src/components/ChangelogShowcase.astro
+++ b/site/src/components/ChangelogShowcase.astro
@@ -3,17 +3,11 @@ import Icon from './Icon.astro';
 import { getChangelog, type ChangelogTag } from '../lib/changelog';
 
 /**
- * ChangelogShowcase - a landing-page CHANGELOG section.
- *
- * A clean vertical timeline of the latest releases. Content is the same
- * build-time data that powers /changelog/ (the most recent merged pull
- * requests on warmbly/warmbly), so the section never drifts from the actual
- * product history. Self-contained, no props, no client JS.
- *
- * Category chips map the changelog tag vocabulary to a reader-friendly set:
- *   shipped -> New      (sky)
- *   changed -> Improved (emerald)
- *   fixed   -> Fixed    (amber)
+ * ChangelogShowcase - landing-page changelog. Copy and CTA on the left; on
+ * the right a plinth artifact holds the release feed as compact cards on a
+ * rail, newest emphasized, older entries dissolving off the bottom edge.
+ * Content is the same build-time data that powers /changelog/ (real merged
+ * pull requests), so the section never drifts from the actual history.
  */
 
 interface Release {
@@ -21,8 +15,7 @@ interface Release {
   category: 'New' | 'Improved' | 'Fixed';
   title: string;
   url: string;
-  number: number;
-  bullets: string[];
+  summary: string;
 }
 
 const categoryByTag: Record<ChangelogTag, Release['category']> = {
@@ -31,119 +24,136 @@ const categoryByTag: Record<ChangelogTag, Release['category']> = {
   fixed: 'Fixed',
 };
 
-// The latest few entries, pulled at build time from the real merged PRs.
-const releases: Release[] = (await getChangelog()).slice(0, 4).map((e) => ({
+// Five latest entries; the plinth crops the tail so the feed reads as ongoing.
+const releases: Release[] = (await getChangelog()).slice(0, 5).map((e) => ({
   date: e.date,
   category: categoryByTag[e.tag],
   title: e.title,
   url: e.url,
-  number: e.number,
-  bullets: e.bullets.length ? e.bullets : [e.body],
+  summary: e.bullets.length ? e.bullets[0] : e.body,
 }));
 
-const categoryStyle = (c: Release['category']) => {
-  if (c === 'New') {
-    return { chip: 'bg-sky-50 text-sky-700 ring-sky-100', dot: 'bg-sky-500', rail: 'bg-sky-500' };
-  }
-  if (c === 'Improved') {
-    return { chip: 'bg-emerald-50 text-emerald-700 ring-emerald-100', dot: 'bg-emerald-500', rail: 'bg-emerald-500' };
-  }
-  return { chip: 'bg-amber-50 text-amber-700 ring-amber-100', dot: 'bg-amber-500', rail: 'bg-amber-500' };
-};
+const styleFor = (c: Release['category']) =>
+  c === 'New' ? { chip: 'bg-sky-50 text-sky-700 ring-sky-200', dot: 'bg-sky-500' }
+  : c === 'Improved' ? { chip: 'bg-emerald-50 text-emerald-700 ring-emerald-200', dot: 'bg-emerald-500' }
+  : { chip: 'bg-amber-50 text-amber-700 ring-amber-200', dot: 'bg-amber-500' };
 ---
-<section class="bg-[color:var(--surface-2)] border-y border-[color:var(--border)] py-20 md:py-28">
-  <div class="container-page">
-    <!-- Header: eyebrow + heading + subcopy -->
-    <div class="flex flex-col md:flex-row md:items-end md:justify-between gap-6 mb-12 md:mb-16">
-      <div class="max-w-2xl">
-        <div class="flex items-center gap-2.5 mb-4">
-          <span class="text-[11px] uppercase tracking-[0.18em] text-[color:var(--brand-strong)] font-mono">
-            Changelog
-          </span>
-          <span class="w-1 h-1 rounded-full bg-[color:var(--border-strong)]"></span>
-          <span class="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground font-mono">
-            <span class="relative inline-flex">
-              <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-              <span class="absolute inset-0 rounded-full bg-emerald-500/40 animate-pulse-soft"></span>
-            </span>
-            Shipping continuously
-          </span>
-        </div>
-        <h2 class="text-[28px] md:text-[40px] font-semibold tracking-[-0.025em] leading-[1.08] text-heading">
-          The latest from Warmbly.
-        </h2>
-        <p class="mt-4 text-[15.5px] md:text-[16.5px] text-foreground/75 leading-relaxed">
-          New features, behavioural changes, and fixes, in the order they reached production. Every entry is dated, tagged, and traceable to a commit.
-        </p>
+<section class="clg container-page py-20 md:py-28">
+  <div class="grid lg:grid-cols-12 gap-10 lg:gap-14 items-center">
+    <!-- ── Copy ──────────────────────────────────────────────────── -->
+    <!-- Copy sits right on lg (artifact left), mirroring the open-source
+         section below so two artifact-and-copy splits do not stack the
+         same way. Mobile keeps copy first. -->
+    <div class="lg:col-span-5 lg:order-2">
+      <div class="flex items-center gap-2.5 mb-4">
+        <span class="text-[11px] uppercase tracking-[0.16em] text-[color:var(--brand)] font-semibold">Changelog</span>
+        <span class="w-1 h-1 rounded-full bg-[color:var(--border-strong)]"></span>
+        <span class="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.14em] text-muted-foreground font-mono">
+          <span class="clg-live w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+          Shipping continuously
+        </span>
       </div>
-
+      <h2 class="text-[32px] md:text-[48px] font-semibold tracking-[-0.03em] leading-[1.04] text-heading">
+        The latest from Warmbly.
+      </h2>
+      <p class="mt-4 text-foreground/75 leading-relaxed max-w-xl">
+        New features, changes and fixes in the order they reached production. Every entry links to its pull request.
+      </p>
       <a
         href="/changelog/"
-        class="group shrink-0 inline-flex items-center gap-1.5 h-9 px-4 rounded-[10px] text-[12.5px] font-medium bg-white ring-1 ring-[color:var(--border)] text-foreground/80 hover:text-heading hover:ring-[color:var(--brand)]/40 hover:-translate-y-0.5 transition-all"
+        class="group mt-7 inline-flex items-center gap-1.5 h-11 px-5 rounded-[10px] text-[14px] font-medium text-heading bg-white ring-1 ring-[color:var(--border)] hover:ring-[color:var(--border-strong)] transition-colors"
       >
         View full changelog
-        <Icon name="arrowUpRight" size={13} class="text-muted-foreground group-hover:text-[color:var(--brand-strong)] transition-colors" />
+        <Icon name="arrowUpRight" size={13} class="text-muted-foreground group-hover:text-heading transition-colors" />
       </a>
     </div>
 
-    <!-- Vertical timeline of releases -->
-    <ol class="relative">
-      <!-- continuous rail -->
-      <span aria-hidden="true" class="absolute left-[7px] top-2 bottom-2 w-px bg-[color:var(--border)] hidden sm:block"></span>
+    <!-- ── Artifact: the release feed ────────────────────────────── -->
+    <div class="lg:col-span-7 lg:order-1">
+      <div class="clg-stage relative overflow-hidden h-[420px] rounded-[18px]"
+           style="background: linear-gradient(175deg, #fbfcfe 0%, var(--surface-2) 100%); box-shadow: inset 0 0 0 1px var(--border);">
+        <span class="clg-texture absolute inset-0 pointer-events-none"></span>
+        <!-- rail -->
+        <span class="absolute left-[34px] top-8 bottom-0 w-px bg-slate-200"></span>
 
-      {releases.map((r) => {
-        const s = categoryStyle(r.category);
-        return (
-          <li class="relative sm:pl-10 mb-4 last:mb-0">
-            <!-- timeline node -->
-            <span aria-hidden="true" class="hidden sm:flex absolute left-0 top-6 w-[15px] h-[15px] items-center justify-center">
-              <span class="w-[15px] h-[15px] rounded-full bg-white ring-1 ring-[color:var(--border)] flex items-center justify-center">
-                <span class={`w-1.5 h-1.5 rounded-full ${s.dot}`}></span>
-              </span>
-            </span>
-
-            <article class="relative bg-white ring-1 ring-[color:var(--border)] rounded-[12px] p-5 md:p-6 hover:ring-[color:var(--brand)]/40 hover:shadow-[0_18px_36px_-22px_rgba(2,132,199,0.3)] transition-all overflow-hidden">
-              <!-- category accent rail -->
-              <span aria-hidden="true" class={`absolute left-0 top-0 bottom-0 w-[3px] ${s.rail}`}></span>
-
-              <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
-                <span class="text-[11.5px] font-mono uppercase tracking-[0.14em] text-muted-foreground tabular-nums">
-                  {r.date}
+        <div class="clg-fade absolute left-12 right-6 top-7 bottom-0">
+          {releases.map((r, i) => {
+            const s = styleFor(r.category);
+            return (
+              <div class="clg-card relative mb-3" style={`--i:${i}`}>
+                <span class="absolute -left-[21px] top-[18px] w-[13px] h-[13px] rounded-full bg-white ring-1 ring-slate-200 grid place-items-center">
+                  <span class={`w-1.5 h-1.5 rounded-full ${s.dot}`}></span>
                 </span>
-                <a href={r.url} class="text-[11.5px] font-mono text-muted-foreground hover:text-[color:var(--brand-strong)] transition-colors tabular-nums">
-                  #{r.number}
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class:list={[
+                    'block rounded-[11px] bg-white ring-1 ring-slate-200 px-4 py-3 transition-shadow',
+                    i === 0
+                      ? 'shadow-[0_22px_50px_-18px_rgb(15_23_42_/_0.28)]'
+                      : 'shadow-[0_10px_30px_-20px_rgb(15_23_42_/_0.25)]',
+                  ]}
+                >
+                  <div class="flex items-center gap-2.5">
+                    <span class={`shrink-0 inline-flex items-center h-5 px-1.5 rounded text-[9.5px] font-semibold uppercase tracking-[0.08em] ring-1 ${s.chip}`}>{r.category}</span>
+                    <span class="text-[12.5px] font-semibold text-slate-900 truncate">{r.title}</span>
+                    <span class="ml-auto shrink-0 text-[10px] font-mono text-slate-400 tabular-nums">{r.date}</span>
+                  </div>
+                  {r.summary && (
+                    <p class="mt-1.5 text-[11.5px] text-slate-500 leading-snug line-clamp-1">{r.summary}</p>
+                  )}
                 </a>
-                <span class={`ml-auto inline-flex items-center gap-1.5 h-5 px-2 rounded-full ring-1 text-[10px] font-semibold uppercase tracking-[0.1em] ${s.chip}`}>
-                  <span class={`w-1 h-1 rounded-full ${s.dot}`}></span>
-                  {r.category}
-                </span>
               </div>
-
-              <h3 class="mt-3 text-[16px] md:text-[17px] font-semibold text-heading tracking-[-0.015em] leading-[1.25]">
-                {r.title}
-              </h3>
-
-              <ul class="mt-3 space-y-1.5">
-                {r.bullets.map((b) => (
-                  <li class="flex gap-2.5 text-[12.5px] text-foreground/70 leading-relaxed">
-                    <span class={`mt-[7px] w-1 h-1 rounded-full shrink-0 ${s.dot}`}></span>
-                    <span>{b}</span>
-                  </li>
-                ))}
-              </ul>
-            </article>
-          </li>
-        );
-      })}
-    </ol>
-
-    <!-- footer link -->
-    <div class="mt-10 flex flex-wrap items-center gap-x-4 gap-y-2 text-[11.5px] font-mono text-muted-foreground sm:pl-10">
-      <span>Older releases and the full history</span>
-      <span class="w-1 h-1 rounded-full bg-[color:var(--border-strong)]"></span>
-      <a href="/changelog/" class="text-[color:var(--brand-strong)] hover:text-[color:var(--brand)] transition-colors">
-        Read the full changelog
-      </a>
+            );
+          })}
+        </div>
+      </div>
     </div>
   </div>
 </section>
+
+<style>
+  .clg-texture {
+    background-image: radial-gradient(circle, rgb(15 23 42 / 0.07) 1px, transparent 1.2px);
+    background-size: 14px 14px;
+    -webkit-mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+    mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+  }
+  /* Older entries dissolve off the bottom: the feed continues past the card. */
+  .clg-fade {
+    -webkit-mask-image: linear-gradient(to bottom, #000 58%, transparent 96%);
+    mask-image: linear-gradient(to bottom, #000 58%, transparent 96%);
+  }
+
+  /* Motion gated on .is-live so nothing runs off screen. */
+  @media (prefers-reduced-motion: no-preference) {
+    .clg.js-ready .clg-card { opacity: 0; }
+    .clg.is-live .clg-card {
+      animation: clg-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 110ms);
+    }
+    .clg.is-live .clg-live { animation: clg-pulse 2.4s ease-in-out infinite; }
+  }
+  @keyframes clg-rise {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes clg-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+</style>
+
+<script is:inline>
+  // Arm hidden start states only when JS runs, so a script failure leaves
+  // the section fully visible.
+  document.querySelectorAll('.clg').forEach((el) => el.classList.add('js-ready'));
+</script>
+
+<script>
+  const clg = document.querySelector('.clg');
+  if (clg) {
+    new IntersectionObserver(
+      (entries) => entries.forEach((e) => clg.classList.toggle('is-live', e.isIntersecting)),
+      { threshold: 0.2 },
+    ).observe(clg);
+  }
+</script>

--- a/site/src/components/OpenSourceShowcase.astro
+++ b/site/src/components/OpenSourceShowcase.astro
@@ -22,7 +22,9 @@ const tree = [
 
 const lines = [
   { kind: 'cmd', text: 'git clone https://github.com/warmbly/warmbly.git' },
-  { kind: 'cmd', text: 'make up' },
+  // cd is part of the command: without it make up runs in the parent
+  // directory, finds no Makefile, and self-host startup fails.
+  { kind: 'cmd', text: 'cd warmbly && make up' },
   { kind: 'ok', text: 'Warmbly is live on http://localhost:8080' },
   { kind: 'caret' },
 ];

--- a/site/src/components/OpenSourceShowcase.astro
+++ b/site/src/components/OpenSourceShowcase.astro
@@ -1,232 +1,239 @@
 ---
 /**
- * Big, information-rich open-source band after the changelog. Fills the full
- * width: a hero (copy + facts left, live self-host terminal right), a row of
- * real info cards (the actual services in the repo, how to contribute, how to
- * self-host), and a links row. No fabricated metrics; everything here is true.
+ * Open-source section. Light, matching the bento's plinth-and-artifact
+ * anatomy: copy and facts on the left, and on the right a tinted plinth
+ * holding a repo browser (the real top-level tree) with a dark self-host
+ * terminal floating over it. The dark band with clouds is gone; the terminal
+ * is the one dark element, which is what makes it read as a terminal.
  */
 const gh = '<path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.8 10.9.6.1.8-.2.8-.5v-2c-3.2.7-3.9-1.4-3.9-1.4-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1.1 1.8 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.4-2.3 1.2-3.2-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2 1-.3 2-.4 3-.4s2 .1 3 .4c2.3-1.5 3.3-1.2 3.3-1.2.7 1.6.2 2.9.1 3.1.8.8 1.2 1.9 1.2 3.2 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.5 4.6-1.5 7.8-5.8 7.8-10.9C23.5 5.7 18.3.5 12 .5z"/>';
 const arrow = '<path d="M7 17 17 7M7 7h10v10"/>';
+const folder = '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>';
 
-const facts = [
-  { value: '100%', label: 'Open source' },
-  { value: 'Apache 2.0', label: 'Fork it, ship it' },
-  { value: '$0', label: 'To self-host' },
-  { value: 'Public', label: 'Issues and pull requests' },
+// The actual top-level tree, with GitHub linguist colors on the dots.
+const tree = [
+  { path: 'cmd/backend', desc: 'API, the control plane', lang: 'Go', dot: '#00add8' },
+  { path: 'cmd/worker', desc: 'Distributed senders', lang: 'Go', dot: '#00add8' },
+  { path: 'tracking', desc: 'Open and click pixels', lang: 'Rust', dot: '#dea584' },
+  { path: 'realtime', desc: 'Live dashboard fanout', lang: 'Elixir', dot: '#6e4a7e' },
+  { path: 'web', desc: 'The dashboard', lang: 'TypeScript', dot: '#3178c6' },
+  { path: 'docs', desc: 'docs.warmbly.com', lang: 'MDX', dot: '#fcb32c' },
 ];
 
 const lines = [
   { kind: 'cmd', text: 'git clone https://github.com/warmbly/warmbly.git' },
-  { kind: 'cmd', text: 'cd warmbly' },
-  { kind: 'cmd', text: 'make up', note: 'build images, boot the full stack' },
+  { kind: 'cmd', text: 'make up' },
   { kind: 'ok', text: 'Warmbly is live on http://localhost:8080' },
   { kind: 'caret' },
 ];
 
-const layers = [
-  { name: 'Backend API', tag: 'Go', desc: 'Control plane and business orchestration' },
-  { name: 'Consumer', tag: 'Go', desc: 'Turns Kafka events into platform state' },
-  { name: 'Workers', tag: 'Go', desc: 'Distributed sending and mailbox sync' },
-  { name: 'Tracking', tag: 'Rust', desc: 'Open and click pixel service' },
-  { name: 'Realtime', tag: 'Elixir', desc: 'Websocket fanout for live dashboards' },
-  { name: 'Dashboard & admin', tag: 'React', desc: 'The product UI and the admin console' },
-  { name: 'Marketing site', tag: 'Astro', desc: 'This very site you are reading' },
+const facts = [
+  { value: '100%', label: 'Open source' },
+  { value: '$0', label: 'To self-host' },
+  { value: '1', label: 'Command to boot' },
+  { value: 'Public', label: 'Issues and PRs' },
 ];
-const contribute = [
-  { label: 'Browse good first issues', href: 'https://github.com/warmbly/warmbly/labels/good%20first%20issue' },
-  { label: 'Read the contributing guide', href: 'https://github.com/warmbly/warmbly/blob/main/CONTRIBUTING.md' },
-  { label: 'Follow the changelog', href: '/changelog/' },
-  { label: 'Open a discussion or RFC', href: 'https://github.com/warmbly/warmbly/discussions' },
-];
-const selfhost = [
-  'Run on your own infra: Postgres, Redis, Kafka, S3, KMS',
-  'One make up command boots the whole stack',
-  'Cloud, with the shared warmup pool, is coming soon',
-  'BYOK encryption and SSO on enterprise',
-];
+
 const links = [
-  { label: 'Docs', href: '/developers/' },
+  { label: 'Good first issues', href: 'https://github.com/warmbly/warmbly/labels/good%20first%20issue' },
+  { label: 'Discussions', href: 'https://github.com/warmbly/warmbly/discussions' },
   { label: 'Architecture', href: '/trust/' },
-  { label: 'Changelog', href: '/changelog/' },
   { label: 'Apache 2.0 license', href: 'https://github.com/warmbly/warmbly/blob/main/LICENSE' },
 ];
 ---
-<section class="relative isolate overflow-hidden text-white"
-         style="background: radial-gradient(ellipse 130% 130% at 50% -10%, #0ea5e9 0%, #0284c7 30%, #075985 62%, #0c2f4a 100%);">
-  <img src="/backdrops/cloud-4.webp" alt="" aria-hidden="true" class="absolute -top-16 -left-20 w-[560px] opacity-[0.18] pointer-events-none select-none cloud-drift cloud-1" loading="lazy" decoding="async" style="mix-blend-mode: screen;" />
-  <img src="/backdrops/cloud-5.webp" alt="" aria-hidden="true" class="absolute top-24 -right-16 w-[520px] opacity-[0.12] pointer-events-none select-none cloud-drift cloud-2" loading="lazy" decoding="async" style="mix-blend-mode: screen;" />
+<section class="os container-page py-20 md:py-28">
+  <div class="grid lg:grid-cols-12 gap-10 lg:gap-14 items-center">
+    <!-- ── Copy ──────────────────────────────────────────────────── -->
+    <div class="lg:col-span-5">
+      <a
+        href="https://github.com/warmbly/warmbly"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="inline-flex items-center gap-2 h-7 pl-2.5 pr-1.5 rounded-full bg-white ring-1 ring-[color:var(--border)] text-[12px] font-medium text-heading shadow-[0_2px_10px_-4px_rgba(15,23,42,0.2)] hover:ring-[color:var(--border-strong)] transition-colors"
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" set:html={gh}></svg>
+        warmbly/warmbly
+        <span class="inline-flex items-center h-[18px] px-1.5 rounded-full text-[9.5px] font-semibold uppercase tracking-[0.06em] bg-[color:var(--brand-soft)] text-[color:var(--brand-strong)]">Apache 2.0</span>
+      </a>
 
-  <div class="container-page relative py-20 md:py-28">
-    <!-- HERO: copy + facts left, terminal right -->
-    <div class="grid lg:grid-cols-12 gap-10 lg:gap-12 items-center">
-      <div class="lg:col-span-6">
-        <a href="https://github.com/warmbly/warmbly" target="_blank" rel="noopener noreferrer"
-           class="inline-flex items-center gap-2 h-7 pl-1 pr-3 rounded-full bg-white/10 backdrop-blur text-[12px] text-white/95">
-          <span class="inline-flex items-center gap-1.5 h-5 px-1.5 rounded-full text-[10.5px] font-semibold uppercase tracking-[0.06em] bg-white text-[color:var(--sky-6)]">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" set:html={gh}></svg>
-            Open source
-          </span>
-          Apache 2.0
+      <h2 class="mt-5 text-[32px] md:text-[48px] font-semibold tracking-[-0.03em] leading-[1.04] text-heading">
+        Read the code. Run it yourself.
+      </h2>
+      <p class="mt-4 text-foreground/75 leading-relaxed max-w-xl">
+        See exactly how warmup, sending and deliverability work, self-host the whole platform on your own infra, and send a pull request when something should be better.
+      </p>
+
+      <div class="mt-7 flex flex-wrap items-center gap-3">
+        <a
+          href="https://github.com/warmbly/warmbly"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex h-11 px-5 items-center gap-2 rounded-[10px] text-[14px] font-medium bg-foreground text-background hover:bg-foreground/85 transition-colors"
+        >
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" class="shrink-0" set:html={gh}></svg>
+          Star on GitHub
         </a>
-        <h2 class="mt-6 text-[40px] md:text-[58px] font-semibold tracking-[-0.035em] leading-[1.02] text-white">
-          Read the code. Run it yourself.
-        </h2>
-        <p class="mt-5 text-[16px] md:text-[17.5px] text-white/80 leading-relaxed max-w-xl">
-          Read exactly how warmup, sending and deliverability really work, self-host the whole platform,
-          and send a pull request. Help us build the largest open-source cold email and warmup platform.
-        </p>
-        <div class="mt-7 flex flex-wrap items-center gap-3">
-          <a href="https://github.com/warmbly/warmbly" target="_blank" rel="noopener noreferrer"
-             class="inline-flex h-11 px-5 items-center gap-2 rounded-[10px] text-[14.5px] font-medium text-[color:var(--sky-6)] bg-white hover:bg-white/95 transition-colors whitespace-nowrap shadow-[0_12px_30px_-12px_rgba(8,47,73,0.6)]">
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" class="shrink-0" set:html={gh}></svg>
-            Star on GitHub
+        <a
+          href="https://github.com/warmbly/warmbly/blob/main/CONTRIBUTING.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="inline-flex h-11 px-5 items-center rounded-[10px] text-[14px] font-medium text-heading bg-white ring-1 ring-[color:var(--border)] hover:ring-[color:var(--border-strong)] transition-colors"
+        >
+          Contributing guide
+        </a>
+      </div>
+
+      <div class="mt-9 grid grid-cols-2 sm:grid-cols-4 gap-y-5">
+        {facts.map((f, i) => (
+          <div class:list={['pr-4', i > 0 && 'sm:border-l sm:border-[color:var(--border)] sm:pl-4']}>
+            <div class="text-[22px] font-semibold tracking-[-0.02em] leading-none text-heading">{f.value}</div>
+            <div class="mt-1.5 text-[10px] uppercase tracking-[0.14em] font-mono text-muted-foreground">{f.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div class="mt-8 flex flex-wrap items-center gap-x-5 gap-y-2">
+        {links.map((l) => (
+          <a
+            href={l.href}
+            target={l.href.startsWith('http') ? '_blank' : undefined}
+            rel="noopener noreferrer"
+            class="group inline-flex items-center gap-1 text-[12.5px] font-medium text-foreground/70 hover:text-heading transition-colors whitespace-nowrap"
+          >
+            {l.label}
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-muted-foreground/60 group-hover:text-heading transition-colors" set:html={arrow}></svg>
           </a>
-          <a href="https://github.com/warmbly/warmbly/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer"
-             class="inline-flex h-11 px-5 items-center gap-2 rounded-[10px] text-[14.5px] font-medium text-white bg-white/[0.14] backdrop-blur hover:bg-white/20 transition-colors whitespace-nowrap">
-            Contributing guide
-          </a>
-        </div>
-        <div class="mt-9 grid grid-cols-2 sm:grid-cols-4 gap-y-6 gap-x-4">
-          {facts.map((f) => (
-            <div>
-              <div class="text-[24px] md:text-[30px] font-semibold tracking-[-0.02em] leading-none text-white">{f.value}</div>
-              <div class="mt-2 text-[10.5px] uppercase tracking-[0.14em] font-mono text-white/55">{f.label}</div>
+        ))}
+      </div>
+    </div>
+
+    <!-- ── Artifact: repo browser + floating terminal ────────────── -->
+    <div class="lg:col-span-7">
+      <div class="os-stage relative overflow-hidden h-[440px] rounded-[18px]"
+           style="background: linear-gradient(175deg, #fbfcfe 0%, var(--surface-2) 100%); box-shadow: inset 0 0 0 1px var(--border);">
+        <span class="os-texture absolute inset-0 pointer-events-none"></span>
+
+        <!-- Back layer: the repository, dissolving toward the bottom. -->
+        <div class="os-fade-b absolute left-7 right-7 top-7 bottom-0 rounded-t-[11px] bg-white ring-1 ring-slate-200/70 shadow-[0_10px_30px_-18px_rgb(15_23_42_/_0.25)]">
+          <div class="h-10 px-4 border-b border-slate-200 flex items-center gap-2">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="currentColor" class="text-slate-500 shrink-0" set:html={gh}></svg>
+            <span class="text-[12px] font-mono text-slate-900">warmbly<span class="text-slate-400">/</span>warmbly</span>
+            <span class="inline-flex items-center gap-1 h-[19px] px-1.5 rounded-full text-[10px] font-mono bg-slate-100 text-slate-600 ring-1 ring-slate-200">
+              <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
+              main
+            </span>
+            <span class="ml-auto text-[10px] font-mono text-slate-400">Go · Rust · Elixir · TS</span>
+          </div>
+          {tree.map((t, i) => (
+            <div class="os-row flex items-center gap-2.5 px-4 py-[9px] border-b border-slate-200/60" style={`--i:${i}`}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-sky-600/80 shrink-0" set:html={folder}></svg>
+              <span class="text-[12px] font-mono text-slate-900 whitespace-nowrap">{t.path}</span>
+              <span class="text-[11.5px] text-slate-500 truncate">{t.desc}</span>
+              <span class="ml-auto inline-flex items-center gap-1.5 text-[10.5px] font-mono text-slate-500 shrink-0">
+                <span class="w-2 h-2 rounded-full" style={`background:${t.dot}`}></span>{t.lang}
+              </span>
             </div>
           ))}
         </div>
-      </div>
 
-      <!-- terminal -->
-      <div class="lg:col-span-6">
-        <div class="os-term w-full text-left rounded-[14px] overflow-hidden bg-[#0a1020]"
-             style="box-shadow: 0 40px 90px -30px rgba(8,47,73,0.75), 0 0 0 1px rgba(125,211,252,0.08);">
-          <div class="flex items-center gap-2 px-4 h-9 border-b border-black/20 bg-white/[0.04]">
-            <span class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></span>
-            <span class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></span>
-            <span class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></span>
-            <span class="ml-2 text-[11px] font-mono text-white/40">warmbly · self-host</span>
+        <!-- Front layer: the self-host terminal. -->
+        <div class="os-term absolute left-12 sm:left-16 right-5 bottom-5 rounded-[11px] overflow-hidden bg-[#0b1120] ring-1 ring-white/10 shadow-[0_26px_60px_-18px_rgb(8_25_45_/_0.6)]">
+          <div class="flex items-center gap-1.5 px-3.5 h-8 border-b border-white/[0.06] bg-white/[0.03]">
+            <span class="w-2 h-2 rounded-full bg-[#ff5f57]"></span>
+            <span class="w-2 h-2 rounded-full bg-[#febc2e]"></span>
+            <span class="w-2 h-2 rounded-full bg-[#28c840]"></span>
+            <span class="ml-2 text-[10px] font-mono text-white/35">self-host</span>
           </div>
-          <div class="px-5 py-4 font-mono text-[12.5px] md:text-[13px] leading-[1.9]">
+          <div class="px-4 py-3 font-mono text-[12px] leading-[1.9]">
             {lines.map((l, i) => (
-              <div class="os-line" style={`animation-delay: ${(-3 + i * 0.7).toFixed(2)}s`}>
+              <div class="os-line" style={`animation-delay: ${(i * 0.9).toFixed(1)}s`}>
                 {l.kind === 'cmd' && (
-                  <span>
-                    <span class="text-sky-400">$</span>
-                    <span class="text-white/90"> {l.text}</span>
-                    {l.note && <span class="text-white/35">  # {l.note}</span>}
-                  </span>
+                  <span><span class="text-sky-400">$</span><span class="text-white/90"> {l.text}</span></span>
                 )}
                 {l.kind === 'ok' && (
                   <span class="inline-flex items-center gap-2 text-emerald-300">
-                    <span class="relative inline-flex">
-                      <span class="w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
-                      <span class="absolute inset-0 rounded-full bg-emerald-400/50 animate-ping"></span>
-                    </span>
+                    <span class="os-live w-1.5 h-1.5 rounded-full bg-emerald-400"></span>
                     <span>{l.text}</span>
                   </span>
                 )}
                 {l.kind === 'caret' && (
-                  <span><span class="text-sky-400">$</span> <span class="os-caret inline-block w-[8px] h-[15px] -mb-0.5 bg-sky-300"></span></span>
+                  <span><span class="text-sky-400">$</span> <span class="os-caret inline-block w-[7px] h-[14px] -mb-0.5 bg-sky-300"></span></span>
                 )}
               </div>
             ))}
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- INFO CARDS (full width) -->
-    <div class="mt-14 grid md:grid-cols-3 gap-4">
-      <!-- card 1: every layer -->
-      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
-        <div class="flex items-center gap-2.5 mb-4">
-          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><path d="m12 2 9 4.9-9 4.9-9-4.9z"/><path d="m3 12 9 4.9 9-4.9"/><path d="m3 17 9 4.9 9-4.9"/></svg>
-          </span>
-          <h3 class="text-[14.5px] font-semibold text-white">Every layer is open</h3>
-        </div>
-        <ul class="space-y-2.5">
-          {layers.map((s) => (
-            <li class="flex items-start gap-2.5">
-              <span class="shrink-0 mt-0.5 inline-flex items-center h-4 px-1.5 rounded text-[9.5px] font-mono font-semibold uppercase tracking-[0.06em] bg-white/12 text-white/70">{s.tag}</span>
-              <span class="min-w-0">
-                <span class="text-[13px] font-medium text-white">{s.name}</span>
-                <span class="block text-[12px] text-white/55 leading-snug">{s.desc}</span>
-              </span>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <!-- card 2: contribute -->
-      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
-        <div class="flex items-center gap-2.5 mb-4">
-          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
-          </span>
-          <h3 class="text-[14.5px] font-semibold text-white">Made to contribute to</h3>
-        </div>
-        <ul class="space-y-1">
-          {contribute.map((c) => (
-            <li>
-              <a href={c.href} target={c.href.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer"
-                 class="group flex items-center gap-2 -mx-2 px-2 py-2 rounded-lg text-[13px] text-white/85 hover:bg-white/10 transition-colors">
-                <span class="flex-1">{c.label}</span>
-                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 text-white/40 group-hover:text-white/80 transition-colors" set:html={arrow}></svg>
-              </a>
-            </li>
-          ))}
-        </ul>
-      </div>
-
-      <!-- card 3: self-host -->
-      <div class="rounded-[14px] bg-white/[0.08] backdrop-blur p-5 transition-colors hover:bg-white/[0.13] shadow-[0_16px_38px_-20px_rgba(2,16,32,0.7)]">
-        <div class="flex items-center gap-2.5 mb-4">
-          <span class="w-8 h-8 rounded-lg bg-white/10 grid place-items-center">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class="text-white"><rect width="20" height="8" x="2" y="2" rx="2"/><rect width="20" height="8" x="2" y="14" rx="2"/><path d="M6 6h.01M6 18h.01"/></svg>
-          </span>
-          <h3 class="text-[14.5px] font-semibold text-white">Run it your way</h3>
-        </div>
-        <ul class="space-y-2.5">
-          {selfhost.map((s) => (
-            <li class="flex items-start gap-2.5 text-[13px] text-white/80 leading-snug">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" class="shrink-0 mt-0.5 text-sky-300"><polyline points="20 6 9 17 4 12"/></svg>
-              <span>{s}</span>
-            </li>
-          ))}
-        </ul>
-        <p class="mt-4 text-[12px] text-white/60 leading-relaxed">
-          One caveat: the shared warmup pool runs on our cloud. It only works with a large base of vetted
-          mailboxes sending to each other, which a single self-hosted instance starts without. Self-hosting
-          still gives you the full sending, inbox, CRM and API stack. The pool is the one part that needs the cloud.
-        </p>
-      </div>
-    </div>
-
-    <!-- links row -->
-    <div class="mt-12 flex flex-wrap items-center gap-x-6 gap-y-3 text-[13px]">
-      <span class="text-[11px] uppercase tracking-[0.18em] font-mono text-white/45">Built with Go · Rust · Elixir · React · Astro</span>
-      <span class="ml-auto flex flex-wrap items-center gap-x-5 gap-y-2">
-        {links.map((l) => (
-          <a href={l.href} target={l.href.startsWith('http') ? '_blank' : undefined} rel="noopener noreferrer"
-             class="text-white/70 hover:text-white transition-colors whitespace-nowrap">{l.label}</a>
-        ))}
-      </span>
+      <p class="mt-4 text-[12.5px] text-muted-foreground leading-relaxed">
+        Self-hosted instances connect to the same shared warmup pool the cloud uses, the network of vetted mailboxes that builds your sender reputation. There is a free tier, so you can start warming on day one.
+      </p>
     </div>
   </div>
-
-  <style>
-    .os-line { opacity: 0; transform: translateY(4px); animation: os-line 8s ease-in-out infinite; }
-    @keyframes os-line {
-      0%, 4%   { opacity: 0; transform: translateY(4px); }
-      9%, 90%  { opacity: 1; transform: translateY(0); }
-      97%, 100%{ opacity: 0; transform: translateY(4px); }
-    }
-    .os-caret { animation: os-caret 1s step-end infinite; }
-    @keyframes os-caret { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
-    @media (prefers-reduced-motion: reduce) {
-      .os-line { opacity: 1; transform: none; animation: none; }
-      .os-caret { animation: none; }
-    }
-  </style>
 </section>
+
+<style>
+  .os-texture {
+    background-image: radial-gradient(circle, rgb(15 23 42 / 0.07) 1px, transparent 1.2px);
+    background-size: 14px 14px;
+    -webkit-mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+    mask-image: radial-gradient(ellipse at 50% 40%, #000 30%, transparent 78%);
+  }
+  .os-fade-b {
+    -webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent 96%);
+    mask-image: linear-gradient(to bottom, #000 55%, transparent 96%);
+  }
+
+  /* Motion is gated on .is-live, set by the observer below, so the loops
+     stop when the section scrolls away. */
+  @media (prefers-reduced-motion: no-preference) {
+    .os.js-ready .os-row,
+    .os.js-ready .os-term { opacity: 0; }
+    .os.is-live .os-row {
+      animation: os-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both;
+      animation-delay: calc(var(--i) * 70ms);
+    }
+    .os.is-live .os-term {
+      animation: os-drop 620ms cubic-bezier(0.34, 1.24, 0.64, 1) 380ms both;
+    }
+    /* Terminal lines type in one after another, then the loop rests. */
+    .os.js-ready .os-line { opacity: 0; }
+    .os.is-live .os-line { animation: os-line 9s ease-in-out infinite; }
+    .os.is-live .os-caret { animation: os-caret 1s step-end infinite; }
+    .os.is-live .os-live { animation: os-pulse 2.4s ease-in-out infinite; }
+  }
+
+  @keyframes os-rise {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes os-drop {
+    from { opacity: 0; transform: translateY(16px) scale(0.97); }
+    to   { opacity: 1; transform: none; }
+  }
+  @keyframes os-line {
+    0%, 8%    { opacity: 0; transform: translateY(3px); }
+    13%, 88%  { opacity: 1; transform: none; }
+    96%, 100% { opacity: 0; transform: translateY(3px); }
+  }
+  @keyframes os-caret { 0%, 49% { opacity: 1; } 50%, 100% { opacity: 0; } }
+  @keyframes os-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+</style>
+
+<script is:inline>
+  // Arm hidden start states only when JS runs, so a script failure leaves
+  // the section fully visible.
+  document.querySelectorAll('.os').forEach((el) => el.classList.add('js-ready'));
+</script>
+
+<script>
+  // Same viewport gating as the bento, without pulling in a library for one
+  // observer: loops run only while the section is on screen.
+  const os = document.querySelector('.os');
+  if (os) {
+    new IntersectionObserver(
+      (entries) => entries.forEach((e) => os.classList.toggle('is-live', e.isIntersecting)),
+      { threshold: 0.2 },
+    ).observe(os);
+  }
+</script>

--- a/site/src/components/TemplatingShowcase.astro
+++ b/site/src/components/TemplatingShowcase.astro
@@ -1,126 +1,225 @@
 ---
 /**
- * TemplatingShowcase - explains how the Go text/template subset works inside
- * Warmbly campaign steps. Mirrors the exact send-time syntax the dashboard
- * composer renders (web/src/components/app/campaigns/sequences/SequenceView.tsx):
+ * TemplatingShowcase - the personalization section. One artifact proves the
+ * pitch (one template renders into a different email per recipient), then a
+ * feature grid covers the whole engine. Everything shown mirrors the real
+ * renderer (internal/tasks/template.go, internal/pkg/tmplfuncs, spintax.go):
  *
- *   - merge fields:  {{.FirstName}} {{.LastName}} {{.Company}} {{.Email}} {{.Phone}}
- *   - conditionals:  {{if eq .role "Engineer"}} ... {{else}} ... {{end}}  + and / or
- *   - spintax:       {Hi|Hey|Hello} {{.FirstName}}  (one variant is picked)
- *
- * Sample data matches the composer's SAMPLE map (Alex Rivera at Acme, role
- * Engineer) so the before/after examples line up with the in-app preview.
- *
- * Self-contained, no props. Dark code style matches the campaign code block on
- * index.astro / campaigns.astro (#0c1224 surface, white/85 text, sky/amber/
- * violet/emerald spans). No app-window frame and no demo cursor.
+ *   - merge fields {{.FirstName}} + custom CSV fields, spaces allowed
+ *   - fallbacks:   {{.FirstName | default "there"}}
+ *   - conditionals if / else / end, eq, and / or, coercing numeric compares
+ *   - helpers:     title, lower, contains, add / sub / mul / div
+ *   - spintax:     {Hi|Hey|Hello}, nested, subject and body
+ *   - A/B variants per step, same editor and preview
+ *   - preview runs the real send engine; a broken {{if}} blocks launch;
+ *     a failed render falls back to plain substitution, never a dead send
  */
 import SectionHead from './SectionHead.astro';
+import Icon from './Icon.astro';
 
-// Merge fields, paired with their resolved value from the composer's SAMPLE.
-const fields = [
-  { token: '{{.FirstName}}', value: 'Alex' },
-  { token: '{{.LastName}}', value: 'Rivera' },
-  { token: '{{.Company}}', value: 'Acme' },
-  { token: '{{.Email}}', value: 'alex@acme.com' },
-  { token: '{{.Phone}}', value: '+1 555-0100' },
+// Three recipients through the same template: the Engineer branch, the else
+// branch, and the default fallback for a contact with no first name. Each
+// carries chips naming the features that fired.
+const results = [
+  {
+    who: 'Alex Rivera',
+    meta: 'alex@acme.com · role: Engineer',
+    grad: 'from-sky-400 to-indigo-400',
+    parts: [
+      { t: 'Hey', c: 'spin' }, { t: ' ' }, { t: 'Alex', c: 'field' }, { t: ', we built this for teams like yours.' },
+    ],
+    chips: ['spintax picked Hey', 'if branch: Engineer'],
+  },
+  {
+    who: 'Jenna Carter',
+    meta: 'jenna@northwind.dev · role: Founder',
+    grad: 'from-rose-400 to-amber-400',
+    parts: [
+      { t: 'Hi', c: 'spin' }, { t: ' ' }, { t: 'Jenna', c: 'field' }, { t: ', thought this might be useful for ' }, { t: 'Northwind', c: 'field' }, { t: '.' },
+    ],
+    chips: ['else branch', '{{.Company}}'],
+  },
+  {
+    who: 'No first name',
+    meta: 'mail@brightco.io · role: empty',
+    grad: 'from-slate-300 to-slate-400',
+    parts: [
+      { t: 'Hello', c: 'spin' }, { t: ' ' }, { t: 'there', c: 'fall' }, { t: ', thought this might be useful for ' }, { t: 'Brightco', c: 'field' }, { t: '.' },
+    ],
+    chips: ['default "there"', 'blank never breaks'],
+  },
+];
+
+const features = [
+  {
+    icon: 'database',
+    title: 'Every field, including yours',
+    body: 'Standard fields plus every column from your CSV import. Keys with spaces or dashes work everywhere, even inside conditions.',
+    code: '{{.job title}}',
+  },
+  {
+    icon: 'cog',
+    title: 'Helper functions',
+    body: 'Case and string helpers, arithmetic, and numeric compares that coerce strings, so number-like fields just work.',
+    code: '{{if gtf .employees 50}}',
+  },
+  {
+    icon: 'shuffle',
+    title: 'Spintax, nested',
+    body: 'Alternation groups resolve innermost first and nest freely. Subjects spin too, so no two sends read identical.',
+    code: '{Hi|Hey {there|again}}',
+  },
+  {
+    icon: 'flask',
+    title: 'A/B variants per step',
+    body: 'Test variants of any step. The original and every variant share the same editor, preview and content score.',
+    code: 'Variant B · 50%',
+  },
+  {
+    icon: 'search',
+    title: 'Previewed with the real engine',
+    body: 'The composer renders your template with the actual send engine against sample data. Conditionals, functions and spintax all run.',
+    code: 'Hey Alex,',
+  },
+  {
+    icon: 'shield',
+    title: 'Validated before launch',
+    body: 'A broken {{if}} blocks the campaign and unresolved tokens get flagged. A failing render falls back to plain substitution, never a lost send.',
+    code: 'if: missing {{end}}',
+  },
 ];
 ---
-<section class="py-20 md:py-28">
+<section class="tpl py-20 md:py-28">
   <div class="container-page">
     <SectionHead
-      eyebrow="Personalization / Templating"
-      title="Go templating, rendered at send time"
-      description="Every step is a Go text/template. Merge fields, if/else conditionals, and spintax all resolve per recipient the moment the email goes out, and the composer previews exactly what each contact will receive."
+      eyebrow="Personalization"
+      title="One template. A different email for every recipient."
+      description="Every step is a template rendered at send time. Merge fields, conditionals, helpers and spintax resolve per recipient, and the composer shows the exact result before you launch."
     />
 
-    <div class="mt-12 md:mt-14 grid gap-5 lg:grid-cols-3">
-      <!-- 1 · MERGE FIELDS -->
-      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
-        <div class="flex items-center gap-2">
-          <span class="grid place-items-center w-7 h-7 rounded-md bg-sky-50 text-sky-600 ring-1 ring-sky-100">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V5a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v2"/><path d="M9 20h6"/><path d="M12 4v16"/></svg>
-          </span>
-          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Merge fields</h3>
-        </div>
-        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
-          Pull any contact field with a leading dot. Missing values render empty, so a blank field never breaks the line.
-        </p>
+    <!-- ── Artifact: template -> three rendered emails ───────────── -->
+    <div class="tpl-stage relative overflow-hidden mt-12 md:mt-14 rounded-[18px] p-5 sm:p-7 lg:p-9"
+         style="background: linear-gradient(175deg, #fbfcfe 0%, var(--surface-2) 100%); box-shadow: inset 0 0 0 1px var(--border);">
+      <span class="tpl-texture absolute inset-0 pointer-events-none"></span>
 
-        <div class="mt-4 flex flex-wrap gap-1.5">
-          {fields.map((f) => (
-            <code class="inline-flex items-center h-6 px-2 rounded-md bg-[#0c1224] text-[11.5px] font-mono text-sky-300 ring-1 ring-white/10">{f.token}</code>
+      <div class="relative grid lg:grid-cols-2 gap-5 lg:gap-8 items-center">
+        <!-- The template, written once. -->
+        <div class="tpl-code rounded-[12px] overflow-hidden bg-[#0c1224] ring-1 ring-white/10 shadow-[0_26px_60px_-20px_rgb(8_25_45_/_0.55)]">
+          <div class="h-9 px-4 border-b border-white/[0.06] bg-white/[0.03] flex items-center gap-2">
+            <span class="text-[9.5px] uppercase tracking-[0.14em] font-mono text-white/40">Step 1 · template</span>
+            <span class="ml-auto text-[10px] font-mono text-white/30">written once</span>
+          </div>
+          <pre class="p-4 sm:p-5 font-mono text-[12px] sm:text-[12.5px] leading-[1.85] text-white/85 overflow-x-auto"><code><span style="color:#6ee7b7">{`{Hi|Hey|Hello}`}</span> <span style="color:#7dd3fc">{`{{.FirstName`}</span> <span style="color:#c4b5fd">| default</span> <span style="color:#fde68a">"there"</span><span style="color:#7dd3fc">{`}}`}</span>,
+
+<span style="color:#c4b5fd">{`{{if eq`}</span> <span style="color:#7dd3fc">.role</span> <span style="color:#fde68a">"Engineer"</span><span style="color:#c4b5fd">{`}}`}</span>we built this for
+teams like yours.<span style="color:#c4b5fd">{`{{else}}`}</span>thought this might
+be useful for <span style="color:#7dd3fc">{`{{.Company}}`}</span>.<span style="color:#c4b5fd">{`{{end}}`}</span></code></pre>
+        </div>
+
+        <!-- What each recipient actually receives. -->
+        <div class="space-y-3">
+          {results.map((r, i) => (
+            <div class="tpl-result rounded-[12px] bg-white ring-1 ring-slate-200 shadow-[0_10px_30px_-18px_rgb(15_23_42_/_0.25)] p-4" style={`--i:${i}`}>
+              <div class="flex items-center gap-2.5">
+                <span class={`w-6 h-6 rounded-full shrink-0 bg-gradient-to-br ${r.grad}`}></span>
+                <span class="text-[12px] font-semibold text-slate-900">{r.who}</span>
+                <span class="text-[10.5px] font-mono text-slate-400 truncate">{r.meta}</span>
+              </div>
+              <p class="mt-2.5 text-[12.5px] leading-relaxed text-slate-700">
+                {r.parts.map((p) => (
+                  p.c
+                    ? <span class:list={[
+                        'rounded px-[3px]',
+                        p.c === 'spin' && 'bg-emerald-50 text-emerald-700',
+                        p.c === 'field' && 'bg-sky-50 text-sky-700',
+                        p.c === 'fall' && 'bg-amber-50 text-amber-700',
+                      ]}>{p.t}</span>
+                    : p.t
+                ))}
+              </p>
+              <div class="mt-2.5 flex flex-wrap gap-1.5">
+                {r.chips.map((c) => (
+                  <span class="inline-flex items-center h-5 px-1.5 rounded text-[9.5px] font-mono text-slate-500 bg-slate-50 ring-1 ring-slate-200">{c}</span>
+                ))}
+              </div>
+            </div>
           ))}
         </div>
-
-        <div class="mt-auto pt-5">
-          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-mono mb-2">Before / after</div>
-          <div class="rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 p-3.5 font-mono text-[12.5px] leading-[1.6] text-white/85">
-            <div>Hi <span class="text-sky-300">{`{{.FirstName}}`}</span></div>
-            <div class="mt-1.5 flex items-center gap-1.5 text-white/50">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-emerald-400"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-              <span class="text-white/85">Hi <span class="text-emerald-400">Alex</span></span>
-            </div>
-          </div>
-        </div>
       </div>
 
-      <!-- 2 · CONDITIONALS -->
-      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
-        <div class="flex items-center gap-2">
-          <span class="grid place-items-center w-7 h-7 rounded-md bg-violet-50 text-violet-600 ring-1 ring-violet-100">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="6" x2="6" y1="3" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg>
-          </span>
-          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Conditionals</h3>
-        </div>
-        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
-          Branch on a contact field with <code class="kbd">if</code> / <code class="kbd">else</code> / <code class="kbd">end</code>. Compare values with <code class="kbd">eq</code>.
-        </p>
-
-        <div class="mt-4 rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 overflow-hidden">
-          <pre class="p-3.5 font-mono text-[12px] leading-[1.7] text-white/85 overflow-x-auto"><code>{`{{`}<span style="color:#c4b5fd">if eq</span> <span style="color:#7dd3fc">.role</span> <span style="color:#fde68a">"Engineer"</span>{`}}`}
-  We built this for teams like yours.
-{`{{`}<span style="color:#c4b5fd">else</span>{`}}`}
-  Thought this might be useful.
-{`{{`}<span style="color:#c4b5fd">end</span>{`}}`}</code></pre>
-        </div>
-
-        <p class="mt-auto pt-5 text-[12.5px] leading-relaxed text-foreground/60">
-          Combine checks with <code class="kbd">and</code> / <code class="kbd">or</code>, for example
-          <code class="inline-flex items-center mt-1 px-1.5 py-0.5 rounded bg-[#0c1224] text-[11px] font-mono text-white/85 ring-1 ring-white/10">{`{{if and (eq .role "Engineer") .Company}}`}</code>.
-        </p>
-      </div>
-
-      <!-- 3 · SPINTAX -->
-      <div class="rounded-[12px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col" style="box-shadow: var(--shadow-sm);">
-        <div class="flex items-center gap-2">
-          <span class="grid place-items-center w-7 h-7 rounded-md bg-emerald-50 text-emerald-600 ring-1 ring-emerald-100">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m18 14 4 4-4 4"/><path d="m18 2 4 4-4 4"/><path d="M2 18h1.973a4 4 0 0 0 3.3-1.7l5.454-8.6a4 4 0 0 1 3.3-1.7H22"/><path d="M2 6h1.972a4 4 0 0 1 3.6 2.2"/><path d="M22 18h-6.041a4 4 0 0 1-3.3-1.8l-.359-.45"/></svg>
-          </span>
-          <h3 class="text-[15px] font-semibold tracking-[-0.01em] text-heading">Spintax</h3>
-        </div>
-        <p class="mt-2.5 text-[13.5px] leading-relaxed text-foreground/65">
-          List variants in braces and Warmbly picks one per send, so the same step reads a little differently to every recipient.
-        </p>
-
-        <div class="mt-4 rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 overflow-hidden">
-          <pre class="p-3.5 font-mono text-[12.5px] leading-[1.7] text-white/85 overflow-x-auto"><code>{`{`}<span style="color:#6ee7b7">Hi</span>|<span style="color:#6ee7b7">Hey</span>|<span style="color:#6ee7b7">Hello</span>{`}`} <span style="color:#7dd3fc">{`{{.FirstName}}`}</span></code></pre>
-        </div>
-
-        <div class="mt-auto pt-5">
-          <div class="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-mono mb-2">Picks one variant</div>
-          <div class="flex flex-wrap gap-1.5">
-            <span class="inline-flex items-center h-6 px-2 rounded-md bg-emerald-50 text-[11.5px] font-medium text-emerald-700 ring-1 ring-emerald-100">Hey Alex</span>
-            <span class="inline-flex items-center h-6 px-2 rounded-md bg-slate-50 text-[11.5px] font-medium text-slate-400 ring-1 ring-slate-200">Hi Alex</span>
-            <span class="inline-flex items-center h-6 px-2 rounded-md bg-slate-50 text-[11.5px] font-medium text-slate-400 ring-1 ring-slate-200">Hello Alex</span>
-          </div>
-        </div>
+      <div class="relative mt-5 flex items-center justify-center gap-2 text-[11px] font-mono uppercase tracking-[0.14em] text-muted-foreground">
+        <Icon name="zap" size={11} class="text-[color:var(--brand)]" />
+        rendered per recipient, at send time
       </div>
     </div>
 
-    <p class="mt-8 flex items-center justify-center gap-2 text-[13px] text-foreground/60">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-sky-500 shrink-0"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>
-      Everything resolves at send time, and the composer previews the result against sample data before you launch.
-    </p>
+    <!-- ── The whole engine ──────────────────────────────────────── -->
+    <div class="mt-5 grid sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {features.map((f) => (
+        <div class="rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-5" style="box-shadow: var(--shadow-sm);">
+          <div class="flex items-center gap-2.5">
+            <span class="grid place-items-center w-7 h-7 rounded-md bg-[color:var(--brand-soft)] text-[color:var(--brand)]">
+              <Icon name={f.icon} size={14} />
+            </span>
+            <h3 class="text-[14px] font-semibold tracking-[-0.01em] text-heading">{f.title}</h3>
+          </div>
+          <p class="mt-2.5 text-[13px] leading-relaxed text-foreground/65">{f.body}</p>
+          <code class="mt-3.5 inline-flex items-center h-6 px-2 rounded-md bg-[#0c1224] text-[11px] font-mono text-sky-300 ring-1 ring-white/10">{f.code}</code>
+        </div>
+      ))}
+    </div>
   </div>
 </section>
+
+<style>
+  .tpl-texture {
+    background-image: radial-gradient(circle, rgb(15 23 42 / 0.07) 1px, transparent 1.2px);
+    background-size: 14px 14px;
+    -webkit-mask-image: radial-gradient(ellipse at 50% 45%, #000 30%, transparent 80%);
+    mask-image: radial-gradient(ellipse at 50% 45%, #000 30%, transparent 80%);
+  }
+
+  /* Motion is gated on .is-live (observer below), so nothing runs off screen. */
+  @media (prefers-reduced-motion: no-preference) {
+    .tpl.js-ready .tpl-code,
+    .tpl.js-ready .tpl-result { opacity: 0; }
+    .tpl.is-live .tpl-code {
+      animation: tpl-rise 620ms cubic-bezier(0.22, 1, 0.36, 1) both;
+    }
+    .tpl.is-live .tpl-result {
+      animation: tpl-rise 520ms cubic-bezier(0.22, 1, 0.36, 1) both,
+                 tpl-spot 9s ease-in-out infinite;
+      animation-delay: calc(var(--i) * 140ms + 200ms), calc(var(--i) * 3s + 1.2s);
+    }
+  }
+
+  @keyframes tpl-rise {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: none; }
+  }
+  /* A soft spotlight visits each rendered email in turn: one template, three
+     different emails, forever. */
+  @keyframes tpl-spot {
+    0%, 30%, 100% { box-shadow: 0 10px 30px -18px rgb(15 23 42 / 0.25); }
+    8%, 22% {
+      box-shadow: 0 18px 44px -18px rgb(2 132 199 / 0.35), 0 0 0 1.5px var(--brand);
+      transform: translateY(-2px);
+    }
+  }
+</style>
+
+<script is:inline>
+  // Arm hidden start states only when JS runs, so a script failure leaves
+  // the section fully visible.
+  document.querySelectorAll('.tpl').forEach((el) => el.classList.add('js-ready'));
+</script>
+
+<script>
+  const tpl = document.querySelector('.tpl');
+  if (tpl) {
+    new IntersectionObserver(
+      (entries) => entries.forEach((e) => tpl.classList.toggle('is-live', e.isIntersecting)),
+      { threshold: 0.12 },
+    ).observe(tpl);
+  }
+</script>

--- a/site/src/components/TemplatingShowcase.astro
+++ b/site/src/components/TemplatingShowcase.astro
@@ -26,7 +26,7 @@ const fields = [
   { token: '{{.Phone}}', value: '+1 555-0100' },
 ];
 ---
-<section class="border-y border-[color:var(--border)] bg-[color:var(--surface-1)]/40 py-20 md:py-28">
+<section class="py-20 md:py-28">
   <div class="container-page">
     <SectionHead
       eyebrow="Personalization / Templating"

--- a/site/src/components/WarmupPoolNotice.astro
+++ b/site/src/components/WarmupPoolNotice.astro
@@ -26,14 +26,14 @@ const { class: className = '', showWaitlist = true } = Astro.props;
     <div class="min-w-0">
       <div class="text-[10.5px] uppercase tracking-[0.18em] font-mono text-muted-foreground mb-1.5">Self-hosting and the warmup pool</div>
       <p class="text-[14px] text-foreground/80 leading-relaxed">
-        The shared warmup pool runs on Warmbly Cloud. It works because a large base of vetted mailboxes send and reply to each other, and any mailbox that starts landing in spam gets quarantined. A self-hosted instance starts with an empty pool, so warmup has no healthy partners to exchange mail with. To run your own pool you need many real, monitored mailboxes and the ongoing work to keep them clean.
+        The shared warmup pool runs on Warmbly Cloud, and self-hosted instances connect to it too. It works because a large base of vetted mailboxes send and reply to each other, and any mailbox that starts landing in spam gets quarantined, so pool quality holds no matter where your instance runs.
       </p>
       <p class="mt-2.5 text-[14px] text-foreground/80 leading-relaxed">
-        Everything else runs on your own infrastructure: sending, sequences, the unified inbox, CRM, tracking, and the API.
+        There is a free tier to start warming, and everything else runs on your own infrastructure: sending, sequences, the unified inbox, CRM, tracking, and the API.
       </p>
       {showWaitlist && (
         <a href="https://app.warmbly.com" class="mt-3 inline-flex items-center gap-1.5 text-[13px] font-medium text-[#0369a1] hover:text-[#075985]">
-          Want the pool without running the mailboxes? Join the cloud waitlist
+          Connect your instance to the pool
           <Icon name="arrowRight" size={12} />
         </a>
       )}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -17,6 +17,7 @@ import ChangelogShowcase from '../components/ChangelogShowcase.astro';
 import OpenSourceShowcase from '../components/OpenSourceShowcase.astro';
 import AutomationsShowcase from '../components/AutomationsShowcase.astro';
 import MobileAppShowcase from '../components/MobileAppShowcase.astro';
+import BentoGrid from '../components/BentoGrid.astro';
 
 const compare = [
   ['Per-mailbox cold cap',     '50 / day default',                 '200 / day if you ask for it'],
@@ -37,12 +38,18 @@ const plans = [
     href: 'https://app.warmbly.com/register?plan=starter',
     highlight: false,
     sendsPerDay: 150,
+    // Annual is 20% off, so the yearly saving is (monthly - annual) * 12.
+    save: '$72',
+    // Log-scaled so 150 -> 15,000 stays legible as a bar.
+    meter: 47,
+    // Daily volume is the headline number on the card, so it is deliberately
+    // not repeated as a bullet here.
     features: [
       'Unlimited warmup',
       'Unlimited mailboxes',
-      '150 emails / day',
-      'Unified inbox + reply detection',
-      'Sequences with branching',
+      'Unified inbox with reply detection',
+      'Sequences that stop on reply',
+      'Inbox placement monitoring',
     ],
   },
   {
@@ -55,12 +62,14 @@ const plans = [
     href: 'https://app.warmbly.com/register?plan=grow',
     highlight: false,
     sendsPerDay: 3000,
+    save: '$216',
+    meter: 76,
     features: [
-      'Unlimited warmup',
-      'Unlimited mailboxes',
-      '3,000 emails / day',
-      'CRM · pipelines · deals · tasks',
-      'API & HMAC-signed webhooks',
+      'Everything in Starter',
+      'CRM with pipelines and deals',
+      'A/B variants per step',
+      'Bulk contact import',
+      'API and signed webhooks',
     ],
   },
   {
@@ -73,11 +82,16 @@ const plans = [
     href: 'https://app.warmbly.com/register?plan=business',
     highlight: true,
     sendsPerDay: 15000,
+    save: '$792',
+    meter: 91,
+    // "Dedicated IPs" was the old wording. The mechanism is a whole worker
+    // machine bound to one org (plan.DedicatedWorkers > 0), and what that buys
+    // is reputation isolation, so the bullet says that instead.
     features: [
       'Everything in Grow',
-      '15,000 emails / day',
-      'Dedicated IPs',
-      'Team roles + audit log',
+      'Sending kept apart from other customers',
+      'Team roles and permissions',
+      'Full audit log',
       'Priority support',
     ],
   },
@@ -91,9 +105,11 @@ const plans = [
     href: '/contact/?topic=sales',
     highlight: false,
     sendsPerDay: Infinity,
+    save: '',
+    meter: 100,
     features: [
       'Everything in Business',
-      '15,000+ emails / day',
+      'Custom volume and contract',
       'BYOK encryption · SSO / SAML',
       'Custom data residency',
       'Dedicated CSM',
@@ -451,127 +467,8 @@ const softwareJsonLd = {
     <!-- ============================================================
          BENTO
     ============================================================ -->
-    <section class="container-page py-16 md:py-20">
-      <div class="max-w-3xl">
-        <div class="text-[11px] uppercase tracking-[0.16em] text-[color:var(--brand)] font-semibold mb-4">One platform</div>
-        <h2 class="text-[32px] md:text-[48px] font-semibold tracking-[-0.03em] leading-[1.04] text-heading">
-          Warmup, sending, inbox, engineered together.
-        </h2>
-        <p class="mt-4 text-foreground/75 leading-relaxed max-w-2xl">
-          The signal one part collects is the signal the next part acts on.
-        </p>
-      </div>
+    <BentoGrid />
 
-      <div class="mt-12 grid grid-cols-1 md:grid-cols-6 gap-3">
-        <div class="bento-card md:col-span-2 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col lift-on-hover" style="box-shadow: var(--shadow-sm);">
-          <Icon name="shield" class="text-[color:var(--brand)]" />
-          <h3 class="mt-4 text-[16px] font-semibold tracking-[-0.01em] text-heading">Quarantines on warning, not catastrophe</h3>
-          <p class="mt-2 text-[13.5px] text-foreground/70 leading-relaxed">
-            Watch band kicks in at 10% spam placement, months before mailbox providers act.
-          </p>
-          <div class="mt-auto pt-5 grid grid-cols-4 gap-1.5">
-            {['Healthy','Watch','Quarantined','Blocked'].map((b, i) => (
-              <div class={`bento-band rounded-md px-1.5 py-1 text-center text-[10px] font-semibold tracking-wider ring-1 ${
-                i === 0 ? 'ring-emerald-200 text-emerald-700 bg-emerald-50' :
-                i === 1 ? 'ring-amber-200 text-amber-700 bg-amber-50' :
-                i === 2 ? 'ring-orange-200 text-orange-700 bg-orange-50' :
-                          'ring-rose-200 text-rose-700 bg-rose-50'}`}>
-                {i === 0 && <span class="inline-block w-1 h-1 rounded-full bg-emerald-500 align-middle mr-1 animate-pulse-soft"></span>}{b}
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div class="bento-card md:col-span-2 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col lift-on-hover" style="box-shadow: var(--shadow-sm);">
-          <Icon name="chart" class="text-[color:var(--brand)]" />
-          <h3 class="mt-4 text-[16px] font-semibold tracking-[-0.01em] text-heading">Placement, not open rate</h3>
-          <p class="mt-2 text-[13.5px] text-foreground/70 leading-relaxed">
-            We probe inbox placement through the pool, then act on it.
-          </p>
-          <div class="mt-auto pt-5 flex items-center justify-center">
-            <div class="relative w-28 h-28">
-              <svg viewBox="0 0 36 36" class="w-full h-full -rotate-90">
-                <circle cx="18" cy="18" r="15.9" fill="none" stroke="#e2e8f0" stroke-width="2.6"></circle>
-                <circle cx="18" cy="18" r="15.9" fill="none" stroke="var(--brand)" stroke-width="2.6" stroke-dasharray="96 100" stroke-linecap="round" class="animate-ring-fill bento-ring"></circle>
-              </svg>
-              <div class="absolute inset-0 flex flex-col items-center justify-center">
-                <span class="text-xl font-semibold tracking-tight text-heading">96%</span>
-                <span class="text-[9.5px] uppercase tracking-wider text-muted-foreground">inbox</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="bento-card md:col-span-2 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-6 flex flex-col lift-on-hover" style="box-shadow: var(--shadow-sm);">
-          <Icon name="cpu" class="text-[color:var(--brand)]" />
-          <h3 class="mt-4 text-[16px] font-semibold tracking-[-0.01em] text-heading">Distributed across workers &amp; IPs</h3>
-          <p class="mt-2 text-[13.5px] text-foreground/70 leading-relaxed">
-            One worker per machine. Each with its own IP. Migrable on the fly.
-          </p>
-          <div class="mt-auto pt-5 space-y-2">
-            {[
-              { name: 'eu-worker-3', pct: 78 },
-              { name: 'us-worker-7', pct: 56 },
-              { name: 'eu-worker-1', pct: 41 },
-            ].map((w) => (
-              <div>
-                <div class="flex items-center justify-between text-[11.5px] font-mono text-muted-foreground mb-1">
-                  <span>{w.name}</span><span>{w.pct}%</span>
-                </div>
-                <div class="h-1.5 rounded-full bg-[color:var(--surface-2)] overflow-hidden">
-                  <div class="h-full rounded-full bg-[color:var(--brand)] animate-bar-grow bento-bar" style={`--target:${w.pct}%`}></div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div class="bento-card md:col-span-3 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-6 lift-on-hover" style="box-shadow: var(--shadow-sm);">
-          <Icon name="workflow" class="text-[color:var(--brand)]" />
-          <h3 class="mt-4 text-[16px] font-semibold tracking-[-0.01em] text-heading">Sequences with branching, A/B and TZ-aware delays</h3>
-          <p class="mt-2 text-[13.5px] text-foreground/70 leading-relaxed">
-            Up to 12 steps. Variants per step. Business-hour delays by recipient time zone.
-          </p>
-          <div class="mt-5 grid grid-cols-4 gap-2">
-            {[
-              { n: 'Step 1', t: 'Intro · plain text',  m: '2 variants' },
-              { n: 'Step 2', t: 'Wait 3 biz days',     m: 'if no reply' },
-              { n: 'Step 3', t: 'Follow-up · context', m: '4 variants' },
-              { n: 'Step 4', t: 'Soft break · 7 days', m: 'if no open' },
-            ].map((s) => (
-              <div class="bento-step rounded-[10px] ring-1 ring-[color:var(--border)] p-2.5">
-                <div class="flex items-center justify-between text-[9.5px] font-mono text-muted-foreground uppercase tracking-wider">
-                  <span>{s.n}</span><span class="text-foreground/60">{s.m}</span>
-                </div>
-                <div class="mt-1.5 text-[12px] font-medium text-heading leading-snug">{s.t}</div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div class="bento-card md:col-span-3 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] p-6 lift-on-hover" style="box-shadow: var(--shadow-sm);">
-          <Icon name="users" class="text-[color:var(--brand)]" />
-          <h3 class="mt-4 text-[16px] font-semibold tracking-[-0.01em] text-heading">Vetted pool, real reputation surface</h3>
-          <p class="mt-2 text-[13.5px] text-foreground/70 leading-relaxed">
-            Premium pool diversity across Gmail, Outlook, iCloud, Yahoo and self-hosted IMAP.
-          </p>
-          <div class="mt-5 grid grid-cols-5 gap-2">
-            {[
-              { name: 'Gmail',     pct: 46 },
-              { name: 'Outlook',   pct: 24 },
-              { name: 'Yahoo',     pct: 12 },
-              { name: 'iCloud',    pct:  9 },
-              { name: 'Self-IMAP', pct:  9 },
-            ].map((p) => (
-              <div class="rounded-[10px] ring-1 ring-[color:var(--border)] p-2.5">
-                <div class="text-[11px] font-medium text-heading">{p.name}</div>
-                <div class="text-[11px] text-muted-foreground font-mono">{p.pct}%</div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
 
     <!-- ============================================================
          PRICING — annual default, premium segmented toggle
@@ -612,40 +509,82 @@ const softwareJsonLd = {
     <section class="relative -mt-32 md:-mt-40 pb-16 md:pb-20 z-10">
       <div class="container-page">
 
-        <!-- Edge-to-edge grid: cards share borders via gap-px, no per-card ring.
-             The whole grid sits inside a single rounded ring. -->
-        <div class="mt-12 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 ring-1 ring-[color:var(--border-strong)] rounded-[10px] overflow-hidden">
-          {plans.map((p, idx) => (
-            <div class={`pricing-card relative flex flex-col bg-white p-7 border-[color:var(--border-strong)] ${idx === 0 ? '' : idx === 1 ? 'border-t sm:border-t-0 sm:border-l' : idx === 2 ? 'border-t lg:border-t-0 lg:border-l' : 'border-t lg:border-t-0 sm:border-l'}`} data-card-idx={idx}>
-              <div class="relative flex flex-col h-full">
-                {p.highlight && (
-                  <span class="absolute -top-2 right-0 inline-flex items-center h-6 px-2.5 rounded-full text-[10px] font-semibold uppercase tracking-[0.10em] bg-[color:var(--brand)] text-white shadow-[0_4px_12px_-2px_rgba(2,132,199,0.55)]">
-                    Most popular
-                  </span>
-                )}
-                <h3 class={`text-[14px] font-semibold uppercase tracking-[0.12em] ${p.highlight ? 'text-[color:var(--brand)]' : 'text-heading'}`}>{p.name}</h3>
-                <p class="mt-1.5 text-[12.5px] text-muted-foreground leading-snug min-h-[40px]">{p.summary}</p>
+        <!-- One panel, four joined columns sharing 1px dividers. The featured
+             plan is marked by a tint and a top accent rule rather than by
+             elevation, so the row stays a single connected surface. -->
+        <div class="pricing-grid mt-12 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] overflow-hidden shadow-[0_18px_50px_-28px_rgba(15,23,42,0.32)]">
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
+            {plans.map((p, idx) => (
+            <div
+              class:list={[
+                'pricing-card relative flex flex-col p-6 border-[color:var(--border)]',
+                p.highlight && 'bg-[color:var(--surface-2)]',
+                idx === 0 ? ''
+                  : idx === 1 ? 'border-t sm:border-t-0 sm:border-l'
+                  : idx === 2 ? 'border-t lg:border-t-0 lg:border-l'
+                  : 'border-t lg:border-t-0 sm:border-l',
+              ]}
+            >
+              {p.highlight && (
+                <span class="absolute inset-x-0 top-0 h-[3px] bg-[color:var(--brand)]"></span>
+              )}
 
-                <div class="mt-6 flex items-baseline gap-1.5">
-                  <span class="text-[48px] font-semibold tracking-[-0.04em] text-heading leading-none flex items-baseline">
-                    <span class="plan-price relative inline-block overflow-hidden h-[48px] align-baseline" data-monthly={p.price} data-annual={p.annual}>
-                      <span class="plan-price-inner block leading-[48px]" style="transform: translateY(0)">{p.annual}</span>
+              <div class="relative flex flex-col h-full">
+                <div class="flex items-center justify-between gap-2 h-6">
+                  <h3 class={`text-[13px] font-semibold uppercase tracking-[0.12em] ${p.highlight ? 'text-[color:var(--brand)]' : 'text-heading'}`}>{p.name}</h3>
+                  {p.highlight && (
+                    <span class="inline-flex items-center h-[22px] px-2 rounded-full text-[9.5px] font-semibold uppercase tracking-[0.10em] bg-[color:var(--brand)] text-white shadow-[0_4px_12px_-2px_rgba(2,132,199,0.55)] whitespace-nowrap">
+                      Most popular
+                    </span>
+                  )}
+                </div>
+                <p class="mt-2 text-[12.5px] text-muted-foreground leading-snug min-h-[36px]">{p.summary}</p>
+
+                <div class="mt-5 flex items-baseline gap-2">
+                  <span class="text-[44px] font-semibold tracking-[-0.04em] text-heading leading-none flex items-baseline">
+                    <span class="plan-price relative inline-block overflow-hidden h-[44px] align-baseline" data-monthly={p.price} data-annual={p.annual}>
+                      <span class="plan-price-inner block leading-[44px]" style="transform: translateY(0)">{p.annual}</span>
                     </span>
                   </span>
+                  {p.save && (
+                    <span class="plan-swap text-[15px] text-muted-foreground/60 line-through" data-monthly="" data-annual={p.price}>{p.price}</span>
+                  )}
                 </div>
                 <p class="mt-2 text-[11.5px] text-muted-foreground">
                   <span class="cadence" data-monthly="/ month · billed monthly" data-annual="/ month · billed yearly">/ month · billed yearly</span>
                 </p>
+                {/* Rendered even when empty so every card's CTA sits on the
+                    same line; Enterprise has no yearly saving to show. */}
+                <p class="mt-1.5 h-[18px]">
+                  {p.save && (
+                    <span
+                      class="plan-swap inline-flex items-center px-1.5 py-0.5 rounded text-[10.5px] font-semibold bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200"
+                      data-monthly=""
+                      data-annual={`Save ${p.save} a year`}
+                    >Save {p.save} a year</span>
+                  )}
+                </p>
 
-                {/* sends per day visual chip */}
-                <div class="mt-4 inline-flex items-center gap-1.5 text-[11px] font-mono text-muted-foreground self-start">
-                  <Icon name="zap" size={10} class="text-[color:var(--brand)]" />
-                  <span>{p.sendsPerDay === Infinity ? '15,000+' : p.sendsPerDay.toLocaleString()} sends / day</span>
+                {/* Daily send volume, the thing each tier actually buys. */}
+                <div class="mt-5">
+                  <div class="flex items-baseline justify-between text-[11px] mb-1.5">
+                    <span class="font-mono text-heading">
+                      {p.sendsPerDay === Infinity ? '15,000+' : p.sendsPerDay.toLocaleString()}
+                    </span>
+                    <span class="text-muted-foreground">sends / day</span>
+                  </div>
+                  {/* Static width: no .bar-fill hook, so nothing animates it. */}
+                  <div class={`h-1 rounded-full overflow-hidden ${p.highlight ? 'bg-white' : 'bg-[color:var(--surface-2)]'}`}>
+                    <span
+                      class={`block h-full rounded-full ${p.highlight ? 'bg-[color:var(--brand)]' : 'bg-[color:var(--border-strong)]'}`}
+                      style={`width:${p.meter}%`}
+                    ></span>
+                  </div>
                 </div>
 
                 <a
                   href={p.href}
-                  class={`mt-7 inline-flex h-11 px-4 items-center justify-center w-full rounded-[10px] text-[14px] font-medium transition-colors ${
+                  class={`mt-6 inline-flex h-11 px-4 items-center justify-center w-full rounded-[10px] text-[14px] font-medium transition-colors ${
                     p.highlight
                       ? 'bg-[color:var(--brand)] text-white hover:bg-[color:var(--brand-strong)] shadow-[0_10px_24px_-10px_rgba(2,132,199,0.65)]'
                       : 'bg-foreground text-background hover:bg-foreground/85'
@@ -654,12 +593,12 @@ const softwareJsonLd = {
                   {p.cta}
                 </a>
 
-                <div class="my-6 h-px bg-[color:var(--border)]"></div>
+                <div class="my-5 h-px bg-[color:var(--border)]"></div>
                 <ul class="space-y-2.5 text-[13px] text-foreground/90">
                   {p.features.map((f) => (
                     <li class="flex items-start gap-2">
-                      <span class={`mt-1 shrink-0 w-3.5 h-3.5 rounded-full inline-flex items-center justify-center ${p.highlight ? 'bg-[color:var(--brand-soft)] text-[color:var(--brand)]' : 'bg-[color:var(--surface-2)] text-foreground/55'}`}>
-                        <Icon name="check" size={9} />
+                      <span class={`mt-[3px] shrink-0 w-4 h-4 rounded-full inline-flex items-center justify-center ${p.highlight ? 'bg-[color:var(--brand)] text-white' : 'bg-[color:var(--surface-2)] text-foreground/55'}`}>
+                        <Icon name="check" size={10} strokeWidth={2.5} />
                       </span>
                       <span>{f}</span>
                     </li>
@@ -667,7 +606,8 @@ const softwareJsonLd = {
                 </ul>
               </div>
             </div>
-          ))}
+            ))}
+          </div>
         </div>
 
         <div class="mt-12 flex flex-wrap items-center justify-center gap-2 text-[13px] text-muted-foreground">
@@ -677,7 +617,7 @@ const softwareJsonLd = {
           </a>
         </div>
         <p class="mt-3 text-center text-[12.5px] text-muted-foreground/85 max-w-xl mx-auto leading-relaxed">
-          The free tier is a limited demo with an unfilled warmup pool. Use it to see what the product does, not to send at volume.
+          The free tier includes access to the shared warmup pool, so a new mailbox can start building reputation before you pay for sending volume.
         </p>
       </div>
     </section>
@@ -788,21 +728,6 @@ const softwareJsonLd = {
       animation: send-spark-anim 3s cubic-bezier(0.22, 1, 0.36, 1) infinite;
     }
 
-    /* Pricing card sweep — subtle highlight crosses the featured card forever */
-    @keyframes pricing-sweep-anim {
-      0%   { transform: translateX(-120%); opacity: 0; }
-      45%  { opacity: 0.55; }
-      100% { transform: translateX(120%); opacity: 0; }
-    }
-    .pricing-sweep {
-      background: linear-gradient(115deg,
-        transparent 0%,
-        transparent 40%,
-        rgba(125,211,252,0.45) 50%,
-        transparent 60%,
-        transparent 100%);
-      animation: pricing-sweep-anim 5s ease-in-out infinite;
-    }
 
     /* Scroll-in fades — only applied once .js-ready is set on <html>,
        so content stays visible if JS / motion fails to load. */
@@ -832,41 +757,6 @@ const softwareJsonLd = {
       animation-play-state: paused;
     }
 
-    /* "One platform" bento: continuous, living data viz. */
-    @media (prefers-reduced-motion: no-preference) {
-      /* health states: a highlight walks Healthy -> Blocked on a loop */
-      .bento-band { animation: bento-band 5s ease-in-out infinite; }
-      .bento-band:nth-child(1) { animation-delay: 0s; }
-      .bento-band:nth-child(2) { animation-delay: -3.75s; }
-      .bento-band:nth-child(3) { animation-delay: -2.5s; }
-      .bento-band:nth-child(4) { animation-delay: -1.25s; }
-      @keyframes bento-band {
-        0%, 16%, 100% { transform: translateY(0); filter: none; }
-        8%            { transform: translateY(-3px); filter: brightness(1.07); }
-      }
-      /* worker bars: a shimmer sweeps the filled bar (live sending) */
-      .bento-bar { position: relative; overflow: hidden; }
-      .bento-bar::after {
-        content: ''; position: absolute; inset: 0;
-        background: linear-gradient(90deg, transparent 0%, rgba(255,255,255,0.6) 50%, transparent 100%);
-        transform: translateX(-130%);
-        animation: bento-shimmer 3.4s ease-in-out infinite;
-      }
-      @keyframes bento-shimmer { 0% { transform: translateX(-130%); } 55%, 100% { transform: translateX(260%); } }
-      /* sequence steps: a sky highlight steps through 1 -> 4 */
-      .bento-step { animation: bento-step 5.6s ease-in-out infinite; }
-      .bento-step:nth-child(1) { animation-delay: 0s; }
-      .bento-step:nth-child(2) { animation-delay: -4.2s; }
-      .bento-step:nth-child(3) { animation-delay: -2.8s; }
-      .bento-step:nth-child(4) { animation-delay: -1.4s; }
-      @keyframes bento-step {
-        0%, 16%, 100% { box-shadow: none; }
-        8%            { box-shadow: 0 0 0 2px var(--brand-soft); }
-      }
-    }
-    @media (hover: hover) and (prefers-reduced-motion: no-preference) {
-      .bento-card:hover .bento-ring { animation: ring-fill 1.1s cubic-bezier(0.22, 1, 0.36, 1) both; }
-    }
   </style>
   <script is:inline>
     // Tag the document so the CSS above can hide fade-in targets only when JS is alive.
@@ -908,11 +798,12 @@ const softwareJsonLd = {
         }, { amount: 0.12 });
       });
     };
-    tag('.pricing-card',    0.10);
+    // The panel reveals as one surface; staggering the joined columns would
+    // pop them in one by one inside their own shared border.
+    tag('.pricing-grid',    0);
     tag('.step-card',       0.10);
     tag('.feature-card',    0.10);
     tag('.metric-cell',     0.06);
-    tag('.bento-card',      0.06);
 
     // ── Bar grow on scroll ──────────────────────────────────────────
     document.querySelectorAll('.bar-fill').forEach((el) => {
@@ -1014,6 +905,14 @@ const softwareJsonLd = {
             return;
           }
           animatePrice(el, next);
+        });
+        // Struck monthly price and the yearly-saving badge. Unlike .cadence
+        // these are empty on monthly, so an empty value has to clear them
+        // rather than be treated as "nothing to do".
+        document.querySelectorAll('.plan-swap').forEach((el) => {
+          const next = el.getAttribute(`data-${mode}`) || '';
+          el.textContent = next;
+          el.classList.toggle('hidden', next === '');
         });
         // Cadence text gets a soft fade-swap so it never just snaps.
         document.querySelectorAll('.cadence').forEach((el) => {

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -19,12 +19,8 @@ import AutomationsShowcase from '../components/AutomationsShowcase.astro';
 import MobileAppShowcase from '../components/MobileAppShowcase.astro';
 import BentoGrid from '../components/BentoGrid.astro';
 
-const compare = [
-  ['Per-mailbox cold cap',     '50 / day default',                 '200 / day if you ask for it'],
-  ['Warmup pool quality',      'Vetted, monitored, quarantined',   'Shared with trial mailboxes'],
-  ['Reputation reaction',      'Acts on the watch band (10%)',     'Acts on the catastrophe band (80%)'],
-  ['Worker concentration',     'Capped by sum of mailbox budgets', 'Flat per-worker ceiling'],
-];
+// "How we differ": warmup ramp bars for the guardrails card (10 -> 40, +1/day).
+const diffRamp = [25, 32, 40, 47, 55, 62, 70, 77, 85, 92, 100];
 
 // Mirrors web/src/lib/plans.ts — single source of truth.
 const plans = [
@@ -434,32 +430,110 @@ const softwareJsonLd = {
         </div>
       </div>
 
-      <div class="overflow-hidden rounded-[10px] ring-1 ring-[color:var(--border)] bg-white">
-        <table class="w-full text-[13.5px]">
-          <thead>
-            <tr class="border-b border-[color:var(--border)] bg-[color:var(--surface-2)]/60">
-              <th class="text-left font-medium text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground py-3.5 px-5">Setting</th>
-              <th class="text-left font-medium text-[10.5px] uppercase tracking-[0.16em] text-[color:var(--brand)] py-3.5 px-5">Warmbly</th>
-              <th class="text-left font-medium text-[10.5px] uppercase tracking-[0.16em] text-muted-foreground py-3.5 px-5">Typical cold-email tool</th>
-            </tr>
-          </thead>
-          <tbody class="divide-y divide-[color:var(--border)]">
-            {[
-              { k: 'Per-mailbox cold cap',     ours: '50 / day default',                  theirs: '200+ / day on request' },
-              { k: 'Warmup pool composition',  ours: 'Vetted, monitored, quarantined',    theirs: 'Mixed with trial mailboxes' },
-              { k: 'Reputation response',      ours: 'Acts at 10% spam placement',        theirs: 'Acts at 80%+ spam placement' },
-              { k: 'Worker concentration',     ours: 'Sum of mailbox budgets',            theirs: 'Flat per-worker ceiling' },
-              { k: 'Auth validation on connect', ours: 'SPF · DKIM · DMARC checked',      theirs: 'Manual DNS setup, no check' },
-              { k: 'Source available',         ours: 'Apache 2.0 on GitHub',              theirs: 'Closed source' },
-            ].map((r) => (
-              <tr class="hover:bg-[color:var(--surface-2)]/30 transition-colors">
-                <td class="py-3.5 px-5 font-medium text-heading">{r.k}</td>
-                <td class="py-3.5 px-5 text-foreground">{r.ours}</td>
-                <td class="py-3.5 px-5 text-muted-foreground">{r.theirs}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      <!-- Six guardrails, drawn instead of written, joined into one panel the
+           way pricing is: shared 1px dividers, one ring, no gaps. -->
+      <div class="diff-panel mt-4 rounded-[14px] bg-white ring-1 ring-[color:var(--border)] overflow-hidden shadow-[0_18px_50px_-28px_rgba(15,23,42,0.32)]">
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3">
+
+        <!-- 1 · Daily cap: our fill stops at the cap; the rest of the track
+             is where others go. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)]">
+          <div class="h-[88px] flex flex-col justify-center">
+            <div class="relative h-2 rounded-full bg-slate-200/70">
+              <span class="bar-fill absolute inset-y-0 left-0 rounded-full bg-[color:var(--brand)]" data-target="25%"></span>
+              <span class="absolute left-[25%] top-1/2 -translate-y-1/2 w-[3px] h-4 rounded-full bg-[color:var(--sky-6)]"></span>
+            </div>
+            <div class="relative mt-2 h-4 text-[10px] font-mono">
+              <span class="absolute left-[25%] -translate-x-1/2 text-[color:var(--brand-strong)] font-semibold whitespace-nowrap">50, our cap</span>
+              <span class="absolute right-0 text-muted-foreground/60">200+, elsewhere</span>
+            </div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">50 a day per mailbox</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">The default cap. Raising it takes proof, not a request.</p>
+        </div>
+
+        <!-- 2 · Spacing: even dots vs a burst. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)] border-t sm:border-t-0 sm:border-l">
+          <div class="h-[88px] flex flex-col justify-center gap-4">
+            <div>
+              <div class="flex items-center justify-between">
+                {[0, 1, 2, 3, 4, 5].map(() => <span class="w-2 h-2 rounded-full bg-[color:var(--brand)]"></span>)}
+              </div>
+              <div class="mt-1.5 text-[10px] font-mono text-[color:var(--brand-strong)] font-semibold">10 minutes apart, always</div>
+            </div>
+            <div>
+              <div class="flex items-center gap-[3px]">
+                {[0, 1, 2, 3, 4, 5].map(() => <span class="w-2 h-2 rounded-full bg-slate-300"></span>)}
+              </div>
+              <div class="mt-1.5 text-[10px] font-mono text-muted-foreground/60">bursts, elsewhere</div>
+            </div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">Sends are spaced out</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">600 seconds minimum between two emails from one mailbox.</p>
+        </div>
+
+        <!-- 3 · Quarantine line: one axis, two markers. The whole argument. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)] border-t lg:border-t-0 lg:border-l">
+          <div class="h-[88px] flex flex-col justify-center">
+            <div class="relative">
+              <div class="h-2 rounded-full" style="background: linear-gradient(90deg, #34d399 0%, #fbbf24 35%, #f43f5e 85%);"></div>
+              <span class="absolute left-[10%] -translate-x-1/2 top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white ring-[2.5px] ring-[color:var(--sky-6)]"></span>
+              <span class="absolute left-[80%] -translate-x-1/2 top-1/2 -translate-y-1/2 w-3 h-3 rounded-full bg-white ring-[2.5px] ring-slate-300"></span>
+            </div>
+            <div class="relative mt-2.5 h-8 text-[10px] font-mono">
+              <span class="absolute left-[10%] -translate-x-1/2 text-center text-[color:var(--brand-strong)] font-semibold leading-tight">10%<br />we quarantine</span>
+              <span class="absolute left-[80%] -translate-x-1/2 text-center text-muted-foreground/60 leading-tight">80%<br />others react</span>
+            </div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">Acts before it hurts</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">A mailbox is pulled at 10% spam placement, not 80%.</p>
+        </div>
+
+        <!-- 4 · Warmup ramp: the staircase. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)] border-t sm:border-l lg:border-l-0">
+          <div class="h-[88px] flex flex-col justify-end">
+            <div class="flex items-end gap-[4px] h-[60px]">
+              {diffRamp.map((v) => (
+                <span class="flex-1 rounded-t-[3px] bg-gradient-to-t from-sky-500/90 to-sky-300/90" style={`height:${v}%`}></span>
+              ))}
+            </div>
+            <div class="mt-1.5 flex justify-between text-[10px] font-mono">
+              <span class="text-[color:var(--brand-strong)] font-semibold">10 / day</span>
+              <span class="text-[color:var(--brand-strong)] font-semibold">40 / day</span>
+            </div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">Warmup climbs by one</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">One more email per day. Elsewhere: full volume on day one.</p>
+        </div>
+
+        <!-- 5 · Auth checks: three green pills. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)] border-t lg:border-l">
+          <div class="h-[88px] flex flex-col justify-center gap-2">
+            <div class="flex flex-wrap gap-1.5">
+              {['SPF', 'DKIM', 'DMARC'].map((c) => (
+                <span class="inline-flex items-center gap-1 h-6 px-2 rounded-full text-[10.5px] font-mono font-semibold bg-emerald-50 text-emerald-700 ring-1 ring-emerald-200">
+                  <Icon name="check" size={10} strokeWidth={2.5} />{c}
+                </span>
+              ))}
+            </div>
+            <div class="text-[10px] font-mono text-muted-foreground/60">elsewhere: paste DNS records, hope</div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">Verified on connect</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">A mailbox does not send until its auth records check out.</p>
+        </div>
+
+        <!-- 6 · Open source: the actual constant. -->
+        <div class="p-5 md:p-6 border-[color:var(--border)] border-t sm:border-l">
+          <div class="h-[88px] flex items-center">
+            <div class="w-full rounded-[10px] bg-[#0c1224] ring-1 ring-white/10 px-3.5 py-3 font-mono text-[11.5px] leading-[1.8]">
+              <div class="text-white/35">// constants.go</div>
+              <div><span class="text-sky-300">CampaignLimitDefault</span><span class="text-white/60"> = </span><span class="text-emerald-300">50</span></div>
+            </div>
+          </div>
+          <div class="mt-3 text-[15px] font-semibold tracking-[-0.01em] text-heading">Read the defaults</div>
+          <p class="mt-1 text-[12.5px] text-foreground/65 leading-snug">Every number on this page is open source. Elsewhere: trust us.</p>
+        </div>
+        </div>
       </div>
     </section>
 
@@ -801,6 +875,7 @@ const softwareJsonLd = {
     // The panel reveals as one surface; staggering the joined columns would
     // pop them in one by one inside their own shared border.
     tag('.pricing-grid',    0);
+    tag('.diff-panel',      0);
     tag('.step-card',       0.10);
     tag('.feature-card',    0.10);
     tag('.metric-cell',     0.06);


### PR DESCRIPTION
Redesigns every major section of the marketing index around one visual system: a tinted plinth carrying real product UI, artifacts that bleed off the card edge and dissolve into a mask fade, and one floating element on top. Motion is viewport-gated throughout, so ambient loops stop when a section scrolls away.

## Sections

**Bento** — rebuilt as five layered product-UI cards (unified inbox, warmup ramp, branching sequence, inbox placement, personalization). The distributed-workers/IPs card is gone; the remaining features are the ones a customer recognizes. Each artifact has one continuous loop.

**How we differ** — the comparison table is replaced by six drawn guardrails joined into a single connected panel: the cap bar, send-spacing dots, a 10%-vs-80% quarantine axis, the warmup staircase, SPF/DKIM/DMARC pills, and the real `CampaignLimitDefault = 50` constant.

**Changelog** — a plinth release feed on a rail, older entries dissolving off the bottom. Columns mirrored against the open-source split below so the two do not stack identically.

**Open source** — the dark cloud-gradient band becomes a light repo browser (real top-level tree, GitHub linguist colors) with the self-host terminal floating over it as the only dark element.

**Personalization** — one template panel beside three recipient results showing the `if` branch, the `else` branch, and the `default` fallback, plus a feature grid covering custom CSV fields with spaces, coercing helpers, nested spintax, per-step A/B variants, real-engine preview, and launch-blocking validation.

**Pricing** — tiers joined into one connected panel, with the yearly saving shown per plan and log-scaled volume meters. `Dedicated IPs` becomes `Sending kept apart from other customers`.

## Copy changes

Self-hosted instances now connect to the shared warmup pool, and there is a free tier. Updated in `OpenSourceShowcase`, `WarmupPoolNotice`, and the pricing footnote.

## Notes

- Every claim was checked against the source before shipping. The constant name, the templating feature set (`internal/tasks/template.go`, `internal/pkg/tmplfuncs`, `spintax.go`), and the dedicated-worker mechanism (`internal/app/worker/assignment.go`) are all verified. The dedicated-IP wording avoids promising a guarantee because assignment falls through to shared placement when no dedicated worker is free.
- Removed dead code: the unused `compare` const, `.pricing-sweep` (defined but applied to nothing), `data-card-idx`, and the `--surface-1` token which was never defined in `global.css`.
- `prefers-reduced-motion` opt-outs added throughout, including for `.pricing-sweep`, which the global reduce rule never covered.

Verified with `pnpm build` (45 pages, clean), which is what Site CI gates on. Not visually reviewed in a browser.