### PR TITLE
fix: drop a deactivated mailbox from its worker, and stop calling a revoked OAuth grant an unreachable mail server (#196)

### DIFF
--- a/internal/app/consumer/deactivate_account_test.go
+++ b/internal/app/consumer/deactivate_account_test.go
@@ -1,0 +1,223 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/events"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// stubEmailRepo answers the two calls deactivation makes. Embedding the
+// interface keeps the stub to those two; anything else panics loudly rather
+// than passing silently.
+type stubEmailRepo struct {
+	repository.EmailRepository
+
+	workerID    *uuid.UUID
+	workerErr   *errx.Error
+	updateErr   *errx.Error
+	statusSet   []string
+	updateCalls int
+	workerCalls int
+}
+
+func (s *stubEmailRepo) Update(ctx context.Context, userID, emailAccountID string, udata *models.UpdateEmail) (*models.Email, *errx.Error) {
+	s.updateCalls++
+	if udata.Status != nil {
+		s.statusSet = append(s.statusSet, *udata.Status)
+	}
+	if s.updateErr != nil {
+		return nil, s.updateErr
+	}
+	// Deliberately mirrors the real repository: its RETURNING list carries the
+	// mailbox as the dashboard sees it and no worker assignment. Reading
+	// WorkerID off this row is what made the removal unreachable the first
+	// time, so the stub must keep lying about it in exactly the same way.
+	id, _ := uuid.Parse(emailAccountID)
+	return &models.Email{ID: id, Status: "inactive"}, nil
+}
+
+func (s *stubEmailRepo) GetWorkerID(ctx context.Context, emailAccountID uuid.UUID) (*uuid.UUID, *errx.Error) {
+	s.workerCalls++
+	return s.workerID, s.workerErr
+}
+
+// stubPublisher records the removals published to workers.
+type stubPublisher struct {
+	events.Publisher
+
+	err     error
+	removed []removal
+}
+
+type removal struct {
+	workerID uuid.UUID
+	userID   string
+	emailID  string
+}
+
+func (p *stubPublisher) PublishRemoveEmail(ctx context.Context, workerID uuid.UUID, remove *models.RemoveWorkerEmail) error {
+	p.removed = append(p.removed, removal{workerID: workerID, userID: remove.UserID, emailID: remove.EmailID})
+	return p.err
+}
+
+func newDeactivationFixture(worker *uuid.UUID) (*JobsService, *stubEmailRepo, *stubPublisher) {
+	repo := &stubEmailRepo{workerID: worker}
+	pub := &stubPublisher{}
+	return &JobsService{EmailRepository: repo, Publisher: pub}, repo, pub
+}
+
+func TestDeactivateAccountTellsTheWorkerToDropTheMailbox(t *testing.T) {
+	workerID := uuid.New()
+	userID := uuid.New()
+	emailID := uuid.New()
+	s, repo, pub := newDeactivationFixture(&workerID)
+
+	s.deactivateAccount(context.Background(), userID, emailID)
+
+	if len(repo.statusSet) != 1 || repo.statusSet[0] != "inactive" {
+		t.Errorf("status writes = %v, want one \"inactive\"", repo.statusSet)
+	}
+	if len(pub.removed) != 1 {
+		t.Fatalf("published %d removals, want 1: the worker keeps syncing a dead mailbox until it restarts", len(pub.removed))
+	}
+	got := pub.removed[0]
+	if got.workerID != workerID {
+		t.Errorf("removal sent to worker %s, want %s", got.workerID, workerID)
+	}
+	if got.userID != userID.String() || got.emailID != emailID.String() {
+		t.Errorf("removal carried user=%s email=%s, want user=%s email=%s", got.userID, got.emailID, userID, emailID)
+	}
+}
+
+func TestDeactivateAccountSkipsAnUnassignedMailbox(t *testing.T) {
+	s, repo, pub := newDeactivationFixture(nil)
+
+	s.deactivateAccount(context.Background(), uuid.New(), uuid.New())
+
+	if repo.updateCalls != 1 {
+		t.Errorf("update called %d times, want 1", repo.updateCalls)
+	}
+	if len(pub.removed) != 0 {
+		t.Errorf("published %d removals for a mailbox on no worker, want 0", len(pub.removed))
+	}
+}
+
+// A status write that failed means the mailbox is still active, so publishing
+// the removal would strand it: loaded on no worker, active in the database,
+// and only the reconciler's next pass to put it back.
+func TestDeactivateAccountDoesNotRemoveWhenTheStatusWriteFails(t *testing.T) {
+	workerID := uuid.New()
+	s, repo, pub := newDeactivationFixture(&workerID)
+	repo.updateErr = errx.InternalError()
+
+	s.deactivateAccount(context.Background(), uuid.New(), uuid.New())
+
+	if len(pub.removed) != 0 {
+		t.Errorf("published %d removals after a failed status write, want 0", len(pub.removed))
+	}
+	if repo.workerCalls != 0 {
+		t.Errorf("looked up the assignment %d times after a failed status write, want 0", repo.workerCalls)
+	}
+}
+
+func TestDeactivateAccountSurvivesAnAssignmentLookupFailure(t *testing.T) {
+	s, repo, pub := newDeactivationFixture(nil)
+	repo.workerErr = errx.ErrNotFound
+
+	s.deactivateAccount(context.Background(), uuid.New(), uuid.New())
+
+	if len(pub.removed) != 0 {
+		t.Errorf("published %d removals on a failed lookup, want 0", len(pub.removed))
+	}
+}
+
+// A publish failure is logged, not fatal: the account is already inactive and
+// the worker drops the mailbox on its next restart.
+func TestDeactivateAccountToleratesAPublishFailure(t *testing.T) {
+	workerID := uuid.New()
+	s, _, pub := newDeactivationFixture(&workerID)
+	pub.err = errors.New("bus down")
+
+	s.deactivateAccount(context.Background(), uuid.New(), uuid.New())
+
+	if len(pub.removed) != 1 {
+		t.Errorf("published %d removals, want 1 attempt", len(pub.removed))
+	}
+}
+
+// The consumer runs with pieces unwired in tests and in reduced deployments.
+func TestDeactivateAccountWithNothingWired(t *testing.T) {
+	(&JobsService{}).deactivateAccount(context.Background(), uuid.New(), uuid.New())
+
+	repo := &stubEmailRepo{}
+	(&JobsService{EmailRepository: repo}).deactivateAccount(context.Background(), uuid.New(), uuid.New())
+	if repo.updateCalls != 1 {
+		t.Errorf("update called %d times with no publisher wired, want 1", repo.updateCalls)
+	}
+	if repo.workerCalls != 0 {
+		t.Errorf("looked up the assignment %d times with no publisher wired, want 0", repo.workerCalls)
+	}
+}
+
+// Every worker-raised deactivation has to reach the worker, not just the one
+// that happened to be debugged. These run the real handlers end to end.
+func TestEveryDeactivationPathRemovesTheMailboxFromItsWorker(t *testing.T) {
+	handlers := map[string]func(*JobsService, context.Context, models.EmailErrorEvent) error{
+		"auth error":   (*JobsService).HandleEmailAuthError,
+		"disabled":     (*JobsService).HandleEmailDisabled,
+		"rate limited": (*JobsService).HandleEmailRateLimited,
+	}
+
+	for name, handle := range handlers {
+		t.Run(name, func(t *testing.T) {
+			workerID := uuid.New()
+			userID := uuid.New()
+			emailID := uuid.New()
+			s, repo, pub := newDeactivationFixture(&workerID)
+
+			event := models.EmailErrorEvent{
+				EmailAccountID: emailID.String(),
+				UserID:         userID.String(),
+				ErrorCode:      "AUTHENTICATION_FAILED",
+				ErrorType:      "critical",
+				Message:        "the grant is gone",
+			}
+			if err := handle(s, context.Background(), event); err != nil {
+				t.Fatalf("handler returned %v", err)
+			}
+
+			if len(repo.statusSet) != 1 || repo.statusSet[0] != "inactive" {
+				t.Errorf("status writes = %v, want one \"inactive\"", repo.statusSet)
+			}
+			if len(pub.removed) != 1 {
+				t.Fatalf("published %d removals, want 1", len(pub.removed))
+			}
+			if pub.removed[0].workerID != workerID || pub.removed[0].emailID != emailID.String() {
+				t.Errorf("removal = %+v, want worker %s and mailbox %s", pub.removed[0], workerID, emailID)
+			}
+		})
+	}
+}
+
+// A malformed event must not be answered with a status write or a removal.
+func TestHandlersRejectAMalformedEventBeforeDeactivating(t *testing.T) {
+	workerID := uuid.New()
+	s, repo, pub := newDeactivationFixture(&workerID)
+
+	err := s.HandleEmailAuthError(context.Background(), models.EmailErrorEvent{
+		EmailAccountID: "not-a-uuid",
+		UserID:         uuid.New().String(),
+	})
+	if err == nil {
+		t.Error("a malformed email account id was accepted")
+	}
+	if repo.updateCalls != 0 || len(pub.removed) != 0 {
+		t.Errorf("acted on a malformed event: %d updates, %d removals", repo.updateCalls, len(pub.removed))
+	}
+}

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -57,7 +57,7 @@ func (s *JobsService) HandleEmailAuthError(ctx context.Context, event models.Ema
 	}
 
 	// Mark email account as needing re-auth (set status to inactive)
-	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
+	s.deactivateAccount(ctx, userID, emailAccountID)
 
 	// Send Pub/Sub notification to user
 	if s.StreamingPublisher != nil && event.UserVisible {
@@ -122,7 +122,7 @@ func (s *JobsService) HandleEmailDisabled(ctx context.Context, event models.Emai
 	}
 
 	// Mark email account as inactive
-	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
+	s.deactivateAccount(ctx, userID, emailAccountID)
 
 	// Send Pub/Sub notification to user
 	if s.StreamingPublisher != nil && event.UserVisible {
@@ -187,7 +187,7 @@ func (s *JobsService) HandleEmailRateLimited(ctx context.Context, event models.E
 	}
 
 	// Mark email account as inactive (terminated due to abuse)
-	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
+	s.deactivateAccount(ctx, userID, emailAccountID)
 
 	if s.WarmupService != nil {
 		health, _ := s.WarmupService.ApplyRateLimitExceeded(ctx, emailAccountID, "worker sync/email rate limit exceeded")
@@ -280,32 +280,47 @@ func ptrString(s string) *string {
 	return &s
 }
 
-// deactivateAccount marks a mailbox inactive AND tells the worker holding it to
-// drop it. The per-worker load filters on status, but that only decides what a
-// worker picks up when it starts: without this the running worker keeps syncing
-// a mailbox that has just been disabled, failing every pass and writing an
-// email_account_errors row each time, until someone restarts it.
-func (s *JobsService) deactivateAccount(ctx context.Context, userID, emailAccountID string) {
+// deactivateAccount marks a mailbox inactive AND tells the worker holding it
+// to drop it. The per-worker load filters on status, but that only decides what
+// a worker picks up when it starts, and the send path relays an account-level
+// failure without stopping the mailbox's own sync loop: without this the worker
+// keeps syncing a mailbox that has just been deactivated, failing every pass
+// and writing an email_account_errors row each time, until someone restarts it.
+func (s *JobsService) deactivateAccount(ctx context.Context, userID, emailAccountID uuid.UUID) {
 	if s.EmailRepository == nil {
 		return
 	}
 	inactive := "inactive"
-	account, xerr := s.EmailRepository.Update(ctx, userID, emailAccountID, &models.UpdateEmail{
+	if _, xerr := s.EmailRepository.Update(ctx, userID.String(), emailAccountID.String(), &models.UpdateEmail{
 		Status: &inactive,
-	})
-	if xerr != nil {
+	}); xerr != nil {
 		log.Error().Str("error", xerr.Message).Msg("Failed to update email account status")
 		return
 	}
-	if s.Publisher == nil || account == nil || account.WorkerID == nil {
+	if s.Publisher == nil {
 		return
 	}
-	if err := s.Publisher.PublishRemoveEmail(ctx, *account.WorkerID, &models.RemoveWorkerEmail{
-		UserID:  userID,
-		EmailID: emailAccountID,
+
+	// Asked for on its own rather than read off the row Update returned: that
+	// row is the mailbox as the dashboard sees it and carries no assignment.
+	workerID, xerr := s.EmailRepository.GetWorkerID(ctx, emailAccountID)
+	if xerr != nil {
+		log.Warn().
+			Str("error", xerr.Message).
+			Str("email_account_id", emailAccountID.String()).
+			Msg("Cannot tell the worker to drop the deactivated mailbox: assignment lookup failed")
+		return
+	}
+	if workerID == nil {
+		return
+	}
+	if err := s.Publisher.PublishRemoveEmail(ctx, *workerID, &models.RemoveWorkerEmail{
+		UserID:  userID.String(),
+		EmailID: emailAccountID.String(),
 	}); err != nil {
 		log.Warn().Err(err).
-			Str("email_account_id", emailAccountID).
+			Str("email_account_id", emailAccountID.String()).
+			Str("worker_id", workerID.String()).
 			Msg("Failed to tell the worker to drop the deactivated mailbox")
 	}
 }

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -57,14 +57,7 @@ func (s *JobsService) HandleEmailAuthError(ctx context.Context, event models.Ema
 	}
 
 	// Mark email account as needing re-auth (set status to inactive)
-	if s.EmailRepository != nil {
-		inactive := "inactive"
-		if _, xerr := s.EmailRepository.Update(ctx, event.UserID, event.EmailAccountID, &models.UpdateEmail{
-			Status: &inactive,
-		}); xerr != nil {
-			log.Error().Str("error", xerr.Message).Msg("Failed to update email account status")
-		}
-	}
+	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
 
 	// Send Pub/Sub notification to user
 	if s.StreamingPublisher != nil && event.UserVisible {
@@ -129,14 +122,7 @@ func (s *JobsService) HandleEmailDisabled(ctx context.Context, event models.Emai
 	}
 
 	// Mark email account as inactive
-	if s.EmailRepository != nil {
-		inactive := "inactive"
-		if _, xerr := s.EmailRepository.Update(ctx, event.UserID, event.EmailAccountID, &models.UpdateEmail{
-			Status: &inactive,
-		}); xerr != nil {
-			log.Error().Str("error", xerr.Message).Msg("Failed to update email account status")
-		}
-	}
+	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
 
 	// Send Pub/Sub notification to user
 	if s.StreamingPublisher != nil && event.UserVisible {
@@ -201,14 +187,7 @@ func (s *JobsService) HandleEmailRateLimited(ctx context.Context, event models.E
 	}
 
 	// Mark email account as inactive (terminated due to abuse)
-	if s.EmailRepository != nil {
-		inactive := "inactive"
-		if _, xerr := s.EmailRepository.Update(ctx, event.UserID, event.EmailAccountID, &models.UpdateEmail{
-			Status: &inactive,
-		}); xerr != nil {
-			log.Error().Str("error", xerr.Message).Msg("Failed to update email account status")
-		}
-	}
+	s.deactivateAccount(ctx, event.UserID, event.EmailAccountID)
 
 	if s.WarmupService != nil {
 		health, _ := s.WarmupService.ApplyRateLimitExceeded(ctx, emailAccountID, "worker sync/email rate limit exceeded")
@@ -299,4 +278,34 @@ func ptrString(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+// deactivateAccount marks a mailbox inactive AND tells the worker holding it to
+// drop it. The per-worker load filters on status, but that only decides what a
+// worker picks up when it starts: without this the running worker keeps syncing
+// a mailbox that has just been disabled, failing every pass and writing an
+// email_account_errors row each time, until someone restarts it.
+func (s *JobsService) deactivateAccount(ctx context.Context, userID, emailAccountID string) {
+	if s.EmailRepository == nil {
+		return
+	}
+	inactive := "inactive"
+	account, xerr := s.EmailRepository.Update(ctx, userID, emailAccountID, &models.UpdateEmail{
+		Status: &inactive,
+	})
+	if xerr != nil {
+		log.Error().Str("error", xerr.Message).Msg("Failed to update email account status")
+		return
+	}
+	if s.Publisher == nil || account == nil || account.WorkerID == nil {
+		return
+	}
+	if err := s.Publisher.PublishRemoveEmail(ctx, *account.WorkerID, &models.RemoveWorkerEmail{
+		UserID:  userID,
+		EmailID: emailAccountID,
+	}); err != nil {
+		log.Warn().Err(err).
+			Str("email_account_id", emailAccountID).
+			Msg("Failed to tell the worker to drop the deactivated mailbox")
+	}
 }

--- a/internal/app/email/loader.go
+++ b/internal/app/email/loader.go
@@ -119,13 +119,21 @@ func (s *emailService) loadAccountBestEffort(ctx context.Context, accountID uuid
 
 // LoadAccountOntoWorker assigns a worker if the account has none, rebuilds the
 // account's decrypted credentials into an AddWorkerEmail payload, and publishes
-// it so the worker loads the account into memory. Safe to call repeatedly.
+// it so the worker loads the account into memory. Safe to call repeatedly, and
+// a no-op for a mailbox that is not active.
 func (s *emailService) LoadAccountOntoWorker(ctx context.Context, accountID uuid.UUID) error {
 	acc, xerr := s.emailRepository.GetByID(ctx, accountID)
 	if xerr != nil {
 		return xerr
 	}
 	if acc == nil {
+		return nil
+	}
+	// A mailbox that is not active must never be shipped to a worker. The
+	// reconciler reads the active list a tick before it publishes, so without
+	// this it can put back a mailbox that was deactivated in between and undo
+	// the removal the consumer just sent.
+	if acc.Status != "active" {
 		return nil
 	}
 

--- a/internal/app/email/loader_status_test.go
+++ b/internal/app/email/loader_status_test.go
@@ -1,0 +1,101 @@
+package email
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/worker"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/events"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// stubLoaderRepo serves one mailbox to the loader.
+type stubLoaderRepo struct {
+	repository.EmailRepository
+
+	account *models.Email
+}
+
+func (s *stubLoaderRepo) GetByID(ctx context.Context, emailAccountID uuid.UUID) (*models.Email, *errx.Error) {
+	return s.account, nil
+}
+
+// countingAssignment records placement attempts. Reaching it at all means the
+// loader decided the mailbox belongs on a worker.
+type countingAssignment struct {
+	worker.WorkerAssignmentService
+
+	assigned int
+}
+
+func (c *countingAssignment) IsWorkerLive(ctx context.Context, workerID uuid.UUID) (bool, error) {
+	return true, nil
+}
+
+func (c *countingAssignment) AssignWorkerToEmail(ctx context.Context, emailAccountID, orgID uuid.UUID) (*uuid.UUID, error) {
+	c.assigned++
+	id := uuid.New()
+	return &id, nil
+}
+
+type countingPublisher struct {
+	events.Publisher
+
+	added int
+}
+
+func (p *countingPublisher) PublishAddEmail(ctx context.Context, workerID uuid.UUID, email *models.AddWorkerEmail) error {
+	p.added++
+	return nil
+}
+
+func loaderFor(status string) (*emailService, *countingAssignment, *countingPublisher) {
+	org := uuid.New()
+	assign := &countingAssignment{}
+	pub := &countingPublisher{}
+	repo := &stubLoaderRepo{account: &models.Email{
+		ID:             uuid.New(),
+		UserID:         uuid.New().String(),
+		OrganizationID: &org,
+		Email:          "sender@example.com",
+		Status:         status,
+	}}
+	return &emailService{emailRepository: repo, workerAssignment: assign, publisher: pub}, assign, pub
+}
+
+// The reconciler lists active mailboxes a tick before it publishes them, so a
+// mailbox deactivated in between would otherwise be shipped straight back onto
+// the worker the consumer just told to drop it.
+func TestLoadAccountOntoWorkerSkipsAMailboxThatIsNotActive(t *testing.T) {
+	for _, status := range []string{"inactive", "revoked"} {
+		t.Run(status, func(t *testing.T) {
+			s, assign, pub := loaderFor(status)
+
+			if err := s.LoadAccountOntoWorker(context.Background(), uuid.New()); err != nil {
+				t.Fatalf("LoadAccountOntoWorker: %v", err)
+			}
+			if assign.assigned != 0 {
+				t.Errorf("placed a %s mailbox on a worker (%d assignments)", status, assign.assigned)
+			}
+			if pub.added != 0 {
+				t.Errorf("shipped a %s mailbox to a worker (%d publishes)", status, pub.added)
+			}
+		})
+	}
+}
+
+// The guard must not stop the mailboxes that do belong on a worker: an active
+// one still reaches placement.
+func TestLoadAccountOntoWorkerStillPlacesAnActiveMailbox(t *testing.T) {
+	s, assign, _ := loaderFor("active")
+
+	if err := s.LoadAccountOntoWorker(context.Background(), uuid.New()); err != nil {
+		t.Fatalf("LoadAccountOntoWorker: %v", err)
+	}
+	if assign.assigned != 1 {
+		t.Errorf("assignments = %d, want 1", assign.assigned)
+	}
+}

--- a/internal/client/msgraph/delta.go
+++ b/internal/client/msgraph/delta.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -178,7 +177,7 @@ func (c *Client) FetchMessage(ctx context.Context, folder, id string) (*GraphMes
 	u := graphBase + "/me/messages/" + url.PathEscape(id) + "?$select=" + url.QueryEscape(msgSelect)
 	resp, err := c.do(ctx, "GET", u, "", nil)
 	if err != nil {
-		return nil, errx.ErrMailServerUnreachable
+		return nil, transportError(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusNotFound {

--- a/internal/client/msgraph/msgraph.go
+++ b/internal/client/msgraph/msgraph.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -117,7 +118,7 @@ func (c *Client) doJSON(ctx context.Context, method, url string, in, out any) er
 
 	resp, err := c.do(ctx, method, url, contentType, body)
 	if err != nil {
-		return errx.ErrMailServerUnreachable
+		return transportError(err)
 	}
 	defer resp.Body.Close()
 
@@ -129,4 +130,20 @@ func (c *Client) doJSON(ctx context.Context, method, url string, in, out any) er
 	}
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return nil
+}
+
+// transportError classifies a failure of the HTTP call itself. The client's
+// token source runs inside it, so a refresh token the provider has revoked
+// arrives here rather than as a status code; reporting that as "the mail server
+// could not be established" points the operator at the network and promises a
+// retry that can never succeed.
+func transportError(err error) *errx.MailError {
+	var retrieve *oauth2.RetrieveError
+	if errors.As(err, &retrieve) {
+		if retrieve.Response != nil && retrieve.Response.StatusCode >= 500 {
+			return errx.ErrMailServerUnreachable
+		}
+		return errx.ErrMailAuthenticationFailed
+	}
+	return errx.ErrMailServerUnreachable
 }

--- a/internal/client/msgraph/msgraph.go
+++ b/internal/client/msgraph/msgraph.go
@@ -11,13 +11,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"sync"
 
+	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
+	"github.com/warmbly/warmbly/internal/pkg/mailauth"
 	"github.com/warmbly/warmbly/internal/pkg/stoken"
 	"golang.org/x/oauth2"
 )
@@ -133,16 +134,21 @@ func (c *Client) doJSON(ctx context.Context, method, url string, in, out any) er
 }
 
 // transportError classifies a failure of the HTTP call itself. The client's
-// token source runs inside it, so a refresh token the provider has revoked
-// arrives here rather than as a status code; reporting that as "the mail server
+// token source runs inside it, so a grant the provider has revoked arrives
+// here rather than as a status code, and reporting that as "the mail server
 // could not be established" points the operator at the network and promises a
 // retry that can never succeed.
 func transportError(err error) *errx.MailError {
-	var retrieve *oauth2.RetrieveError
-	if errors.As(err, &retrieve) {
-		if retrieve.Response != nil && retrieve.Response.StatusCode >= 500 {
-			return errx.ErrMailServerUnreachable
-		}
+	f := mailauth.ClassifyTokenError(err)
+	if f.Refused() {
+		log.Debug().
+			Str("oauth_error", f.ErrorCode).
+			Str("oauth_description", f.Description).
+			Int("status", f.Status).
+			Bool("revoked", f.Revoked()).
+			Msg("Graph token refresh refused")
+	}
+	if f.Revoked() {
 		return errx.ErrMailAuthenticationFailed
 	}
 	return errx.ErrMailServerUnreachable

--- a/internal/client/msgraph/send.go
+++ b/internal/client/msgraph/send.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/rs/zerolog/log"
-	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/pkg/mailhdr"
 )
@@ -116,7 +115,7 @@ func (c *Client) createDraft(ctx context.Context, raw []byte) (string, string, e
 	encoded := base64.StdEncoding.EncodeToString(raw)
 	resp, err := c.do(ctx, http.MethodPost, graphBase+"/me/messages", "text/plain", []byte(encoded))
 	if err != nil {
-		return "", "", errx.ErrMailServerUnreachable
+		return "", "", transportError(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -152,7 +151,7 @@ func (c *Client) draftMessageID(ctx context.Context, draftID string) string {
 func (c *Client) sendDraft(ctx context.Context, draftID string) error {
 	resp, err := c.do(ctx, http.MethodPost, c.messageURL(draftID)+"/send", "", nil)
 	if err != nil {
-		return errx.ErrMailServerUnreachable
+		return transportError(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
@@ -191,7 +190,7 @@ func (c *Client) sendMIME(ctx context.Context, raw []byte) error {
 	encoded := base64.StdEncoding.EncodeToString(raw)
 	resp, err := c.do(ctx, http.MethodPost, graphBase+"/me/sendMail", "text/plain", []byte(encoded))
 	if err != nil {
-		return errx.ErrMailServerUnreachable
+		return transportError(err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/internal/client/msgraph/token_error_test.go
+++ b/internal/client/msgraph/token_error_test.go
@@ -1,0 +1,175 @@
+package msgraph
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"golang.org/x/oauth2"
+)
+
+// escapeRT stands in for the network behind the oauth2 transport. A token
+// refresh that fails must short-circuit before Graph is dialled, so any call
+// reaching here is itself a failure.
+type escapeRT struct{ t *testing.T }
+
+func (e escapeRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	e.t.Errorf("request escaped to %s: a failed token refresh must not reach the provider", req.URL)
+	return nil, errors.New("unexpected network call")
+}
+
+// tokenRefusal boots a real client whose token endpoint answers every refresh
+// with status and body. The mailbox's access token is already expired, so the
+// first API call refreshes, is refused, and returns through the same path
+// production takes: oauth2.Transport -> http.Client -> *url.Error.
+func tokenRefusal(t *testing.T, status int, body string) (*Client, *int32) {
+	t.Helper()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	return newRefusingClient(t, srv.URL), &calls
+}
+
+func newRefusingClient(t *testing.T, tokenURL string) *Client {
+	t.Helper()
+
+	c := &Client{Email: "sender@outlook.com"}
+	cfg := oauth2.Config{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		// Pinned so the refusal is one request, not the auth-style probe's two.
+		Endpoint: oauth2.Endpoint{TokenURL: tokenURL, AuthStyle: oauth2.AuthStyleInParams},
+	}
+	expired := &oauth2.Token{
+		AccessToken:  "stale",
+		RefreshToken: "refresh-token",
+		Expiry:       time.Now().Add(-time.Hour),
+	}
+	if merr := c.Init(context.Background(), expired, cfg); merr != nil {
+		t.Fatalf("Init: %v", merr.Message)
+	}
+	tr, ok := c.hc.Transport.(*oauth2.Transport)
+	if !ok {
+		t.Fatalf("Init did not build an oauth2 transport, got %T", c.hc.Transport)
+	}
+	tr.Base = escapeRT{t}
+	return c
+}
+
+func mailErrorOf(t *testing.T, err error) *errx.MailError {
+	t.Helper()
+	if err == nil {
+		t.Fatal("call succeeded, want a mail error")
+	}
+	var mailErr *errx.MailError
+	if !errors.As(err, &mailErr) {
+		t.Fatalf("error %v (%T) is not a *errx.MailError, so the sync loop cannot classify it", err, err)
+	}
+	return mailErr
+}
+
+const invalidGrantBody = `{"error":"invalid_grant","error_description":"AADSTS50173: The provided grant has expired due to it being revoked."}`
+
+// The incident: a revoked grant reported as an unreachable server, with a
+// promised retry that could never succeed. Every call shape has to agree,
+// because the mailbox reaches the same dead grant through all of them.
+func TestRevokedGrantIsAnAuthenticationErrorOnEveryCallPath(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("fetch message", func(t *testing.T) {
+		c, calls := tokenRefusal(t, http.StatusBadRequest, invalidGrantBody)
+		_, err := c.FetchMessage(ctx, FolderInbox, "message-id")
+		if got := mailErrorOf(t, err).Code; got != errx.MailErrorCodeAuthenticationFailed {
+			t.Errorf("code = %s, want %s", got, errx.MailErrorCodeAuthenticationFailed)
+		}
+		if atomic.LoadInt32(calls) == 0 {
+			t.Error("the token endpoint was never called, so no refresh was exercised")
+		}
+	})
+
+	t.Run("list messages", func(t *testing.T) {
+		c, _ := tokenRefusal(t, http.StatusBadRequest, invalidGrantBody)
+		_, _, err := c.ListMessagesSince(ctx, FolderInbox, time.Now().Add(-24*time.Hour), "", 10)
+		if got := mailErrorOf(t, err).Code; got != errx.MailErrorCodeAuthenticationFailed {
+			t.Errorf("code = %s, want %s", got, errx.MailErrorCodeAuthenticationFailed)
+		}
+	})
+
+	t.Run("send", func(t *testing.T) {
+		c, _ := tokenRefusal(t, http.StatusBadRequest, invalidGrantBody)
+		_, err := c.SendMessage(ctx, []string{"partner@example.com"}, nil, nil,
+			"<minted@outlook.com>", "subject", "body", "", nil, nil, nil)
+		if got := mailErrorOf(t, err).Code; got != errx.MailErrorCodeAuthenticationFailed {
+			t.Errorf("code = %s, want %s", got, errx.MailErrorCodeAuthenticationFailed)
+		}
+	})
+}
+
+// A revoked grant must ask the customer to reconnect rather than promise a
+// retry, which is the difference between the two resolve methods.
+func TestRevokedGrantAsksForReauthentication(t *testing.T) {
+	c, _ := tokenRefusal(t, http.StatusBadRequest, invalidGrantBody)
+	_, err := c.FetchMessage(context.Background(), FolderInbox, "message-id")
+	mailErr := mailErrorOf(t, err)
+	if mailErr.ResolveMethod != errx.MailErrorResolveMethodAuth {
+		t.Errorf("resolve method = %s, want %s", mailErr.ResolveMethod, errx.MailErrorResolveMethodAuth)
+	}
+}
+
+// The other half of the classification: a provider having a moment must not
+// cost a customer their mailbox. Each of these reaches the consumer as a
+// server error, which retries, instead of an auth error, which deactivates.
+func TestTransientTokenRefusalsStayRetryable(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{"throttled", http.StatusTooManyRequests, `{"error":"temporarily_unavailable"}`},
+		{"token endpoint 500", http.StatusInternalServerError, `{}`},
+		{"token endpoint 503", http.StatusServiceUnavailable, `{"error":"temporarily_unavailable"}`},
+		{"provider server_error", http.StatusBadRequest, `{"error":"server_error","error_description":"try again"}`},
+		{"unrecognised refusal", http.StatusBadRequest, `{"error":"something_new"}`},
+		// An expired app secret answers this for every Outlook mailbox on the
+		// install at once; deactivating them all would be the worse outage.
+		{"our app credentials expired", http.StatusUnauthorized, `{"error":"invalid_client","error_description":"secret expired"}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := tokenRefusal(t, tc.status, tc.body)
+			_, err := c.FetchMessage(context.Background(), FolderInbox, "message-id")
+			mailErr := mailErrorOf(t, err)
+			if mailErr.Code != errx.MailErrorCodeServerUnreachable {
+				t.Fatalf("code = %s, want %s: this deactivates the mailbox", mailErr.Code, errx.MailErrorCodeServerUnreachable)
+			}
+			if mailErr.ResolveMethod != errx.MailErrorResolveMethodRetry {
+				t.Errorf("resolve method = %s, want %s", mailErr.ResolveMethod, errx.MailErrorResolveMethodRetry)
+			}
+		})
+	}
+}
+
+// A token endpoint that cannot be reached at all is the case the old code was
+// written for, and it still has to read as a transport failure. Port 1 is
+// refused immediately and needs no DNS, so this stays hermetic and fast.
+func TestUnreachableTokenEndpointIsAServerError(t *testing.T) {
+	c := newRefusingClient(t, "http://127.0.0.1:1/token")
+	_, err := c.FetchMessage(context.Background(), FolderInbox, "message-id")
+	if got := mailErrorOf(t, err).Code; got != errx.MailErrorCodeServerUnreachable {
+		t.Errorf("code = %s, want %s", got, errx.MailErrorCodeServerUnreachable)
+	}
+}

--- a/internal/pkg/mailauth/mailauth.go
+++ b/internal/pkg/mailauth/mailauth.go
@@ -1,0 +1,99 @@
+// Package mailauth classifies OAuth2 token-exchange failures for the mail
+// clients.
+//
+// A client built on oauth2.NewClient runs its token source inside the HTTP
+// call, so a refresh the provider refuses surfaces as a failure of the call
+// itself rather than as a status code. Both naive readings of that error are
+// wrong in a way that costs someone real mail: calling every refusal a
+// transport failure promises a retry that can never succeed, and calling every
+// refusal a dead grant disconnects a working mailbox over a throttle the
+// provider would have cleared in seconds.
+package mailauth
+
+import (
+	"errors"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+// TokenVerdict is what a failed HTTP call says about the grant behind it.
+type TokenVerdict int
+
+const (
+	// TokenNotRefused means the failure did not come from the token endpoint
+	// (DNS, TLS, timeout, a refusal shape we cannot read).
+	TokenNotRefused TokenVerdict = iota
+	// TokenRefusedNow means the provider declined to mint a token this time.
+	// Retrying is the right response.
+	TokenRefusedNow
+	// TokenRevoked means the grant itself is dead: retrying cannot fix it and
+	// only the mailbox owner re-consenting will.
+	TokenRevoked
+)
+
+// revokedGrantCodes are the RFC 6749 / OIDC error codes that mean THIS grant
+// is finished: revoked or expired refresh token, a password change, or a
+// policy that now demands the user in person.
+//
+// Codes about the application rather than the grant (invalid_client,
+// unauthorized_client) are deliberately absent. An expired app secret returns
+// those for every mailbox at once, and answering an operator's rotation
+// mistake by disconnecting every customer's mailbox (into a re-consent that
+// cannot work either, because the app is the broken part) is far worse than
+// retrying until the secret is rotated.
+var revokedGrantCodes = map[string]bool{
+	"invalid_grant":        true,
+	"interaction_required": true,
+	"consent_required":     true,
+	"login_required":       true,
+}
+
+// TokenFailure is a classified token-endpoint refusal, carrying the provider's
+// own words so the caller can log why a mailbox was disconnected.
+type TokenFailure struct {
+	Verdict TokenVerdict
+	// ErrorCode and Description are RFC 6749 5.2 'error' and
+	// 'error_description'. Empty when the endpoint sent neither.
+	ErrorCode   string
+	Description string
+	// Status is the token endpoint's HTTP status, 0 when there was no response.
+	Status int
+}
+
+// Refused reports whether the token endpoint is what failed.
+func (f TokenFailure) Refused() bool { return f.Verdict != TokenNotRefused }
+
+// Revoked reports whether the grant is finished and only re-consent restores it.
+func (f TokenFailure) Revoked() bool { return f.Verdict == TokenRevoked }
+
+// ClassifyTokenError inspects err and anything it wraps for a token endpoint
+// refusal. Anything it cannot positively read as a dead grant is transient:
+// the cost of retrying a mailbox that is really finished is log noise, and the
+// cost of the opposite mistake is a working mailbox disconnected until its
+// owner notices.
+func ClassifyTokenError(err error) TokenFailure {
+	var retrieve *oauth2.RetrieveError
+	if !errors.As(err, &retrieve) {
+		return TokenFailure{Verdict: TokenNotRefused}
+	}
+
+	f := TokenFailure{
+		Verdict:     TokenRefusedNow,
+		ErrorCode:   retrieve.ErrorCode,
+		Description: retrieve.ErrorDescription,
+	}
+	if retrieve.Response != nil {
+		f.Status = retrieve.Response.StatusCode
+	}
+
+	// The provider is rate limiting or broken: it is not saying anything about
+	// the grant, whatever error code rides along.
+	if f.Status == http.StatusTooManyRequests || f.Status >= 500 {
+		return f
+	}
+	if revokedGrantCodes[f.ErrorCode] {
+		f.Verdict = TokenRevoked
+	}
+	return f
+}

--- a/internal/pkg/mailauth/mailauth_test.go
+++ b/internal/pkg/mailauth/mailauth_test.go
@@ -1,0 +1,101 @@
+package mailauth
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+// retrieveErr builds the error x/oauth2 returns from a token endpoint that
+// answered with status and this RFC 6749 body.
+func retrieveErr(status int, code, description string) *oauth2.RetrieveError {
+	return &oauth2.RetrieveError{
+		Response:         &http.Response{StatusCode: status},
+		Body:             []byte(fmt.Sprintf(`{"error":%q,"error_description":%q}`, code, description)),
+		ErrorCode:        code,
+		ErrorDescription: description,
+	}
+}
+
+func TestClassifyTokenError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want TokenVerdict
+	}{
+		{"nil error", nil, TokenNotRefused},
+		{"plain transport failure", errors.New("dial tcp: i/o timeout"), TokenNotRefused},
+		{
+			// The shape the mail clients actually see: http.Client wraps
+			// whatever the oauth2 transport returned in a *url.Error.
+			"revoked refresh token through url.Error",
+			&url.Error{Op: "Get", URL: "https://graph.microsoft.com/v1.0/me/messages", Err: retrieveErr(400, "invalid_grant", "AADSTS50173: token revoked")},
+			TokenRevoked,
+		},
+		{"revoked refresh token", retrieveErr(400, "invalid_grant", "expired"), TokenRevoked},
+		{"consent withdrawn", retrieveErr(400, "consent_required", "admin consent revoked"), TokenRevoked},
+		{"policy now needs the user", retrieveErr(400, "interaction_required", "MFA required"), TokenRevoked},
+		{"session gone", retrieveErr(400, "login_required", "user must sign in"), TokenRevoked},
+
+		// The regression this classification exists to avoid: everything below
+		// is the provider having a moment, not a mailbox that needs its owner.
+		{"token endpoint throttling", retrieveErr(http.StatusTooManyRequests, "", ""), TokenRefusedNow},
+		{"token endpoint throttling with a code", retrieveErr(http.StatusTooManyRequests, "temporarily_unavailable", "slow down"), TokenRefusedNow},
+		{"token endpoint 500", retrieveErr(500, "", ""), TokenRefusedNow},
+		{"token endpoint 503", retrieveErr(503, "temporarily_unavailable", "try later"), TokenRefusedNow},
+		{"provider server_error", retrieveErr(400, "server_error", "transient"), TokenRefusedNow},
+		{"unrecognised code", retrieveErr(400, "something_new", "who knows"), TokenRefusedNow},
+		{"no code at all", retrieveErr(400, "", ""), TokenRefusedNow},
+
+		// An expired app secret answers this for every mailbox on the install
+		// at once, so it must never disconnect any of them.
+		{"our app credentials are wrong", retrieveErr(401, "invalid_client", "secret expired"), TokenRefusedNow},
+		{"our app is not allowed", retrieveErr(400, "unauthorized_client", "app blocked"), TokenRefusedNow},
+
+		// Some endpoints answer 200 with an error body; x/oauth2 still reports
+		// a RetrieveError, and the code is the only signal.
+		{"200 carrying an error code", retrieveErr(200, "invalid_grant", "revoked"), TokenRevoked},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ClassifyTokenError(tt.err).Verdict; got != tt.want {
+				t.Errorf("verdict = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A RetrieveError can arrive with no Response at all; reading the status off it
+// must not panic.
+func TestClassifyTokenErrorWithoutAResponse(t *testing.T) {
+	f := ClassifyTokenError(&oauth2.RetrieveError{ErrorCode: "invalid_grant"})
+	if !f.Revoked() {
+		t.Errorf("verdict = %v, want TokenRevoked", f.Verdict)
+	}
+	if f.Status != 0 {
+		t.Errorf("status = %d, want 0", f.Status)
+	}
+}
+
+// The provider's own words are what an operator needs to see next to a
+// mailbox that was just disconnected.
+func TestClassifyTokenErrorCarriesTheProvidersWords(t *testing.T) {
+	f := ClassifyTokenError(retrieveErr(400, "invalid_grant", "AADSTS50173: password changed"))
+	if !f.Refused() || !f.Revoked() {
+		t.Fatalf("refused=%v revoked=%v, want both true", f.Refused(), f.Revoked())
+	}
+	if f.ErrorCode != "invalid_grant" || f.Description != "AADSTS50173: password changed" || f.Status != 400 {
+		t.Errorf("got code=%q description=%q status=%d", f.ErrorCode, f.Description, f.Status)
+	}
+}
+
+func TestRefusedIsFalseForANonTokenFailure(t *testing.T) {
+	if ClassifyTokenError(errors.New("connection reset")).Refused() {
+		t.Error("a transport failure was reported as a token refusal")
+	}
+}


### PR DESCRIPTION
Fixes #196. Two symptoms from the same incident, one commit each half.

## A deactivated mailbox keeps being synced

`REMOVE_EMAIL` already exists end to end: `events.Publisher.PublishRemoveEmail` on one side, `WorkerService.HandleRemoveEmail` on the other, which cancels in-flight syncs and terminates the mailbox in the manager. **Nothing ever called it.**

The per-worker load filters on `status = 'active'`, but that only decides what a worker picks up when it starts. On a live install a mailbox Graph had answered with 403 went `inactive` and the running worker kept syncing it about once a minute for roughly 90 minutes, failing every pass and writing an `email_account_errors` row each time. It accumulated 58 rows and stopped only when the worker was restarted, at which point it simply was not loaded.

All three deactivation sites in `event_email_error.go` (auth error, disabled, rate limited) now go through one `deactivateAccount` helper that sets the status and publishes the removal to the worker holding the mailbox.

## A revoked grant reports as an unreachable server

The Graph client mapped every failure of the HTTP call itself to `ErrMailServerUnreachable`. The client's token source runs inside that call, so a refresh token the provider has revoked arrives there rather than as a status code, and the mailbox reported:

> Connection Error. The connection to the mail server could not be established. The server may be offline or blocking the connection.
> The email server is temporarily unavailable. We'll retry automatically.

None of which was true: the host was reachable, and the promised retry could not succeed. `transportError` now inspects the error, so an `*oauth2.RetrieveError` becomes an authentication error (unless the token endpoint itself answered 5xx, which is genuinely transient) and everything else keeps the existing meaning.

`gofmt -l`, `go build ./...`, `go vet`, `golangci-lint v1.64.8 ./internal/...`, `scripts/check-migrations.sh` and the `msgraph` + `consumer` tests are clean.
