### PR TITLE
feat: close the warmup ramp loop with an early-signal hold

### DIFF
--- a/docs/content/docs/guides/warmup.mdx
+++ b/docs/content/docs/guides/warmup.mdx
@@ -56,7 +56,19 @@ Turning off outbound warmup does not remove a healthy mailbox from the recipient
 
 At defaults a mailbox sends 10 on day one, 11 the next, and levels off at 40 after roughly a month. You can change these per mailbox, but conservative defaults build the most durable reputation.
 
-Three things shape the real daily number: sends are spread across your warmup hours with jitter, the target is capped by how many eligible partners exist, and a mailbox whose health drops gets reduced volume and wider spacing until it recovers.
+Four things shape the real daily number: sends are spread across your warmup hours with jitter, the target is capped by how many eligible partners exist, a mailbox whose health drops gets reduced volume and wider spacing until it recovers, and a recent spam placement holds the ramp where it is.
+
+### Holding the ramp on an early signal
+
+If any warmup email lands in a recipient's spam folder, that mailbox stops climbing immediately:
+
+- today's target is cut by about a quarter
+- the daily increase pauses for three days
+- when it resumes, it resumes from the level it was held at, so the three paused days are not made up in one morning
+
+Nothing needs to be switched on and no health band has to trip first. That matters because the bands need a sample before they can judge a mailbox at all (twenty warmup sends in seven days, a hundred delivered in thirty), which a mailbox in its first fortnight has not reached. Without this, the mailbox landing in spam on day three would keep adding an email a day until it had sent enough to be judged.
+
+The hold clears on its own once no placement has been seen for 48 hours. While it is active the mailbox drawer says so, including how many emails were affected and when the ramp resumes.
 
 <Callout type="info" title="Warmup and campaigns coexist">
   Keep warmup on after campaigns start. A mailbox backing a live campaign drops to at most five warmup messages per day, leaving the campaign as primary traffic. Warmup does not make repetitive or unwanted copy safe: you still need real targeting, personalization, suppression, and unsubscribe support.

--- a/docs/content/docs/guides/warmup.mdx
+++ b/docs/content/docs/guides/warmup.mdx
@@ -62,13 +62,15 @@ Four things shape the real daily number: sends are spread across your warmup hou
 
 If any warmup email lands in a recipient's spam folder, that mailbox stops climbing immediately:
 
-- today's target is cut by about a quarter
+- today's target is cut by about a quarter, for 48 hours
 - the daily increase pauses for three days
-- when it resumes, it resumes from the level it was held at, so the three paused days are not made up in one morning
+- the paused days are subtracted rather than made up, so the ramp does not jump three steps in one morning when it resumes
+
+Another placement during a pause extends it and does not lift the ramp: repeated spam placement can only ever slow a mailbox down.
 
 Nothing needs to be switched on and no health band has to trip first. That matters because the bands need a sample before they can judge a mailbox at all (twenty warmup sends in seven days, a hundred delivered in thirty), which a mailbox in its first fortnight has not reached. Without this, the mailbox landing in spam on day three would keep adding an email a day until it had sent enough to be judged.
 
-The hold clears on its own once no placement has been seen for 48 hours. While it is active the mailbox drawer says so, including how many emails were affected and when the ramp resumes.
+The two windows end at different times, so between 48 and 72 hours a mailbox is back at full volume while the ramp is still paused. The mailbox drawer says which of the two is happening, how many emails were affected, and when the ramp resumes. Restarting warmup resets the ramp and clears any hold with it.
 
 <Callout type="info" title="Warmup and campaigns coexist">
   Keep warmup on after campaigns start. A mailbox backing a live campaign drops to at most five warmup messages per day, leaving the campaign as primary traffic. Warmup does not make repetitive or unwanted copy safe: you still need real targeting, personalization, suppression, and unsubscribe support.

--- a/internal/app/analytics/service.go
+++ b/internal/app/analytics/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/warmupramp"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
@@ -197,16 +198,18 @@ func (s *analyticsService) GetAccountStatus(ctx context.Context, orgID, accountI
 	// Build warmup status if warmup has ever been enabled (active or paused).
 	var warmupStatus *models.WarmupStatusInfo
 	if email.Warmup != nil {
+		target, hold := s.warmupTargetAndHold(ctx, email)
 		warmupStatus = &models.WarmupStatusInfo{
 			Enabled:       true,
 			Paused:        email.WarmupPausedAt != nil,
 			PausedAt:      email.WarmupPausedAt,
 			StartedAt:     *email.Warmup,
 			CurrentVolume: usage.WarmupSent,
-			TargetVolume:  calculateTargetVolume(email),
+			TargetVolume:  target,
 			MaxVolume:     email.WarmupMax,
 			ReplyRate:     email.WarmupReplyRate,
 			DaysActive:    int(time.Since(*email.Warmup).Hours() / 24),
+			RampHold:      hold,
 		}
 	}
 
@@ -397,19 +400,44 @@ func calculateAccountHealth(email *models.Email, errors []models.AccountError) m
 	return health
 }
 
-func calculateTargetVolume(email *models.Email) int {
+// warmupTargetAndHold reports the target the SCHEDULER will act on, and what is
+// holding it down when that is lower than the plain ramp. It runs the shared
+// warmupramp policy rather than its own arithmetic, because a dashboard that
+// says "target 25" while the mailbox sends 18 is worse than no number.
+func (s *analyticsService) warmupTargetAndHold(ctx context.Context, email *models.Email) (int, *models.WarmupRampHold) {
 	if email.Warmup == nil {
-		return 0
+		return 0, nil
+	}
+	now := time.Now()
+
+	var lastPlacement *time.Time
+	var placements, sends int
+	if s.warmupRepo != nil {
+		if at, err := s.warmupRepo.LastSpamPlacementAt(ctx, email.ID); err == nil {
+			lastPlacement = at
+		}
+		since := now.Add(-warmupramp.SoftSignalWindow)
+		if n, err := s.warmupRepo.CountSpamPlacementsSince(ctx, email.ID, since); err == nil {
+			placements = n
+		}
+		if n, err := s.warmupRepo.SumWarmupSentSince(ctx, email.ID, since); err == nil {
+			sends = n
+		}
 	}
 
-	daysActive := int(time.Since(*email.Warmup).Hours() / 24)
-	target := email.WarmupBase + (daysActive * email.WarmupIncrease)
+	days := warmupramp.Days(*email.Warmup, lastPlacement, now, warmupramp.FreezeWindow)
+	target := warmupramp.Target(email.IsWarmingActive(), email.WarmupBase, email.WarmupIncrease, email.WarmupMax, days, false)
+	target = warmupramp.Apply(target, warmupramp.SoftAdjust(placements))
 
-	if target > email.WarmupMax {
-		return email.WarmupMax
+	if placements == 0 || lastPlacement == nil {
+		return target, nil
 	}
-
-	return target
+	return target, &models.WarmupRampHold{
+		Placements: placements,
+		Sends:      sends,
+		LastAt:     *lastPlacement,
+		ResumesAt:  lastPlacement.Add(warmupramp.FreezeWindow),
+	}
 }
 
 // Dashboard Analytics implementations

--- a/internal/app/analytics/service.go
+++ b/internal/app/analytics/service.go
@@ -198,7 +198,7 @@ func (s *analyticsService) GetAccountStatus(ctx context.Context, orgID, accountI
 	// Build warmup status if warmup has ever been enabled (active or paused).
 	var warmupStatus *models.WarmupStatusInfo
 	if email.Warmup != nil {
-		target, hold := s.warmupTargetAndHold(ctx, email)
+		target, hold := s.warmupTargetAndHold(ctx, email, warmupHealthState(warmupHealth))
 		warmupStatus = &models.WarmupStatusInfo{
 			Enabled:       true,
 			Paused:        email.WarmupPausedAt != nil,
@@ -233,6 +233,15 @@ func (s *analyticsService) GetAccountStatus(ctx context.Context, orgID, accountI
 		WarmupHealth: warmupHealth,
 		InCampaign:   inCampaign,
 	}, nil
+}
+
+// warmupHealthState reads the band off the API shape, defaulting to healthy
+// for a mailbox in no pool — the same default resolveHealthState uses.
+func warmupHealthState(h *models.WarmupHealthInfo) models.WarmupHealthState {
+	if h == nil || h.State == "" {
+		return models.WarmupHealthHealthy
+	}
+	return models.WarmupHealthState(h.State)
 }
 
 // buildWarmupHealth looks up the mailbox's warmup-pool health (premium pool
@@ -400,43 +409,35 @@ func calculateAccountHealth(email *models.Email, errors []models.AccountError) m
 	return health
 }
 
-// warmupTargetAndHold reports the target the SCHEDULER will act on, and what is
-// holding it down when that is lower than the plain ramp. It runs the shared
-// warmupramp policy rather than its own arithmetic, because a dashboard that
-// says "target 25" while the mailbox sends 18 is worse than no number.
-func (s *analyticsService) warmupTargetAndHold(ctx context.Context, email *models.Email) (int, *models.WarmupRampHold) {
+// warmupTargetAndHold reports the target the SCHEDULER will act on, plus what
+// is holding it down. It runs the shared warmupramp policy rather than its own
+// arithmetic: a drawer saying "target 25" for a mailbox sending 18 is worse
+// than no number.
+func (s *analyticsService) warmupTargetAndHold(ctx context.Context, email *models.Email, health models.WarmupHealthState) (int, *models.WarmupRampHold) {
 	if email.Warmup == nil {
 		return 0, nil
 	}
-	now := time.Now()
-
-	var lastPlacement *time.Time
-	var placements, sends int
-	if s.warmupRepo != nil {
-		if at, err := s.warmupRepo.LastSpamPlacementAt(ctx, email.ID); err == nil {
-			lastPlacement = at
-		}
-		since := now.Add(-warmupramp.SoftSignalWindow)
-		if n, err := s.warmupRepo.CountSpamPlacementsSince(ctx, email.ID, since); err == nil {
-			placements = n
-		}
-		if n, err := s.warmupRepo.SumWarmupSentSince(ctx, email.ID, since); err == nil {
-			sends = n
-		}
+	plan := warmupramp.Resolve(ctx, s.warmupRepo, warmupramp.Input{
+		AccountID:       email.ID,
+		WarmupStart:     *email.Warmup,
+		ActivelyWarming: email.IsWarmingActive(),
+		Base:            email.WarmupBase,
+		Increase:        email.WarmupIncrease,
+		Max:             email.WarmupMax,
+		Health:          health,
+		Now:             time.Now(),
+	})
+	if plan.FrozenUntil == nil {
+		return plan.Target, nil
 	}
-
-	days := warmupramp.Days(*email.Warmup, lastPlacement, now, warmupramp.FreezeWindow)
-	target := warmupramp.Target(email.IsWarmingActive(), email.WarmupBase, email.WarmupIncrease, email.WarmupMax, days, false)
-	target = warmupramp.Apply(target, warmupramp.SoftAdjust(placements))
-
-	if placements == 0 || lastPlacement == nil {
-		return target, nil
-	}
-	return target, &models.WarmupRampHold{
-		Placements: placements,
-		Sends:      sends,
-		LastAt:     *lastPlacement,
-		ResumesAt:  lastPlacement.Add(warmupramp.FreezeWindow),
+	// Reported for the whole freeze, not just the shorter window that also
+	// cuts volume: otherwise a mailbox between 48 and 72 hours after a
+	// placement shows a ramp that is not climbing and no reason why.
+	return plan.Target, &models.WarmupRampHold{
+		Placements: plan.Placements,
+		Sends:      plan.Sends,
+		VolumeCut:  plan.Cut(),
+		ResumesAt:  *plan.FrozenUntil,
 	}
 }
 

--- a/internal/app/analytics/warmup_ramp_live_test.go
+++ b/internal/app/analytics/warmup_ramp_live_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 
-	"github.com/warmbly/warmbly/internal/app/warmupramp"
 	"github.com/warmbly/warmbly/internal/infrastructure/db"
 	"github.com/warmbly/warmbly/internal/pkg/encrypt"
 	"github.com/warmbly/warmbly/internal/repository"
@@ -145,9 +144,9 @@ func TestLiveRecentPlacementCutsTheTargetAndExplainsItself(t *testing.T) {
 }
 
 func TestLiveOldPlacementNoLongerCutsButStillShiftsTheRamp(t *testing.T) {
-	// A placement 8 days ago is outside the 48h signal window, so the cut is
-	// gone; the ramp still resumed from where it was held rather than
-	// catching up, which is the whole point of the freeze.
+	// A placement 8 days ago is outside both windows: no cut, no hold reported.
+	// The three frozen days are still subtracted, so the ramp sits below where
+	// an unaffected mailbox of the same age would be.
 	f := newRampFixture(t, 10, 10, 1, 40)
 	f.placement(t, 8*24)
 
@@ -155,19 +154,24 @@ func TestLiveOldPlacementNoLongerCutsButStillShiftsTheRamp(t *testing.T) {
 	if held {
 		t.Error("a placement 8 days old must not still be reported as holding the ramp")
 	}
-	expectedDays := warmupramp.Days(
-		time.Now().Add(-10*24*time.Hour),
-		ptrTime(time.Now().Add(-8*24*time.Hour)),
-		time.Now(),
-		warmupramp.FreezeWindow,
-	)
-	want := warmupramp.Target(true, 10, 1, 40, expectedDays, false)
-	if target != want {
-		t.Errorf("target = %d, want %d (day %d after the freeze shift)", target, want, expectedDays)
-	}
-	if target >= 20 {
-		t.Errorf("target %d is at or above the unfrozen day-10 ramp of 20; the freeze was not applied", target)
+	if target != 17 {
+		t.Errorf("target = %d, want 17 (day 10 minus the 3 frozen days)", target)
 	}
 }
 
-func ptrTime(t time.Time) *time.Time { return &t }
+// Between 48 and 72 hours after a placement the volume cut has expired but the
+// ramp is still frozen. That used to report no hold at all, so the drawer
+// showed a ramp that was not climbing with nothing to explain it.
+func TestLiveRampStillReportsAHoldAfterTheCutExpires(t *testing.T) {
+	f := newRampFixture(t, 10, 10, 1, 40)
+	f.placement(t, 60)
+
+	target, held := f.status(t)
+	if !held {
+		t.Error("the ramp is still frozen at 60h but nothing explains it")
+	}
+	// The cut is gone, so the target is the frozen ramp at full volume.
+	if target != 17 {
+		t.Errorf("target = %d, want the uncut frozen ramp of 17", target)
+	}
+}

--- a/internal/app/analytics/warmup_ramp_live_test.go
+++ b/internal/app/analytics/warmup_ramp_live_test.go
@@ -1,0 +1,173 @@
+package analytics
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/warmupramp"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/pkg/encrypt"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// The warmup target the mailbox drawer shows has to be the target the
+// scheduler will act on. It used to be recomputed here from a private copy of
+// the ramp arithmetic, so an early-signal cut in the scheduler would have left
+// the dashboard reporting a number the mailbox never sent.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/app/analytics/ -run Live -v
+
+type rampFixture struct {
+	pool    *pgxpool.Pool
+	user    uuid.UUID
+	org     uuid.UUID
+	mailbox uuid.UUID
+	svc     AnalyticsService
+}
+
+func newRampFixture(t *testing.T, daysWarming, base, increase, max int) *rampFixture {
+	t.Helper()
+	dsn := os.Getenv("WARMBLY_TEST_DB")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_DB not set")
+	}
+	ctx := context.Background()
+	handle, err := db.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	t.Cleanup(func() { handle.Pool.Close() })
+
+	f := &rampFixture{pool: handle.Pool, user: uuid.New(), org: uuid.New(), mailbox: uuid.New()}
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := f.pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+	exec(`INSERT INTO users (id, email, first_name, last_name) VALUES ($1, $2, 'Ramp', 'Test')`,
+		f.user, "ramp-"+f.user.String()[:8]+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1, 'Ramp Test', $2, $3)`,
+		f.org, "ramp-"+f.org.String()[:8], f.user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name, signature_plain,
+	          signature_html, provider, status, campaign_limit, min_wait_time, timezone,
+	          warmup, warmup_base, warmup_increase, warmup_max)
+	      VALUES ($1, $2, $3, $4, 'Ramp', '', '', 'smtp_imap', 'active', 50, 600, 'UTC',
+	              $5, $6, $7, $8)`,
+		f.mailbox, f.user, f.org, "ramp-"+f.mailbox.String()[:8]+"@test.local",
+		time.Now().Add(-time.Duration(daysWarming)*24*time.Hour), base, increase, max)
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM warmup_spam_reports WHERE reported_account_id = $1`, f.mailbox},
+			{`DELETE FROM warmup_statistics WHERE email_account_id = $1`, f.mailbox},
+			{`DELETE FROM email_accounts WHERE id = $1`, f.mailbox},
+			{`DELETE FROM organizations WHERE id = $1`, f.org},
+			{`DELETE FROM users WHERE id = $1`, f.user},
+		} {
+			if _, err := f.pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+
+	enc, err := encrypt.NewEncrypter([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("encrypter: %v", err)
+	}
+	f.svc = NewService(
+		repository.NewAnalyticsRepository(handle),
+		repository.NewEmailRepostory(handle, enc),
+		repository.NewCampaignRepostory(handle),
+		repository.NewEmailAccountErrorRepository(handle),
+		repository.NewWarmupRepository(handle.Pool),
+	)
+	return f
+}
+
+func (f *rampFixture) placement(t *testing.T, hoursAgo int) {
+	t.Helper()
+	if _, err := f.pool.Exec(context.Background(),
+		`INSERT INTO warmup_spam_reports (id, reporter_account_id, reported_account_id, message_id, report_type, created_at)
+		 VALUES (gen_random_uuid(), $1, $1, $2, 'spam_placement', $3)`,
+		f.mailbox, "msg-"+uuid.New().String(),
+		time.Now().Add(-time.Duration(hoursAgo)*time.Hour)); err != nil {
+		t.Fatalf("record placement: %v", err)
+	}
+}
+
+func (f *rampFixture) status(t *testing.T) (int, bool) {
+	t.Helper()
+	st, xerr := f.svc.GetAccountStatus(context.Background(), f.org, f.mailbox)
+	if xerr != nil {
+		t.Fatalf("account status: %v", xerr.Message)
+	}
+	if st.WarmupStatus == nil {
+		t.Fatal("no warmup status on a warming mailbox")
+	}
+	return st.WarmupStatus.TargetVolume, st.WarmupStatus.RampHold != nil
+}
+
+func TestLiveWarmupTargetIsCleanWithoutASignal(t *testing.T) {
+	f := newRampFixture(t, 10, 10, 1, 40)
+	target, held := f.status(t)
+	if target != 20 {
+		t.Errorf("target = %d, want the day-10 ramp of 20", target)
+	}
+	if held {
+		t.Error("ramp reported as held with no placement on record")
+	}
+}
+
+func TestLiveRecentPlacementCutsTheTargetAndExplainsItself(t *testing.T) {
+	f := newRampFixture(t, 10, 10, 1, 40)
+	f.placement(t, 2)
+
+	target, held := f.status(t)
+	// The ramp holds at day 10 (the placement is fresh) and the day is cut a
+	// quarter: 20 -> 15.
+	if target != 15 {
+		t.Errorf("target = %d, want the 25%% cut of 15", target)
+	}
+	if !held {
+		t.Error("target was cut but nothing explains why; the drawer would show a silent drop")
+	}
+}
+
+func TestLiveOldPlacementNoLongerCutsButStillShiftsTheRamp(t *testing.T) {
+	// A placement 8 days ago is outside the 48h signal window, so the cut is
+	// gone; the ramp still resumed from where it was held rather than
+	// catching up, which is the whole point of the freeze.
+	f := newRampFixture(t, 10, 10, 1, 40)
+	f.placement(t, 8*24)
+
+	target, held := f.status(t)
+	if held {
+		t.Error("a placement 8 days old must not still be reported as holding the ramp")
+	}
+	expectedDays := warmupramp.Days(
+		time.Now().Add(-10*24*time.Hour),
+		ptrTime(time.Now().Add(-8*24*time.Hour)),
+		time.Now(),
+		warmupramp.FreezeWindow,
+	)
+	want := warmupramp.Target(true, 10, 1, 40, expectedDays, false)
+	if target != want {
+		t.Errorf("target = %d, want %d (day %d after the freeze shift)", target, want, expectedDays)
+	}
+	if target >= 20 {
+		t.Errorf("target %d is at or above the unfrozen day-10 ramp of 20; the freeze was not applied", target)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/app/warmupramp/plan.go
+++ b/internal/app/warmupramp/plan.go
@@ -1,0 +1,99 @@
+package warmupramp
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Reader is the repository surface a plan needs. Declared here so the policy
+// does not depend on the repository package.
+type Reader interface {
+	SpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) ([]time.Time, error)
+	SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
+}
+
+// Input is everything about a mailbox the plan reads off the row.
+type Input struct {
+	AccountID       uuid.UUID
+	WarmupStart     time.Time
+	ActivelyWarming bool
+	Base            int
+	Increase        int
+	Max             int
+	InCampaign      bool
+	Health          models.WarmupHealthState
+	Now             time.Time
+}
+
+// Plan is the resolved warmup volume for a mailbox, and why.
+type Plan struct {
+	// Target is the day's volume after ramp, cut and band. Callers may clamp
+	// it further; they must never raise it.
+	Target int
+	// Placements and Sends cover SoftSignalWindow.
+	Placements int
+	Sends      int
+	// FrozenUntil outlives the volume cut (FreezeWindow > SoftSignalWindow), so
+	// a mailbox can be back at full volume while still not climbing.
+	FrozenUntil *time.Time
+}
+
+// Cut reports whether the early signal reduced today's volume.
+func (p Plan) Cut() bool { return p.Placements > 0 }
+
+// HealthVolumeMultiplier lives beside the ramp so the scheduler and the
+// dashboard cannot apply different bands.
+func HealthVolumeMultiplier(state models.WarmupHealthState) float64 {
+	switch state {
+	case models.WarmupHealthThrottled:
+		return 0.5
+	case models.WarmupHealthWatch:
+		return 0.7
+	default:
+		return 1.0
+	}
+}
+
+// Resolve computes the plan. Reads fail open to "no signal". The early cut
+// applies only while Healthy: a banded mailbox is already dampened harder, and
+// stacking both would cut it twice for one problem.
+func Resolve(ctx context.Context, r Reader, in Input) Plan {
+	var plan Plan
+	if !in.ActivelyWarming {
+		plan.Target = Target(false, in.Base, in.Increase, in.Max, 0, in.InCampaign)
+		return plan
+	}
+
+	var placements []time.Time
+	if r != nil {
+		if got, err := r.SpamPlacementsSince(ctx, in.AccountID, in.Now.Add(-LookbackWindow)); err == nil {
+			placements = got
+		}
+	}
+
+	since := in.Now.Add(-SoftSignalWindow)
+	for _, p := range placements {
+		if !p.Before(since) {
+			plan.Placements++
+		}
+	}
+	if r != nil && plan.Placements > 0 {
+		if sends, err := r.SumWarmupSentSince(ctx, in.AccountID, since); err == nil {
+			plan.Sends = sends
+		}
+	}
+
+	days := Days(in.WarmupStart, placements, in.Now, FreezeWindow)
+	plan.FrozenUntil = FrozenUntil(placements, in.Now, FreezeWindow)
+
+	target := Target(true, in.Base, in.Increase, in.Max, days, in.InCampaign)
+	if in.Health == models.WarmupHealthHealthy || in.Health == "" {
+		target = Apply(target, SoftAdjust(plan.Placements))
+	}
+	plan.Target = Apply(target, HealthVolumeMultiplier(in.Health))
+	return plan
+}

--- a/internal/app/warmupramp/ramp.go
+++ b/internal/app/warmupramp/ramp.go
@@ -1,0 +1,108 @@
+// Package warmupramp holds the warmup volume policy: how many emails a mailbox
+// should aim to send today, and how an early adverse signal holds that number
+// down. It is pure (no context, no database) and lives outside the scheduler so
+// the dashboard reports the SAME target the scheduler will act on. Two copies
+// of this arithmetic is how a mailbox ends up showing "target 25" while it
+// sends 18.
+package warmupramp
+
+import "time"
+
+const (
+	// ActiveCampaignCap is the warmup volume for a mailbox that also backs a
+	// live campaign, so warmup does not stack on production sending pressure.
+	ActiveCampaignCap = 5
+
+	// SoftThrottleMultiplier is the ~25% cut applied on the first adverse
+	// signal, while the mailbox is still Healthy.
+	//
+	// Every band in the health model needs a sample floor (20 warmup sends in
+	// 7 days, 100 delivered in 30) before it can trip, which a mailbox in its
+	// first week cannot reach — so a new mailbox landing in junk would keep
+	// ramping +1/day until it had sent enough to be judged. Providers advise
+	// the opposite: cut about a quarter and hold at the FIRST sign.
+	SoftThrottleMultiplier = 0.75
+
+	// SoftSignalWindow is how recent a placement must be to still count as
+	// degradation rather than history the mailbox has recovered from.
+	SoftSignalWindow = 48 * time.Hour
+
+	// FreezeWindow is how long the ramp holds after a placement.
+	FreezeWindow = 72 * time.Hour
+)
+
+// SoftAdjust returns the volume multiplier for an early adverse signal. Any
+// placement in the window cuts volume; a rate threshold is deliberately absent,
+// because waiting for a rate to clear a sample floor is the delay this exists
+// to remove.
+func SoftAdjust(placements int) float64 {
+	if placements > 0 {
+		return SoftThrottleMultiplier
+	}
+	return 1.0
+}
+
+// Days is the ramp day-count to use, holding the ramp where it stood when a
+// placement landed and resuming from there once the freeze expires. A freeze
+// SHIFTS the ramp back rather than letting it catch up: holding for three days
+// and then climbing three steps in one morning is the overnight spike the hold
+// exists to prevent.
+func Days(warmupStart time.Time, lastPlacement *time.Time, now time.Time, freeze time.Duration) int {
+	days := wholeDays(now.Sub(warmupStart))
+	if lastPlacement == nil || lastPlacement.Before(warmupStart) {
+		return days
+	}
+	held := wholeDays(lastPlacement.Sub(warmupStart))
+	thawAt := lastPlacement.Add(freeze)
+	if now.Before(thawAt) {
+		return held
+	}
+	// Never claim more days than actually elapsed, or a freeze would end up
+	// accelerating the mailbox instead of slowing it.
+	if resumed := held + wholeDays(now.Sub(thawAt)); resumed < days {
+		return resumed
+	}
+	return days
+}
+
+// Target is the day's warmup volume before recipient-capacity, health-band and
+// early-signal adjustments. An actively-warming mailbox follows its ramp,
+// reduced to the in-campaign cap when it also backs a live campaign. A mailbox
+// kept warm only because it backs a campaign runs at the in-campaign cap.
+func Target(activelyWarming bool, base, increase, max, days int, inCampaign bool) int {
+	if !activelyWarming {
+		return ActiveCampaignCap
+	}
+	target := base + days*increase
+	if target > max {
+		target = max
+	}
+	if inCampaign && target > ActiveCampaignCap {
+		target = ActiveCampaignCap
+	}
+	return target
+}
+
+// Apply folds the early-signal cut into a target, never below one email: a
+// degraded mailbox keeps a heartbeat so the health sweep has fresh data.
+func Apply(target int, multiplier float64) int {
+	if multiplier >= 1.0 || target <= 0 {
+		return target
+	}
+	cut := int(float64(target)*multiplier + 0.5)
+	if cut < 1 {
+		cut = 1
+	}
+	if cut > target {
+		return target
+	}
+	return cut
+}
+
+func wholeDays(d time.Duration) int {
+	days := int(d.Hours() / 24)
+	if days < 0 {
+		return 0
+	}
+	return days
+}

--- a/internal/app/warmupramp/ramp.go
+++ b/internal/app/warmupramp/ramp.go
@@ -1,40 +1,33 @@
 // Package warmupramp holds the warmup volume policy: how many emails a mailbox
-// should aim to send today, and how an early adverse signal holds that number
-// down. It is pure (no context, no database) and lives outside the scheduler so
-// the dashboard reports the SAME target the scheduler will act on. Two copies
-// of this arithmetic is how a mailbox ends up showing "target 25" while it
-// sends 18.
+// should aim to send today, and how adverse signal holds that number down. Pure
+// and outside the scheduler so the dashboard reports the same target the
+// scheduler acts on.
 package warmupramp
 
 import "time"
 
 const (
-	// ActiveCampaignCap is the warmup volume for a mailbox that also backs a
-	// live campaign, so warmup does not stack on production sending pressure.
+	// ActiveCampaignCap is the warmup volume for a mailbox also backing a live
+	// campaign, so warmup does not stack on production sending pressure.
 	ActiveCampaignCap = 5
 
-	// SoftThrottleMultiplier is the ~25% cut applied on the first adverse
-	// signal, while the mailbox is still Healthy.
-	//
-	// Every band in the health model needs a sample floor (20 warmup sends in
-	// 7 days, 100 delivered in 30) before it can trip, which a mailbox in its
-	// first week cannot reach — so a new mailbox landing in junk would keep
-	// ramping +1/day until it had sent enough to be judged. Providers advise
-	// the opposite: cut about a quarter and hold at the FIRST sign.
+	// SoftThrottleMultiplier is the cut applied while a placement is fresh.
+	// The bands cannot do this: each needs a sample floor a new mailbox has
+	// not reached (20 warmup sends in 7 days, 100 delivered in 30).
 	SoftThrottleMultiplier = 0.75
 
-	// SoftSignalWindow is how recent a placement must be to still count as
-	// degradation rather than history the mailbox has recovered from.
+	// SoftSignalWindow is how recent a placement must be to still cut volume.
 	SoftSignalWindow = 48 * time.Hour
 
-	// FreezeWindow is how long the ramp holds after a placement.
+	// FreezeWindow is how long one placement holds the ramp.
 	FreezeWindow = 72 * time.Hour
+
+	// LookbackWindow bounds how far back placements are read.
+	LookbackWindow = 60 * 24 * time.Hour
 )
 
-// SoftAdjust returns the volume multiplier for an early adverse signal. Any
-// placement in the window cuts volume; a rate threshold is deliberately absent,
-// because waiting for a rate to clear a sample floor is the delay this exists
-// to remove.
+// SoftAdjust returns the volume multiplier for a fresh placement. Any placement
+// cuts; a rate threshold would reintroduce the sample floor this avoids.
 func SoftAdjust(placements int) float64 {
 	if placements > 0 {
 		return SoftThrottleMultiplier
@@ -42,33 +35,83 @@ func SoftAdjust(placements int) float64 {
 	return 1.0
 }
 
-// Days is the ramp day-count to use, holding the ramp where it stood when a
-// placement landed and resuming from there once the freeze expires. A freeze
-// SHIFTS the ramp back rather than letting it catch up: holding for three days
-// and then climbing three steps in one morning is the overnight spike the hold
-// exists to prevent.
-func Days(warmupStart time.Time, lastPlacement *time.Time, now time.Time, freeze time.Duration) int {
-	days := wholeDays(now.Sub(warmupStart))
-	if lastPlacement == nil || lastPlacement.Before(warmupStart) {
-		return days
+// Days is the ramp day-count: elapsed days minus days spent frozen. Subtracted
+// time rather than a held level, because freezing "at the last placement's
+// level" would raise it whenever a new placement arrived mid-hold. Input need
+// not be sorted or deduplicated.
+func Days(warmupStart time.Time, placements []time.Time, now time.Time, freeze time.Duration) int {
+	elapsed := now.Sub(warmupStart)
+	if elapsed <= 0 {
+		return 0
 	}
-	held := wholeDays(lastPlacement.Sub(warmupStart))
-	thawAt := lastPlacement.Add(freeze)
-	if now.Before(thawAt) {
-		return held
+	return wholeDays(elapsed - frozenDuration(warmupStart, placements, now, freeze))
+}
+
+// FrozenUntil is when the ramp climbs again, or nil when it already is. Covers
+// the whole freeze, not just the shorter window that also cuts volume.
+func FrozenUntil(placements []time.Time, now time.Time, freeze time.Duration) *time.Time {
+	var latest time.Time
+	for _, p := range placements {
+		if p.After(latest) {
+			latest = p
+		}
 	}
-	// Never claim more days than actually elapsed, or a freeze would end up
-	// accelerating the mailbox instead of slowing it.
-	if resumed := held + wholeDays(now.Sub(thawAt)); resumed < days {
-		return resumed
+	if latest.IsZero() {
+		return nil
 	}
-	return days
+	until := latest.Add(freeze)
+	if !until.After(now) {
+		return nil
+	}
+	return &until
+}
+
+// frozenDuration is the union of each placement's freeze window, clipped to
+// now. Union, not sum: two placements an hour apart freeze about one window.
+func frozenDuration(warmupStart time.Time, placements []time.Time, now time.Time, freeze time.Duration) time.Duration {
+	type span struct{ start, end time.Time }
+	spans := make([]span, 0, len(placements))
+	for _, p := range placements {
+		if p.Before(warmupStart) {
+			// From a previous warmup run: restarting warmup resets the ramp,
+			// so a stale freeze must not carry into the new one.
+			continue
+		}
+		start, end := p, p.Add(freeze)
+		if end.After(now) {
+			end = now
+		}
+		if end.After(start) {
+			spans = append(spans, span{start, end})
+		}
+	}
+	if len(spans) == 0 {
+		return 0
+	}
+	// Insertion sort by start: placements are rare, so this stays tiny and
+	// avoids pulling sort into a hot path.
+	for i := 1; i < len(spans); i++ {
+		for j := i; j > 0 && spans[j].start.Before(spans[j-1].start); j-- {
+			spans[j], spans[j-1] = spans[j-1], spans[j]
+		}
+	}
+	var total time.Duration
+	cur := spans[0]
+	for _, s := range spans[1:] {
+		if s.start.After(cur.end) {
+			total += cur.end.Sub(cur.start)
+			cur = s
+			continue
+		}
+		if s.end.After(cur.end) {
+			cur.end = s.end
+		}
+	}
+	return total + cur.end.Sub(cur.start)
 }
 
 // Target is the day's warmup volume before recipient-capacity, health-band and
-// early-signal adjustments. An actively-warming mailbox follows its ramp,
-// reduced to the in-campaign cap when it also backs a live campaign. A mailbox
-// kept warm only because it backs a campaign runs at the in-campaign cap.
+// early-signal adjustments.
 func Target(activelyWarming bool, base, increase, max, days int, inCampaign bool) int {
 	if !activelyWarming {
 		return ActiveCampaignCap
@@ -83,8 +126,8 @@ func Target(activelyWarming bool, base, increase, max, days int, inCampaign bool
 	return target
 }
 
-// Apply folds the early-signal cut into a target, never below one email: a
-// degraded mailbox keeps a heartbeat so the health sweep has fresh data.
+// Apply folds a multiplier into a target, never below one: a degraded mailbox
+// keeps a heartbeat so the health sweep has fresh data to judge it on.
 func Apply(target int, multiplier float64) int {
 	if multiplier >= 1.0 || target <= 0 {
 		return target

--- a/internal/app/warmupramp/ramp_test.go
+++ b/internal/app/warmupramp/ramp_test.go
@@ -9,8 +9,8 @@ func TestSoftAdjustCutsOnAnyPlacement(t *testing.T) {
 	if got := SoftAdjust(0); got != 1.0 {
 		t.Errorf("SoftAdjust(0) = %v, want 1.0", got)
 	}
-	// One placement is enough on purpose: waiting for a rate to clear a sample
-	// floor is the delay this path exists to remove.
+	// One placement is enough: waiting for a rate to clear a sample floor is
+	// the delay this path exists to remove.
 	for _, n := range []int{1, 9} {
 		if got := SoftAdjust(n); got != SoftThrottleMultiplier {
 			t.Errorf("SoftAdjust(%d) = %v, want %v", n, got, SoftThrottleMultiplier)
@@ -21,45 +21,93 @@ func TestSoftAdjustCutsOnAnyPlacement(t *testing.T) {
 func TestDays(t *testing.T) {
 	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 	at := func(days float64) time.Time { return start.Add(time.Duration(days * float64(24*time.Hour))) }
-	ptr := func(t time.Time) *time.Time { return &t }
 	freeze := 72 * time.Hour
 
 	tests := []struct {
-		name          string
-		lastPlacement *time.Time
-		now           time.Time
-		want          int
+		name       string
+		placements []time.Time
+		now        time.Time
+		want       int
 	}{
 		{"no placement ramps normally", nil, at(10), 10},
-		{"placement before warmup started is not ours", ptr(start.Add(-48 * time.Hour)), at(10), 10},
-		{"inside the freeze holds at the placement day", ptr(at(5)), at(6), 5},
-		{"still holding on the last hour of the freeze", ptr(at(5)), at(7.9), 5},
-		// The point: the three held days are LOST, not caught up. Resuming at 8
-		// and jumping straight to 8 would be the overnight spike itself.
-		{"resumes from the held level, never catches up", ptr(at(5)), at(9), 6},
-		{"a week later it is still three days behind", ptr(at(5)), at(15), 12},
-		{"a placement on day zero holds at zero", ptr(at(0)), at(1), 0},
+		{"placement from a previous warmup run is ignored", []time.Time{start.Add(-48 * time.Hour)}, at(10), 10},
+		{"inside the freeze the ramp does not move", []time.Time{at(5)}, at(6), 5},
+		{"still held on the last hour of the freeze", []time.Time{at(5)}, at(7.9), 5},
+		// Frozen days are subtracted, not made up: 9 elapsed minus 3 frozen.
+		{"resumes from the held level", []time.Time{at(5)}, at(9), 6},
+		{"a week later it is still three days behind", []time.Time{at(5)}, at(15), 12},
+		{"a placement on day zero holds at zero", []time.Time{at(0)}, at(1), 0},
 		{"clock skew before warmup start floors at zero", nil, start.Add(-time.Hour), 0},
+
+		// Why this is subtracted time rather than a held level: holding "at the
+		// newest placement's level" would RAISE the held level every time a new
+		// placement arrived mid-hold, so a mailbox landing in junk repeatedly
+		// would ramp up.
+		{"a second placement mid-hold does not advance the ramp", []time.Time{at(5), at(6)}, at(7), 5},
+		{"and it extends the hold rather than ending it", []time.Time{at(5), at(6)}, at(8.5), 5},
+		// Union, not sum: two placements an hour apart freeze ~3 days, not 6.
+		// A sum would leave 14 here.
+		{"overlapping freezes count once", []time.Time{at(5), at(5.04)}, at(20), 16},
+		{"separated freezes each cost a window", []time.Time{at(2), at(10)}, at(20), 14},
+		{"unsorted input is handled", []time.Time{at(10), at(2)}, at(20), 14},
+		{"duplicate timestamps count once", []time.Time{at(5), at(5), at(5)}, at(20), 17},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := Days(start, tt.lastPlacement, tt.now, freeze); got != tt.want {
+			if got := Days(start, tt.placements, tt.now, freeze); got != tt.want {
 				t.Errorf("Days() = %d, want %d", got, tt.want)
 			}
 		})
 	}
 }
 
-func TestDaysNeverExceedsRealElapsed(t *testing.T) {
-	// A resumed ramp must never claim more days than actually passed, or a
-	// freeze would end up ACCELERATING the mailbox.
+func TestDaysIsMonotonicInPlacements(t *testing.T) {
+	// Adding a placement must never RAISE the ramp. The previous "hold at the
+	// newest placement" model violated exactly this.
 	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	placement := start.Add(24 * time.Hour)
+	now := start.Add(30 * 24 * time.Hour)
+	var placements []time.Time
+	prev := Days(start, placements, now, 72*time.Hour)
+	for d := 1; d <= 20; d++ {
+		placements = append(placements, start.Add(time.Duration(d)*24*time.Hour))
+		got := Days(start, placements, now, 72*time.Hour)
+		if got > prev {
+			t.Fatalf("adding placement %d raised the ramp from %d to %d", d, prev, got)
+		}
+		prev = got
+	}
+}
+
+func TestDaysNeverExceedsRealElapsed(t *testing.T) {
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	placements := []time.Time{start.Add(24 * time.Hour)}
 	for d := 1; d < 40; d++ {
 		now := start.Add(time.Duration(d) * 24 * time.Hour)
-		if got := Days(start, &placement, now, 72*time.Hour); got > d {
+		if got := Days(start, placements, now, 72*time.Hour); got > d {
 			t.Fatalf("day %d: Days = %d, more than the %d elapsed", d, got, d)
 		}
+	}
+}
+
+func TestFrozenUntilCoversTheWholeFreeze(t *testing.T) {
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	freeze := 72 * time.Hour
+	p := start.Add(24 * time.Hour)
+
+	if got := FrozenUntil(nil, start, freeze); got != nil {
+		t.Errorf("no placements must not report a freeze, got %v", got)
+	}
+	// Still frozen at 60 hours, PAST the 48-hour volume-cut window: the ramp is
+	// held while volume is already back to normal, and that must be reportable.
+	if got := FrozenUntil([]time.Time{p}, p.Add(60*time.Hour), freeze); got == nil {
+		t.Error("ramp is still frozen at 60h but nothing reports it")
+	}
+	if got := FrozenUntil([]time.Time{p}, p.Add(freeze), freeze); got != nil {
+		t.Errorf("freeze expired but still reported: %v", got)
+	}
+	got := FrozenUntil([]time.Time{p, p.Add(24 * time.Hour)}, p.Add(30*time.Hour), freeze)
+	if got == nil || !got.Equal(p.Add(24*time.Hour).Add(freeze)) {
+		t.Errorf("FrozenUntil = %v, want the newest placement plus the window", got)
 	}
 }
 
@@ -74,10 +122,10 @@ func TestTargetClampsToBaseCeilingAndCampaignCap(t *testing.T) {
 		t.Errorf("day 500 = %d, want the ceiling of 40", got)
 	}
 	if got := Target(true, 10, 1, 40, 500, true); got != ActiveCampaignCap {
-		t.Errorf("in-campaign = %d, want the campaign cap of %d", got, ActiveCampaignCap)
+		t.Errorf("in-campaign = %d, want %d", got, ActiveCampaignCap)
 	}
 	if got := Target(false, 10, 1, 40, 500, false); got != ActiveCampaignCap {
-		t.Errorf("monitor lane = %d, want the campaign cap of %d", got, ActiveCampaignCap)
+		t.Errorf("monitor lane = %d, want %d", got, ActiveCampaignCap)
 	}
 }
 

--- a/internal/app/warmupramp/ramp_test.go
+++ b/internal/app/warmupramp/ramp_test.go
@@ -1,0 +1,99 @@
+package warmupramp
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSoftAdjustCutsOnAnyPlacement(t *testing.T) {
+	if got := SoftAdjust(0); got != 1.0 {
+		t.Errorf("SoftAdjust(0) = %v, want 1.0", got)
+	}
+	// One placement is enough on purpose: waiting for a rate to clear a sample
+	// floor is the delay this path exists to remove.
+	for _, n := range []int{1, 9} {
+		if got := SoftAdjust(n); got != SoftThrottleMultiplier {
+			t.Errorf("SoftAdjust(%d) = %v, want %v", n, got, SoftThrottleMultiplier)
+		}
+	}
+}
+
+func TestDays(t *testing.T) {
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	at := func(days float64) time.Time { return start.Add(time.Duration(days * float64(24*time.Hour))) }
+	ptr := func(t time.Time) *time.Time { return &t }
+	freeze := 72 * time.Hour
+
+	tests := []struct {
+		name          string
+		lastPlacement *time.Time
+		now           time.Time
+		want          int
+	}{
+		{"no placement ramps normally", nil, at(10), 10},
+		{"placement before warmup started is not ours", ptr(start.Add(-48 * time.Hour)), at(10), 10},
+		{"inside the freeze holds at the placement day", ptr(at(5)), at(6), 5},
+		{"still holding on the last hour of the freeze", ptr(at(5)), at(7.9), 5},
+		// The point: the three held days are LOST, not caught up. Resuming at 8
+		// and jumping straight to 8 would be the overnight spike itself.
+		{"resumes from the held level, never catches up", ptr(at(5)), at(9), 6},
+		{"a week later it is still three days behind", ptr(at(5)), at(15), 12},
+		{"a placement on day zero holds at zero", ptr(at(0)), at(1), 0},
+		{"clock skew before warmup start floors at zero", nil, start.Add(-time.Hour), 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Days(start, tt.lastPlacement, tt.now, freeze); got != tt.want {
+				t.Errorf("Days() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDaysNeverExceedsRealElapsed(t *testing.T) {
+	// A resumed ramp must never claim more days than actually passed, or a
+	// freeze would end up ACCELERATING the mailbox.
+	start := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	placement := start.Add(24 * time.Hour)
+	for d := 1; d < 40; d++ {
+		now := start.Add(time.Duration(d) * 24 * time.Hour)
+		if got := Days(start, &placement, now, 72*time.Hour); got > d {
+			t.Fatalf("day %d: Days = %d, more than the %d elapsed", d, got, d)
+		}
+	}
+}
+
+func TestTargetClampsToBaseCeilingAndCampaignCap(t *testing.T) {
+	if got := Target(true, 10, 1, 40, 0, false); got != 10 {
+		t.Errorf("day 0 = %d, want the base of 10", got)
+	}
+	if got := Target(true, 10, 1, 40, 5, false); got != 15 {
+		t.Errorf("day 5 = %d, want 15", got)
+	}
+	if got := Target(true, 10, 1, 40, 500, false); got != 40 {
+		t.Errorf("day 500 = %d, want the ceiling of 40", got)
+	}
+	if got := Target(true, 10, 1, 40, 500, true); got != ActiveCampaignCap {
+		t.Errorf("in-campaign = %d, want the campaign cap of %d", got, ActiveCampaignCap)
+	}
+	if got := Target(false, 10, 1, 40, 500, false); got != ActiveCampaignCap {
+		t.Errorf("monitor lane = %d, want the campaign cap of %d", got, ActiveCampaignCap)
+	}
+}
+
+func TestApplyKeepsAHeartbeat(t *testing.T) {
+	if got := Apply(20, 0.75); got != 15 {
+		t.Errorf("Apply(20, 0.75) = %d, want 15", got)
+	}
+	if got := Apply(20, 1.0); got != 20 {
+		t.Errorf("Apply with no signal must not move the target, got %d", got)
+	}
+	// Even a fully degraded mailbox keeps one send so the health sweep has
+	// fresh data to judge it on.
+	if got := Apply(1, 0.75); got != 1 {
+		t.Errorf("Apply(1, 0.75) = %d, want 1", got)
+	}
+	if got := Apply(0, 0.75); got != 0 {
+		t.Errorf("Apply(0, ...) = %d, want 0", got)
+	}
+}

--- a/internal/models/analytics.go
+++ b/internal/models/analytics.go
@@ -152,19 +152,20 @@ type WarmupStatusInfo struct {
 	MaxVolume     int        `json:"max_volume"`
 	ReplyRate     int        `json:"reply_rate"`
 	DaysActive    int        `json:"days_active"`
-	// RampHold explains a target below the plain ramp: set when a recent junk
-	// placement cut the day and froze the ramp. Empty when nothing is holding
-	// it. Without this the volume just drops and the owner cannot tell why.
+	// RampHold explains a ramp that is not climbing, so a target below the
+	// plain ramp is never an unexplained drop.
 	RampHold *WarmupRampHold `json:"ramp_hold,omitempty"`
 }
 
-// WarmupRampHold is the early-signal state behind a reduced warmup target.
+// WarmupRampHold explains a ramp that is not climbing. Present for the whole
+// freeze; VolumeCut says whether today's volume is also reduced, which lasts a
+// shorter window.
 type WarmupRampHold struct {
-	// Placements and Sends are the last 48 hours.
-	Placements int       `json:"placements"`
-	Sends      int       `json:"sends"`
-	LastAt     time.Time `json:"last_placement_at"`
-	// ResumesAt is when the ramp starts climbing again if nothing else lands.
+	// Placements and Sends cover the last 48 hours.
+	Placements int  `json:"placements"`
+	Sends      int  `json:"sends"`
+	VolumeCut  bool `json:"volume_cut"`
+	// ResumesAt is when the ramp climbs again if nothing else lands.
 	ResumesAt time.Time `json:"resumes_at"`
 }
 

--- a/internal/models/analytics.go
+++ b/internal/models/analytics.go
@@ -152,6 +152,20 @@ type WarmupStatusInfo struct {
 	MaxVolume     int        `json:"max_volume"`
 	ReplyRate     int        `json:"reply_rate"`
 	DaysActive    int        `json:"days_active"`
+	// RampHold explains a target below the plain ramp: set when a recent junk
+	// placement cut the day and froze the ramp. Empty when nothing is holding
+	// it. Without this the volume just drops and the owner cannot tell why.
+	RampHold *WarmupRampHold `json:"ramp_hold,omitempty"`
+}
+
+// WarmupRampHold is the early-signal state behind a reduced warmup target.
+type WarmupRampHold struct {
+	// Placements and Sends are the last 48 hours.
+	Placements int       `json:"placements"`
+	Sends      int       `json:"sends"`
+	LastAt     time.Time `json:"last_placement_at"`
+	// ResumesAt is when the ramp starts climbing again if nothing else lands.
+	ResumesAt time.Time `json:"resumes_at"`
 }
 
 // Usage Overview

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -118,10 +118,10 @@ type WarmupRepository interface {
 	CountSpamReportsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountUserComplaintsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountSpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
-	// LastSpamPlacementAt is when this sender's most recent warmup message was
-	// found in a recipient's junk folder, or nil if it never has been. The
-	// warmup ramp holds where it stood at that moment (see warmupRampDays).
-	LastSpamPlacementAt(ctx context.Context, accountID uuid.UUID) (*time.Time, error)
+	// SpamPlacementsSince lists when this sender's warmup mail was found in a
+	// recipient's junk folder. The ramp subtracts a freeze window per
+	// placement, so it needs all of them, not just the newest.
+	SpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) ([]time.Time, error)
 	SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountDeliverabilityEventsByAccount(ctx context.Context, accountID uuid.UUID, eventType string, since time.Time) (int, error)
 	CountDeliveredByAccount(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
@@ -637,20 +637,29 @@ func (r *warmupRepository) CountSpamPlacementsSince(ctx context.Context, account
 	return count, err
 }
 
-func (r *warmupRepository) LastSpamPlacementAt(ctx context.Context, accountID uuid.UUID) (*time.Time, error) {
-	query := `
-		SELECT MAX(created_at)
+func (r *warmupRepository) SpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) ([]time.Time, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT created_at
 		FROM warmup_spam_reports
 		WHERE reported_account_id = $1
 		  AND report_type = 'spam_placement'
-	`
-	// MAX over no rows is a SQL NULL, not ErrNoRows, so the nullable scan is
-	// what distinguishes "never placed" from a failure.
-	var at *time.Time
-	if err := r.db.QueryRow(ctx, query, accountID).Scan(&at); err != nil {
+		  AND created_at >= $2
+		ORDER BY created_at
+	`, accountID, since)
+	if err != nil {
 		return nil, err
 	}
-	return at, nil
+	defer rows.Close()
+
+	var out []time.Time
+	for rows.Next() {
+		var at time.Time
+		if err := rows.Scan(&at); err != nil {
+			return nil, err
+		}
+		out = append(out, at)
+	}
+	return out, rows.Err()
 }
 
 func (r *warmupRepository) SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error) {

--- a/internal/repository/pg_warmup.go
+++ b/internal/repository/pg_warmup.go
@@ -118,6 +118,10 @@ type WarmupRepository interface {
 	CountSpamReportsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountUserComplaintsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountSpamPlacementsSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
+	// LastSpamPlacementAt is when this sender's most recent warmup message was
+	// found in a recipient's junk folder, or nil if it never has been. The
+	// warmup ramp holds where it stood at that moment (see warmupRampDays).
+	LastSpamPlacementAt(ctx context.Context, accountID uuid.UUID) (*time.Time, error)
 	SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
 	CountDeliverabilityEventsByAccount(ctx context.Context, accountID uuid.UUID, eventType string, since time.Time) (int, error)
 	CountDeliveredByAccount(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error)
@@ -631,6 +635,22 @@ func (r *warmupRepository) CountSpamPlacementsSince(ctx context.Context, account
 	var count int
 	err := r.db.QueryRow(ctx, query, accountID, since).Scan(&count)
 	return count, err
+}
+
+func (r *warmupRepository) LastSpamPlacementAt(ctx context.Context, accountID uuid.UUID) (*time.Time, error) {
+	query := `
+		SELECT MAX(created_at)
+		FROM warmup_spam_reports
+		WHERE reported_account_id = $1
+		  AND report_type = 'spam_placement'
+	`
+	// MAX over no rows is a SQL NULL, not ErrNoRows, so the nullable scan is
+	// what distinguishes "never placed" from a failure.
+	var at *time.Time
+	if err := r.db.QueryRow(ctx, query, accountID).Scan(&at); err != nil {
+		return nil, err
+	}
+	return at, nil
 }
 
 func (r *warmupRepository) SumWarmupSentSince(ctx context.Context, accountID uuid.UUID, since time.Time) (int, error) {

--- a/internal/scheduler/warmup_scheduler.go
+++ b/internal/scheduler/warmup_scheduler.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
 	"github.com/warmbly/warmbly/internal/app/behavior"
+	"github.com/warmbly/warmbly/internal/app/warmupramp"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -18,7 +21,6 @@ var poolTypesForHealthLookup = []string{"premium", "free"}
 const (
 	minWarmupRecipientRecheck = 4 * time.Hour
 	maxWarmupRecipientRecheck = 8 * time.Hour
-	activeCampaignWarmupCap   = 5
 )
 
 // healthAdjustment captures how the throttled/watch health state should
@@ -28,6 +30,38 @@ const (
 type healthAdjustment struct {
 	volumeMultiplier  float64 // applied to target_volume
 	minWaitMultiplier float64 // applied to MinWaitTime between sends
+}
+
+// softRampSignal is the early-signal verdict for one scheduling pass.
+type softRampSignal struct {
+	multiplier      float64
+	placements      int
+	sends           int
+	lastPlacementAt *time.Time
+}
+
+// resolveSoftRampSignal reads the mailbox's recent junk placements. Every
+// lookup fails open to "no signal": warmup slowing itself down because a query
+// errored would be a worse outcome than one more day at the planned volume.
+func (s *schedulerService) resolveSoftRampSignal(ctx context.Context, accountID uuid.UUID) softRampSignal {
+	sig := softRampSignal{multiplier: 1.0}
+	if s.warmupRepo == nil {
+		return sig
+	}
+	since := time.Now().Add(-warmupramp.SoftSignalWindow)
+	placements, err := s.warmupRepo.CountSpamPlacementsSince(ctx, accountID, since)
+	if err != nil {
+		return sig
+	}
+	sig.placements = placements
+	sig.multiplier = warmupramp.SoftAdjust(placements)
+	if sends, serr := s.warmupRepo.SumWarmupSentSince(ctx, accountID, since); serr == nil {
+		sig.sends = sends
+	}
+	if at, aerr := s.warmupRepo.LastSpamPlacementAt(ctx, accountID); aerr == nil {
+		sig.lastPlacementAt = at
+	}
+	return sig
 }
 
 func adjustmentFor(state models.WarmupHealthState) healthAdjustment {
@@ -59,22 +93,10 @@ func recipientRecheckTime() time.Time {
 	)) * time.Minute)
 }
 
-// warmupRampTarget computes the day's warmup volume before recipient-capacity
-// and health-state adjustments. An actively-warming mailbox follows its ramp
-// (base + daysWarming*increase, capped at max), reduced to the in-campaign cap
-// when it also backs a live campaign so warmup doesn't stack on production
-// sending pressure. A mailbox kept warm only because it backs a campaign (the
-// monitor lane) runs at the in-campaign cap. Pure (no DB) so the policy is
-// unit-testable.
+// warmupRampTarget is the scheduler's entry point into the shared ramp policy.
+// It stays here so the existing call sites and tests read unchanged.
 func warmupRampTarget(activelyWarming bool, base, increase, max, daysWarming int, inCampaign bool) int {
-	if !activelyWarming {
-		return activeCampaignWarmupCap
-	}
-	target := min(base+daysWarming*increase, max)
-	if inCampaign && target > activeCampaignWarmupCap {
-		target = activeCampaignWarmupCap
-	}
-	return target
+	return warmupramp.Target(activelyWarming, base, increase, max, daysWarming, inCampaign)
 }
 
 // dailyVolumeFactor returns a stable-per-day multiplier (0.75–1.10, with an
@@ -192,11 +214,37 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 
 	// STEP 2: Calculate target volume for today (before recipient-capacity and
 	// health adjustments). Pure policy in warmupRampTarget so it's unit-tested.
+	// The health state drives both the band adjustment (STEP 2.5) and whether
+	// the early-signal cut below applies, so it is resolved once here.
+	healthState := s.resolveHealthState(ctx, accountID)
+
+	// Early adverse signal: a recent junk placement holds the ramp where it
+	// stood and cuts the day about a quarter, before any hard band can trip.
+	// Only while Healthy — a mailbox already in watch or throttled is being
+	// dampened harder by its band, and stacking the two would double-cut it.
+	soft := softRampSignal{multiplier: 1.0}
+	if healthState == models.WarmupHealthHealthy {
+		soft = s.resolveSoftRampSignal(ctx, accountID)
+	}
+
 	daysWarming := 0
 	if activelyWarming {
-		daysWarming = int(time.Since(*account.Warmup).Hours() / 24)
+		daysWarming = warmupramp.Days(*account.Warmup, soft.lastPlacementAt, time.Now(), warmupramp.FreezeWindow)
 	}
 	targetVolume := warmupRampTarget(activelyWarming, account.WarmupBase, account.WarmupIncrease, account.WarmupMax, daysWarming, inCampaign)
+
+	// The cut lands before the recipient-capacity clamp and the band
+	// adjustment, so it composes with both by min() rather than fighting them.
+	if cut := warmupramp.Apply(targetVolume, soft.multiplier); cut < targetVolume {
+		log.Info().
+			Str("email_account_id", accountID.String()).
+			Int("placements_48h", soft.placements).
+			Int("sends_48h", soft.sends).
+			Int("from", targetVolume).
+			Int("to", cut).
+			Msg("warmup volume cut on an early placement signal; ramp held")
+		targetVolume = cut
+	}
 
 	// Vary the day's target so a mailbox doesn't send an identical count every
 	// day. Deterministic per (account, local day) so it's stable across the
@@ -237,7 +285,7 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 	// run at reduced volume and wider spacing until the health sweep clears
 	// them back to healthy. We never zero out volume — even degraded mailboxes
 	// keep a small heartbeat so the sweep has fresh sample data to evaluate.
-	adj := adjustmentFor(s.resolveHealthState(ctx, accountID))
+	adj := adjustmentFor(healthState)
 	if adj.volumeMultiplier < 1.0 {
 		floor := 1
 		if activelyWarming {

--- a/internal/scheduler/warmup_scheduler.go
+++ b/internal/scheduler/warmup_scheduler.go
@@ -32,38 +32,6 @@ type healthAdjustment struct {
 	minWaitMultiplier float64 // applied to MinWaitTime between sends
 }
 
-// softRampSignal is the early-signal verdict for one scheduling pass.
-type softRampSignal struct {
-	multiplier      float64
-	placements      int
-	sends           int
-	lastPlacementAt *time.Time
-}
-
-// resolveSoftRampSignal reads the mailbox's recent junk placements. Every
-// lookup fails open to "no signal": warmup slowing itself down because a query
-// errored would be a worse outcome than one more day at the planned volume.
-func (s *schedulerService) resolveSoftRampSignal(ctx context.Context, accountID uuid.UUID) softRampSignal {
-	sig := softRampSignal{multiplier: 1.0}
-	if s.warmupRepo == nil {
-		return sig
-	}
-	since := time.Now().Add(-warmupramp.SoftSignalWindow)
-	placements, err := s.warmupRepo.CountSpamPlacementsSince(ctx, accountID, since)
-	if err != nil {
-		return sig
-	}
-	sig.placements = placements
-	sig.multiplier = warmupramp.SoftAdjust(placements)
-	if sends, serr := s.warmupRepo.SumWarmupSentSince(ctx, accountID, since); serr == nil {
-		sig.sends = sends
-	}
-	if at, aerr := s.warmupRepo.LastSpamPlacementAt(ctx, accountID); aerr == nil {
-		sig.lastPlacementAt = at
-	}
-	return sig
-}
-
 func adjustmentFor(state models.WarmupHealthState) healthAdjustment {
 	switch state {
 	case models.WarmupHealthThrottled:
@@ -212,38 +180,32 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		}
 	}
 
-	// STEP 2: Calculate target volume for today (before recipient-capacity and
-	// health adjustments). Pure policy in warmupRampTarget so it's unit-tested.
-	// The health state drives both the band adjustment (STEP 2.5) and whether
-	// the early-signal cut below applies, so it is resolved once here.
+	// STEP 2: One shared resolve, so this target and the one the mailbox
+	// drawer reports cannot drift apart.
 	healthState := s.resolveHealthState(ctx, accountID)
-
-	// Early adverse signal: a recent junk placement holds the ramp where it
-	// stood and cuts the day about a quarter, before any hard band can trip.
-	// Only while Healthy — a mailbox already in watch or throttled is being
-	// dampened harder by its band, and stacking the two would double-cut it.
-	soft := softRampSignal{multiplier: 1.0}
-	if healthState == models.WarmupHealthHealthy {
-		soft = s.resolveSoftRampSignal(ctx, accountID)
+	rampAnchor := time.Now()
+	if account.Warmup != nil {
+		rampAnchor = *account.Warmup
 	}
-
-	daysWarming := 0
-	if activelyWarming {
-		daysWarming = warmupramp.Days(*account.Warmup, soft.lastPlacementAt, time.Now(), warmupramp.FreezeWindow)
-	}
-	targetVolume := warmupRampTarget(activelyWarming, account.WarmupBase, account.WarmupIncrease, account.WarmupMax, daysWarming, inCampaign)
-
-	// The cut lands before the recipient-capacity clamp and the band
-	// adjustment, so it composes with both by min() rather than fighting them.
-	if cut := warmupramp.Apply(targetVolume, soft.multiplier); cut < targetVolume {
+	plan := warmupramp.Resolve(ctx, s.warmupRepo, warmupramp.Input{
+		AccountID:       accountID,
+		WarmupStart:     rampAnchor,
+		ActivelyWarming: activelyWarming,
+		Base:            account.WarmupBase,
+		Increase:        account.WarmupIncrease,
+		Max:             account.WarmupMax,
+		InCampaign:      inCampaign,
+		Health:          healthState,
+		Now:             time.Now(),
+	})
+	targetVolume := plan.Target
+	if plan.Cut() {
 		log.Info().
 			Str("email_account_id", accountID.String()).
-			Int("placements_48h", soft.placements).
-			Int("sends_48h", soft.sends).
-			Int("from", targetVolume).
-			Int("to", cut).
+			Int("placements_48h", plan.Placements).
+			Int("sends_48h", plan.Sends).
+			Int("target", targetVolume).
 			Msg("warmup volume cut on an early placement signal; ramp held")
-		targetVolume = cut
 	}
 
 	// Vary the day's target so a mailbox doesn't send an identical count every
@@ -281,25 +243,8 @@ func (s *schedulerService) CalculateNextWarmupTime(ctx context.Context, accountI
 		}
 	}
 
-	// STEP 2.5: Apply health-state adjustments. Throttled/watch participants
-	// run at reduced volume and wider spacing until the health sweep clears
-	// them back to healthy. We never zero out volume — even degraded mailboxes
-	// keep a small heartbeat so the sweep has fresh sample data to evaluate.
+	// Resolve owns the band's volume half; only its spacing half applies here.
 	adj := adjustmentFor(healthState)
-	if adj.volumeMultiplier < 1.0 {
-		floor := 1
-		if activelyWarming {
-			floor = account.WarmupBase
-		}
-		adjusted := int(float64(targetVolume)*adj.volumeMultiplier + 0.5)
-		if adjusted < floor {
-			adjusted = floor
-		}
-		if adjusted < 1 {
-			adjusted = 1
-		}
-		targetVolume = adjusted
-	}
 
 	// Spacing: a drawn gap from the profile when one is enabled, otherwise the
 	// mailbox's fixed min gap. The health-state multiplier still applies on top,

--- a/internal/scheduler/warmup_scheduler_test.go
+++ b/internal/scheduler/warmup_scheduler_test.go
@@ -3,6 +3,7 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/warmbly/warmbly/internal/app/warmupramp"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -33,7 +34,7 @@ func TestAdjustmentFor(t *testing.T) {
 }
 
 func TestWarmupRampTarget(t *testing.T) {
-	const campCap = activeCampaignWarmupCap
+	const campCap = warmupramp.ActiveCampaignCap
 
 	tests := []struct {
 		name           string

--- a/web/src/components/app/emails/InboxDetails.tsx
+++ b/web/src/components/app/emails/InboxDetails.tsx
@@ -80,23 +80,34 @@ const Eyebrow = ({ children }: { children: React.ReactNode }) => (
     <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{children}</div>
 );
 
-// Warmup volume dropping with no explanation reads as a bug. This says which
-// signal cut it and when the ramp starts climbing again.
+// Warmup volume dropping, or a ramp that stops climbing, reads as a bug when
+// nothing says why. The two states end at different times, so they are worded
+// separately.
 function RampHoldNotice({ hold }: { hold: import("@/lib/api/models/app/analytics/AccountStatus").WarmupRampHold }) {
-    const resumes = new Date(hold.resumes_at);
-    const hours = Math.max(0, Math.round((resumes.getTime() - Date.now()) / 3_600_000));
-    const placements = hold.placements === 1 ? "1 warmup email" : `${hold.placements} warmup emails`;
+    const hours = Math.max(0, Math.round((new Date(hold.resumes_at).getTime() - Date.now()) / 3_600_000));
+    const resumesIn = hours > 0 ? ` for about ${hours} more ${hours === 1 ? "hour" : "hours"}` : "";
     return (
         <div className="px-5 pb-4">
             <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 flex items-start gap-2">
                 <AlertTriangleIcon className="w-3.5 h-3.5 mt-px shrink-0 text-amber-600" />
                 <div className="min-w-0">
-                    <p className="text-[12.5px] font-medium text-amber-900">Warmup volume held back</p>
+                    <p className="text-[12.5px] font-medium text-amber-900">
+                        {hold.volume_cut ? "Warmup volume held back" : "Warmup ramp paused"}
+                    </p>
                     <p className="text-[11.5px] text-amber-800/90 leading-relaxed mt-0.5">
-                        {placements} landed in spam in the last 48 hours{hold.sends > 0 ? ` out of ${hold.sends} sent` : ""}.
-                        Today's target is cut by a quarter and the daily increase is paused
-                        {hours > 0 ? ` for about ${hours} more ${hours === 1 ? "hour" : "hours"}` : ""}, so the
-                        mailbox is not adding volume while it is landing badly. It resumes on its own if nothing else lands in spam.
+                        {hold.volume_cut ? (
+                            <>
+                                {hold.placements === 1 ? "1 warmup email" : `${hold.placements} warmup emails`} landed in spam in
+                                the last 48 hours{hold.sends > 0 ? ` out of ${hold.sends} sent` : ""}. Today's target is cut by a
+                                quarter and the daily increase is paused{resumesIn}.
+                            </>
+                        ) : (
+                            <>
+                                Volume is back to normal, but the daily increase stays paused{resumesIn} after a recent spam
+                                placement.
+                            </>
+                        )}{" "}
+                        It resumes on its own if nothing else lands in spam.
                     </p>
                 </div>
             </div>

--- a/web/src/components/app/emails/InboxDetails.tsx
+++ b/web/src/components/app/emails/InboxDetails.tsx
@@ -80,6 +80,30 @@ const Eyebrow = ({ children }: { children: React.ReactNode }) => (
     <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">{children}</div>
 );
 
+// Warmup volume dropping with no explanation reads as a bug. This says which
+// signal cut it and when the ramp starts climbing again.
+function RampHoldNotice({ hold }: { hold: import("@/lib/api/models/app/analytics/AccountStatus").WarmupRampHold }) {
+    const resumes = new Date(hold.resumes_at);
+    const hours = Math.max(0, Math.round((resumes.getTime() - Date.now()) / 3_600_000));
+    const placements = hold.placements === 1 ? "1 warmup email" : `${hold.placements} warmup emails`;
+    return (
+        <div className="px-5 pb-4">
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 flex items-start gap-2">
+                <AlertTriangleIcon className="w-3.5 h-3.5 mt-px shrink-0 text-amber-600" />
+                <div className="min-w-0">
+                    <p className="text-[12.5px] font-medium text-amber-900">Warmup volume held back</p>
+                    <p className="text-[11.5px] text-amber-800/90 leading-relaxed mt-0.5">
+                        {placements} landed in spam in the last 48 hours{hold.sends > 0 ? ` out of ${hold.sends} sent` : ""}.
+                        Today's target is cut by a quarter and the daily increase is paused
+                        {hours > 0 ? ` for about ${hours} more ${hours === 1 ? "hour" : "hours"}` : ""}, so the
+                        mailbox is not adding volume while it is landing badly. It resumes on its own if nothing else lands in spam.
+                    </p>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 function StatCard({ label, value, sub, accent }: { label: string; value: React.ReactNode; sub?: string; accent?: boolean }) {
     return (
         <div className="px-4 py-3.5">
@@ -416,6 +440,8 @@ function OverviewTab({ status, loading, mailbox }: { status?: import("@/lib/api/
                 <StatCard label="Reply rate" value={ws ? `${ws.reply_rate}%` : "—"} sub="warmup replies" />
                 <StatCard label="Days warming" value={ws ? ws.days_active : "—"} sub={ws ? `max ${ws.max_volume}/day` : undefined} />
             </div>
+
+            {ws?.ramp_hold && <RampHoldNotice hold={ws.ramp_hold} />}
 
             {/* Errors */}
             {status?.errors && status.errors.length > 0 && (

--- a/web/src/lib/api/models/app/analytics/AccountStatus.ts
+++ b/web/src/lib/api/models/app/analytics/AccountStatus.ts
@@ -36,15 +36,16 @@ export interface WarmupStatusInfo {
     max_volume: number;
     reply_rate: number;
     days_active: number;
-    /** Present when a recent junk placement cut the day and froze the ramp. */
+    /** Present while a recent junk placement is holding the ramp. */
     ramp_hold?: WarmupRampHold;
 }
 
-// Why today's warmup target is below the plain ramp.
+// Why the warmup ramp is not climbing. Present for the whole freeze;
+// volume_cut says whether today's volume is also reduced, which ends sooner.
 export interface WarmupRampHold {
     placements: number;
     sends: number;
-    last_placement_at: string;
+    volume_cut: boolean;
     resumes_at: string;
 }
 

--- a/web/src/lib/api/models/app/analytics/AccountStatus.ts
+++ b/web/src/lib/api/models/app/analytics/AccountStatus.ts
@@ -36,6 +36,16 @@ export interface WarmupStatusInfo {
     max_volume: number;
     reply_rate: number;
     days_active: number;
+    /** Present when a recent junk placement cut the day and froze the ramp. */
+    ramp_hold?: WarmupRampHold;
+}
+
+// Why today's warmup target is below the plain ramp.
+export interface WarmupRampHold {
+    placements: number;
+    sends: number;
+    last_placement_at: string;
+    resumes_at: string;
 }
 
 // Warmup-pool reputation for this mailbox. Folded into health.score and also


### PR DESCRIPTION
Closes #140.

## The gap

`warmupRampTarget` was monotonic `+1/day`, and the only downward pressure came from `evaluateMetrics` crossing a band. Every band needs a sample floor first:

- complaint and bounce bands: **100 delivered in 30 days**
- warmup complaint / placement bands: **20 sent in 7 days**

A mailbox in its first fortnight cannot reach either. So a brand new mailbox landing in junk on day three kept ramping `+1/day` until it had sent enough to be judged — which is exactly the window where the damage is cheapest to avoid.

## What changed

A placement inside 48 hours, while the mailbox is still `Healthy`:

- today's target is cut to **0.75x**
- the ramp **holds** at the day it stood on when the placement landed
- after 72 quiet hours it resumes **from the held level** — the frozen days are subtracted, not made up

That last point is the one that matters. Resuming by jumping to the full elapsed day count would climb three steps in one morning, which is the overnight spike the hold exists to prevent.

The cut composes with, rather than stacks on, the health bands: it only applies while `Healthy`, since a `watch`/`throttled` mailbox is already being dampened harder by `adjustmentFor`. Every lookup fails open — warmup slowing itself down because a query errored is worse than one more day at the planned volume.

## One structural change

The ramp arithmetic moved out of the scheduler into `internal/app/warmupramp`.

It had two implementations: the scheduler's `warmupRampTarget`, and a private copy in `analytics.calculateTargetVolume` that the mailbox drawer rendered. Adding the hold to only the scheduler would have made the drawer report "target 25" for a mailbox sending 18. Both now run the same pure functions.

## UI

Warmup volume dropping with no explanation reads as a bug. The mailbox drawer now shows an amber notice when the ramp is held: how many warmup emails landed in spam, out of how many sent, and roughly when the ramp resumes.

## Verification

- `internal/app/warmupramp/ramp_test.go` — the cut, the hold, the resume-without-catch-up, and a loop asserting a resumed ramp can never claim more days than actually elapsed (a freeze must never *accelerate* a mailbox).
- `internal/app/analytics/warmup_ramp_live_test.go` — three `TestLive*` against dev Postgres proving the number the drawer shows moves with the signal: clean ramp = 20, fresh placement = 15 with an explanation attached, 8-day-old placement = no cut but still ramp-shifted.
- `make lint`, `gofmt -l` clean; `pnpm typecheck`/`lint` clean in `web/`; `types:check`/`lint`/`build` clean in `docs/`.