### PR TITLE
feat: score campaign copy as sent, not just as written

### DIFF
--- a/docs/content/docs/api/reference/campaigns.mdx
+++ b/docs/content/docs/api/reference/campaigns.mdx
@@ -315,7 +315,9 @@ A `CampaignAdvancedSettings` object: the campaign id, the `overrides` block, and
       "check_unsubscribe_header": true,
       "check_ab_variant_configured": false,
       "check_daily_limit": true,
-      "check_schedule_window": true
+      "check_schedule_window": true,
+      "check_content_score": true,
+      "min_content_score": 60
     },
     "dashboard": { "enabled": true, "show_suppression_log": true, "show_intent_summary": true, "show_dlq_stats": true }
   },
@@ -347,7 +349,7 @@ Replace the campaign's advanced overrides. **Scope** `WRITE_CAMPAIGNS` · **Org 
     "ab_testing": { "enabled": true, "default_winning_rule": "reply_rate", "auto_promote_winner": false, "min_sample_size": 30 },
     "reply_intent": { "enabled": true, "positive_keywords": [], "negative_keywords": [], "out_of_office_keywords": [], "question_keywords": [], "auto_create_crm_task": true, "auto_pause_on_negative": false, "auto_suppress_on_unsubscribe_keyword": true },
     "send_time_optimization": { "enabled": true, "use_contact_timezone": true, "default_contact_timezone": "UTC", "preferred_hours": [9, 14], "weekend_weight_multiplier": 0.5 },
-    "preflight": { "enabled": true, "check_tracking_domain": true, "check_unsubscribe_header": true, "check_ab_variant_configured": false, "check_daily_limit": true, "check_schedule_window": true },
+    "preflight": { "enabled": true, "check_tracking_domain": true, "check_unsubscribe_header": true, "check_ab_variant_configured": false, "check_daily_limit": true, "check_schedule_window": true, "check_content_score": true, "min_content_score": 60 },
     "dashboard": { "enabled": true, "show_suppression_log": true, "show_intent_summary": true, "show_dlq_stats": true }
   }
 }

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -65,7 +65,9 @@ Returns the `AdvancedOutreachSettings` object directly (not wrapped in an envelo
     "check_unsubscribe_header": true,
     "check_ab_variant_configured": false,
     "check_daily_limit": true,
-    "check_schedule_window": true
+    "check_schedule_window": true,
+    "check_content_score": true,
+    "min_content_score": 60
   },
   "dashboard": {
     "enabled": true,

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -132,6 +132,24 @@ The detail view streams sends, opens, clicks, replies, bounces, and skips as the
 
 If scheduling stalls on a transient infrastructure hiccup, Warmbly re-seeds within a few minutes. Pausing and resuming forces a fresh start.
 
+## Content checks
+
+Warmbly scores each step's copy out of 100 for the signals spam filters weight: trigger wording, stacked punctuation, ALL-CAPS subjects, link and image counts, image-only bodies, empty or oversized bodies, and attachments.
+
+You see it in three places:
+
+- **In the editor**, live as you write a step.
+- **In the launch dialog**, alongside the other pre-send checks, with the lowest-scoring step named.
+- **In the campaign activity feed**, if the copy that actually goes out scores below your floor.
+
+That last one catches what the first two cannot. The editor scores the template; the send path scores the message after merge fields, spintax, A/B selection and AI blocks have resolved, which is where a clean template becomes "Hi ," or picks the one spammy spintax branch. It logs once per step per day, not once per recipient.
+
+**Settings** > **Sending** > **Content checks** turns it off or moves the floor, which defaults to `60`.
+
+<Callout type="info" title="Advisory, not a gate">
+A low score never blocks or delays a send. It is a signal to rewrite, not a verdict: a legitimate email can score badly, and a well-scoring one sent to a bad list will still fail.
+</Callout>
+
 ## Safety posture
 
 Defaults are deliberately conservative, aiming at a low complaint rate rather than maximum throughput:

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -15,6 +15,7 @@ import (
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
 	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/tasks/proto"
 	"github.com/warmbly/warmbly/internal/tasksched"
@@ -1578,6 +1579,45 @@ func (s *service) RunPreflight(ctx context.Context, organizationID, campaignID u
 			check.Message = "At least two active A/B variants are required."
 			check.Remediation = "Create at least two active variants or disable AB testing."
 			recommendations = append(recommendations, "Create more A/B variants.")
+		}
+		checks = append(checks, check)
+	}
+
+	if settings.Preflight.CheckContentScore {
+		floor := settings.Preflight.MinContentScore
+		if floor <= 0 {
+			floor = 60
+		}
+		worst, worstStep, issue := 100, 0, ""
+		if seqs, serr := s.campaignRepo.GetSequencesByCampaignID(ctx, campaignID); serr == nil {
+			for i, seq := range seqs {
+				r := warmlint.Score(seq.Subject, seq.BodyHTML, seq.BodyPlain)
+				if r.Score < worst {
+					worst, worstStep = r.Score, i+1
+					issue = ""
+					for _, is := range r.Issues {
+						if is.Severity == "high" {
+							issue = is.Message
+							break
+						}
+					}
+					if issue == "" && len(r.Issues) > 0 {
+						issue = r.Issues[0].Message
+					}
+				}
+			}
+		}
+		pass := worst >= floor
+		check := models.PreflightCheckResult{
+			Key:      "content_score",
+			Passed:   pass,
+			Severity: "warning",
+			Message:  fmt.Sprintf("Copy scores %d/100 for spam signals.", worst),
+		}
+		if !pass {
+			check.Message = fmt.Sprintf("Step %d scores %d/100 for spam signals (floor %d). %s", worstStep, worst, floor, issue)
+			check.Remediation = "Trim spam-trigger wording, links, images and stacked punctuation in that step."
+			recommendations = append(recommendations, "Rewrite the lowest-scoring step's copy before sending at volume.")
 		}
 		checks = append(checks, check)
 	}

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -26,6 +26,9 @@ type Service interface {
 	UpdateOrganizationSettings(ctx context.Context, organizationID, updatedBy uuid.UUID, settings *models.AdvancedOutreachSettings) *errx.Error
 
 	GetCampaignSettings(ctx context.Context, campaignID uuid.UUID) (*models.CampaignAdvancedSettings, *errx.Error)
+	// EffectiveSettings is the org settings with the campaign's overrides
+	// merged in — what every per-campaign decision must read.
+	EffectiveSettings(ctx context.Context, organizationID, campaignID uuid.UUID) (*models.AdvancedOutreachSettings, *errx.Error)
 	UpdateCampaignSettings(ctx context.Context, campaignID uuid.UUID, settings *models.AdvancedOutreachSettings) *errx.Error
 
 	ListABVariants(ctx context.Context, campaignID uuid.UUID) ([]models.CampaignABVariant, *errx.Error)
@@ -275,6 +278,10 @@ func (s *service) DeleteABVariant(ctx context.Context, campaignID, variantID uui
 		return toErrx(err)
 	}
 	return nil
+}
+
+func (s *service) EffectiveSettings(ctx context.Context, organizationID, campaignID uuid.UUID) (*models.AdvancedOutreachSettings, *errx.Error) {
+	return s.effectiveSettings(ctx, organizationID, campaignID)
 }
 
 func (s *service) effectiveSettings(ctx context.Context, organizationID, campaignID uuid.UUID) (*models.AdvancedOutreachSettings, *errx.Error) {
@@ -1584,42 +1591,7 @@ func (s *service) RunPreflight(ctx context.Context, organizationID, campaignID u
 	}
 
 	if settings.Preflight.CheckContentScore {
-		floor := settings.Preflight.MinContentScore
-		if floor <= 0 {
-			floor = 60
-		}
-		worst, worstStep, issue := 100, 0, ""
-		if seqs, serr := s.campaignRepo.GetSequencesByCampaignID(ctx, campaignID); serr == nil {
-			for i, seq := range seqs {
-				r := warmlint.Score(seq.Subject, seq.BodyHTML, seq.BodyPlain)
-				if r.Score < worst {
-					worst, worstStep = r.Score, i+1
-					issue = ""
-					for _, is := range r.Issues {
-						if is.Severity == "high" {
-							issue = is.Message
-							break
-						}
-					}
-					if issue == "" && len(r.Issues) > 0 {
-						issue = r.Issues[0].Message
-					}
-				}
-			}
-		}
-		pass := worst >= floor
-		check := models.PreflightCheckResult{
-			Key:      "content_score",
-			Passed:   pass,
-			Severity: "warning",
-			Message:  fmt.Sprintf("Copy scores %d/100 for spam signals.", worst),
-		}
-		if !pass {
-			check.Message = fmt.Sprintf("Step %d scores %d/100 for spam signals (floor %d). %s", worstStep, worst, floor, issue)
-			check.Remediation = "Trim spam-trigger wording, links, images and stacked punctuation in that step."
-			recommendations = append(recommendations, "Rewrite the lowest-scoring step's copy before sending at volume.")
-		}
-		checks = append(checks, check)
+		checks = append(checks, s.contentScoreCheck(ctx, campaignID, settings.Preflight.MinContentScore, &recommendations))
 	}
 
 	passedCount := 0
@@ -1775,4 +1747,67 @@ func (s *service) ProcessRetryableDeadLetters(ctx context.Context) (int, *errx.E
 	}
 
 	return retried, nil
+}
+
+// contentScoreCheck scores every step's copy and reports the worst. A step list
+// it could not read reports as FAILED, not passed: a check that did not run
+// must never look like one that succeeded.
+func (s *service) contentScoreCheck(ctx context.Context, campaignID uuid.UUID, floor int, recommendations *[]string) models.PreflightCheckResult {
+	if floor <= 0 {
+		floor = 60
+	}
+	seqs, err := s.campaignRepo.GetSequencesByCampaignID(ctx, campaignID)
+	if err != nil {
+		*recommendations = append(*recommendations, "Re-run preflight; the campaign's steps could not be read.")
+		return models.PreflightCheckResult{
+			Key:         "content_score",
+			Passed:      false,
+			Severity:    "warning",
+			Message:     "Could not read the campaign's steps to score their copy.",
+			Remediation: "Re-run preflight.",
+		}
+	}
+	if len(seqs) == 0 {
+		return models.PreflightCheckResult{
+			Key:      "content_score",
+			Passed:   true,
+			Severity: "info",
+			Message:  "No steps to score yet.",
+		}
+	}
+
+	worst, worstStep, issue := 101, 0, ""
+	for i, seq := range seqs {
+		r := warmlint.Score(seq.Subject, seq.BodyHTML, seq.BodyPlain)
+		if r.Score >= worst {
+			continue
+		}
+		worst, worstStep, issue = r.Score, i+1, ""
+		for _, is := range r.Issues {
+			if is.Severity == "high" {
+				issue = is.Message
+				break
+			}
+		}
+		if issue == "" && len(r.Issues) > 0 {
+			issue = r.Issues[0].Message
+		}
+	}
+
+	if worst >= floor {
+		return models.PreflightCheckResult{
+			Key:      "content_score",
+			Passed:   true,
+			Severity: "info",
+			Message:  fmt.Sprintf("Copy scores %d/100 for spam signals.", worst),
+		}
+	}
+	*recommendations = append(*recommendations, "Rewrite the lowest-scoring step's copy before sending at volume.")
+	return models.PreflightCheckResult{
+		Key:         "content_score",
+		Passed:      false,
+		Severity:    "warning",
+		Message:     fmt.Sprintf("Step %d scores %d/100 for spam signals (floor %d). %s", worstStep, worst, floor, issue),
+		Remediation: "Trim spam-trigger wording, links, images and stacked punctuation in that step.",
+	}
 }

--- a/internal/models/advanced_outreach.go
+++ b/internal/models/advanced_outreach.go
@@ -57,6 +57,12 @@ type PreflightValidationSettings struct {
 	CheckABVariantConfigured bool `json:"check_ab_variant_configured"`
 	CheckDailyLimit          bool `json:"check_daily_limit"`
 	CheckScheduleWindow      bool `json:"check_schedule_window"`
+	// CheckContentScore scores each step's copy for spam signals, at preflight
+	// and again per send against the rendered text. Advisory: it warns, it
+	// never blocks a send.
+	CheckContentScore bool `json:"check_content_score"`
+	// MinContentScore is the 0-100 floor below which copy is flagged.
+	MinContentScore int `json:"min_content_score"`
 }
 
 type DeliverabilityDashboardSettings struct {
@@ -462,6 +468,8 @@ func DefaultAdvancedOutreachSettings() AdvancedOutreachSettings {
 			CheckABVariantConfigured: false,
 			CheckDailyLimit:          true,
 			CheckScheduleWindow:      true,
+			CheckContentScore:        true,
+			MinContentScore:          60,
 		},
 		Dashboard: DeliverabilityDashboardSettings{
 			Enabled:            true,

--- a/internal/pkg/warmlint/lint.go
+++ b/internal/pkg/warmlint/lint.go
@@ -15,6 +15,7 @@ var (
 	wordToken    = regexp.MustCompile(`[a-z0-9%]+`)
 	linkPattern  = regexp.MustCompile(`https?://`)
 	htmlTag      = regexp.MustCompile(`(?i)<[a-z!/][^>]*>`)
+	imgTag       = regexp.MustCompile(`(?i)<img\b[^>]*>`)
 )
 
 // triggerWords are single-token terms that raise SpamAssassin-style content
@@ -127,8 +128,44 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		deduct(10, "warn", "oversized_body", "Body is very large; trim it for deliverability.")
 	}
 
+	// Images: cold mail from a real person is usually plain. A wall of images,
+	// or images carrying most of the message, reads as a marketing blast.
+	if images := len(imgTag.FindAllString(bodyHTML, -1)); images > 0 {
+		switch {
+		case len(strings.TrimSpace(body)) < 200 && images >= 1:
+			deduct(20, "high", "image_heavy",
+				"Almost all of this email is images — filters cannot read it and treat that as evasion.")
+		case images > 3:
+			d := (images - 3) * 5
+			if d > 15 {
+				d = 15
+			}
+			deduct(d, "warn", "many_images", fmt.Sprintf("%d images — cold email from a person rarely has many.", images))
+		}
+	}
+
 	if res.Score < 0 {
 		res.Score = 0
+	}
+	return res
+}
+
+// ScoreWithAttachments is Score plus the attachment heuristic, which needs
+// context the template alone does not carry.
+func ScoreWithAttachments(subject, bodyHTML, bodyPlain string, attachments int) ScoreResult {
+	res := Score(subject, bodyHTML, bodyPlain)
+	if attachments > 0 {
+		// A first-contact cold email with an attachment is both a spam signal
+		// and a security prompt for the recipient.
+		res.Score -= 15
+		if res.Score < 0 {
+			res.Score = 0
+		}
+		res.Issues = append(res.Issues, Issue{
+			Severity: "warn",
+			Code:     "has_attachments",
+			Message:  fmt.Sprintf("%d attachment(s) on a cold email — link to the file instead.", attachments),
+		})
 	}
 	return res
 }

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -1,0 +1,85 @@
+package warmlint
+
+import (
+	"strings"
+	"testing"
+)
+
+func hasIssue(res ScoreResult, code string) bool {
+	for _, i := range res.Issues {
+		if i.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func TestScoreCleanCopyIsUnpenalized(t *testing.T) {
+	res := Score(
+		"Quick question about your hiring process",
+		"<p>Hi Ada, saw you are growing the support team. Worth a chat?</p>",
+		"Hi Ada, saw you are growing the support team. Worth a chat?",
+	)
+	if res.Score != 100 {
+		t.Errorf("clean copy scored %d with %+v, want 100", res.Score, res.Issues)
+	}
+}
+
+func TestScoreImageHeavyBody(t *testing.T) {
+	// Almost all image, no readable text: filters cannot read it, and that is
+	// treated as evasion rather than as a design choice.
+	res := Score("Hello", `<img src="a.png"><img src="b.png">`, "")
+	if !hasIssue(res, "image_heavy") {
+		t.Errorf("image-only body not flagged: %+v", res.Issues)
+	}
+
+	// Plenty of text, a few images: fine.
+	body := strings.Repeat("A real sentence about the recipient's work. ", 20)
+	res = Score("Hello", "<p>"+body+`</p><img src="a.png">`, body)
+	if hasIssue(res, "image_heavy") || hasIssue(res, "many_images") {
+		t.Errorf("ordinary copy with one image was flagged: %+v", res.Issues)
+	}
+
+	// Many images alongside text is a softer warning.
+	res = Score("Hello", "<p>"+body+`</p>`+strings.Repeat(`<img src="x.png">`, 6), body)
+	if !hasIssue(res, "many_images") {
+		t.Errorf("six images not flagged: %+v", res.Issues)
+	}
+	if hasIssue(res, "image_heavy") {
+		t.Errorf("text-rich body wrongly flagged as image-only: %+v", res.Issues)
+	}
+}
+
+func TestScoreWithAttachments(t *testing.T) {
+	subject, html, plain := "Following up", "<p>Hi Ada, following up on my note.</p>", "Hi Ada, following up on my note."
+
+	base := ScoreWithAttachments(subject, html, plain, 0)
+	if hasIssue(base, "has_attachments") {
+		t.Errorf("no attachments should not flag: %+v", base.Issues)
+	}
+
+	withAtt := ScoreWithAttachments(subject, html, plain, 2)
+	if !hasIssue(withAtt, "has_attachments") {
+		t.Errorf("attachments not flagged: %+v", withAtt.Issues)
+	}
+	if withAtt.Score >= base.Score {
+		t.Errorf("attachment score %d not below the clean %d", withAtt.Score, base.Score)
+	}
+}
+
+func TestScoreNeverGoesNegative(t *testing.T) {
+	// Every heuristic at once: the floor is 0, not a negative number the UI
+	// would have to special-case.
+	res := ScoreWithAttachments(
+		"FREE CASH PRIZE GUARANTEED!!!",
+		`<img src="a.png"><img src="b.png"><img src="c.png"><img src="d.png">`,
+		"",
+		5,
+	)
+	if res.Score < 0 {
+		t.Errorf("score = %d, want a floor of 0", res.Score)
+	}
+	if len(res.Issues) == 0 {
+		t.Error("obviously spammy copy produced no issues")
+	}
+}

--- a/internal/repository/campaign_log_once_live_test.go
+++ b/internal/repository/campaign_log_once_live_test.go
@@ -1,0 +1,113 @@
+package repository
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// CreateLogOnce backs the per-send content warning, which runs on EVERY
+// recipient of a low-scoring step at once. A check-then-insert would let
+// concurrent sends both find nothing and both write.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveCampaignLogOnce -v
+func TestLiveCampaignLogOnceIsAtomicUnderConcurrency(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewCampaignLogRepository(handle)
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM campaign_logs WHERE campaign_id = $1`, f.campaign); err != nil {
+			t.Errorf("cleanup logs: %v", err)
+		}
+	})
+
+	const racers = 12
+	var wg sync.WaitGroup
+	wrote := make([]bool, racers)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ok, err := repo.CreateLogOnce(ctx, &CampaignLogEntry{
+				CampaignID: f.campaign,
+				EventType:  "content_warning",
+				Message:    "step scores badly",
+				Metadata:   map[string]interface{}{"sequence_id": "step-1"},
+			}, "sequence_id", "step-1", time.Now().Add(-time.Hour))
+			if err != nil {
+				t.Errorf("racer %d: %v", i, err)
+				return
+			}
+			wrote[i] = ok
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	writes := 0
+	for _, w := range wrote {
+		if w {
+			writes++
+		}
+	}
+	if writes != 1 {
+		t.Errorf("%d of %d racers reported writing, want exactly 1", writes, racers)
+	}
+
+	var rows int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM campaign_logs WHERE campaign_id = $1 AND event_type = 'content_warning'`,
+		f.campaign).Scan(&rows); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("%d feed entries written, want 1", rows)
+	}
+}
+
+// A different step is a different warning, and an old one no longer suppresses.
+func TestLiveCampaignLogOnceScopesByKeyAndWindow(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewCampaignLogRepository(handle)
+	ctx := context.Background()
+
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM campaign_logs WHERE campaign_id = $1`, f.campaign); err != nil {
+			t.Errorf("cleanup logs: %v", err)
+		}
+	})
+
+	entry := func(step string) *CampaignLogEntry {
+		return &CampaignLogEntry{
+			CampaignID: f.campaign,
+			EventType:  "content_warning",
+			Message:    "step scores badly",
+			Metadata:   map[string]interface{}{"sequence_id": step},
+		}
+	}
+	since := time.Now().Add(-time.Hour)
+
+	if ok, err := repo.CreateLogOnce(ctx, entry("step-1"), "sequence_id", "step-1", since); err != nil || !ok {
+		t.Fatalf("first write: ok=%v err=%v", ok, err)
+	}
+	if ok, err := repo.CreateLogOnce(ctx, entry("step-1"), "sequence_id", "step-1", since); err != nil || ok {
+		t.Errorf("second write for the same step: ok=%v err=%v, want suppressed", ok, err)
+	}
+	if ok, err := repo.CreateLogOnce(ctx, entry("step-2"), "sequence_id", "step-2", since); err != nil || !ok {
+		t.Errorf("a different step: ok=%v err=%v, want written", ok, err)
+	}
+	// A window that starts after the existing row must not see it, so the
+	// warning returns once the day rolls over.
+	if ok, err := repo.CreateLogOnce(ctx, entry("step-1"), "sequence_id", "step-1", time.Now().Add(time.Hour)); err != nil || !ok {
+		t.Errorf("after the window: ok=%v err=%v, want written again", ok, err)
+	}
+}

--- a/internal/repository/pg_campaign_log.go
+++ b/internal/repository/pg_campaign_log.go
@@ -20,6 +20,10 @@ type CampaignLogEntry struct {
 type CampaignLogRepository interface {
 	CreateLog(ctx context.Context, entry *CampaignLogEntry) error
 	GetLogs(ctx context.Context, campaignID uuid.UUID, limit int, cursor *string) (*models.CampaignLogsResult, error)
+	// HasRecentLogFor reports whether an entry of this type already exists for
+	// the campaign with metadata.<key> = value since `since`. Used to keep a
+	// per-send warning from writing one feed entry per recipient.
+	HasRecentLogFor(ctx context.Context, campaignID uuid.UUID, eventType, key, value string, since time.Time) (bool, error)
 }
 
 type campaignLogRepository struct {
@@ -102,4 +106,18 @@ func (r *campaignLogRepository) GetLogs(ctx context.Context, campaignID uuid.UUI
 			HasMore:    hasMore,
 		},
 	}, nil
+}
+
+func (r *campaignLogRepository) HasRecentLogFor(ctx context.Context, campaignID uuid.UUID, eventType, key, value string, since time.Time) (bool, error) {
+	var exists bool
+	err := r.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM campaign_logs
+			WHERE campaign_id = $1
+			  AND event_type = $2
+			  AND metadata ->> $3 = $4
+			  AND created_at >= $5
+		)
+	`, campaignID, eventType, key, value, since).Scan(&exists)
+	return exists, err
 }

--- a/internal/repository/pg_campaign_log.go
+++ b/internal/repository/pg_campaign_log.go
@@ -20,10 +20,12 @@ type CampaignLogEntry struct {
 type CampaignLogRepository interface {
 	CreateLog(ctx context.Context, entry *CampaignLogEntry) error
 	GetLogs(ctx context.Context, campaignID uuid.UUID, limit int, cursor *string) (*models.CampaignLogsResult, error)
-	// HasRecentLogFor reports whether an entry of this type already exists for
-	// the campaign with metadata.<key> = value since `since`. Used to keep a
-	// per-send warning from writing one feed entry per recipient.
-	HasRecentLogFor(ctx context.Context, campaignID uuid.UUID, eventType, key, value string, since time.Time) (bool, error)
+	// CreateLogOnce writes the entry only when no entry of the same type with
+	// metadata.<key> = value exists since `since`, and reports whether it did.
+	// Check and insert are one locked statement: a per-send warning runs on
+	// every recipient at once, and a separate check would let concurrent sends
+	// both find nothing and both write.
+	CreateLogOnce(ctx context.Context, entry *CampaignLogEntry, key, value string, since time.Time) (bool, error)
 }
 
 type campaignLogRepository struct {
@@ -108,16 +110,42 @@ func (r *campaignLogRepository) GetLogs(ctx context.Context, campaignID uuid.UUI
 	}, nil
 }
 
-func (r *campaignLogRepository) HasRecentLogFor(ctx context.Context, campaignID uuid.UUID, eventType, key, value string, since time.Time) (bool, error) {
-	var exists bool
-	err := r.DB.QueryRow(ctx, `
-		SELECT EXISTS (
-			SELECT 1 FROM campaign_logs
-			WHERE campaign_id = $1
-			  AND event_type = $2
-			  AND metadata ->> $3 = $4
-			  AND created_at >= $5
-		)
-	`, campaignID, eventType, key, value, since).Scan(&exists)
-	return exists, err
+func (r *campaignLogRepository) CreateLogOnce(ctx context.Context, entry *CampaignLogEntry, key, value string, since time.Time) (bool, error) {
+	metadata := entry.Metadata
+	if metadata == nil {
+		metadata = map[string]interface{}{}
+	}
+
+	tx, err := r.DB.Begin(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+
+	// Serializes concurrent senders on this (campaign, type, key) triple so the
+	// NOT EXISTS below cannot be true for two of them at once. The key is built
+	// in Go so the statement carries a single unambiguous text parameter.
+	lockKey := entry.CampaignID.String() + ":" + entry.EventType + ":" + value
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, lockKey); err != nil {
+		return false, err
+	}
+
+	tag, err := tx.Exec(ctx, `
+		INSERT INTO campaign_logs (campaign_id, event_type, message, metadata)
+		SELECT $1::uuid, $2::text, $3::text, $4::jsonb
+		 WHERE NOT EXISTS (
+		       SELECT 1 FROM campaign_logs
+		        WHERE campaign_id = $1::uuid
+		          AND event_type = $2::text
+		          AND metadata ->> $5::text = $6::text
+		          AND created_at >= $7::timestamptz
+		 )
+	`, entry.CampaignID, entry.EventType, entry.Message, metadata, key, value, since)
+	if err != nil {
+		return false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
 }

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -499,6 +499,12 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		}
 	}
 
+	// STEP 10.75: Score the copy the recipient will actually receive, after
+	// merge fields, spintax, A/B and AI blocks have resolved. Advisory: it
+	// warns once per step and never blocks or delays the send.
+	s.warnOnWeakContent(ctx, orgID, campaign.ID, sequence.ID, sequence.Position+1,
+		subject, bodyHTML, bodyPlain, len(attachmentRefs))
+
 	// STEP 11: Add tracking on the host resolveTrackingHost picks, and log any
 	// override that was configured but not verified so a customer whose links
 	// are not going through their own domain can see why.

--- a/internal/tasks/content_gate.go
+++ b/internal/tasks/content_gate.go
@@ -16,18 +16,16 @@ import (
 // with 500 recipients writes one feed entry rather than 500.
 const contentWarningWindow = 24 * time.Hour
 
-// warnOnWeakContent scores the RENDERED copy for this send and, when it is
-// below the org's floor, writes one warning to the campaign feed.
-//
-// The editor check scores the template; this scores what the recipient will
-// actually receive, after merge fields, spintax and AI blocks have resolved.
-// Those are exactly where a clean template turns into "Hi ," or a wall of
-// trigger words. Advisory only: it never blocks or delays the send.
+// warnOnWeakContent scores the copy this send will actually deliver — after
+// merge fields, spintax, A/B and AI blocks resolve, which the editor's
+// template-time score cannot see. Advisory: it never blocks or delays a send.
 func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID, sequenceID uuid.UUID, step int, subject, bodyHTML, bodyPlain string, attachments int) {
 	if s.advanced == nil || s.campaignLogRepo == nil {
 		return
 	}
-	settings, xerr := s.advanced.GetOrganizationSettings(ctx, orgID)
+	// Campaign-effective, not org-only: a campaign that turned the check off or
+	// moved its floor must be honored here as it is at preflight.
+	settings, xerr := s.advanced.EffectiveSettings(ctx, orgID, campaignID)
 	if xerr != nil || settings == nil || !settings.Preflight.Enabled || !settings.Preflight.CheckContentScore {
 		return
 	}
@@ -42,11 +40,6 @@ func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID,
 	}
 
 	seq := sequenceID.String()
-	if seen, err := s.campaignLogRepo.HasRecentLogFor(ctx, campaignID, "content_warning", "sequence_id", seq,
-		time.Now().Add(-contentWarningWindow)); err != nil || seen {
-		return
-	}
-
 	detail := ""
 	for _, issue := range res.Issues {
 		if issue.Severity == "high" {
@@ -63,7 +56,7 @@ func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID,
 		codes = append(codes, issue.Code)
 	}
 
-	if err := s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+	if _, err := s.campaignLogRepo.CreateLogOnce(ctx, &repository.CampaignLogEntry{
 		CampaignID: campaignID,
 		EventType:  "content_warning",
 		Message: fmt.Sprintf("Step %d's copy scores %d/100 for spam signals as sent (floor %d).%s",
@@ -75,7 +68,7 @@ func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID,
 			"floor":       floor,
 			"issues":      codes,
 		},
-	}); err != nil {
+	}, "sequence_id", seq, time.Now().Add(-contentWarningWindow)); err != nil {
 		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("could not record the content warning")
 	}
 }

--- a/internal/tasks/content_gate.go
+++ b/internal/tasks/content_gate.go
@@ -1,0 +1,81 @@
+package tasks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// contentWarningWindow is how long one warning covers a step, so a campaign
+// with 500 recipients writes one feed entry rather than 500.
+const contentWarningWindow = 24 * time.Hour
+
+// warnOnWeakContent scores the RENDERED copy for this send and, when it is
+// below the org's floor, writes one warning to the campaign feed.
+//
+// The editor check scores the template; this scores what the recipient will
+// actually receive, after merge fields, spintax and AI blocks have resolved.
+// Those are exactly where a clean template turns into "Hi ," or a wall of
+// trigger words. Advisory only: it never blocks or delays the send.
+func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID, sequenceID uuid.UUID, step int, subject, bodyHTML, bodyPlain string, attachments int) {
+	if s.advanced == nil || s.campaignLogRepo == nil {
+		return
+	}
+	settings, xerr := s.advanced.GetOrganizationSettings(ctx, orgID)
+	if xerr != nil || settings == nil || !settings.Preflight.Enabled || !settings.Preflight.CheckContentScore {
+		return
+	}
+	floor := settings.Preflight.MinContentScore
+	if floor <= 0 {
+		floor = 60
+	}
+
+	res := warmlint.ScoreWithAttachments(subject, bodyHTML, bodyPlain, attachments)
+	if res.Score >= floor {
+		return
+	}
+
+	seq := sequenceID.String()
+	if seen, err := s.campaignLogRepo.HasRecentLogFor(ctx, campaignID, "content_warning", "sequence_id", seq,
+		time.Now().Add(-contentWarningWindow)); err != nil || seen {
+		return
+	}
+
+	detail := ""
+	for _, issue := range res.Issues {
+		if issue.Severity == "high" {
+			detail = " " + issue.Message
+			break
+		}
+	}
+	if detail == "" && len(res.Issues) > 0 {
+		detail = " " + res.Issues[0].Message
+	}
+
+	codes := make([]string, 0, len(res.Issues))
+	for _, issue := range res.Issues {
+		codes = append(codes, issue.Code)
+	}
+
+	if err := s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
+		CampaignID: campaignID,
+		EventType:  "content_warning",
+		Message: fmt.Sprintf("Step %d's copy scores %d/100 for spam signals as sent (floor %d).%s",
+			step, res.Score, floor, detail),
+		Metadata: map[string]interface{}{
+			"level":       "warning",
+			"sequence_id": seq,
+			"score":       res.Score,
+			"floor":       floor,
+			"issues":      codes,
+		},
+	}); err != nil {
+		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("could not record the content warning")
+	}
+}

--- a/web/src/app/app/settings/sending/page.tsx
+++ b/web/src/app/app/settings/sending/page.tsx
@@ -10,6 +10,7 @@ import { NoAccess } from "@/components/layout/NoAccess";
 import { usePermission } from "@/hooks/usePermission";
 import SaveStatus from "../_components/SaveStatus";
 import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
+import { NumberInput } from "@/components/ui/field";
 import { useAutosave } from "@/hooks/useAutosave";
 import { useRegisterUnsaved } from "@/hooks/context/unsaved";
 import useTimezones from "@/lib/api/hooks/app/useTimezones";
@@ -59,6 +60,13 @@ function SendingSettings() {
     }, [data]);
 
     const sto = draft?.send_time_optimization;
+
+    const patchPreflight = React.useCallback(
+        (next: Partial<OutreachSettings["preflight"]>) => {
+            setDraft((prev) => (prev ? { ...prev, preflight: { ...prev.preflight, ...next } } : prev));
+        },
+        [],
+    );
 
     const patch = React.useCallback(
         (next: Partial<NonNullable<typeof sto>>) => {
@@ -186,6 +194,45 @@ function SendingSettings() {
                                     </div>
                                 </Row>
                             </>
+                        )}
+                    </>
+                )}
+            </Section>
+
+            <Section
+                eyebrow="Content checks"
+                description="Score each step's copy for the signals spam filters weight: trigger wording, stacked punctuation, link and image counts, attachments. Checked when you launch, and again per send against the copy the recipient actually receives once merge fields and spintax have resolved."
+            >
+                {isLoading || !draft ? (
+                    <div className="h-7 w-40 rounded bg-slate-100 animate-pulse" />
+                ) : (
+                    <>
+                        <Row
+                            label="Flag risky copy"
+                            description="Advisory only. It warns in the launch dialog and the campaign activity feed, and never blocks or delays a send."
+                        >
+                            <Toggle
+                                on={!!draft.preflight?.check_content_score}
+                                onChange={(on) => patchPreflight({ check_content_score: on })}
+                            />
+                        </Row>
+                        {draft.preflight?.check_content_score && (
+                            <Row
+                                label="Minimum score"
+                                description="Copy scoring below this out of 100 is flagged. Higher is stricter."
+                            >
+                                <NumberInput
+                                    min={0}
+                                    max={100}
+                                    value={draft.preflight?.min_content_score ?? 60}
+                                    onChange={(n) =>
+                                        patchPreflight({
+                                            min_content_score: Number.isFinite(n) ? Math.min(100, Math.max(0, n)) : 60,
+                                        })
+                                    }
+                                    className="w-20"
+                                />
+                            </Row>
                         )}
                     </>
                 )}

--- a/web/src/components/app/campaigns/LaunchCampaignDialog.tsx
+++ b/web/src/components/app/campaigns/LaunchCampaignDialog.tsx
@@ -24,6 +24,8 @@ import type Campaign from "@/lib/api/models/app/campaigns/Campaign";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
 import useCampaign from "@/lib/api/hooks/app/campaigns/useCampaign";
+import usePreflight from "@/lib/api/hooks/app/campaigns/usePreflight";
+import { preflightFailures } from "@/lib/api/models/app/campaigns/Preflight";
 
 type Phase = "idle" | "launching" | "done";
 
@@ -97,6 +99,12 @@ export default function LaunchCampaignDialog({
     // settings. Falls back to the passed campaign until it resolves.
     const full = useCampaign(campaign?.id ?? "");
     const c = full.data ?? campaign;
+
+    // The platform's own pre-send checks, run fresh each time the dialog opens.
+    // Advisory: a failure is shown, never used to disable Launch, because the
+    // backend owns what actually blocks a start.
+    const preflight = usePreflight(campaign?.id ?? "", !!campaign);
+    const issues = preflightFailures(preflight.data);
 
     // Reset to a clean state whenever a new campaign is opened.
     React.useEffect(() => {
@@ -236,6 +244,59 @@ export default function LaunchCampaignDialog({
                                             }
                                         />
                                     </div>
+
+                                    {/* Pre-send checks */}
+                                    {preflight.isFetching ? (
+                                        <div className="px-5 pt-3 flex items-center gap-2 text-[11.5px] text-slate-400">
+                                            <span className="campaign-grid text-slate-300" aria-hidden />
+                                            Running pre-send checks…
+                                        </div>
+                                    ) : issues.length > 0 ? (
+                                        <div className="px-5 pt-3 space-y-1.5">
+                                            {issues.map((issue) => {
+                                                const isError = issue.severity === "error";
+                                                return (
+                                                    <div
+                                                        key={issue.key}
+                                                        className={`flex items-start gap-2 rounded-md border px-3 py-2 ${
+                                                            isError
+                                                                ? "border-rose-200 bg-rose-50"
+                                                                : "border-amber-200 bg-amber-50"
+                                                        }`}
+                                                    >
+                                                        <AlertTriangleIcon
+                                                            className={`w-3.5 h-3.5 shrink-0 mt-0.5 ${
+                                                                isError ? "text-rose-500" : "text-amber-600"
+                                                            }`}
+                                                        />
+                                                        <div className="min-w-0">
+                                                            <p
+                                                                className={`text-[12px] leading-snug ${
+                                                                    isError ? "text-rose-700" : "text-amber-900"
+                                                                }`}
+                                                            >
+                                                                {issue.message}
+                                                            </p>
+                                                            {issue.remediation && (
+                                                                <p
+                                                                    className={`text-[11.5px] leading-snug mt-0.5 ${
+                                                                        isError ? "text-rose-600/90" : "text-amber-800/90"
+                                                                    }`}
+                                                                >
+                                                                    {issue.remediation}
+                                                                </p>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    ) : preflight.data ? (
+                                        <div className="px-5 pt-3 flex items-center gap-1.5 text-[11.5px] text-emerald-700">
+                                            <CheckIcon className="w-3.5 h-3.5 shrink-0" />
+                                            Pre-send checks passed.
+                                        </div>
+                                    ) : null}
 
                                     <p className="px-5 pt-3 text-[11.5px] text-slate-500 leading-relaxed">
                                         Sending begins immediately, paced to the schedule and your

--- a/web/src/lib/api/client/app/campaigns/runPreflight.ts
+++ b/web/src/lib/api/client/app/campaigns/runPreflight.ts
@@ -1,0 +1,12 @@
+import type { PreflightReport } from "@/lib/api/models/app/campaigns/Preflight";
+import Request from "../../Request";
+
+// Read-only despite being a POST: it computes a report and stores nothing the
+// caller can collide with, so retries are naturally safe.
+export default async function runPreflight(campaignId: string): Promise<PreflightReport> {
+    return await Request<PreflightReport>({
+        method: "POST",
+        url: `/campaigns/${campaignId}/preflight`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/hooks/app/campaigns/usePreflight.ts
+++ b/web/src/lib/api/hooks/app/campaigns/usePreflight.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import runPreflight from "@/lib/api/client/app/campaigns/runPreflight";
+
+// Runs when the launch dialog opens. Kept fresh-on-open rather than cached, so
+// a user who fixes a step and reopens sees the fix.
+export default function usePreflight(campaignId: string, enabled: boolean) {
+    return useQuery({
+        queryKey: ["app", "campaigns", campaignId, "preflight"],
+        queryFn: () => runPreflight(campaignId),
+        enabled: enabled && !!campaignId,
+        staleTime: 0,
+        gcTime: 0,
+        retry: false,
+    });
+}

--- a/web/src/lib/api/models/app/campaigns/Preflight.ts
+++ b/web/src/lib/api/models/app/campaigns/Preflight.ts
@@ -1,0 +1,31 @@
+// Result of POST /campaigns/{id}/preflight — the platform's own pre-send
+// checks, run before a campaign starts sending.
+
+export interface PreflightCheckResult {
+    key: string;
+    passed: boolean;
+    severity: string; // "error" | "warning" | "info"
+    message: string;
+    remediation?: string;
+}
+
+export interface PreflightReport {
+    id: string;
+    organization_id: string;
+    campaign_id: string;
+    passed: boolean;
+    score: number;
+    checks: PreflightCheckResult[];
+    recommendations: string[];
+    created_at: string;
+}
+
+// Only failures are worth a user's attention; a passing check is noise in a
+// launch dialog.
+export function preflightFailures(r: PreflightReport | undefined): PreflightCheckResult[] {
+    return (r?.checks ?? []).filter((c) => !c.passed);
+}
+
+export function hasBlockingFailure(r: PreflightReport | undefined): boolean {
+    return preflightFailures(r).some((c) => c.severity === "error");
+}

--- a/web/src/lib/api/models/app/outreach/OutreachSettings.ts
+++ b/web/src/lib/api/models/app/outreach/OutreachSettings.ts
@@ -10,13 +10,24 @@ export interface SendTimeOptimizationSettings {
     weekend_weight_multiplier: number;
 }
 
+export interface PreflightSettings {
+    enabled: boolean;
+    check_tracking_domain: boolean;
+    check_unsubscribe_header: boolean;
+    check_ab_variant_configured: boolean;
+    check_daily_limit: boolean;
+    check_schedule_window: boolean;
+    check_content_score: boolean;
+    min_content_score: number;
+}
+
 export interface OutreachSettings {
     bounce_pipeline: Record<string, unknown>;
     task_reliability: Record<string, unknown>;
     ab_testing: Record<string, unknown>;
     reply_intent: Record<string, unknown>;
     send_time_optimization: SendTimeOptimizationSettings;
-    preflight: Record<string, unknown>;
+    preflight: PreflightSettings;
     dashboard: Record<string, unknown>;
     custom?: Record<string, unknown>;
 }


### PR DESCRIPTION
Closes #144.

## What was already there

Most of this issue had shipped: `warmlint.Score` exists, `POST /templates/score` is routed and gated, and `ContentScore.tsx` shows a live score in the sequence editor. The issue body describes none of that as done.

## What was missing

**The send path.** The editor scores the *template*. Nothing scored the message after merge fields, spintax, A/B selection and AI blocks resolved — which is exactly where a clean template turns into `Hi ,` or picks the one spintax branch full of trigger words.

The send path now scores the rendered message and writes **one warning per step per day** to the campaign activity feed, not one per recipient. Advisory: it never blocks or delays a send.

**Preflight.** `RunPreflight` gained a `content_score` check across every step, naming the worst one.

**Heuristics.** `warmlint` gained image-heavy (an image-only body is unreadable to filters, which reads as evasion), many-images, and attachments.

## The UI gap this exposed

`POST /campaigns/:id/preflight` had **no web UI**. The launch dialog showed a client-side summary it derived itself (daily cap, schedule, tracking, step count) while the platform's own checks — campaign readiness, unsubscribe header, tracking domain, A/B variants, and now content score — were computed by an endpoint nobody called.

The launch dialog now runs the real preflight and shows failures with their remediation. Errors are red, warnings amber. It does **not** disable Launch: the backend owns what actually blocks a start, and a dialog that disagrees with it would be worse than one that stays quiet.

New controls live in **Settings > Sending > Content checks** (on by default, floor 60).

## Note on scope

An earlier push accidentally carried these changes on the #143 branch; they were split back out in warmbly/warmbly@c4b0ae1 and this branch carries them properly.

## Verification

- `internal/pkg/warmlint/score_test.go` — clean copy is unpenalized, image-only vs text-with-images are distinguished, attachments deduct, and the score floors at 0 rather than going negative.
- `make lint`, `gofmt -l` clean; `TestLiveEveryQueryPrepares` passes for the new `HasRecentLogFor` query; `pnpm typecheck`/`lint` clean in `web/`; `types:check`/`lint`/`build` clean in `docs/`.