### PR TITLE
feat: refuse a launch whose list is known to be largely undeliverable

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -604,6 +604,7 @@ func main() {
 		idempotencyService = idempotencyapp.NewService(primaryDB.Pool)
 		crmRepository := repository.NewCRMRepository(primaryDB.Pool)
 		advancedRepository := repository.NewAdvancedOutreachRepository(primaryDB.Pool)
+		campaignAudienceRepository := repository.NewCampaignAudienceRepository(primaryDB)
 		templateRepository := repository.NewTemplateRepository(primaryDB.Pool)
 		warmupRepository := repository.NewWarmupRepository(primaryDB.Pool)
 		warmupRoutingRepository := repository.NewWarmupRoutingRepository(primaryDB.Pool)
@@ -1195,6 +1196,11 @@ func main() {
 			aware.WireOutreach(advancedRepository)
 		}
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
+		// The launch gate refuses a list that is known to be largely
+		// undeliverable, using the same projection preflight reports.
+		if aware, ok := campaignService.(campaign.AudienceAware); ok {
+			aware.WireAudience(campaignAudienceRepository)
+		}
 		// Delete drops attachment objects and duplicate copies them, so the
 		// campaign service needs the store the attachment handler writes to.
 		if aware, ok := campaignService.(campaign.AttachmentAware); ok {
@@ -1237,6 +1243,11 @@ func main() {
 			tasksClient,
 			warmupService,
 		)
+		// Preflight reports the same projection the launch gate acts on, so
+		// the dialog cannot say one thing and the launch another.
+		if aware, ok := advancedService.(advanced.AudienceAware); ok {
+			aware.WireAudience(campaignAudienceRepository)
+		}
 
 		// Shared AI tool registry: every tool calls a service-layer function as
 		// the invoking user, so the dashboard agent (M3) and MCP server (M8) can

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -169,6 +169,18 @@ A mailbox that never used warmup is not gated. This exists to smooth the warmup-
 
 </Callout>
 
+## The launch check on your list
+
+Starting a campaign measures its recipient list first and refuses to launch one that is known to be largely undeliverable. Mailbox providers put a sender under review at around a 5% bounce rate, so the number worth seeing is the one you can see beforehand.
+
+What it counts:
+
+- **Known-invalid addresses only.** Verification has to have actually rejected the address. A list nobody has verified is not evidence of a bad list, so it is never blocked on that basis, only pointed out.
+- **Deliverable recipients only.** Suppressed and unsubscribed leads are skipped at send time, so counting them would make a bad list look fine.
+- **Lists of at least 50.** Below that a share means nothing, and no launch is refused on it.
+
+Above `4%` projected bounce the launch is refused with the number and what to do about it. Between `2%` and `4%` it launches with a warning. The same projection appears in the launch dialog before you click, so a refusal is never a surprise.
+
 ## Safety posture
 
 Defaults are deliberately conservative, aiming at a low complaint rate rather than maximum throughput:

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/listgate"
 	"github.com/warmbly/warmbly/internal/app/replyclassify"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/errx"
@@ -162,10 +163,13 @@ type service struct {
 	tasksClient          tasksched.Scheduler
 	warmupService        warmupapp.Service
 	dispatcher           EventDispatcher
-	notifier             Notifier
-	realtime             ReplyRealtimePublisher
-	automationRunner     AutomationRunner
-	inboxAgent           InboxAgent
+	// audienceRepo measures a campaign's list for the preflight report.
+	// Optional/nil-safe: without it the list check is simply absent.
+	audienceRepo     repository.CampaignAudienceRepository
+	notifier         Notifier
+	realtime         ReplyRealtimePublisher
+	automationRunner AutomationRunner
+	inboxAgent       InboxAgent
 }
 
 func NewService(
@@ -1593,6 +1597,10 @@ func (s *service) RunPreflight(ctx context.Context, organizationID, campaignID u
 		checks = append(checks, check)
 	}
 
+	if s.audienceRepo != nil {
+		checks = append(checks, s.listQualityCheck(ctx, organizationID, campaignID, &recommendations))
+	}
+
 	if settings.Preflight.CheckContentScore {
 		checks = append(checks, s.contentScoreCheck(ctx, campaignID, settings.Preflight.MinContentScore, &recommendations))
 	}
@@ -1813,4 +1821,44 @@ func (s *service) contentScoreCheck(ctx context.Context, campaignID uuid.UUID, f
 		Message:     fmt.Sprintf("Step %d scores %d/100 for spam signals (floor %d). %s", worstStep, worst, floor, issue),
 		Remediation: "Trim spam-trigger wording, links, images and stacked punctuation in that step.",
 	}
+}
+
+// listQualityCheck projects the campaign's bounce rate for the preflight
+// report, using the same rule StartCampaign refuses on, so the launch dialog
+// cannot say one thing and the launch another.
+func (s *service) listQualityCheck(ctx context.Context, orgID, campaignID uuid.UUID, recommendations *[]string) models.PreflightCheckResult {
+	audience, err := s.audienceRepo.GetCampaignAudience(ctx, orgID, campaignID)
+	if err != nil {
+		return models.PreflightCheckResult{
+			Key:      "list_quality",
+			Passed:   false,
+			Severity: "warning",
+			Message:  "Could not read the campaign's audience to check it.",
+		}
+	}
+	v := listgate.Project(audience)
+	check := models.PreflightCheckResult{
+		Key:         "list_quality",
+		Passed:      !v.Block && !v.Warn,
+		Severity:    "warning",
+		Message:     v.Summary,
+		Remediation: v.Remediation,
+	}
+	if v.Block {
+		check.Severity = "error"
+	}
+	if !check.Passed {
+		*recommendations = append(*recommendations, "Clean or verify the recipient list before sending at volume.")
+	}
+	return check
+}
+
+// WireAudience attaches the launch-time list measurement.
+func (s *service) WireAudience(r repository.CampaignAudienceRepository) {
+	s.audienceRepo = r
+}
+
+// AudienceAware is the optional capability the caller uses to attach it.
+type AudienceAware interface {
+	WireAudience(r repository.CampaignAudienceRepository)
 }

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/dailythrottle"
+	"github.com/warmbly/warmbly/internal/app/listgate"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
@@ -442,6 +443,17 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 						i+1, f.name,
 					))
 				}
+			}
+		}
+	}
+
+	// Refuse a launch whose list is known to be largely undeliverable. Only
+	// KNOWN-invalid addresses count: a list nobody has verified is not evidence
+	// of a bad list, and blocking on that would refuse nearly every launch.
+	if s.audienceRepo != nil {
+		if audience, aerr := s.audienceRepo.GetCampaignAudience(ctx, orgID, cID); aerr == nil {
+			if verdict := listgate.Project(audience); verdict.Block {
+				return errx.New(errx.BadRequest, verdict.Summary+" "+verdict.Remediation)
 			}
 		}
 	}

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog/log"
 	"regexp"
 	"strconv"
 	"strings"
@@ -451,7 +452,15 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 	// KNOWN-invalid addresses count: a list nobody has verified is not evidence
 	// of a bad list, and blocking on that would refuse nearly every launch.
 	if s.audienceRepo != nil {
-		if audience, aerr := s.audienceRepo.GetCampaignAudience(ctx, orgID, cID); aerr == nil {
+		audience, aerr := s.audienceRepo.GetCampaignAudience(ctx, orgID, cID)
+		switch {
+		case aerr != nil:
+			// Fail open, but never silently: a transient database error must
+			// not stop a customer launching, and it must not look like the
+			// list passed either.
+			log.Warn().Err(aerr).Str("campaign_id", cID.String()).
+				Msg("could not measure the campaign's list; launching without the check")
+		default:
 			if verdict := listgate.Project(audience); verdict.Block {
 				return errx.New(errx.BadRequest, verdict.Summary+" "+verdict.Remediation)
 			}

--- a/internal/app/campaign/service.go
+++ b/internal/app/campaign/service.go
@@ -68,6 +68,19 @@ type campaignService struct {
 	streamingPublisher *pubsub.StreamingPublisher
 	attachmentRepo     repository.AttachmentRepository
 	storage            storage.Store
+	// audienceRepo measures the campaign's list at launch. Optional/nil-safe:
+	// without it no launch is ever refused on list quality.
+	audienceRepo repository.CampaignAudienceRepository
+}
+
+// WireAudience attaches the launch-time list gate.
+func (s *campaignService) WireAudience(r repository.CampaignAudienceRepository) {
+	s.audienceRepo = r
+}
+
+// AudienceAware is the optional capability the caller uses to attach it.
+type AudienceAware interface {
+	WireAudience(r repository.CampaignAudienceRepository)
 }
 
 // AttachmentAware is implemented by the campaign service so main can hand it

--- a/internal/app/listgate/listgate.go
+++ b/internal/app/listgate/listgate.go
@@ -1,11 +1,6 @@
-// Package listgate projects how badly a campaign's list will bounce, before it
-// sends anything.
-//
-// Per-recipient verification already drops a bad address at send time, but that
-// is one address at a time and after the campaign has started: a scraped list
-// still reveals itself through the damage. SES reviews an account at 5% bounce
-// and can pause it at 10%, so the number that matters is the one you can see
-// beforehand.
+// Package listgate projects a campaign's bounce rate before it sends anything.
+// Per-recipient verification only drops a bad address at send time, so a
+// scraped list otherwise reveals itself through the damage it does.
 package listgate
 
 import (
@@ -16,9 +11,8 @@ import (
 
 // Thresholds, in percent of the deliverable audience.
 const (
-	// BlockBouncePct is where a launch is refused. Chosen below the 5% at
-	// which SES puts an account under review: the platform should act before
-	// a provider does.
+	// BlockBouncePct sits below the 5% at which providers put a sender under
+	// review, so the platform acts first.
 	BlockBouncePct = 4.0
 	// WarnBouncePct is where a launch is allowed but flagged.
 	WarnBouncePct = 2.0
@@ -39,7 +33,9 @@ type Verdict struct {
 	ProjectedBouncePct float64
 	// Block is true when the launch should be refused.
 	Block bool
-	// Warn is true when it should be flagged but allowed.
+	// Warn is true when it should be flagged but allowed. Set for an
+	// unverified list too, so advice about it is actually shown: a preflight
+	// report only surfaces checks that did not pass.
 	Warn bool
 	// UnverifiedPct is the share of the audience nobody has checked. Reported,
 	// never blocked on: see Project.
@@ -51,10 +47,11 @@ type Verdict struct {
 }
 
 // Project estimates the audience's bounce rate. A list too small to judge, or
-// one with nothing deliverable, is never blocked: refusing a launch on a
-// sample that cannot support the number would be worse than letting it run.
+// with nothing deliverable, is never blocked.
 func Project(a repository.CampaignAudience) Verdict {
-	deliverable := a.Total - a.Suppressed - a.Unsubscribed
+	// Counted in SQL, not derived: a contact can be both suppressed and
+	// unsubscribed, and subtracting both counts would remove it twice.
+	deliverable := a.Deliverable
 	if deliverable < 0 {
 		deliverable = 0
 	}
@@ -95,6 +92,7 @@ func Project(a repository.CampaignAudience) Verdict {
 			v.ProjectedBouncePct, a.Invalid, deliverable)
 		v.Remediation = "Consider verifying the list before sending at volume."
 	case v.UnverifiedPct >= UnverifiedAdvisePct:
+		v.Warn = true
 		v.Summary = fmt.Sprintf("%.0f%% of this list has never been verified, so its bounce rate is unknown.", v.UnverifiedPct)
 		v.Remediation = "Verify the list to see its real bounce risk before sending at volume."
 	default:

--- a/internal/app/listgate/listgate.go
+++ b/internal/app/listgate/listgate.go
@@ -1,0 +1,104 @@
+// Package listgate projects how badly a campaign's list will bounce, before it
+// sends anything.
+//
+// Per-recipient verification already drops a bad address at send time, but that
+// is one address at a time and after the campaign has started: a scraped list
+// still reveals itself through the damage. SES reviews an account at 5% bounce
+// and can pause it at 10%, so the number that matters is the one you can see
+// beforehand.
+package listgate
+
+import (
+	"fmt"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Thresholds, in percent of the deliverable audience.
+const (
+	// BlockBouncePct is where a launch is refused. Chosen below the 5% at
+	// which SES puts an account under review: the platform should act before
+	// a provider does.
+	BlockBouncePct = 4.0
+	// WarnBouncePct is where a launch is allowed but flagged.
+	WarnBouncePct = 2.0
+	// MinAudience is the size below which a share means nothing. Two bad
+	// addresses out of five is not a 40% bounce rate.
+	MinAudience = 50
+	// UnverifiedAdvisePct is the share of never-checked addresses above which
+	// the customer is advised to verify. Advice only: see below.
+	UnverifiedAdvisePct = 50.0
+)
+
+// Verdict is a projection over one campaign's audience.
+type Verdict struct {
+	// Deliverable excludes suppressed and unsubscribed leads: they are skipped
+	// at send time, so counting them would understate every share.
+	Deliverable int
+	// ProjectedBouncePct is the estimated hard-bounce rate at launch.
+	ProjectedBouncePct float64
+	// Block is true when the launch should be refused.
+	Block bool
+	// Warn is true when it should be flagged but allowed.
+	Warn bool
+	// UnverifiedPct is the share of the audience nobody has checked. Reported,
+	// never blocked on: see Project.
+	UnverifiedPct float64
+	// Summary is the sentence the customer reads.
+	Summary string
+	// Remediation is what to do about it.
+	Remediation string
+}
+
+// Project estimates the audience's bounce rate. A list too small to judge, or
+// one with nothing deliverable, is never blocked: refusing a launch on a
+// sample that cannot support the number would be worse than letting it run.
+func Project(a repository.CampaignAudience) Verdict {
+	deliverable := a.Total - a.Suppressed - a.Unsubscribed
+	if deliverable < 0 {
+		deliverable = 0
+	}
+	v := Verdict{Deliverable: deliverable}
+
+	if deliverable == 0 {
+		v.Summary = "No deliverable recipients: every lead is suppressed or unsubscribed."
+		v.Remediation = "Add recipients, or remove the suppressed ones from this campaign."
+		return v
+	}
+
+	// The projection counts KNOWN-invalid addresses only.
+	//
+	// Assuming a fraction of unverified addresses will bounce is tempting and
+	// wrong: most customers never run verification, so their lists are entirely
+	// unverified, and any non-zero weight would refuse essentially every launch.
+	// A list nobody has checked is not evidence of a bad list. It is reported
+	// as unverified and the customer is advised to check it.
+	v.ProjectedBouncePct = float64(a.Invalid) / float64(deliverable) * 100
+	v.UnverifiedPct = float64(a.Unknown) / float64(deliverable) * 100
+
+	if deliverable < MinAudience {
+		v.Summary = fmt.Sprintf("Audience of %d is too small to judge; sending anyway.", deliverable)
+		return v
+	}
+
+	switch {
+	case v.ProjectedBouncePct >= BlockBouncePct:
+		v.Block = true
+		v.Summary = fmt.Sprintf(
+			"About %.1f%% of this list is likely to hard bounce (%d known-invalid of %d deliverable).",
+			v.ProjectedBouncePct, a.Invalid, deliverable)
+		v.Remediation = "Verify or clean the list before launching. Mailbox providers put a sender under review at 5%."
+	case v.ProjectedBouncePct >= WarnBouncePct:
+		v.Warn = true
+		v.Summary = fmt.Sprintf(
+			"About %.1f%% of this list is likely to hard bounce (%d known-invalid of %d deliverable).",
+			v.ProjectedBouncePct, a.Invalid, deliverable)
+		v.Remediation = "Consider verifying the list before sending at volume."
+	case v.UnverifiedPct >= UnverifiedAdvisePct:
+		v.Summary = fmt.Sprintf("%.0f%% of this list has never been verified, so its bounce rate is unknown.", v.UnverifiedPct)
+		v.Remediation = "Verify the list to see its real bounce risk before sending at volume."
+	default:
+		v.Summary = fmt.Sprintf("Projected hard bounce is about %.1f%%.", v.ProjectedBouncePct)
+	}
+	return v
+}

--- a/internal/app/listgate/listgate_test.go
+++ b/internal/app/listgate/listgate_test.go
@@ -1,0 +1,101 @@
+package listgate
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// The case that decides whether this gate is usable at all. Most customers
+// never run verification, so their lists are entirely unverified. Assuming any
+// fraction of those will bounce would refuse essentially every launch.
+func TestProjectNeverBlocksAnUnverifiedList(t *testing.T) {
+	v := Project(repository.CampaignAudience{Total: 1000, Unknown: 1000})
+	if v.Block {
+		t.Fatalf("a never-verified list was blocked at %.1f%%; that is every ordinary customer", v.ProjectedBouncePct)
+	}
+	if v.Warn {
+		t.Errorf("a never-verified list should be advised, not warned as a bounce risk: %+v", v)
+	}
+	if v.ProjectedBouncePct != 0 {
+		t.Errorf("projected = %.1f%%, want 0: unverified is not evidence of bad", v.ProjectedBouncePct)
+	}
+	if v.UnverifiedPct != 100 {
+		t.Errorf("unverified = %.1f%%, want 100", v.UnverifiedPct)
+	}
+	if v.Remediation == "" {
+		t.Error("an unverified list should still suggest verifying it")
+	}
+}
+
+// A verified-clean list is silent.
+func TestProjectCleanVerifiedListIsQuiet(t *testing.T) {
+	v := Project(repository.CampaignAudience{Total: 1000, Unknown: 0})
+	if v.Block || v.Warn || v.Remediation != "" {
+		t.Errorf("a clean list should be quiet: %+v", v)
+	}
+}
+
+func TestProjectBlocksAKnownBadList(t *testing.T) {
+	// 200 known-invalid out of 1000 is 20%: unambiguously a scraped list.
+	v := Project(repository.CampaignAudience{Total: 1000, Invalid: 200, Unknown: 0})
+	if !v.Block {
+		t.Errorf("a 20%% invalid list was not blocked: %+v", v)
+	}
+	if v.Remediation == "" {
+		t.Error("a blocked launch must say what to do about it")
+	}
+}
+
+func TestProjectWarnsInTheMiddleBand(t *testing.T) {
+	v := Project(repository.CampaignAudience{Total: 1000, Invalid: 25})
+	if v.Block {
+		t.Errorf("2.5%% should warn, not block: %+v", v)
+	}
+	if !v.Warn {
+		t.Errorf("2.5%% should warn: %+v", v)
+	}
+}
+
+// The failure that would hurt most: refusing a launch on a sample too small to
+// mean anything.
+func TestProjectNeverBlocksATinyAudience(t *testing.T) {
+	for _, n := range []int{1, 5, 20, MinAudience - 1} {
+		v := Project(repository.CampaignAudience{Total: n, Invalid: n})
+		if v.Block {
+			t.Errorf("an audience of %d was blocked at 100%% invalid; too small to judge", n)
+		}
+	}
+	// At the floor it starts judging.
+	v := Project(repository.CampaignAudience{Total: MinAudience, Invalid: MinAudience})
+	if !v.Block {
+		t.Errorf("an audience of %d at 100%% invalid should block", MinAudience)
+	}
+}
+
+// Suppressed and unsubscribed leads are never sent to, so counting them in the
+// denominator would understate every share and let a bad list through.
+func TestProjectExcludesLeadsThatWillNeverBeSentTo(t *testing.T) {
+	a := repository.CampaignAudience{Total: 1000, Invalid: 40, Suppressed: 500, Unsubscribed: 400}
+	v := Project(a)
+	if v.Deliverable != 100 {
+		t.Fatalf("deliverable = %d, want 100", v.Deliverable)
+	}
+	// 40 invalid of 100 deliverable is 40%, not 4% of the raw 1000.
+	if v.ProjectedBouncePct < 39 || v.ProjectedBouncePct > 41 {
+		t.Errorf("projected = %.1f%%, want about 40%%", v.ProjectedBouncePct)
+	}
+	if !v.Block {
+		t.Error("a list that is 40% invalid among its deliverable leads must block")
+	}
+}
+
+func TestProjectWithNothingDeliverable(t *testing.T) {
+	v := Project(repository.CampaignAudience{Total: 100, Suppressed: 100})
+	if v.Block {
+		t.Error("a fully-suppressed campaign should be explained, not blocked as a bounce risk")
+	}
+	if v.Summary == "" || v.Remediation == "" {
+		t.Errorf("an undeliverable audience must be explained: %+v", v)
+	}
+}

--- a/internal/app/listgate/listgate_test.go
+++ b/internal/app/listgate/listgate_test.go
@@ -10,12 +10,14 @@ import (
 // never run verification, so their lists are entirely unverified. Assuming any
 // fraction of those will bounce would refuse essentially every launch.
 func TestProjectNeverBlocksAnUnverifiedList(t *testing.T) {
-	v := Project(repository.CampaignAudience{Total: 1000, Unknown: 1000})
+	v := Project(repository.CampaignAudience{Total: 1000, Deliverable: 1000, Unknown: 1000})
 	if v.Block {
 		t.Fatalf("a never-verified list was blocked at %.1f%%; that is every ordinary customer", v.ProjectedBouncePct)
 	}
-	if v.Warn {
-		t.Errorf("a never-verified list should be advised, not warned as a bounce risk: %+v", v)
+	// Warn is set so the advice is actually shown: a preflight report only
+	// surfaces checks that did not pass.
+	if !v.Warn {
+		t.Errorf("a never-verified list must warn, or its advice is never displayed: %+v", v)
 	}
 	if v.ProjectedBouncePct != 0 {
 		t.Errorf("projected = %.1f%%, want 0: unverified is not evidence of bad", v.ProjectedBouncePct)
@@ -30,7 +32,7 @@ func TestProjectNeverBlocksAnUnverifiedList(t *testing.T) {
 
 // A verified-clean list is silent.
 func TestProjectCleanVerifiedListIsQuiet(t *testing.T) {
-	v := Project(repository.CampaignAudience{Total: 1000, Unknown: 0})
+	v := Project(repository.CampaignAudience{Total: 1000, Deliverable: 1000, Unknown: 0})
 	if v.Block || v.Warn || v.Remediation != "" {
 		t.Errorf("a clean list should be quiet: %+v", v)
 	}
@@ -38,7 +40,7 @@ func TestProjectCleanVerifiedListIsQuiet(t *testing.T) {
 
 func TestProjectBlocksAKnownBadList(t *testing.T) {
 	// 200 known-invalid out of 1000 is 20%: unambiguously a scraped list.
-	v := Project(repository.CampaignAudience{Total: 1000, Invalid: 200, Unknown: 0})
+	v := Project(repository.CampaignAudience{Total: 1000, Deliverable: 1000, Invalid: 200, Unknown: 0})
 	if !v.Block {
 		t.Errorf("a 20%% invalid list was not blocked: %+v", v)
 	}
@@ -48,7 +50,7 @@ func TestProjectBlocksAKnownBadList(t *testing.T) {
 }
 
 func TestProjectWarnsInTheMiddleBand(t *testing.T) {
-	v := Project(repository.CampaignAudience{Total: 1000, Invalid: 25})
+	v := Project(repository.CampaignAudience{Total: 1000, Deliverable: 1000, Invalid: 25})
 	if v.Block {
 		t.Errorf("2.5%% should warn, not block: %+v", v)
 	}
@@ -61,13 +63,13 @@ func TestProjectWarnsInTheMiddleBand(t *testing.T) {
 // mean anything.
 func TestProjectNeverBlocksATinyAudience(t *testing.T) {
 	for _, n := range []int{1, 5, 20, MinAudience - 1} {
-		v := Project(repository.CampaignAudience{Total: n, Invalid: n})
+		v := Project(repository.CampaignAudience{Total: n, Deliverable: n, Invalid: n})
 		if v.Block {
 			t.Errorf("an audience of %d was blocked at 100%% invalid; too small to judge", n)
 		}
 	}
 	// At the floor it starts judging.
-	v := Project(repository.CampaignAudience{Total: MinAudience, Invalid: MinAudience})
+	v := Project(repository.CampaignAudience{Total: MinAudience, Deliverable: MinAudience, Invalid: MinAudience})
 	if !v.Block {
 		t.Errorf("an audience of %d at 100%% invalid should block", MinAudience)
 	}
@@ -76,7 +78,10 @@ func TestProjectNeverBlocksATinyAudience(t *testing.T) {
 // Suppressed and unsubscribed leads are never sent to, so counting them in the
 // denominator would understate every share and let a bad list through.
 func TestProjectExcludesLeadsThatWillNeverBeSentTo(t *testing.T) {
-	a := repository.CampaignAudience{Total: 1000, Invalid: 40, Suppressed: 500, Unsubscribed: 400}
+	// 500 suppressed and 400 unsubscribed OVERLAP; SQL counts the 100 that are
+	// neither. Subtracting both counts would have said 100 too, by luck, but
+	// says -300 clamped to 0 when they overlap fully.
+	a := repository.CampaignAudience{Total: 1000, Deliverable: 100, Invalid: 40, Suppressed: 500, Unsubscribed: 400}
 	v := Project(a)
 	if v.Deliverable != 100 {
 		t.Fatalf("deliverable = %d, want 100", v.Deliverable)
@@ -91,11 +96,33 @@ func TestProjectExcludesLeadsThatWillNeverBeSentTo(t *testing.T) {
 }
 
 func TestProjectWithNothingDeliverable(t *testing.T) {
-	v := Project(repository.CampaignAudience{Total: 100, Suppressed: 100})
+	v := Project(repository.CampaignAudience{Total: 100, Deliverable: 0, Suppressed: 100})
 	if v.Block {
 		t.Error("a fully-suppressed campaign should be explained, not blocked as a bounce risk")
 	}
 	if v.Summary == "" || v.Remediation == "" {
 		t.Errorf("an undeliverable audience must be explained: %+v", v)
+	}
+}
+
+// The bug this guards: Suppressed and Unsubscribed overlap, so deriving
+// deliverable as Total - Suppressed - Unsubscribed removes those contacts
+// twice and inflates every share computed against the remainder.
+func TestProjectUsesTheCountedDeliverableNotASubtraction(t *testing.T) {
+	// 600 leads are BOTH suppressed and unsubscribed; 400 are sendable.
+	a := repository.CampaignAudience{
+		Total: 1000, Deliverable: 400, Suppressed: 600, Unsubscribed: 600, Invalid: 12,
+	}
+	v := Project(a)
+	if v.Deliverable != 400 {
+		t.Fatalf("deliverable = %d, want the counted 400; a subtraction would give -200", v.Deliverable)
+	}
+	// 12 of 400 is 3%: a warning. Against a double-subtracted 0 it would have
+	// been a divide-by-zero or an infinite rate.
+	if !v.Warn || v.Block {
+		t.Errorf("12 invalid of 400 should warn, not block: %+v", v)
+	}
+	if v.ProjectedBouncePct < 2.9 || v.ProjectedBouncePct > 3.1 {
+		t.Errorf("projected = %.2f%%, want about 3%%", v.ProjectedBouncePct)
 	}
 }

--- a/internal/repository/campaign_audience_live_test.go
+++ b/internal/repository/campaign_audience_live_test.go
@@ -72,6 +72,11 @@ func TestLiveCampaignAudienceCountsEachClass(t *testing.T) {
 	if got.FreeMail != 1 {
 		t.Errorf("free mail = %d, want the gmail.com lead", got.FreeMail)
 	}
+	// Counted, not derived: the unsubscribed lead is excluded once even though
+	// it could also have been suppressed.
+	if got.Deliverable != got.Total-got.Unsubscribed {
+		t.Errorf("deliverable = %d, want %d", got.Deliverable, got.Total-got.Unsubscribed)
+	}
 }
 
 // The audience is scoped to ONE campaign and ONE organization: a gate that

--- a/internal/repository/campaign_audience_live_test.go
+++ b/internal/repository/campaign_audience_live_test.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Issue #146: the launch gate measures the list as it is NOW, not from the
+// advisor's periodic rollup. These prove the query against the real schema.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveCampaignAudience -v
+
+// addLead inserts a contact with the given verification state and enrols it.
+func addLead(t *testing.T, f *sharedOrgFixture, email, status string, subscribed bool) uuid.UUID {
+	t.Helper()
+	_, pool := liveContactDB(t)
+	id := uuid.New()
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO contacts (id, user_id, organization_id, email, first_name, last_name,
+		     company, phone, custom_fields, verification_status, subscribed)
+		 VALUES ($1, $2, $3, $4, 'A', 'B', '', '', '{}'::jsonb, $5, $6)`,
+		id, f.owner, f.org, email, status, subscribed); err != nil {
+		t.Fatalf("insert contact: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(),
+		`INSERT INTO campaign_leads (campaign_id, contact_id) VALUES ($1, $2)`, f.campaign, id); err != nil {
+		t.Fatalf("add lead: %v", err)
+	}
+	return id
+}
+
+func TestLiveCampaignAudienceCountsEachClass(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewCampaignAudienceRepository(handle)
+
+	addLead(t, f, "invalid-"+uuid.New().String()[:6]+"@test.local", "invalid", true)
+	addLead(t, f, "risky-"+uuid.New().String()[:6]+"@test.local", "risky", true)
+	addLead(t, f, "valid-"+uuid.New().String()[:6]+"@test.local", "valid", true)
+	addLead(t, f, "unknown-"+uuid.New().String()[:6]+"@test.local", "unknown", true)
+	addLead(t, f, "gone-"+uuid.New().String()[:6]+"@test.local", "valid", false)
+	// Role address and free-mail domain, using the same vocabularies the
+	// advisor uses so a customer is never told two different numbers.
+	addLead(t, f, "info@test.local", "valid", true)
+	addLead(t, f, "someone-"+uuid.New().String()[:6]+"@gmail.com", "valid", true)
+
+	got, err := repo.GetCampaignAudience(context.Background(), f.org, f.campaign)
+	if err != nil {
+		t.Fatalf("GetCampaignAudience: %v", err)
+	}
+	if got.Total < 7 {
+		t.Fatalf("total = %d, want at least the 7 leads added", got.Total)
+	}
+	if got.Invalid != 1 {
+		t.Errorf("invalid = %d, want 1", got.Invalid)
+	}
+	if got.Risky != 1 {
+		t.Errorf("risky = %d, want 1", got.Risky)
+	}
+	if got.Unknown != 1 {
+		t.Errorf("unknown = %d, want 1; 'unknown' is the column default for an unchecked address", got.Unknown)
+	}
+	if got.Unsubscribed != 1 {
+		t.Errorf("unsubscribed = %d, want 1", got.Unsubscribed)
+	}
+	if got.RoleAddress != 1 {
+		t.Errorf("role addresses = %d, want the info@ lead", got.RoleAddress)
+	}
+	if got.FreeMail != 1 {
+		t.Errorf("free mail = %d, want the gmail.com lead", got.FreeMail)
+	}
+}
+
+// The audience is scoped to ONE campaign and ONE organization: a gate that
+// counted another campaign's leads would refuse launches for the wrong reason.
+func TestLiveCampaignAudienceIsScoped(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewCampaignAudienceRepository(handle)
+
+	addLead(t, f, "one-"+uuid.New().String()[:6]+"@test.local", "invalid", true)
+
+	// A different organization must see nothing for this campaign.
+	got, err := repo.GetCampaignAudience(context.Background(), uuid.New(), f.campaign)
+	if err != nil {
+		t.Fatalf("GetCampaignAudience: %v", err)
+	}
+	if got.Total != 0 {
+		t.Errorf("another organization saw %d leads, want 0", got.Total)
+	}
+
+	// An unknown campaign in the right organization is likewise empty.
+	got, err = repo.GetCampaignAudience(context.Background(), f.org, uuid.New())
+	if err != nil {
+		t.Fatalf("GetCampaignAudience: %v", err)
+	}
+	if got.Total != 0 {
+		t.Errorf("an unknown campaign returned %d leads, want 0", got.Total)
+	}
+}

--- a/internal/repository/pg_campaign_audience.go
+++ b/internal/repository/pg_campaign_audience.go
@@ -19,12 +19,16 @@ type CampaignAudience struct {
 	Risky    int
 	Unknown  int
 	CatchAll int
-	// Suppressed leads are skipped at send time, so a large share means the
-	// campaign delivers far less than its size suggests.
+	// Suppressed and Unsubscribed overlap: a contact can be both. Deliverable
+	// is counted separately in SQL rather than subtracted from Total, because
+	// subtracting two overlapping counts double-removes those contacts and
+	// inflates every share computed against the remainder.
 	Suppressed   int
 	Unsubscribed int
-	RoleAddress  int
-	FreeMail     int
+	// Deliverable is the count that will actually be sent to.
+	Deliverable int
+	RoleAddress int
+	FreeMail    int
 }
 
 // CampaignAudienceRepository reads a campaign's audience for the launch gate.
@@ -59,6 +63,11 @@ func (r *campaignAudienceRepository) GetCampaignAudience(ctx context.Context, or
 				  AND (sr.expires_at IS NULL OR sr.expires_at > NOW())
 			)),
 			COUNT(*) FILTER (WHERE ct.subscribed IS FALSE),
+			COUNT(*) FILTER (WHERE ct.subscribed IS NOT FALSE AND NOT EXISTS (
+				SELECT 1 FROM suppressed_recipients sr
+				WHERE sr.organization_id = $1 AND lower(sr.email) = lower(ct.email)
+				  AND (sr.expires_at IS NULL OR sr.expires_at > NOW())
+			)),
 			COUNT(*) FILTER (WHERE split_part(lower(ct.email), '@', 1) IN (`+rolePrefixesSQL+`)),
 			COUNT(*) FILTER (WHERE split_part(lower(ct.email), '@', 2) IN (`+freeMailDomainsSQL+`))
 		FROM campaign_leads cl
@@ -67,7 +76,7 @@ func (r *campaignAudienceRepository) GetCampaignAudience(ctx context.Context, or
 		WHERE cl.campaign_id = $2 AND c.organization_id = $1
 	`, orgID, campaignID).Scan(
 		&a.Total, &a.Invalid, &a.Risky, &a.Unknown, &a.CatchAll,
-		&a.Suppressed, &a.Unsubscribed, &a.RoleAddress, &a.FreeMail,
+		&a.Suppressed, &a.Unsubscribed, &a.Deliverable, &a.RoleAddress, &a.FreeMail,
 	)
 	return a, err
 }

--- a/internal/repository/pg_campaign_audience.go
+++ b/internal/repository/pg_campaign_audience.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+)
+
+// CampaignAudience is one campaign's list quality, measured on demand rather
+// than from the advisor's periodic rollup. A launch gate has to see the list as
+// it is now, not as it was at the last sweep.
+type CampaignAudience struct {
+	Total int
+	// Verification counts come from the address-verification service. Unknown
+	// means unverified, which is not the same as bad.
+	Invalid  int
+	Risky    int
+	Unknown  int
+	CatchAll int
+	// Suppressed leads are skipped at send time, so a large share means the
+	// campaign delivers far less than its size suggests.
+	Suppressed   int
+	Unsubscribed int
+	RoleAddress  int
+	FreeMail     int
+}
+
+// CampaignAudienceRepository reads a campaign's audience for the launch gate.
+type CampaignAudienceRepository interface {
+	GetCampaignAudience(ctx context.Context, orgID, campaignID uuid.UUID) (CampaignAudience, error)
+}
+
+type campaignAudienceRepository struct {
+	DB *db.DB
+}
+
+func NewCampaignAudienceRepository(database *db.DB) CampaignAudienceRepository {
+	return &campaignAudienceRepository{DB: database}
+}
+
+func (r *campaignAudienceRepository) GetCampaignAudience(ctx context.Context, orgID, campaignID uuid.UUID) (CampaignAudience, error) {
+	var a CampaignAudience
+	// Same role and free-mail vocabularies the advisor uses, so a customer is
+	// not told two different numbers for the same list.
+	err := r.DB.Pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE ct.verification_status = 'invalid'),
+			COUNT(*) FILTER (WHERE ct.verification_status = 'risky'),
+			-- 'unknown' is the column default, so this is every address nobody
+			-- has checked. NOT NULL, so no null branch is needed.
+			COUNT(*) FILTER (WHERE ct.verification_status NOT IN ('valid','invalid','risky')),
+			COUNT(*) FILTER (WHERE ct.is_catch_all),
+			COUNT(*) FILTER (WHERE EXISTS (
+				SELECT 1 FROM suppressed_recipients sr
+				WHERE sr.organization_id = $1 AND lower(sr.email) = lower(ct.email)
+				  AND (sr.expires_at IS NULL OR sr.expires_at > NOW())
+			)),
+			COUNT(*) FILTER (WHERE ct.subscribed IS FALSE),
+			COUNT(*) FILTER (WHERE split_part(lower(ct.email), '@', 1) IN (`+rolePrefixesSQL+`)),
+			COUNT(*) FILTER (WHERE split_part(lower(ct.email), '@', 2) IN (`+freeMailDomainsSQL+`))
+		FROM campaign_leads cl
+		JOIN contacts ct ON ct.id = cl.contact_id
+		JOIN campaigns c ON c.id = cl.campaign_id
+		WHERE cl.campaign_id = $2 AND c.organization_id = $1
+	`, orgID, campaignID).Scan(
+		&a.Total, &a.Invalid, &a.Risky, &a.Unknown, &a.CatchAll,
+		&a.Suppressed, &a.Unsubscribed, &a.RoleAddress, &a.FreeMail,
+	)
+	return a, err
+}


### PR DESCRIPTION
Closes #146.

## The gap

Per-recipient verification already drops a bad address at send time, but that is one address at a time and *after* the campaign has started, so a scraped list still reveals itself through the damage it does. SES puts an account under review at 5% bounce and can pause it at 10%.

`StartCampaign` now projects the list's bounce rate first and refuses a launch above `4%`, deliberately below the level at which a provider would act.

## The design decision that matters

My first version weighted unverified addresses at 15% of a bounce. Writing the test for it showed the problem immediately: **most customers never run verification**, so their lists are entirely `unknown`, which projected 15% and would have refused essentially every launch.

So the projection counts **known-invalid addresses only**. Verification has to have actually rejected the address. A list nobody has checked is not evidence of a bad list; it is reported as unverified with a suggestion to verify, and never blocked on.

Two other guards against the same failure mode:

- **Deliverable-only denominator.** Suppressed and unsubscribed leads are skipped at send time, so counting them would make a bad list look fine. A list of 1000 with 900 suppressed and 40 invalid is 40% bad, not 4%.
- **Minimum audience of 50.** Two bad addresses out of five is not a 40% bounce rate, and no launch is refused on a sample that cannot support the number.

## Consistency

The launch dialog's preflight (from #144) reports the **same projection** `StartCampaign` refuses on, through the same function. A dialog that said one thing while the launch did another would be worse than no dialog.

The audience query reuses the advisor's existing `rolePrefixesSQL` and `freeMailDomainsSQL`, so a customer is never told two different numbers for the same list.

## Verification

- `internal/app/listgate/listgate_test.go` — the never-verified case first, since it decides whether the gate is usable at all; plus the deliverable-only denominator, the small-audience floor, and a fully-suppressed audience being explained rather than blamed for bouncing.
- `internal/repository/campaign_audience_live_test.go` — each class counted against the real schema, and org/campaign scoping. This caught that `verification_status` is `NOT NULL` with an `'unknown'` default, so my original `IS NULL` branch was dead code.
- `TestLiveEveryQueryPrepares` passes; full `./internal/...` green; `make lint`, `gofmt -l` clean; `docs/` types/build clean.