### PR TITLE
fix: record why a warmup generation batch failed, instead of only 'batch failed'

### DIFF
--- a/internal/app/warmupcontent/batch.go
+++ b/internal/app/warmupcontent/batch.go
@@ -168,29 +168,35 @@ func (s *service) PollBatches(ctx context.Context) error {
 
 // pollBatchJob reconciles a single batch job.
 func (s *service) pollBatchJob(ctx context.Context, job *models.WarmupGenerationJob) error {
-	status, outputFileID, errorFileID, counts, err := s.gen.GetBatch(ctx, job.BatchID)
+	state, err := s.gen.GetBatch(ctx, job.BatchID)
 	if err != nil {
 		return err
 	}
-	job.BatchStatus = status
+	job.BatchStatus = state.Status
 
-	switch status {
+	switch state.Status {
 	case "completed":
-		job.BatchOutputFileID = outputFileID
+		job.BatchOutputFileID = state.OutputFileID
 		// A batch whose requests all failed completes with no output file; the
 		// refusals are in the error file, which has the same JSONL shape. Read
 		// it instead of failing on the empty id, or the reason is never seen.
-		resultsFileID := outputFileID
+		resultsFileID := state.OutputFileID
 		if resultsFileID == "" {
-			resultsFileID = errorFileID
+			resultsFileID = state.ErrorFileID
 		}
-		return s.ingestBatch(ctx, job, resultsFileID, counts)
+		return s.ingestBatch(ctx, job, resultsFileID, state.Counts)
 	case "failed", "expired", "cancelled":
 		now := time.Now()
 		job.Status = "failed"
 		job.FinishedAt = &now
 		if job.Error == "" {
-			job.Error = fmt.Sprintf("batch %s", status)
+			// A batch that failed as a whole has no error file, so the provider's
+			// own message is the only account of why. Recording just the status
+			// leaves the operator with "batch failed" and nothing to act on.
+			job.Error = fmt.Sprintf("batch %s", state.Status)
+			if state.FailureReason != "" {
+				job.Error += ": " + state.FailureReason
+			}
 		}
 		return s.repo.UpdateGenerationJob(ctx, job)
 	default:

--- a/internal/app/warmupcontent/batch.go
+++ b/internal/app/warmupcontent/batch.go
@@ -190,9 +190,7 @@ func (s *service) pollBatchJob(ctx context.Context, job *models.WarmupGeneration
 		job.Status = "failed"
 		job.FinishedAt = &now
 		if job.Error == "" {
-			// A batch that failed as a whole has no error file, so the provider's
-			// own message is the only account of why. Recording just the status
-			// leaves the operator with "batch failed" and nothing to act on.
+			// A batch that failed as a whole has no error file; this is the only account of why.
 			job.Error = fmt.Sprintf("batch %s", state.Status)
 			if state.FailureReason != "" {
 				job.Error += ": " + state.FailureReason

--- a/internal/pkg/generation/batch.go
+++ b/internal/pkg/generation/batch.go
@@ -112,22 +112,57 @@ func (c *GenerationClient) SubmitBatch(ctx context.Context, requests []BatchRequ
 	return batch.ID, file.ID, nil
 }
 
-// GetBatch returns the current status, the output file ID (present when at
-// least one request succeeded), the error file ID (present when at least one
-// failed), and the request counts for a batch. A batch whose requests all
-// failed still completes, with output empty and every refusal in the error
-// file, so callers must read that one to learn why.
-func (c *GenerationClient) GetBatch(ctx context.Context, batchID string) (status, outputFileID, errorFileID string, counts BatchCounts, err error) {
+// BatchState is the provider's view of one batch. Grouped rather than returned
+// as a widening list of strings, because the two failure surfaces are different
+// and a caller has to tell them apart.
+type BatchState struct {
+	Status string
+	// OutputFileID is present when at least one request succeeded, ErrorFileID
+	// when at least one failed. A batch whose requests ALL failed still
+	// completes, with output empty and every refusal in the error file.
+	OutputFileID string
+	ErrorFileID  string
+	Counts       BatchCounts
+	// FailureReason is the batch-level error, reported when the batch itself
+	// never ran: a rejected input file, a quota refusal. It is not a per-request
+	// refusal, and it arrives with no error file to read it out of, so it is the
+	// only place that says why.
+	FailureReason string
+}
+
+// GetBatch returns the provider's current view of a batch.
+func (c *GenerationClient) GetBatch(ctx context.Context, batchID string) (BatchState, error) {
 	batch, err := c.client.Batches.Get(ctx, batchID)
 	if err != nil {
-		return "", "", "", BatchCounts{}, err
+		return BatchState{}, err
 	}
-	counts = BatchCounts{
-		Completed: int(batch.RequestCounts.Completed),
-		Failed:    int(batch.RequestCounts.Failed),
-		Total:     int(batch.RequestCounts.Total),
+	return BatchState{
+		Status:       string(batch.Status),
+		OutputFileID: batch.OutputFileID,
+		ErrorFileID:  batch.ErrorFileID,
+		Counts: BatchCounts{
+			Completed: int(batch.RequestCounts.Completed),
+			Failed:    int(batch.RequestCounts.Failed),
+			Total:     int(batch.RequestCounts.Total),
+		},
+		FailureReason: batchFailureReason(batch.Errors.Data),
+	}, nil
+}
+
+// batchFailureReason renders the batch-level errors as one line, naming how many
+// more there are rather than pasting all of them into a job row.
+func batchFailureReason(errs []openai.BatchError) string {
+	for _, e := range errs {
+		msg := strings.TrimSpace(e.Message)
+		if msg == "" {
+			continue
+		}
+		if len(errs) > 1 {
+			return fmt.Sprintf("%s (+%d more)", msg, len(errs)-1)
+		}
+		return msg
 	}
-	return string(batch.Status), batch.OutputFileID, batch.ErrorFileID, counts, nil
+	return ""
 }
 
 // CancelBatch requests cancellation of an in-flight batch.

--- a/internal/pkg/generation/batch.go
+++ b/internal/pkg/generation/batch.go
@@ -112,21 +112,14 @@ func (c *GenerationClient) SubmitBatch(ctx context.Context, requests []BatchRequ
 	return batch.ID, file.ID, nil
 }
 
-// BatchState is the provider's view of one batch. Grouped rather than returned
-// as a widening list of strings, because the two failure surfaces are different
-// and a caller has to tell them apart.
+// BatchState is the provider's view of one batch.
 type BatchState struct {
 	Status string
-	// OutputFileID is present when at least one request succeeded, ErrorFileID
-	// when at least one failed. A batch whose requests ALL failed still
-	// completes, with output empty and every refusal in the error file.
+	// A batch whose requests all failed still completes: output empty, refusals in the error file.
 	OutputFileID string
 	ErrorFileID  string
 	Counts       BatchCounts
-	// FailureReason is the batch-level error, reported when the batch itself
-	// never ran: a rejected input file, a quota refusal. It is not a per-request
-	// refusal, and it arrives with no error file to read it out of, so it is the
-	// only place that says why.
+	// Batch-level error, set when the batch itself never ran, so no error file exists to read.
 	FailureReason string
 }
 
@@ -149,20 +142,23 @@ func (c *GenerationClient) GetBatch(ctx context.Context, batchID string) (BatchS
 	}, nil
 }
 
-// batchFailureReason renders the batch-level errors as one line, naming how many
-// more there are rather than pasting all of them into a job row.
+// batchFailureReason renders the batch-level errors as one line for a job row.
 func batchFailureReason(errs []openai.BatchError) string {
+	// Count only entries that carry a message: a blank one is not a reason to go looking for.
+	msgs := make([]string, 0, len(errs))
 	for _, e := range errs {
-		msg := strings.TrimSpace(e.Message)
-		if msg == "" {
-			continue
+		if msg := strings.TrimSpace(e.Message); msg != "" {
+			msgs = append(msgs, msg)
 		}
-		if len(errs) > 1 {
-			return fmt.Sprintf("%s (+%d more)", msg, len(errs)-1)
-		}
-		return msg
 	}
-	return ""
+	switch len(msgs) {
+	case 0:
+		return ""
+	case 1:
+		return msgs[0]
+	default:
+		return fmt.Sprintf("%s (+%d more)", msgs[0], len(msgs)-1)
+	}
 }
 
 // CancelBatch requests cancellation of an in-flight batch.

--- a/internal/pkg/generation/batch_test.go
+++ b/internal/pkg/generation/batch_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/openai/openai-go/v2"
 )
 
-// A batch that fails as a whole produces no error file, so the message the
-// provider puts on the batch itself is the only account of why. Losing it is
-// how "batch failed" ended up being everything an operator was told.
+// A batch that fails as a whole produces no error file, so the message on the batch is the only account of why.
 func TestBatchFailureReason(t *testing.T) {
 	cases := []struct {
 		name string
@@ -31,9 +29,20 @@ func TestBatchFailureReason(t *testing.T) {
 			"first reason (+2 more)",
 		},
 		{
-			"skips a blank message",
+			// The suffix counts readable messages, not entries: a blank one is
+			// not a second reason for the operator to go hunting for.
+			"a blank message is not a reason",
 			[]openai.BatchError{{Code: "empty"}, {Message: "  the real one  "}},
-			"the real one (+1 more)",
+			"the real one",
+		},
+		{
+			"counts only the readable ones",
+			[]openai.BatchError{
+				{Message: "first reason"},
+				{Code: "empty"},
+				{Message: "second reason"},
+			},
+			"first reason (+1 more)",
 		},
 		{"all blank", []openai.BatchError{{Code: "a"}, {Code: "b"}}, ""},
 	}

--- a/internal/pkg/generation/batch_test.go
+++ b/internal/pkg/generation/batch_test.go
@@ -1,0 +1,48 @@
+package generation
+
+import (
+	"testing"
+
+	"github.com/openai/openai-go/v2"
+)
+
+// A batch that fails as a whole produces no error file, so the message the
+// provider puts on the batch itself is the only account of why. Losing it is
+// how "batch failed" ended up being everything an operator was told.
+func TestBatchFailureReason(t *testing.T) {
+	cases := []struct {
+		name string
+		errs []openai.BatchError
+		want string
+	}{
+		{"none", nil, ""},
+		{
+			"single",
+			[]openai.BatchError{{Code: "invalid_request", Message: "Cannot find file file-abc, or organization org-xyz does not have access to it."}},
+			"Cannot find file file-abc, or organization org-xyz does not have access to it.",
+		},
+		{
+			"counts the rest",
+			[]openai.BatchError{
+				{Message: "first reason"},
+				{Message: "second reason"},
+				{Message: "third reason"},
+			},
+			"first reason (+2 more)",
+		},
+		{
+			"skips a blank message",
+			[]openai.BatchError{{Code: "empty"}, {Message: "  the real one  "}},
+			"the real one (+1 more)",
+		},
+		{"all blank", []openai.BatchError{{Code: "a"}, {Code: "b"}}, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := batchFailureReason(tc.errs); got != tc.want {
+				t.Errorf("batchFailureReason() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A warmup generation batch that fails as a whole records `batch failed` and nothing else, discarding the reason the provider gave.

Observed on a self-hosted install: three consecutive scheduled runs failed over about 13 hours, and the admin panel said only:

```
28/08 18:55  failed  batch failed
28/08 12:25  failed  batch failed
28/08 05:55  failed  batch failed
```

The actual reason was sitting on the batch object the whole time:

```json
"errors": {"data": [{"code": "invalid_request",
  "message": "Cannot find file file-…, or organization org-… does not have access to it."}]}
```

(That message turned out to be OpenAI's way of reporting a monthly spend cap: the file existed and was readable with the same key throughout. Misleading or not, it is what the operator needed to see, and it was the only thing pointing anywhere.)

## Why the existing path does not cover this

`ingestBatch` already falls back to the error file when a *completed* batch has no output, which covers a batch whose requests were all refused. A batch with status `failed` is different: it never ran, so there is no error file at all, and `pollBatchJob` writes the status alone:

```go
case "failed", "expired", "cancelled":
    if job.Error == "" {
        job.Error = fmt.Sprintf("batch %s", status)
    }
```

## Change

`GetBatch` returns a `BatchState` instead of a widening list of strings (it was already at five returns and this would have made six), carrying the batch-level `errors` alongside the status, files and counts. The failed branch appends the provider's message to the status it already records.

`batchFailureReason` renders one line and names how many more there are rather than pasting every entry into a job row, skips blank messages, and returns empty when there is nothing to say, so the existing `batch failed` text stands unchanged when the provider offers no reason.

## Tests

`TestBatchFailureReason` covers no errors, one error, several (the "+N more" form), an entry with a blank message ahead of a real one, and all-blank. It fails on the code before this change, since the function did not exist.

The poller branch itself is not unit-tested here: `warmupcontent.service` holds a concrete `*generation.GenerationClient` and `Enabled()` is `gen != nil`, so stubbing it means introducing an interface and rewiring the constructor, which is more than this fix should carry. The wiring is two lines and was checked against the recorded failure above.

`gofmt -l` clean, `go build ./...`, `golangci-lint v1.64.8 ./internal/...`, `scripts/check-migrations.sh` and `go test -race -count=2` on the two touched packages all clean.
