### PR TITLE
Contact activity timeline, source attribution and per-contact campaign state (#255, PR 2 of 2)

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1258,6 +1258,11 @@ func main() {
 		// and Cloud Tasks client exist.
 		if contactService != nil {
 			contactService.SetCampaignWaker(campaignService)
+			// The contact drawer's "next action" is a read-only pass through
+			// the scheduler's own constraints, never a stored time.
+			if previewer, ok := schedulerService.(scheduler.ContactSendPreviewer); ok {
+				contactService.SetNextSendPreviewer(previewer)
+			}
 		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		if aware, ok := emailSendService.(emailsend.OrgRiskAware); ok {

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -81,6 +81,7 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | DELETE | `/contacts/:id` | `WRITE_CONTACTS` |
 | GET | `/contacts/:id/emails` | `READ_CONTACTS` |
 | GET | `/contacts/:id/timeline` | `READ_CONTACTS` |
+| GET | `/contacts/:id/campaigns` | `READ_CONTACTS` |
 | POST | `/contacts/export` | `READ_CONTACTS` |
 | POST | `/contacts/import/preview` | `WRITE_CONTACTS` |
 | POST | `/contacts/import/commit` | `BULK_CONTACTS` |

--- a/docs/content/docs/api/reference/contacts.mdx
+++ b/docs/content/docs/api/reference/contacts.mdx
@@ -462,6 +462,9 @@ Auth: **Scope** `READ_CONTACTS` · **Org permission** `view_contacts`
   "esp_provider": "gmail",
   "updated_at": "2026-06-10T12:00:00Z",
   "created_at": "2026-05-01T09:30:00Z",
+  "source": "import",
+  "source_detail": "q3-leads.csv",
+  "first_seen_at": "2026-05-01T09:30:00Z",
   "engagement": {
     "total_sent": 4,
     "total_opened": 3,
@@ -602,7 +605,7 @@ Returns a `data` array plus a `pagination` envelope.
 
 `GET /contacts/:id/timeline`
 
-Returns the merged activity feed for a contact: sends, opens, clicks, replies, bounces, deliverability and suppression events, notes, and meeting bookings. Requires a selected organization (org-scoped events would otherwise be hidden), so a request with no organization returns `400`.
+Returns the merged activity feed for a contact: sends, opens, clicks, replies, bounces, deliverability and suppression events, notes, meeting bookings, and lifecycle events (the contact's creation with its first-touch source, and every time it joined or left a campaign or a category). Requires a selected organization (org-scoped events would otherwise be hidden), so a request with no organization returns `400`.
 
 Auth: **Scope** `READ_CONTACTS` · **Org permission** `view_contacts`
 
@@ -634,13 +637,86 @@ Returns a `data` array and a `has_more` flag (not a cursor envelope). Paginate b
       "at": "2026-06-08T16:30:00Z",
       "content": "Met at the conference, wants a follow-up in July.",
       "user_id": "u1..."
+    },
+    {
+      "type": "campaign_added",
+      "at": "2026-05-01T09:31:00Z",
+      "campaign_id": "c1...",
+      "campaign_name": "Q3 Outbound",
+      "user_id": "u1..."
+    },
+    {
+      "type": "contact_created",
+      "at": "2026-05-01T09:30:00Z",
+      "source": "import",
+      "source_detail": "q3-leads.csv",
+      "user_id": "u1..."
     }
   ],
   "has_more": false
 }
 ```
 
-`type` is one of `email_sent`, `email_opened`, `email_clicked`, `email_replied`, `email_bounced`, `reply_received`, `deliverability`, `suppressed`, `note`, `meeting_booked`, `meeting_rescheduled`, or `meeting_canceled`. Fields not relevant to an event type are omitted.
+`type` is one of `email_sent`, `email_opened`, `email_clicked`, `email_replied`, `email_bounced`, `reply_received`, `deliverability`, `suppressed`, `note`, `meeting_booked`, `meeting_rescheduled`, `meeting_canceled`, `contact_created`, `campaign_added`, `campaign_removed`, `category_added`, or `category_removed`. Fields not relevant to an event type are omitted.
+
+Lifecycle events carry the name of what changed as it was at the time (`campaign_name`, or `category_id` plus `category_title`), so a later rename or deletion does not rewrite history. A `contact_created` event carries `source` (`manual`, `campaign`, `import`, `sheet_sync`, `api`, `ai_assistant`, or `unknown` for contacts that predate attribution) and `source_detail` (the file, campaign, sheet or API key name). The same values are on the contact itself as `source`, `source_detail` and `first_seen_at`, and never change after creation.
+
+## Get a contact's campaign state
+
+`GET /contacts/:id/campaigns`
+
+Returns, for every campaign the contact is a lead of, the flow with this contact's progress on each step, the derived lead status, the last thing that happened, and what happens next. Requires a selected organization.
+
+The next action is derived on read by the scheduler through the same constraints a real send goes through (the step's wait, the campaign's start date and sending windows, mailbox caps and spacing, the new-lead limit); a campaign is one self-perpetuating task, so nothing per contact is stored. `next.state` says how firm the timing is: `due` carries `scheduled_at`, the slot the scheduler would give the step on its next pass (leads ahead in the queue can still push it later); `waiting` carries `not_before` and a `constraint`; `paused` and `blocked` carry only the reason. `next` is absent once the flow has ended for the contact, and `ended_reason` says why.
+
+Auth: **Scope** `READ_CONTACTS` · **Org permission** `view_contacts`
+
+| Parameter | In | Type | Description |
+| --- | --- | --- | --- |
+| `id` | path | UUID | Contact ID. |
+
+### Response
+
+```json
+{
+  "data": [
+    {
+      "campaign_id": "c1...",
+      "campaign_name": "Q3 Outbound",
+      "campaign_status": "active",
+      "lead_status": "active",
+      "steps": [
+        {
+          "id": "s1...",
+          "label": "Email 1",
+          "kind": "email",
+          "position": 0,
+          "subject": "Quick question",
+          "sent_at": "2026-06-09T08:00:00Z",
+          "opened_at": "2026-06-09T08:14:00Z"
+        },
+        { "id": "s2...", "label": "Email 2", "kind": "email", "position": 1, "subject": "Following up" }
+      ],
+      "completed_steps": 1,
+      "total_steps": 2,
+      "current_step": { "id": "s1...", "label": "Email 1", "kind": "email", "position": 0, "subject": "Quick question", "sent_at": "2026-06-09T08:00:00Z", "opened_at": "2026-06-09T08:14:00Z" },
+      "last_action": "Opened",
+      "last_action_at": "2026-06-09T08:14:00Z",
+      "next": {
+        "step_id": "s2...",
+        "step_label": "Email 2",
+        "kind": "email",
+        "subject": "Following up",
+        "state": "waiting",
+        "not_before": "2026-06-12T08:00:00Z",
+        "constraint": "Waiting 3 days after Email 1"
+      }
+    }
+  ]
+}
+```
+
+`lead_status` uses the same values as the campaign Leads view: `pending`, `active`, `completed`, `replied`, `bounced`, `failed`, `unsubscribed`, or `undeliverable`. Each step carries whichever of `sent_at`, `opened_at`, `clicked_at`, `replied_at`, `bounced_at` and `failed_at` apply, plus `attempts` and `in_flight` (reserved for a worker whose result has not come back). While a branch condition is undecided, `next.step_id` is absent and `next.step_label` says the step depends on the contact's response.
 
 ## List a contact's activities
 
@@ -679,7 +755,7 @@ Auth: **Scope** `READ_CONTACTS` · **Org permission** `view_contacts`
 }
 ```
 
-`activity_type` is a closed enum including `email_sent`, `email_opened`, `email_clicked`, `email_replied`, `email_bounced`, `note_added`, `note_updated`, `deal_created`, `deal_stage_changed`, `deal_won`, `deal_lost`, `task_created`, `task_completed`, `contact_created`, `contact_updated`, `campaign_added`, and `campaign_removed`.
+`activity_type` is a closed enum including `email_sent`, `email_opened`, `email_clicked`, `email_replied`, `email_bounced`, `note_added`, `note_updated`, `deal_created`, `deal_stage_changed`, `deal_won`, `deal_lost`, `task_created`, `task_completed`, `contact_created`, `contact_updated`, `campaign_added`, `campaign_removed`, `category_added`, and `category_removed`.
 
 ## List a contact's notes
 

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -75,6 +75,21 @@ The **Leads** tab takes contacts four ways. **From contacts** opens a picker ove
 
 A lead is **Processing** only while steps remain, so a finished campaign reads as done rather than stuck mid-flight.
 
+### What one lead is doing next
+
+Open a contact and go to **Activity**: the panel at the top lists every campaign the contact is in, with the flow drawn step by step (sent, opened, clicked, replied, bounced or failed on each), the lead status, the last thing that happened, and the next action.
+
+The next action is worked out on the spot by the scheduler, through the same rules a real send goes through: the step's wait, the campaign's start date and sending windows, each mailbox's daily cap and spacing, and the new-lead limit. Nothing is stored per contact, because a campaign is a single task that picks the next lead each time it runs. So the panel shows one of:
+
+| State | Meaning |
+|-------|---------|
+| Due | The step is due now. The time shown is the slot the scheduler would give it on the next pass; leads queued ahead of this one can still push it later |
+| Waiting | A hard constraint holds the step back. The panel names it (`Waiting 3 days after Email 1`, `Outside the campaign's sending window`, `Today's new-lead limit is reached`) and shows the earliest the step can go, not a promised time |
+| Paused | The campaign is not running, so nothing is scheduled |
+| Blocked | The campaign cannot send at all right now: no mailbox attached, every sending domain failing authentication, or past its end date |
+
+When a step's branches are still undecided (`if they open within 3 days`), the panel says the next step depends on their response and when that window closes. A lead that has finished, replied, bounced, failed or unsubscribed shows why the flow ended instead.
+
 A step counts as sent only once the sending worker has handed it to the mailbox provider. If the worker cannot send (the mailbox was still loading, the provider refused the message, a storage hiccup), the step goes back to the queue, the failure appears in **Needs attention** with the reason, and the next pass retries it. After five failed attempts the lead is marked **Failed** and dropped from the campaign, so a mailbox that can never send does not loop forever. A recipient the mail server refuses outright is not retried: it is recorded as a **Bounced** lead straight away and goes through the same bounce handling (suppression, guardrails, webhooks) as a bounce notice. A campaign that finished while a send was still in flight reopens to retry it.
 
 No contact is emailed the same step twice. Each step is recorded as attempted before the send is handed to a worker, so a crash, a restart, or a database hiccup in the moment between the two cannot make the step look unsent and send it again. The trade-off is a step whose outcome is genuinely unknown, when the worker stops responding mid-send: after 30 minutes with no answer the step is treated as a failed attempt, appears in **Needs attention**, and is retried like any other failure.

--- a/docs/content/docs/guides/contacts-crm.mdx
+++ b/docs/content/docs/guides/contacts-crm.mdx
@@ -73,6 +73,30 @@ It supports type-ahead search, and typing an unmatched name offers **Create** to
 
 Categories also drive automation: a sequence can run **Add tag** or **Remove tag** as a contact moves through a flow, so a label can be applied automatically on a positive reply.
 
+## Where a contact came from
+
+Every contact records its first-touch source: how it entered the workspace, with a detail you would recognise, and when it was first seen. It is shown on the contact's **Overview** tab and as the first event of its activity timeline, and it never changes afterwards, however the contact is edited or re-imported.
+
+| Source | Set when | Detail |
+| --- | --- | --- |
+| Manual | Added with **Add contact** on the Contacts page | |
+| Campaign | Added with **Add lead** on a campaign's Leads tab | The campaign |
+| Import | Created by the file import wizard | The file name |
+| Sheet sync | Created by a Google Sheets sync source | The sheet |
+| API | Created through the API with an API key | The key's name |
+| AI assistant | Created by the assistant on your behalf | |
+| Unknown | Created before Warmbly recorded sources | |
+
+Only new contacts get a source. An import or API call that matches an existing contact updates its fields and leaves the original source in place, so an address that arrived by hand and later turned up in a file still reads as manual.
+
+## Activity timeline
+
+The **Activity** tab of a contact is one feed, newest first, of everything Warmbly knows about them: every campaign email sent, opened, clicked, replied to or bounced (with the campaign, step, subject and sending mailbox), replies with their classified intent, deliverability and suppression events, notes, meetings, and the contact's lifecycle: when it was created and how, and each time it joined or left a campaign or a category.
+
+Filter chips narrow the feed (**Emails**, **Replies**, **Deliv.**, **Notes**, **Meetings**, **Campaigns**, **Lifecycle**), the search box matches subjects, campaigns, steps, mailboxes, categories and reasons, and the date picker bounds it. Each row stays to one line until you click it; expanded, it shows every detail the event carries. The feed updates live as teammates and the schedulers write to it.
+
+At the top of the tab sits the campaign panel: for each campaign the contact is in, its flow with this contact's progress, the lead status, and what the scheduler will do next. See [Campaigns](/guides/campaigns/) for how the next action is worked out and what its states mean.
+
 ## Deals and pipelines
 
 A **pipeline** is a named, ordered sequence of **stages** a deal advances through. On the Pipelines page you create pipelines (new ones start with `Open`, `Qualified`, `Won`), then add, rename, recolor, and delete stages, each showing its deal count. Stage order is the left-to-right column order on the board.

--- a/internal/api/handler/contact.go
+++ b/internal/api/handler/contact.go
@@ -39,6 +39,10 @@ func (h *Handler) AddContacts(c *gin.Context) {
 		return
 	}
 
+	for i := range data {
+		data[i].Source, data[i].SourceDetail = contactSourceFor(c, data[i].Source)
+	}
+
 	resp, err := h.ContactService.Add(c.Request.Context(), userIDStr, *orgID, data)
 	if err != nil {
 		errx.Handle(c, err)
@@ -49,6 +53,20 @@ func (h *Handler) AddContacts(c *gin.Context) {
 	h.auditOrg(c, models.AuditActionImport, models.AuditEntityContact, nil, nil, map[string]string{"count": fmt.Sprintf("%d", len(data))})
 
 	c.JSON(http.StatusOK, resp)
+}
+
+// contactSourceFor decides a new contact's first-touch source from the
+// request: an API key is always "api" (named after the key), a dashboard
+// session may say "campaign" when adding from a campaign's Leads tab, and
+// anything else is a manual create.
+func contactSourceFor(c *gin.Context, claimed models.ContactSource) (models.ContactSource, string) {
+	if middleware.GetAPIKeyID(c) != nil {
+		return models.ContactSourceAPI, middleware.GetAPIKeyName(c)
+	}
+	if claimed.RequestSettable() {
+		return claimed, ""
+	}
+	return models.ContactSourceManual, ""
 }
 
 func (h *Handler) SearchContacts(c *gin.Context) {

--- a/internal/api/handler/contact_detail.go
+++ b/internal/api/handler/contact_detail.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/api/middleware"
 	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
 )
 
 // GetContact returns the hydrated contact 360 payload. Used by the
@@ -112,6 +113,28 @@ func (h *Handler) ListContactEmails(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, res)
+}
+
+// ListContactCampaignStates returns, for every campaign the contact is a
+// lead of, the flow with this contact's progress and a scheduler-derived next
+// action. Org-scoped, like the timeline.
+func (h *Handler) ListContactCampaignStates(c *gin.Context) {
+	contactID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.Handle(c, errx.ErrUuid)
+		return
+	}
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.Handle(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+	states, xerr := h.ContactService.CampaignStates(c.Request.Context(), *orgID, contactID)
+	if xerr != nil {
+		errx.Handle(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, models.ContactCampaignStatesResult{Data: states})
 }
 
 // ListContactTimeline returns the merged activity feed for a contact.

--- a/internal/api/middleware/apikey.go
+++ b/internal/api/middleware/apikey.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	APIKeyIDKey                   = "api_key_id"
+	APIKeyNameKey                 = "api_key_name"
 	APIKeyPermissionsKey          = "api_key_permissions"
 	APIKeyAllowedEmailAccountsKey = "api_key_allowed_email_accounts"
 	APIKeyUserIDKey               = "api_key_user_id"
@@ -132,6 +133,7 @@ func (h *Handler) validateAPIKey(c *gin.Context, rawKey string) {
 
 	c.Set(AuthTypeKey, AuthTypeAPIKey)
 	c.Set(APIKeyIDKey, key.ID.String())
+	c.Set(APIKeyNameKey, key.Name)
 	c.Set(APIKeyPermissionsKey, key.Permissions)
 	c.Set(APIKeyAllowedEmailAccountsKey, key.AllowedEmailAccounts)
 	c.Set(UserIDKey, key.UserID.String())
@@ -362,6 +364,12 @@ func RequireAPIKeyEmailAccountParam(param string) gin.HandlerFunc {
 // GetAuthType returns "jwt" or "api_key" (empty if unauthenticated).
 func GetAuthType(c *gin.Context) string {
 	return c.GetString(AuthTypeKey)
+}
+
+// GetAPIKeyName returns the authenticating API key's display name, or ""
+// for a session (JWT) request.
+func GetAPIKeyName(c *gin.Context) string {
+	return c.GetString(APIKeyNameKey)
 }
 
 // GetAPIKeyID returns the authenticating API key's ID, or nil when the

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -556,6 +556,7 @@ func Run(
 				contacts.GET("/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetContact)
 				contacts.GET("/:id/emails", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListContactEmails)
 				contacts.GET("/:id/timeline", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListContactTimeline)
+				contacts.GET("/:id/campaigns", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListContactCampaignStates)
 
 				// AI contact research (dedicated AI_RESEARCH scope; JWT callers by
 				// the matching contact permission). Batch queues and drains in the

--- a/internal/app/aitools/tools_contacts.go
+++ b/internal/app/aitools/tools_contacts.go
@@ -175,6 +175,7 @@ func (d Deps) addContact(ctx context.Context, inv Invocation, args json.RawMessa
 		Phone:        in.Phone,
 		Categories:   in.Categories,
 		CustomFields: in.CustomFields,
+		Source:       models.ContactSourceAIAssistant,
 	}})
 	if xerr != nil {
 		return "", fromErrx(xerr)

--- a/internal/app/contact/campaign_state.go
+++ b/internal/app/contact/campaign_state.go
@@ -13,14 +13,10 @@ import (
 	"github.com/warmbly/warmbly/internal/scheduler"
 )
 
-// SetNextSendPreviewer wires the scheduler's read-only preview. Optional: with
-// no previewer the campaign state still lists steps and status, just without
-// a next action.
+// SetNextSendPreviewer is optional; without it the panel has no next action.
 func (s *contactService) SetNextSendPreviewer(p scheduler.ContactSendPreviewer) { s.previewer = p }
 
-// CampaignStates is the per-campaign panel of the contact drawer: the flow,
-// this contact's progress, the lead status, and a scheduler-backed next
-// action.
+// CampaignStates returns the contact's campaigns with a scheduler-backed next action.
 func (s *contactService) CampaignStates(ctx context.Context, orgID, contactID uuid.UUID) ([]models.ContactCampaignState, *errx.Error) {
 	states, xerr := s.contactRepository.ListCampaignStates(ctx, orgID, contactID)
 	if xerr != nil {

--- a/internal/app/contact/campaign_state.go
+++ b/internal/app/contact/campaign_state.go
@@ -1,0 +1,151 @@
+package contact
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/scheduler"
+)
+
+// SetNextSendPreviewer wires the scheduler's read-only preview. Optional: with
+// no previewer the campaign state still lists steps and status, just without
+// a next action.
+func (s *contactService) SetNextSendPreviewer(p scheduler.ContactSendPreviewer) { s.previewer = p }
+
+// CampaignStates is the per-campaign panel of the contact drawer: the flow,
+// this contact's progress, the lead status, and a scheduler-backed next
+// action.
+func (s *contactService) CampaignStates(ctx context.Context, orgID, contactID uuid.UUID) ([]models.ContactCampaignState, *errx.Error) {
+	states, xerr := s.contactRepository.ListCampaignStates(ctx, orgID, contactID)
+	if xerr != nil {
+		return nil, xerr
+	}
+	for i := range states {
+		s.fillNextAction(ctx, &states[i], contactID)
+	}
+	return states, nil
+}
+
+func (s *contactService) fillNextAction(ctx context.Context, st *models.ContactCampaignState, contactID uuid.UUID) {
+	switch st.LeadStatus {
+	case models.LeadStatusUnsubscribed:
+		st.EndedReason = "Unsubscribed, sending stopped"
+		return
+	case models.LeadStatusBounced:
+		st.EndedReason = "Bounced, sending stopped"
+		return
+	case models.LeadStatusReplied:
+		st.EndedReason = "Replied, sending stopped"
+		return
+	case models.LeadStatusFailed:
+		st.EndedReason = "Dropped after every send attempt failed"
+		return
+	case models.LeadStatusUndeliverable:
+		st.EndedReason = "Address failed verification, so the campaign skips it"
+		return
+	}
+	if s.previewer == nil {
+		return
+	}
+	pv, err := s.previewer.PreviewContactSend(ctx, st.CampaignID, contactID)
+	if err != nil {
+		// The panel still shows the flow and status; only the preview is missing.
+		log.Warn().Err(err).Str("campaign_id", st.CampaignID.String()).Str("contact_id", contactID.String()).Msg("contact next-send preview failed")
+		return
+	}
+	route := pv.Route
+	if route.Excluded == "suppressed" {
+		st.EndedReason = "Suppressed, sending stopped"
+		return
+	}
+	current := "the current step"
+	if st.CurrentStep != nil {
+		current = st.CurrentStep.Label
+	}
+	if route.Target == nil {
+		if route.WaitUntil != nil {
+			st.Next = &models.ContactNextAction{
+				StepLabel:  "Depends on their response",
+				State:      models.NextActionWaiting,
+				NotBefore:  route.WaitUntil,
+				Constraint: "Waiting to see how they respond to " + current,
+			}
+			return
+		}
+		if st.LeadStatus == models.LeadStatusCompleted {
+			st.EndedReason = "Every step has been sent"
+		} else if st.CurrentStep != nil {
+			st.EndedReason = "Reached the end of the flow"
+		} else {
+			st.EndedReason = "The campaign has no steps"
+		}
+		return
+	}
+
+	next := &models.ContactNextAction{
+		StepID:      route.Target,
+		StepLabel:   "Next step",
+		State:       pv.State,
+		ScheduledAt: pv.ScheduledAt,
+		NotBefore:   pv.NotBefore,
+	}
+	for _, step := range st.Steps {
+		if step.ID == *route.Target {
+			next.StepLabel, next.Kind, next.Subject = step.Label, step.Kind, step.Subject
+			break
+		}
+	}
+	next.Constraint = constraintCopy(pv.Constraint, st, route.DueAt, current)
+	st.Next = next
+}
+
+// constraintCopy turns the scheduler's gate into the sentence the drawer shows.
+func constraintCopy(c scheduler.ContactSendConstraint, st *models.ContactCampaignState, dueAt *time.Time, current string) string {
+	switch c {
+	case scheduler.ConstraintStepWait:
+		if st.CurrentStep != nil && st.CurrentStep.SentAt != nil && dueAt != nil {
+			days := int(math.Round(dueAt.Sub(*st.CurrentStep.SentAt).Hours() / 24))
+			if days >= 1 {
+				unit := "days"
+				if days == 1 {
+					unit = "day"
+				}
+				return fmt.Sprintf("Waiting %d %s after %s", days, unit, current)
+			}
+		}
+		return "Waiting for the step's delay after " + current
+	case scheduler.ConstraintConditionWindow:
+		return "Waiting to see how they respond to " + current
+	case scheduler.ConstraintStartDate:
+		return "Waiting for the campaign's start date"
+	case scheduler.ConstraintSendingWindow:
+		return "Outside the campaign's sending window"
+	case scheduler.ConstraintNewLeadCap:
+		return "Today's new-lead limit is reached"
+	case scheduler.ConstraintCapacity:
+		return "No mailbox can take it right now (daily cap, spacing, or health)"
+	case scheduler.ConstraintCampaignInactive:
+		switch st.CampaignStatus {
+		case "draft":
+			return "Campaign has not been started"
+		case "completed":
+			return "Campaign has finished"
+		case "paused_guardrail":
+			return "Campaign was auto-paused by a guardrail"
+		}
+		return "Campaign is paused"
+	case scheduler.ConstraintNoMailbox:
+		return "No sending mailbox is attached to the campaign"
+	case scheduler.ConstraintDomainAuth:
+		return "Every sending domain fails SPF/DMARC authentication"
+	case scheduler.ConstraintCampaignEnded:
+		return "Campaign is past its end date"
+	}
+	return ""
+}

--- a/internal/app/contact/import.go
+++ b/internal/app/contact/import.go
@@ -169,6 +169,11 @@ func (s *contactService) ImportCommit(
 	if perr != nil {
 		return nil, errx.ErrUuid
 	}
+	// A plain file import unless the caller (the Google Sheets sync) says
+	// otherwise; the file name is the detail a user recognises.
+	if opts.Source == "" {
+		opts.Source, opts.SourceDetail = models.ContactSourceImport, filename
+	}
 
 	dedup := opts.Dedup
 	switch dedup {
@@ -428,6 +433,9 @@ func (s *contactService) ImportCommit(
 			end = len(toInsert)
 		}
 		chunk := toInsert[start:end]
+		for i := range chunk {
+			chunk[i].Source, chunk[i].SourceDetail = opts.Source, opts.SourceDetail
+		}
 		inserted, xerr := s.Add(ctx, userID, orgID, chunk)
 		if xerr != nil {
 			// Per-row reasons are easier to act on than a "batch

--- a/internal/app/contact/service.go
+++ b/internal/app/contact/service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
+	"github.com/warmbly/warmbly/internal/scheduler"
 )
 
 type ContactService interface {
@@ -72,6 +73,13 @@ type ContactService interface {
 	// running campaign wakes that campaign's parked send chain. Optional: with
 	// no waker the leads still send, just not until the chain's next tick.
 	SetCampaignWaker(w CampaignWaker)
+
+	// CampaignStates returns the contact's campaigns with steps, progress,
+	// lead status and a scheduler-backed next action.
+	CampaignStates(ctx context.Context, orgID, contactID uuid.UUID) ([]models.ContactCampaignState, *errx.Error)
+	// SetNextSendPreviewer wires the scheduler preview behind CampaignStates.
+	// Optional; without it the panel carries no next action.
+	SetNextSendPreviewer(p scheduler.ContactSendPreviewer)
 }
 
 // CampaignWaker pulls the parked wakeup of a running campaign forward when
@@ -89,6 +97,7 @@ type contactService struct {
 	planRepo           repository.PlanRepository
 	streamingPublisher *pubsub.StreamingPublisher
 	campaignWaker      CampaignWaker
+	previewer          scheduler.ContactSendPreviewer
 	// orgRisk files import-quality findings on the workspace's posture.
 	// Optional/nil-safe: without it a bad import is reported but not fused.
 	orgRisk orgrisk.Service

--- a/internal/app/leadsync/service.go
+++ b/internal/app/leadsync/service.go
@@ -303,6 +303,8 @@ func (s *service) SyncNow(ctx context.Context, triggeringUserID, orgID, sourceID
 		CategoryIDs:       src.CategoryIDs,
 		CampaignIDs:       campaignIDs,
 		SubscribedDefault: &subscribed,
+		Source:            models.ContactSourceSheetSync,
+		SourceDetail:      src.SheetTitle,
 	}
 
 	result, ierr := s.contacts.ImportCommit(ctx, triggeringUserID.String(), orgID, bytes.NewReader(csvBytes), "google-sheets-sync.csv", opts)

--- a/internal/infrastructure/db/migrations/000106_contact_source.down.sql
+++ b/internal/infrastructure/db/migrations/000106_contact_source.down.sql
@@ -1,0 +1,9 @@
+-- Postgres cannot drop a single enum value, so 'category_added' and
+-- 'category_removed' stay on the type; the rows that use them are removed.
+DELETE FROM public.contact_activities WHERE activity_type IN ('category_added', 'category_removed');
+
+ALTER TABLE public.contacts
+    DROP CONSTRAINT IF EXISTS contacts_source_check,
+    DROP COLUMN IF EXISTS source,
+    DROP COLUMN IF EXISTS source_detail,
+    DROP COLUMN IF EXISTS first_seen_at;

--- a/internal/infrastructure/db/migrations/000106_contact_source.up.sql
+++ b/internal/infrastructure/db/migrations/000106_contact_source.up.sql
@@ -1,0 +1,25 @@
+-- First-touch source attribution for contacts (issue #255).
+--
+-- Existing rows are stamped 'unknown' rather than guessed at: nothing in the
+-- database records how they arrived. first_seen_at is the row's creation
+-- time, which is a fact, not a guess.
+ALTER TABLE public.contacts
+    ADD COLUMN source text NOT NULL DEFAULT 'unknown',
+    ADD COLUMN source_detail text NOT NULL DEFAULT '',
+    ADD COLUMN first_seen_at timestamp with time zone NOT NULL DEFAULT now();
+
+UPDATE public.contacts SET first_seen_at = created_at;
+
+ALTER TABLE public.contacts
+    ADD CONSTRAINT contacts_source_check
+    CHECK (source IN ('unknown', 'manual', 'campaign', 'import', 'sheet_sync', 'api', 'ai_assistant'));
+
+COMMENT ON COLUMN public.contacts.source IS
+    'First-touch origin of the contact; never rewritten once set.';
+COMMENT ON COLUMN public.contacts.source_detail IS
+    'Free-form detail for the source: the import file name, the campaign, the API key or the sheet.';
+
+-- Category membership changes join the lifecycle events already carried by
+-- contact_activities (contact_created, campaign_added, campaign_removed).
+ALTER TYPE public.activity_type ADD VALUE IF NOT EXISTS 'category_added';
+ALTER TYPE public.activity_type ADD VALUE IF NOT EXISTS 'category_removed';

--- a/internal/models/contact.go
+++ b/internal/models/contact.go
@@ -193,6 +193,11 @@ type ContactDetail struct {
 	Contact
 	Engagement  ContactEngagement   `json:"engagement"`
 	Suppression *ContactSuppression `json:"suppression,omitempty"`
+
+	// First-touch attribution. Source never changes after creation.
+	Source       ContactSource `json:"source"`
+	SourceDetail string        `json:"source_detail"`
+	FirstSeenAt  time.Time     `json:"first_seen_at"`
 }
 
 // ContactSentEmail is one row in the "Emails sent to this contact"
@@ -250,6 +255,15 @@ const (
 	TimelineMeetingBooked      ContactTimelineEventType = "meeting_booked"
 	TimelineMeetingRescheduled ContactTimelineEventType = "meeting_rescheduled"
 	TimelineMeetingCanceled    ContactTimelineEventType = "meeting_canceled"
+
+	// Lifecycle events, read from contact_activities. contact_created carries
+	// the first-touch Source (and SourceDetail), which is how "imported" and
+	// "created via API" are told apart without a type per origin.
+	TimelineContactCreated  ContactTimelineEventType = "contact_created"
+	TimelineCampaignAdded   ContactTimelineEventType = "campaign_added"
+	TimelineCampaignRemoved ContactTimelineEventType = "campaign_removed"
+	TimelineCategoryAdded   ContactTimelineEventType = "category_added"
+	TimelineCategoryRemoved ContactTimelineEventType = "category_removed"
 )
 
 // ContactTimelineEvent is one entry in the merged activity feed. The
@@ -287,7 +301,14 @@ type ContactTimelineEvent struct {
 	JoinURL      *string    `json:"join_url,omitempty"`      // video/conference link
 	MeetingState *string    `json:"meeting_state,omitempty"` // booked / rescheduled / canceled
 
-	// Author (notes).
+	// Lifecycle events: the category a contact joined or left, and the
+	// free-form detail behind a contact_created source (file name, campaign,
+	// API key).
+	CategoryID    *uuid.UUID `json:"category_id,omitempty"`
+	CategoryTitle *string    `json:"category_title,omitempty"`
+	SourceDetail  *string    `json:"source_detail,omitempty"`
+
+	// Author (notes, lifecycle events).
 	UserID *uuid.UUID `json:"user_id,omitempty"`
 }
 
@@ -327,6 +348,45 @@ type AddContact struct {
 	// whatever it already had. Set explicitly by the importer when the file
 	// carries a subscribed column.
 	Subscribed *bool `json:"subscribed,omitempty"`
+
+	// Source is the first-touch origin stamped on a NEW contact (an existing
+	// one keeps its original). Dashboard callers may say "manual" or
+	// "campaign"; every other value is decided server-side by the creation
+	// path, and an API-key request is always "api". SourceDetail is never
+	// read from the request body.
+	Source       ContactSource `json:"source,omitempty"`
+	SourceDetail string        `json:"-"`
+}
+
+// ContactSource is where a contact first came from. Mirrors the CHECK on
+// contacts.source; ContactSourceUnknown is the honest value for rows created
+// before attribution existed.
+type ContactSource string
+
+const (
+	ContactSourceUnknown     ContactSource = "unknown"
+	ContactSourceManual      ContactSource = "manual"
+	ContactSourceCampaign    ContactSource = "campaign"
+	ContactSourceImport      ContactSource = "import"
+	ContactSourceSheetSync   ContactSource = "sheet_sync"
+	ContactSourceAPI         ContactSource = "api"
+	ContactSourceAIAssistant ContactSource = "ai_assistant"
+)
+
+// Valid reports whether the value is one the database accepts.
+func (s ContactSource) Valid() bool {
+	switch s {
+	case ContactSourceUnknown, ContactSourceManual, ContactSourceCampaign, ContactSourceImport,
+		ContactSourceSheetSync, ContactSourceAPI, ContactSourceAIAssistant:
+		return true
+	}
+	return false
+}
+
+// RequestSettable reports whether a dashboard request body may claim the
+// source. Only the two origins a dashboard user can actually be in.
+func (s ContactSource) RequestSettable() bool {
+	return s == ContactSourceManual || s == ContactSourceCampaign
 }
 
 type SearchContactsFilterType string

--- a/internal/models/contact_campaign_state.go
+++ b/internal/models/contact_campaign_state.go
@@ -1,0 +1,101 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContactCampaignState is one campaign a contact belongs to, read the way the
+// contact drawer shows it: the flow with the steps this contact has been
+// through, the lead status the Leads list derives, and what happens next.
+type ContactCampaignState struct {
+	CampaignID     uuid.UUID `json:"campaign_id"`
+	CampaignName   string    `json:"campaign_name"`
+	CampaignStatus string    `json:"campaign_status"`
+	// LeadStatus follows ContactCampaignProgress.Status exactly.
+	LeadStatus string `json:"lead_status"`
+	// FailureReason is the worker's reason for the last failed send.
+	FailureReason string `json:"failure_reason,omitempty"`
+
+	Steps          []ContactCampaignStep `json:"steps"`
+	CompletedSteps int                   `json:"completed_steps"`
+	TotalSteps     int                   `json:"total_steps"`
+
+	// CurrentStep is the step the contact is on now: the latest one sent.
+	CurrentStep *ContactCampaignStep `json:"current_step,omitempty"`
+	// LastAction is the most recent thing that happened on this campaign for
+	// the contact ("Email sent", "Opened", ...) and when.
+	LastAction   string     `json:"last_action,omitempty"`
+	LastActionAt *time.Time `json:"last_action_at,omitempty"`
+
+	// Next is what the scheduler will do next for this contact. Nil when the
+	// flow has ended for them (finished, replied, bounced, stopped).
+	Next *ContactNextAction `json:"next,omitempty"`
+	// EndedReason says why Next is nil, in the words the timeline uses.
+	EndedReason string `json:"ended_reason,omitempty"`
+}
+
+// ContactCampaignStep is one node of the campaign flow with this contact's
+// progress on it.
+type ContactCampaignStep struct {
+	ID       uuid.UUID `json:"id"`
+	Label    string    `json:"label"`
+	Kind     string    `json:"kind"`
+	Position int       `json:"position"`
+	Subject  string    `json:"subject,omitempty"`
+
+	SentAt    *time.Time `json:"sent_at,omitempty"`
+	OpenedAt  *time.Time `json:"opened_at,omitempty"`
+	ClickedAt *time.Time `json:"clicked_at,omitempty"`
+	RepliedAt *time.Time `json:"replied_at,omitempty"`
+	BouncedAt *time.Time `json:"bounced_at,omitempty"`
+	FailedAt  *time.Time `json:"failed_at,omitempty"`
+	// Attempts is how many sends of this step have failed so far.
+	Attempts int `json:"attempts,omitempty"`
+	// InFlight is a step reserved for a worker whose result has not come back.
+	InFlight bool `json:"in_flight,omitempty"`
+}
+
+// ContactNextActionState says how firm the timing of the next action is.
+type ContactNextActionState string
+
+const (
+	// NextActionDue: the step is due and the scheduler produced a slot for it.
+	NextActionDue ContactNextActionState = "due"
+	// NextActionWaiting: a hard constraint holds the step back (a step wait, a
+	// sending window, a start date, a condition window, mailbox capacity).
+	// NotBefore is the earliest it can go; there is no promised slot.
+	NextActionWaiting ContactNextActionState = "waiting"
+	// NextActionPaused: the campaign is not active, so nothing is scheduled.
+	NextActionPaused ContactNextActionState = "paused"
+	// NextActionBlocked: the campaign cannot send at all right now (no
+	// mailbox, authentication failing, past its end date).
+	NextActionBlocked ContactNextActionState = "blocked"
+)
+
+// ContactNextAction is a scheduler-backed preview of the contact's next step.
+// A campaign is one self-perpetuating task, so this is derived on read through
+// the scheduler's own constraints, never stored.
+type ContactNextAction struct {
+	// StepID is nil while a condition window is still open: which step comes
+	// next depends on how the contact responds.
+	StepID    *uuid.UUID `json:"step_id,omitempty"`
+	StepLabel string     `json:"step_label"`
+	Kind      string     `json:"kind,omitempty"`
+	Subject   string     `json:"subject,omitempty"`
+
+	State ContactNextActionState `json:"state"`
+	// ScheduledAt is the slot the scheduler computed for this step. Only set
+	// when the step is due now; other contacts ahead in the queue can still
+	// push it later.
+	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
+	// NotBefore is the earliest the hard constraints let the step go.
+	NotBefore *time.Time `json:"not_before,omitempty"`
+	// Constraint is the human-readable reason the step is not going out now.
+	Constraint string `json:"constraint,omitempty"`
+}
+
+type ContactCampaignStatesResult struct {
+	Data []ContactCampaignState `json:"data"`
+}

--- a/internal/models/contact_campaign_state.go
+++ b/internal/models/contact_campaign_state.go
@@ -6,9 +6,8 @@ import (
 	"github.com/google/uuid"
 )
 
-// ContactCampaignState is one campaign a contact belongs to, read the way the
-// contact drawer shows it: the flow with the steps this contact has been
-// through, the lead status the Leads list derives, and what happens next.
+// ContactCampaignState is one campaign a contact is a lead of: steps with
+// this contact's progress, the derived lead status, and the next action.
 type ContactCampaignState struct {
 	CampaignID     uuid.UUID `json:"campaign_id"`
 	CampaignName   string    `json:"campaign_name"`
@@ -22,22 +21,17 @@ type ContactCampaignState struct {
 	CompletedSteps int                   `json:"completed_steps"`
 	TotalSteps     int                   `json:"total_steps"`
 
-	// CurrentStep is the step the contact is on now: the latest one sent.
-	CurrentStep *ContactCampaignStep `json:"current_step,omitempty"`
-	// LastAction is the most recent thing that happened on this campaign for
-	// the contact ("Email sent", "Opened", ...) and when.
-	LastAction   string     `json:"last_action,omitempty"`
-	LastActionAt *time.Time `json:"last_action_at,omitempty"`
+	// CurrentStep is the latest step sent.
+	CurrentStep  *ContactCampaignStep `json:"current_step,omitempty"`
+	LastAction   string               `json:"last_action,omitempty"`
+	LastActionAt *time.Time           `json:"last_action_at,omitempty"`
 
-	// Next is what the scheduler will do next for this contact. Nil when the
-	// flow has ended for them (finished, replied, bounced, stopped).
-	Next *ContactNextAction `json:"next,omitempty"`
-	// EndedReason says why Next is nil, in the words the timeline uses.
-	EndedReason string `json:"ended_reason,omitempty"`
+	// Next is nil once the flow has ended for the contact; EndedReason says why.
+	Next        *ContactNextAction `json:"next,omitempty"`
+	EndedReason string             `json:"ended_reason,omitempty"`
 }
 
-// ContactCampaignStep is one node of the campaign flow with this contact's
-// progress on it.
+// ContactCampaignStep is one flow node with this contact's progress on it.
 type ContactCampaignStep struct {
 	ID       uuid.UUID `json:"id"`
 	Label    string    `json:"label"`
@@ -51,49 +45,36 @@ type ContactCampaignStep struct {
 	RepliedAt *time.Time `json:"replied_at,omitempty"`
 	BouncedAt *time.Time `json:"bounced_at,omitempty"`
 	FailedAt  *time.Time `json:"failed_at,omitempty"`
-	// Attempts is how many sends of this step have failed so far.
-	Attempts int `json:"attempts,omitempty"`
-	// InFlight is a step reserved for a worker whose result has not come back.
+	// Attempts counts failed sends; InFlight is a reservation with no result yet.
+	Attempts int  `json:"attempts,omitempty"`
 	InFlight bool `json:"in_flight,omitempty"`
 }
 
-// ContactNextActionState says how firm the timing of the next action is.
+// ContactNextActionState says how firm the next action's timing is; only
+// "due" carries a slot.
 type ContactNextActionState string
 
 const (
-	// NextActionDue: the step is due and the scheduler produced a slot for it.
-	NextActionDue ContactNextActionState = "due"
-	// NextActionWaiting: a hard constraint holds the step back (a step wait, a
-	// sending window, a start date, a condition window, mailbox capacity).
-	// NotBefore is the earliest it can go; there is no promised slot.
+	NextActionDue     ContactNextActionState = "due"
 	NextActionWaiting ContactNextActionState = "waiting"
-	// NextActionPaused: the campaign is not active, so nothing is scheduled.
-	NextActionPaused ContactNextActionState = "paused"
-	// NextActionBlocked: the campaign cannot send at all right now (no
-	// mailbox, authentication failing, past its end date).
+	NextActionPaused  ContactNextActionState = "paused"
 	NextActionBlocked ContactNextActionState = "blocked"
 )
 
-// ContactNextAction is a scheduler-backed preview of the contact's next step.
-// A campaign is one self-perpetuating task, so this is derived on read through
-// the scheduler's own constraints, never stored.
+// ContactNextAction is derived on read through the scheduler; never stored.
 type ContactNextAction struct {
-	// StepID is nil while a condition window is still open: which step comes
-	// next depends on how the contact responds.
+	// StepID is nil while a branch condition is still undecided.
 	StepID    *uuid.UUID `json:"step_id,omitempty"`
 	StepLabel string     `json:"step_label"`
 	Kind      string     `json:"kind,omitempty"`
 	Subject   string     `json:"subject,omitempty"`
 
 	State ContactNextActionState `json:"state"`
-	// ScheduledAt is the slot the scheduler computed for this step. Only set
-	// when the step is due now; other contacts ahead in the queue can still
-	// push it later.
+	// ScheduledAt is set only when due; NotBefore is the earliest the hard
+	// constraints allow; Constraint names the gate in user-facing words.
 	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
-	// NotBefore is the earliest the hard constraints let the step go.
-	NotBefore *time.Time `json:"not_before,omitempty"`
-	// Constraint is the human-readable reason the step is not going out now.
-	Constraint string `json:"constraint,omitempty"`
+	NotBefore   *time.Time `json:"not_before,omitempty"`
+	Constraint  string     `json:"constraint,omitempty"`
 }
 
 type ContactCampaignStatesResult struct {

--- a/internal/models/contact_import.go
+++ b/internal/models/contact_import.go
@@ -100,6 +100,11 @@ type ContactImportCommit struct {
 	// SubscribedDefault is what new contacts inherit when no
 	// subscribed column was mapped. Defaults to true server-side.
 	SubscribedDefault *bool `json:"subscribed_default,omitempty"`
+
+	// Source / SourceDetail stamp new contacts' first-touch attribution. Set by
+	// the caller (file import, Google Sheets sync), never from the request.
+	Source       ContactSource `json:"-"`
+	SourceDetail string        `json:"-"`
 }
 
 // ContactImportRowError is a row that couldn't be imported. The line

--- a/internal/models/crm.go
+++ b/internal/models/crm.go
@@ -59,6 +59,8 @@ const (
 	ActivityContactUpdated  ActivityType = "contact_updated"
 	ActivityCampaignAdded   ActivityType = "campaign_added"
 	ActivityCampaignRemoved ActivityType = "campaign_removed"
+	ActivityCategoryAdded   ActivityType = "category_added"
+	ActivityCategoryRemoved ActivityType = "category_removed"
 )
 
 type ContactActivity struct {

--- a/internal/repository/contact_timeline_live_test.go
+++ b/internal/repository/contact_timeline_live_test.go
@@ -1,0 +1,185 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Live cover for the contact timeline's lifecycle events and first-touch
+// source attribution (issue #255): creation, campaign and category membership
+// changes are written inside the same transactions as the links, and read
+// back through ListTimeline with the names resolved at write time.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveContactTimeline -v
+
+func countTimeline(events []models.ContactTimelineEvent, typ models.ContactTimelineEventType, match func(models.ContactTimelineEvent) bool) int {
+	n := 0
+	for _, e := range events {
+		if e.Type == typ && (match == nil || match(e)) {
+			n++
+		}
+	}
+	return n
+}
+
+func TestLiveContactTimelineLifecycleEvents(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	ctx := context.Background()
+	repo := NewContactRepostory(handle)
+
+	category := uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO categories (id, user_id, title, color, position) VALUES ($1, $2, 'Warm lead', '#ff8800', 0)`,
+		category, f.owner); err != nil {
+		t.Fatalf("category: %v", err)
+	}
+	t.Cleanup(func() {
+		// Registered after the fixture, so it runs before the fixture drops
+		// the contacts and users the category hangs off.
+		_, _ = pool.Exec(context.Background(), `DELETE FROM contact_categories WHERE category_id = $1`, category)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM categories WHERE id = $1`, category)
+	})
+
+	email := "i255-" + uuid.New().String()[:8] + "@test.local"
+	created, xerr := repo.Add(ctx, f.owner.String(), f.org, []models.AddContact{{
+		FirstName: "Dana", LastName: "Ruiz", Email: email,
+		Campaigns:  []string{f.campaign.String()},
+		Categories: []string{category.String()},
+		Source:     models.ContactSourceManual,
+	}})
+	if xerr != nil || len(created) != 1 {
+		t.Fatalf("add: %v (%d created)", xerr, len(created))
+	}
+	id := created[0].ID
+
+	timeline := func() []models.ContactTimelineEvent {
+		t.Helper()
+		res, xerr := repo.ListTimeline(ctx, f.owner, &f.org, id, 50, nil)
+		if xerr != nil {
+			t.Fatalf("timeline: %v", xerr)
+		}
+		return res.Data
+	}
+	byCampaign := func(name string) func(models.ContactTimelineEvent) bool {
+		return func(e models.ContactTimelineEvent) bool { return e.CampaignName != nil && *e.CampaignName == name }
+	}
+	byCategory := func(e models.ContactTimelineEvent) bool {
+		return e.CategoryTitle != nil && *e.CategoryTitle == "Warm lead" && e.CategoryID != nil && *e.CategoryID == category
+	}
+
+	ev := timeline()
+	if n := countTimeline(ev, models.TimelineContactCreated, func(e models.ContactTimelineEvent) bool {
+		return e.Source != nil && *e.Source == "manual" && e.UserID != nil && *e.UserID == f.owner
+	}); n != 1 {
+		t.Fatalf("want one manual contact_created event by the owner, got %d in %+v", n, ev)
+	}
+	if n := countTimeline(ev, models.TimelineCampaignAdded, byCampaign("Agency partnerships")); n != 1 {
+		t.Fatalf("want campaign_added for Agency partnerships, got %d", n)
+	}
+	if n := countTimeline(ev, models.TimelineCategoryAdded, byCategory); n != 1 {
+		t.Fatalf("want category_added for Warm lead, got %d", n)
+	}
+
+	// Re-adding the same address is an upsert, not a creation: no second
+	// contact_created, and the original source survives the import's claim.
+	if _, xerr := repo.Add(ctx, f.owner.String(), f.org, []models.AddContact{{
+		Email: email, Company: "Pied Piper", Source: models.ContactSourceImport, SourceDetail: "leads.csv",
+	}}); xerr != nil {
+		t.Fatalf("re-add: %v", xerr)
+	}
+	if n := countTimeline(timeline(), models.TimelineContactCreated, nil); n != 1 {
+		t.Fatalf("an upsert must not log a second creation, got %d", n)
+	}
+	detail, xerr := repo.GetDetail(ctx, f.owner, &f.org, id)
+	if xerr != nil {
+		t.Fatalf("detail: %v", xerr)
+	}
+	if detail.Source != models.ContactSourceManual || detail.FirstSeenAt.IsZero() {
+		t.Fatalf("want first-touch source manual with a first-seen time, got %q at %v", detail.Source, detail.FirstSeenAt)
+	}
+
+	// Single-contact update: swap campaigns, drop the category.
+	if _, xerr := repo.Update(ctx, f.owner.String(), id.String(), f.org, &models.UpdateContact{
+		Campaigns:        []string{f.other.String()},
+		RemoveCategories: []string{category.String()},
+	}); xerr != nil {
+		t.Fatalf("update: %v", xerr)
+	}
+	ev = timeline()
+	if n := countTimeline(ev, models.TimelineCampaignRemoved, byCampaign("Agency partnerships")); n != 1 {
+		t.Fatalf("want campaign_removed for Agency partnerships, got %d", n)
+	}
+	if n := countTimeline(ev, models.TimelineCampaignAdded, byCampaign("RevOps outreach")); n != 1 {
+		t.Fatalf("want campaign_added for RevOps outreach, got %d", n)
+	}
+	if n := countTimeline(ev, models.TimelineCategoryRemoved, byCategory); n != 1 {
+		t.Fatalf("want category_removed for Warm lead, got %d", n)
+	}
+
+	// Bulk edit: the other direction for both link kinds.
+	if _, xerr := repo.BulkUpdate(ctx, f.owner.String(), f.org, &models.BulkEditContactsData{
+		Contacts:        []string{id.String()},
+		RemoveCampaigns: []string{f.other.String()},
+		AddCategories:   []string{category.String()},
+	}); xerr != nil {
+		t.Fatalf("bulk update: %v", xerr)
+	}
+	ev = timeline()
+	if n := countTimeline(ev, models.TimelineCampaignRemoved, byCampaign("RevOps outreach")); n != 1 {
+		t.Fatalf("want campaign_removed for RevOps outreach, got %d", n)
+	}
+	if n := countTimeline(ev, models.TimelineCategoryAdded, byCategory); n != 2 {
+		t.Fatalf("want a second category_added for Warm lead, got %d", n)
+	}
+	// A no-op bulk edit (already linked) writes nothing.
+	if _, xerr := repo.BulkUpdate(ctx, f.owner.String(), f.org, &models.BulkEditContactsData{
+		Contacts: []string{id.String()}, AddCategories: []string{category.String()},
+	}); xerr != nil {
+		t.Fatalf("bulk no-op: %v", xerr)
+	}
+	if n := countTimeline(timeline(), models.TimelineCategoryAdded, byCategory); n != 2 {
+		t.Fatalf("an already-linked category must not log again, got %d", n)
+	}
+
+	// Newest first, and the whole feed is in order.
+	for i := 1; i < len(ev); i++ {
+		if ev[i].At.After(ev[i-1].At) {
+			t.Fatalf("timeline out of order at %d: %s after %s", i, ev[i].At, ev[i-1].At)
+		}
+	}
+}
+
+// A contact created from a campaign's Leads tab is attributed to that campaign
+// by name, resolved server-side.
+func TestLiveContactSourceCampaignResolvesName(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	ctx := context.Background()
+	repo := NewContactRepostory(handle)
+
+	created, xerr := repo.Add(ctx, f.mate.String(), f.org, []models.AddContact{{
+		Email:     "i255-" + uuid.New().String()[:8] + "@test.local",
+		Campaigns: []string{f.campaign.String()},
+		Source:    models.ContactSourceCampaign,
+	}})
+	if xerr != nil || len(created) != 1 {
+		t.Fatalf("add: %v", xerr)
+	}
+	detail, xerr := repo.GetDetail(ctx, f.mate, &f.org, created[0].ID)
+	if xerr != nil {
+		t.Fatalf("detail: %v", xerr)
+	}
+	if detail.Source != models.ContactSourceCampaign || detail.SourceDetail != "Agency partnerships" {
+		t.Fatalf("want source campaign/Agency partnerships, got %q/%q", detail.Source, detail.SourceDetail)
+	}
+	if _, xerr := repo.Add(ctx, f.mate.String(), f.org, []models.AddContact{{
+		Email: "i255-bad-" + uuid.New().String()[:8] + "@test.local", Source: "website",
+	}}); xerr == nil {
+		t.Fatal("an unknown source must be refused, not stored")
+	}
+}

--- a/internal/repository/pg_campaign_progress.go
+++ b/internal/repository/pg_campaign_progress.go
@@ -187,6 +187,10 @@ type CampaignProgressRepository interface {
 	// nil, is the soonest time a waiting contact's condition window elapses — the
 	// scheduler should defer and re-check then rather than completing.
 	FindNextRoutedPair(ctx context.Context, campaignID uuid.UUID, orderBy, orderDir, orderField string, prioritizeNewLeads, excludeNewLeads bool) (*ContactSequencePair, *time.Time, error)
+	// RouteContact runs the same routing for ONE contact and reports where
+	// their flow goes next, plus the pre-send gate that excludes them, so a
+	// per-contact preview reads the facts the send path reads.
+	RouteContact(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactRoute, error)
 
 	// CountUndeliverableLeads counts the leads FindNextRoutedPair excludes
 	// because address verification refused them. Reported when a campaign
@@ -833,191 +837,12 @@ func undeliverableClause(cp string) string {
 // condition window closing) so the scheduler defers exactly until then.
 // Returns (nil, nil, nil) when the campaign is genuinely complete.
 func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, campaignID uuid.UUID, orderBy, orderDir, orderField string, prioritizeNewLeads, excludeNewLeads bool) (*ContactSequencePair, *time.Time, error) {
-	// 1. Load steps (position + branch tree + wait) once, ordered by position.
-	type stepInfo struct {
-		id          uuid.UUID
-		bc          models.BranchConditions
-		waitAfter   int
-		waitMinutes int // a "wait" node's own delay, gating the step after it
-	}
-	srows, err := r.db.Query(ctx, `SELECT id, conditions, wait_after, kind, action FROM sequences WHERE campaign_id = $1 ORDER BY position ASC, created_at ASC`, campaignID)
+	router, err := r.loadRouter(ctx, campaignID)
 	if err != nil {
 		return nil, nil, err
 	}
-	var steps []stepInfo
-	idxByID := map[uuid.UUID]int{}
-	for srows.Next() {
-		var si stepInfo
-		var raw, action []byte
-		var kind string
-		if serr := srows.Scan(&si.id, &raw, &si.waitAfter, &kind, &action); serr != nil {
-			srows.Close()
-			return nil, nil, serr
-		}
-		if len(raw) > 0 {
-			_ = json.Unmarshal(raw, &si.bc)
-		}
-		if kind != "email" && len(action) > 0 {
-			var cfg models.ActionConfig
-			if json.Unmarshal(action, &cfg) == nil && cfg.Type == "wait" && cfg.WaitMinutes != nil && *cfg.WaitMinutes > 0 {
-				si.waitMinutes = *cfg.WaitMinutes
-			}
-		}
-		idxByID[si.id] = len(steps)
-		steps = append(steps, si)
-	}
-	srows.Close()
-	if serr := srows.Err(); serr != nil {
-		return nil, nil, serr
-	}
-	if len(steps) == 0 {
+	if router == nil {
 		return nil, nil, nil
-	}
-	entry := steps[0].id
-	now := time.Now()
-
-	// Route-aware stop_on_reply. Rather than blanket-excluding every contact who
-	// has replied (which also kills the reply branch's OWN follow-up steps), a
-	// replied contact keeps moving ONLY while their next routed step is part of the
-	// REPLY FLOW: the subgraph downstream of a reply branch that is NOT also part
-	// of the cold sequence. The normal / fall-through cold sequence stops; the
-	// reply branch's path (its actions AND any follow-up emails) runs to
-	// completion. Compute the reply-flow step set once and load the flag.
-	var stopOnReply bool
-	if serr := r.db.QueryRow(ctx, `SELECT stop_on_reply FROM campaigns WHERE id = $1`, campaignID).Scan(&stopOnReply); serr != nil {
-		return nil, nil, serr
-	}
-	replyFlowSteps := map[uuid.UUID]bool{}
-	if stopOnReply {
-		// bfs walks a directed reachability closure from `seeds`, following the
-		// targets selected by `follow`, and records every visited step into `into`.
-		bfs := func(seeds []uuid.UUID, into map[uuid.UUID]bool, follow func(b *models.Branch) bool) {
-			queue := append([]uuid.UUID(nil), seeds...)
-			for _, s := range seeds {
-				into[s] = true
-			}
-			for len(queue) > 0 {
-				cur := queue[0]
-				queue = queue[1:]
-				idx, ok := idxByID[cur]
-				if !ok {
-					continue
-				}
-				for j := range steps[idx].bc.Branches {
-					b := &steps[idx].bc.Branches[j]
-					if b.TargetSequenceID == nil || into[*b.TargetSequenceID] || !follow(b) {
-						continue
-					}
-					into[*b.TargetSequenceID] = true
-					queue = append(queue, *b.TargetSequenceID)
-				}
-			}
-		}
-
-		// 1. Cold trunk: every step a NON-replier reaches from the entry, i.e.
-		//    following every branch EXCEPT the ones that route on a positive reply.
-		//    A step that also sits here (a reply branch merged back into the cold
-		//    sequence) is NOT reply flow — a replier must stop when they reach it.
-		coldReachable := map[uuid.UUID]bool{}
-		bfs([]uuid.UUID{entry}, coldReachable, func(b *models.Branch) bool {
-			return !branchHasPositiveReplyCondition(b)
-		})
-
-		// 2. Reply flow: everything reachable from a positive-reply branch target
-		//    (following ALL onward branches, so internal reply-flow branching is
-		//    kept), MINUS the cold trunk.
-		var seeds []uuid.UUID
-		for i := range steps {
-			for j := range steps[i].bc.Branches {
-				b := &steps[i].bc.Branches[j]
-				if b.TargetSequenceID != nil && branchHasPositiveReplyCondition(b) && !coldReachable[*b.TargetSequenceID] {
-					seeds = append(seeds, *b.TargetSequenceID)
-				}
-			}
-		}
-		bfs(seeds, replyFlowSteps, func(b *models.Branch) bool {
-			return b.TargetSequenceID != nil && !coldReachable[*b.TargetSequenceID]
-		})
-	}
-
-	// routeResult is the outcome of routing a contact out of their current step:
-	// send `target`, fully `stop`, or `wait` until a condition window elapses.
-	type routeResult struct {
-		target *uuid.UUID
-		stop   bool
-		wait   *time.Time
-	}
-	// routeNext follows the first DECIDABLE branch out of fromID. A branch whose
-	// window is still open leaves the contact waiting (so "if opened within 3d"
-	// gets its 3 days instead of being judged the instant the step is sent).
-	routeNext := func(fromID uuid.UUID, prog *CampaignContactProgress, sentAt time.Time) routeResult {
-		idx, ok := idxByID[fromID]
-		if !ok {
-			return routeResult{stop: true}
-		}
-		bc := steps[idx].bc
-		// Routing is purely the connections the user drew. A step with no
-		// outgoing connection, or whose connections don't match, ends the
-		// contact (STOP). There is NO implicit "advance to the next step by
-		// position" — steps are only linked when explicitly connected, and an
-		// unconditional connection (a branch with no conditions) is the "just go
-		// there after the wait" default.
-		if len(bc.Branches) == 0 {
-			return routeResult{stop: true}
-		}
-		for i := range bc.Branches {
-			b := &bc.Branches[i]
-			st, recheck := evaluateBranchState(b, prog, sentAt, now)
-			if st == BranchNoMatch {
-				continue
-			}
-			if st == BranchUndecided {
-				rc := recheck
-				return routeResult{wait: &rc}
-			}
-			// Matched: a nil / deleted target ends the contact (STOP).
-			if b.TargetSequenceID == nil {
-				return routeResult{stop: true}
-			}
-			if _, live := idxByID[*b.TargetSequenceID]; !live {
-				return routeResult{stop: true}
-			}
-			t := *b.TargetSequenceID
-			return routeResult{target: &t}
-		}
-		// Nothing matched -> the flow ends with STOP.
-		return routeResult{stop: true}
-	}
-
-	// routeReplyOnly is the routing used for a contact who HAS REPLIED but is still
-	// on the cold trunk (stop_on_reply on). It considers ONLY positive-reply
-	// branches that lead into the reply flow, giving them priority regardless of
-	// declared order, and never waits on a cold window. The first such branch that
-	// matches right now routes the contact into the reply flow; anything else means
-	// "no reply handling here for this reply" -> STOP the cold sequence. This is
-	// what lets a non-instant reply branch fire even when an engagement branch is
-	// declared ahead of it, and stops a replier instead of deferring on a cold
-	// "did not open within N days" window forever.
-	routeReplyOnly := func(fromID uuid.UUID, prog *CampaignContactProgress, sentAt time.Time) routeResult {
-		idx, ok := idxByID[fromID]
-		if !ok {
-			return routeResult{stop: true}
-		}
-		for i := range steps[idx].bc.Branches {
-			b := &steps[idx].bc.Branches[i]
-			if b.TargetSequenceID == nil || !branchHasPositiveReplyCondition(b) || !replyFlowSteps[*b.TargetSequenceID] {
-				continue
-			}
-			if st, _ := evaluateBranchState(b, prog, sentAt, now); st != BranchMatch {
-				continue
-			}
-			if _, live := idxByID[*b.TargetSequenceID]; !live {
-				continue
-			}
-			t := *b.TargetSequenceID
-			return routeResult{target: &t}
-		}
-		return routeResult{stop: true}
 	}
 
 	// 2. Ordered candidate contacts + their last-sent step (with engagement) + sent set.
@@ -1112,90 +937,32 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 			nextDue = &at
 		}
 	}
-	// A task fires at (or a breath before) the slot it was scheduled for, so
-	// "due" tolerates the same grace the scheduler's hard-floor check does.
-	dueBy := now.Add(config.CampaignNotDueGraceSeconds * time.Second)
 	for rows.Next() {
+		var in routeInput
 		var contactID uuid.UUID
-		var lastSeq *uuid.UUID
-		var sentAt, openedAt, clickedAt, repliedAt *time.Time
-		var replyClass, aiLabel string
-		var sentIDs []uuid.UUID
-		var hasReplied bool
-		if serr := rows.Scan(&contactID, &lastSeq, &sentAt, &openedAt, &clickedAt, &repliedAt, &replyClass, &aiLabel, &sentIDs, &hasReplied); serr != nil {
+		if serr := rows.Scan(&contactID, &in.lastSeq, &in.sentAt, &in.openedAt, &in.clickedAt, &in.repliedAt, &in.replyClass, &in.aiLabel, &in.sentIDs, &in.hasReplied); serr != nil {
 			return nil, nil, serr
 		}
-
-		isNew := lastSeq == nil
-		var res routeResult
-		if isNew {
-			if excludeNewLeads {
-				continue
-			}
-			e := entry
-			res = routeResult{target: &e}
-		} else {
-			prog := &CampaignContactProgress{
-				CampaignID: campaignID, ContactID: contactID, SequenceID: *lastSeq,
-				SentAt: sentAt, OpenedAt: openedAt, ClickedAt: clickedAt, RepliedAt: repliedAt,
-				ReplyClass: replyClass, AILabel: aiLabel,
-			}
-			sa := time.Time{}
-			if sentAt != nil {
-				sa = *sentAt
-			}
-			res = routeNext(*lastSeq, prog, sa)
-
-			// Route-aware stop_on_reply for a contact who has replied:
-			//   - still on the cold trunk (lastSeq not in the reply flow): they may
-			//     only ENTER the reply flow via a positive-reply branch. Any cold
-			//     route, an undecided cold window, or a stop ends them here — no cold
-			//     sends and no deferring on a cold window.
-			//   - already inside the reply flow: keep the reply flow's own routing
-			//     (its waits are legitimate), but if it would route back out into the
-			//     cold sequence, stop instead.
-			if stopOnReply && hasReplied {
-				if !replyFlowSteps[*lastSeq] {
-					res = routeReplyOnly(*lastSeq, prog, sa)
-				} else if res.target != nil && !replyFlowSteps[*res.target] {
-					res = routeResult{stop: true}
-				}
-			}
+		if in.lastSeq == nil && excludeNewLeads {
+			continue
 		}
-
-		if res.wait != nil {
+		res := router.route(campaignID, contactID, in)
+		if res.WaitUntil != nil {
 			// Not decidable yet — remember the soonest window so the scheduler
 			// can re-check exactly then instead of guessing or completing.
-			noteDue(*res.wait)
+			noteDue(*res.WaitUntil)
 			continue
 		}
-		if res.stop || res.target == nil {
-			continue // reached the end / a STOP (incl. a replied contact stopped above)
-		}
-		// Loop guard: never re-send a step the contact already received.
-		already := false
-		for _, sid := range sentIDs {
-			if sid == *res.target {
-				already = true
-				break
-			}
-		}
-		if already {
-			continue
+		if res.Target == nil {
+			continue // reached the end / a STOP / a step already received
 		}
 		// When is this step due? Skip it (but remember when) if not yet: the
 		// contacts behind this one may be sendable right now.
-		if !isNew && sentAt != nil {
-			due := sentAt.Add(24 * time.Hour * time.Duration(steps[idxByID[*res.target]].waitAfter))
-			if last, ok := idxByID[*lastSeq]; ok && steps[last].waitMinutes > 0 {
-				due = due.Add(time.Duration(steps[last].waitMinutes) * time.Minute)
-			}
-			if due.After(dueBy) {
-				noteDue(due)
-				continue
-			}
+		if res.DueAt != nil && res.DueAt.After(router.dueBy) {
+			noteDue(*res.DueAt)
+			continue
 		}
-		return &ContactSequencePair{ContactID: contactID, SequenceID: *res.target, IsNewLead: isNew}, nil, nil
+		return &ContactSequencePair{ContactID: contactID, SequenceID: *res.Target, IsNewLead: res.IsNewLead}, nil, nil
 	}
 	if rerr := rows.Err(); rerr != nil {
 		return nil, nil, rerr
@@ -1203,6 +970,387 @@ func (r *campaignProgressRepository) FindNextRoutedPair(ctx context.Context, cam
 	// Nobody sendable now. Hand back the soonest moment somebody will be so the
 	// scheduler defers until then rather than completing.
 	return nil, nextDue, nil
+}
+
+// ContactRoute is where a contact's flow goes next inside one campaign.
+type ContactRoute struct {
+	// Target is the next step to send. Nil when the flow has ended for the
+	// contact, a step they already received is next (loop guard), or a
+	// condition window is still open (WaitUntil set).
+	Target    *uuid.UUID
+	IsNewLead bool
+	// DueAt is when the target's wait (the step's wait_after, plus a preceding
+	// wait node) elapses. Nil means due now.
+	DueAt *time.Time
+	// WaitUntil is when an undecided condition window closes.
+	WaitUntil *time.Time
+	// Excluded names the pre-send gate that keeps routing from ever offering
+	// the contact: "bounced", "failed", "suppressed", "undeliverable" or
+	// "not_a_lead". Empty when routing considers them.
+	Excluded string
+	// LastSentStep is the step the contact is on now (nil before any send).
+	LastSentStep *uuid.UUID
+}
+
+// RouteContact runs the campaign's routing for ONE contact and reports where
+// their flow goes next, including the gate that would exclude them. It reads
+// exactly what FindNextRoutedPair reads, so a preview never disagrees with
+// the send path.
+func (r *campaignProgressRepository) RouteContact(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactRoute, error) {
+	router, err := r.loadRouter(ctx, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	query := `
+		SELECT
+		       lp.sequence_id, lp.sent_at, lp.opened_at, lp.clicked_at, lp.replied_at, COALESCE(lp.reply_class, ''), COALESCE(lp.ai_label, ''),
+		       COALESCE(ss.ids, '{}') AS sent_ids,
+		       EXISTS (
+		         SELECT 1 FROM campaign_contact_progress rp
+		         WHERE rp.campaign_id = $1 AND rp.contact_id = cl.contact_id AND rp.replied_at IS NOT NULL
+		       ) AS has_replied,
+		       EXISTS (
+		         SELECT 1 FROM campaign_contact_progress b
+		         WHERE b.contact_id = cl.contact_id AND b.bounced_at IS NOT NULL
+		       ) AS bounced,
+		       EXISTS (
+		         SELECT 1 FROM campaign_contact_progress f
+		         WHERE f.campaign_id = $1 AND f.contact_id = cl.contact_id
+		           AND f.sent_at IS NULL AND f.failed_at IS NOT NULL
+		           AND f.send_attempts >= $2
+		       ) AS failed,
+		       EXISTS (
+		         SELECT 1 FROM suppressed_recipients sr
+		         JOIN campaigns camp ON camp.organization_id = sr.organization_id
+		         WHERE camp.id = $1
+		           AND LOWER(sr.email) = LOWER(c.email)
+		           AND (sr.expires_at IS NULL OR sr.expires_at > NOW())
+		       ) AS suppressed,
+		       ` + undeliverableClause("$1") + ` AS undeliverable
+		FROM campaign_leads cl
+		JOIN contacts c ON c.id = cl.contact_id
+		LEFT JOIN LATERAL (
+			SELECT sequence_id, sent_at, opened_at, clicked_at, replied_at, reply_class, ai_label
+			FROM campaign_contact_progress p
+			WHERE p.campaign_id = $1 AND p.contact_id = cl.contact_id AND p.sent_at IS NOT NULL
+			ORDER BY p.sent_at DESC LIMIT 1
+		) lp ON true
+		LEFT JOIN LATERAL (
+			SELECT array_agg(sequence_id) AS ids
+			FROM campaign_contact_progress p2
+			WHERE p2.campaign_id = $1 AND p2.contact_id = cl.contact_id
+			  AND (p2.sent_at IS NOT NULL OR p2.dispatched_at IS NOT NULL)
+		) ss ON true
+		WHERE cl.campaign_id = $1 AND cl.contact_id = $3
+	`
+	var in routeInput
+	var bounced, failed, suppressed, undeliverable bool
+	err = r.db.QueryRow(ctx, query, campaignID, config.CampaignSendMaxAttempts, contactID).Scan(
+		&in.lastSeq, &in.sentAt, &in.openedAt, &in.clickedAt, &in.repliedAt, &in.replyClass, &in.aiLabel, &in.sentIDs, &in.hasReplied,
+		&bounced, &failed, &suppressed, &undeliverable,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return &ContactRoute{Excluded: "not_a_lead"}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	out := &ContactRoute{LastSentStep: in.lastSeq}
+	switch {
+	case bounced:
+		out.Excluded = "bounced"
+	case failed:
+		out.Excluded = "failed"
+	case suppressed:
+		out.Excluded = "suppressed"
+	case undeliverable:
+		out.Excluded = "undeliverable"
+	}
+	if router == nil {
+		return out, nil
+	}
+	res := router.route(campaignID, contactID, in)
+	out.Target, out.IsNewLead, out.DueAt, out.WaitUntil = res.Target, res.IsNewLead, res.DueAt, res.WaitUntil
+	return out, nil
+}
+
+// routeInput is a lead's routing facts as the finder query returns them.
+type routeInput struct {
+	lastSeq                                *uuid.UUID
+	sentAt, openedAt, clickedAt, repliedAt *time.Time
+	replyClass, aiLabel                    string
+	sentIDs                                []uuid.UUID
+	hasReplied                             bool
+}
+
+// campaignRouter is a campaign's flow graph loaded once per pass, with the
+// routing rules that decide where a contact goes out of their current step.
+type campaignRouter struct {
+	steps   []routeStep
+	idxByID map[uuid.UUID]int
+	entry   uuid.UUID
+	now     time.Time
+	// dueBy tolerates the same grace the scheduler's hard-floor check does: a
+	// task fires at (or a breath before) the slot it was scheduled for.
+	dueBy          time.Time
+	stopOnReply    bool
+	replyFlowSteps map[uuid.UUID]bool
+}
+
+type routeStep struct {
+	id          uuid.UUID
+	bc          models.BranchConditions
+	waitAfter   int
+	waitMinutes int // a "wait" node's own delay, gating the step after it
+}
+
+// routeResult is the outcome of routing a contact out of their current step:
+// send `target`, fully `stop`, or `wait` until a condition window elapses.
+type routeResult struct {
+	target *uuid.UUID
+	stop   bool
+	wait   *time.Time
+}
+
+// loadRouter reads the steps (position + branch tree + wait) once, ordered by
+// position, and precomputes the reply-flow step set for route-aware
+// stop_on_reply. Returns nil when the campaign has no steps.
+func (r *campaignProgressRepository) loadRouter(ctx context.Context, campaignID uuid.UUID) (*campaignRouter, error) {
+	srows, err := r.db.Query(ctx, `SELECT id, conditions, wait_after, kind, action FROM sequences WHERE campaign_id = $1 ORDER BY position ASC, created_at ASC`, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	cr := &campaignRouter{idxByID: map[uuid.UUID]int{}, replyFlowSteps: map[uuid.UUID]bool{}}
+	for srows.Next() {
+		var si routeStep
+		var raw, action []byte
+		var kind string
+		if serr := srows.Scan(&si.id, &raw, &si.waitAfter, &kind, &action); serr != nil {
+			srows.Close()
+			return nil, serr
+		}
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &si.bc)
+		}
+		if kind != "email" && len(action) > 0 {
+			var cfg models.ActionConfig
+			if json.Unmarshal(action, &cfg) == nil && cfg.Type == "wait" && cfg.WaitMinutes != nil && *cfg.WaitMinutes > 0 {
+				si.waitMinutes = *cfg.WaitMinutes
+			}
+		}
+		cr.idxByID[si.id] = len(cr.steps)
+		cr.steps = append(cr.steps, si)
+	}
+	srows.Close()
+	if serr := srows.Err(); serr != nil {
+		return nil, serr
+	}
+	if len(cr.steps) == 0 {
+		return nil, nil
+	}
+	cr.entry = cr.steps[0].id
+	cr.now = time.Now()
+	cr.dueBy = cr.now.Add(config.CampaignNotDueGraceSeconds * time.Second)
+
+	// Route-aware stop_on_reply. Rather than blanket-excluding every contact who
+	// has replied (which also kills the reply branch's OWN follow-up steps), a
+	// replied contact keeps moving ONLY while their next routed step is part of the
+	// REPLY FLOW: the subgraph downstream of a reply branch that is NOT also part
+	// of the cold sequence. The normal / fall-through cold sequence stops; the
+	// reply branch's path (its actions AND any follow-up emails) runs to
+	// completion. Compute the reply-flow step set once and load the flag.
+	if serr := r.db.QueryRow(ctx, `SELECT stop_on_reply FROM campaigns WHERE id = $1`, campaignID).Scan(&cr.stopOnReply); serr != nil {
+		return nil, serr
+	}
+	if cr.stopOnReply {
+		steps := cr.steps
+		idxByID := cr.idxByID
+		// bfs walks a directed reachability closure from `seeds`, following the
+		// targets selected by `follow`, and records every visited step into `into`.
+		bfs := func(seeds []uuid.UUID, into map[uuid.UUID]bool, follow func(b *models.Branch) bool) {
+			queue := append([]uuid.UUID(nil), seeds...)
+			for _, s := range seeds {
+				into[s] = true
+			}
+			for len(queue) > 0 {
+				cur := queue[0]
+				queue = queue[1:]
+				idx, ok := idxByID[cur]
+				if !ok {
+					continue
+				}
+				for j := range steps[idx].bc.Branches {
+					b := &steps[idx].bc.Branches[j]
+					if b.TargetSequenceID == nil || into[*b.TargetSequenceID] || !follow(b) {
+						continue
+					}
+					into[*b.TargetSequenceID] = true
+					queue = append(queue, *b.TargetSequenceID)
+				}
+			}
+		}
+
+		// 1. Cold trunk: every step a NON-replier reaches from the entry, i.e.
+		//    following every branch EXCEPT the ones that route on a positive reply.
+		//    A step that also sits here (a reply branch merged back into the cold
+		//    sequence) is NOT reply flow — a replier must stop when they reach it.
+		coldReachable := map[uuid.UUID]bool{}
+		bfs([]uuid.UUID{cr.entry}, coldReachable, func(b *models.Branch) bool {
+			return !branchHasPositiveReplyCondition(b)
+		})
+
+		// 2. Reply flow: everything reachable from a positive-reply branch target
+		//    (following ALL onward branches, so internal reply-flow branching is
+		//    kept), MINUS the cold trunk.
+		var seeds []uuid.UUID
+		for i := range steps {
+			for j := range steps[i].bc.Branches {
+				b := &steps[i].bc.Branches[j]
+				if b.TargetSequenceID != nil && branchHasPositiveReplyCondition(b) && !coldReachable[*b.TargetSequenceID] {
+					seeds = append(seeds, *b.TargetSequenceID)
+				}
+			}
+		}
+		bfs(seeds, cr.replyFlowSteps, func(b *models.Branch) bool {
+			return b.TargetSequenceID != nil && !coldReachable[*b.TargetSequenceID]
+		})
+	}
+	return cr, nil
+}
+
+// routeNext follows the first DECIDABLE branch out of fromID. A branch whose
+// window is still open leaves the contact waiting (so "if opened within 3d"
+// gets its 3 days instead of being judged the instant the step is sent).
+func (cr *campaignRouter) routeNext(fromID uuid.UUID, prog *CampaignContactProgress, sentAt time.Time) routeResult {
+	idx, ok := cr.idxByID[fromID]
+	if !ok {
+		return routeResult{stop: true}
+	}
+	bc := cr.steps[idx].bc
+	// Routing is purely the connections the user drew. A step with no
+	// outgoing connection, or whose connections don't match, ends the
+	// contact (STOP). There is NO implicit "advance to the next step by
+	// position" — steps are only linked when explicitly connected, and an
+	// unconditional connection (a branch with no conditions) is the "just go
+	// there after the wait" default.
+	if len(bc.Branches) == 0 {
+		return routeResult{stop: true}
+	}
+	for i := range bc.Branches {
+		b := &bc.Branches[i]
+		st, recheck := evaluateBranchState(b, prog, sentAt, cr.now)
+		if st == BranchNoMatch {
+			continue
+		}
+		if st == BranchUndecided {
+			rc := recheck
+			return routeResult{wait: &rc}
+		}
+		// Matched: a nil / deleted target ends the contact (STOP).
+		if b.TargetSequenceID == nil {
+			return routeResult{stop: true}
+		}
+		if _, live := cr.idxByID[*b.TargetSequenceID]; !live {
+			return routeResult{stop: true}
+		}
+		t := *b.TargetSequenceID
+		return routeResult{target: &t}
+	}
+	// Nothing matched -> the flow ends with STOP.
+	return routeResult{stop: true}
+}
+
+// routeReplyOnly is the routing used for a contact who HAS REPLIED but is still
+// on the cold trunk (stop_on_reply on). It considers ONLY positive-reply
+// branches that lead into the reply flow, giving them priority regardless of
+// declared order, and never waits on a cold window. The first such branch that
+// matches right now routes the contact into the reply flow; anything else means
+// "no reply handling here for this reply" -> STOP the cold sequence. This is
+// what lets a non-instant reply branch fire even when an engagement branch is
+// declared ahead of it, and stops a replier instead of deferring on a cold
+// "did not open within N days" window forever.
+func (cr *campaignRouter) routeReplyOnly(fromID uuid.UUID, prog *CampaignContactProgress, sentAt time.Time) routeResult {
+	idx, ok := cr.idxByID[fromID]
+	if !ok {
+		return routeResult{stop: true}
+	}
+	for i := range cr.steps[idx].bc.Branches {
+		b := &cr.steps[idx].bc.Branches[i]
+		if b.TargetSequenceID == nil || !branchHasPositiveReplyCondition(b) || !cr.replyFlowSteps[*b.TargetSequenceID] {
+			continue
+		}
+		if st, _ := evaluateBranchState(b, prog, sentAt, cr.now); st != BranchMatch {
+			continue
+		}
+		if _, live := cr.idxByID[*b.TargetSequenceID]; !live {
+			continue
+		}
+		t := *b.TargetSequenceID
+		return routeResult{target: &t}
+	}
+	return routeResult{stop: true}
+}
+
+// route decides one contact's next step from their routing facts: the entry
+// step for a new lead, otherwise the route out of their last-sent step, with
+// the loop guard and the step's wait applied.
+func (cr *campaignRouter) route(campaignID, contactID uuid.UUID, in routeInput) ContactRoute {
+	out := ContactRoute{LastSentStep: in.lastSeq, IsNewLead: in.lastSeq == nil}
+	var res routeResult
+	if out.IsNewLead {
+		e := cr.entry
+		res = routeResult{target: &e}
+	} else {
+		prog := &CampaignContactProgress{
+			CampaignID: campaignID, ContactID: contactID, SequenceID: *in.lastSeq,
+			SentAt: in.sentAt, OpenedAt: in.openedAt, ClickedAt: in.clickedAt, RepliedAt: in.repliedAt,
+			ReplyClass: in.replyClass, AILabel: in.aiLabel,
+		}
+		sa := time.Time{}
+		if in.sentAt != nil {
+			sa = *in.sentAt
+		}
+		res = cr.routeNext(*in.lastSeq, prog, sa)
+
+		// Route-aware stop_on_reply for a contact who has replied:
+		//   - still on the cold trunk (lastSeq not in the reply flow): they may
+		//     only ENTER the reply flow via a positive-reply branch. Any cold
+		//     route, an undecided cold window, or a stop ends them here — no cold
+		//     sends and no deferring on a cold window.
+		//   - already inside the reply flow: keep the reply flow's own routing
+		//     (its waits are legitimate), but if it would route back out into the
+		//     cold sequence, stop instead.
+		if cr.stopOnReply && in.hasReplied {
+			if !cr.replyFlowSteps[*in.lastSeq] {
+				res = cr.routeReplyOnly(*in.lastSeq, prog, sa)
+			} else if res.target != nil && !cr.replyFlowSteps[*res.target] {
+				res = routeResult{stop: true}
+			}
+		}
+	}
+
+	if res.wait != nil {
+		out.WaitUntil = res.wait
+		return out
+	}
+	if res.stop || res.target == nil {
+		return out // reached the end / a STOP (incl. a replied contact stopped above)
+	}
+	// Loop guard: never re-send a step the contact already received.
+	for _, sid := range in.sentIDs {
+		if sid == *res.target {
+			return out
+		}
+	}
+	out.Target = res.target
+	if !out.IsNewLead && in.sentAt != nil {
+		due := in.sentAt.Add(24 * time.Hour * time.Duration(cr.steps[cr.idxByID[*res.target]].waitAfter))
+		if last, ok := cr.idxByID[*in.lastSeq]; ok && cr.steps[last].waitMinutes > 0 {
+			due = due.Add(time.Duration(cr.steps[last].waitMinutes) * time.Minute)
+		}
+		out.DueAt = &due
+	}
+	return out
 }
 
 // branchHasPositiveReplyCondition reports whether a branch is a "reply branch":

--- a/internal/repository/pg_contact.go
+++ b/internal/repository/pg_contact.go
@@ -75,6 +75,9 @@ type ContactRepository interface {
 	GetDetail(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, contactID uuid.UUID) (*models.ContactDetail, *errx.Error)
 	ListSentEmails(ctx context.Context, userID, contactID uuid.UUID, limit int, beforeSentAt *time.Time, beforeTaskID *uuid.UUID) (*models.ContactSentEmailsResult, *errx.Error)
 	ListTimeline(ctx context.Context, userID uuid.UUID, orgID *uuid.UUID, contactID uuid.UUID, limit int, before *time.Time) (*models.ContactTimelineResult, *errx.Error)
+	// ListCampaignStates returns the contact's campaigns with their flow,
+	// this contact's progress on every step, and the derived lead status.
+	ListCampaignStates(ctx context.Context, orgID, contactID uuid.UUID) ([]models.ContactCampaignState, *errx.Error)
 }
 
 type contactRepository struct {
@@ -220,6 +223,16 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			cats = append(cats, cid)
 		}
 
+		// First-touch attribution. Every creation path stamps one; an empty
+		// value is recorded honestly rather than guessed.
+		if lead.Source == "" {
+			lead.Source = models.ContactSourceUnknown
+		}
+		if !lead.Source.Valid() {
+			return nil, errx.New(errx.BadRequest, "invalid contact source")
+		}
+		lead.SourceDetail = strings.TrimSpace(lead.SourceDetail)
+
 		normalized = append(normalized, lead)
 		campaignIDs = append(campaignIDs, cids)
 		categoryIDs = append(categoryIDs, cats)
@@ -241,9 +254,11 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			// inference sites for one placeholder, so it is passed twice with
 			// explicit casts. NULL means "leave the flag alone".
 			`INSERT INTO contacts (
-			 id, user_id, organization_id, first_name, last_name, email, company, phone, custom_fields, subscribed
+			 id, user_id, organization_id, first_name, last_name, email, company, phone, custom_fields, subscribed,
+			 source, source_detail, first_seen_at
 			 ) VALUES (
-			  gen_random_uuid(), $1, $2, $3, $4, LOWER($5), $6, $7, $8, COALESCE($9::boolean, TRUE)
+			  gen_random_uuid(), $1, $2, $3, $4, LOWER($5), $6, $7, $8, COALESCE($9::boolean, TRUE),
+			  $11, $12, NOW()
 			 )
 			 ON CONFLICT (user_id, (LOWER(email))) DO UPDATE SET
 			  organization_id = COALESCE(contacts.organization_id, EXCLUDED.organization_id),
@@ -256,24 +271,29 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			  custom_fields = contacts.custom_fields || EXCLUDED.custom_fields,
 			  subscribed = COALESCE($10::boolean, contacts.subscribed),
 			  updated_at = NOW()
-			 RETURNING id, first_name, last_name, email, company, phone, custom_fields, subscribed, updated_at, created_at`,
+			 -- xmax = 0 only on a fresh row: the source is first-touch, so an
+			 -- upsert that hit an existing contact is not a creation.
+			 RETURNING id, first_name, last_name, email, company, phone, custom_fields, subscribed, updated_at, created_at, (xmax = 0)`,
 			userID, orgID, lead.FirstName, lead.LastName, lead.Email, lead.Company, lead.Phone, lead.CustomFields,
-			lead.Subscribed, lead.Subscribed,
+			lead.Subscribed, lead.Subscribed, string(lead.Source), lead.SourceDetail,
 		)
 	}
 
 	br := tx.SendBatch(ctx, &insertBatch)
 
 	ncontacts := make([]models.Contact, 0, len(normalized))
+	var createdIDs []uuid.UUID
+	created := make([]bool, 0, len(normalized))
 	for range normalized {
 		ncon := models.Contact{
 			Campaigns:  []models.MiniCampaign{},
 			Categories: []models.MiniCategory{},
 			Subscribed: true,
 		}
+		var inserted bool
 		if err := br.QueryRow().Scan(
 			&ncon.ID, &ncon.FirstName, &ncon.LastName, &ncon.Email, &ncon.Company,
-			&ncon.Phone, &ncon.CustomFields, &ncon.Subscribed, &ncon.UpdatedAt, &ncon.CreatedAt,
+			&ncon.Phone, &ncon.CustomFields, &ncon.Subscribed, &ncon.UpdatedAt, &ncon.CreatedAt, &inserted,
 		); err != nil {
 			br.Close()
 			db.CaptureError(err, "", nil, "batch queryrow")
@@ -285,11 +305,19 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			ncon.CustomFields = map[string]string{}
 		}
 		ncontacts = append(ncontacts, ncon)
+		created = append(created, inserted)
+		if inserted {
+			createdIDs = append(createdIDs, ncon.ID)
+		}
 	}
 	if err := br.Close(); err != nil {
 		db.CaptureError(err, "", nil, "batch close")
 		return nil, errx.InternalError()
 	}
+
+	// Lifecycle events for the activity timeline, written in this transaction.
+	actor := actorID(userID)
+	var campaignLinks, categoryLinks []contactLink
 
 	// Link campaigns. Original code's RETURNING clause referenced a
 	// non-inserted table, which is invalid SQL; resolve by inserting
@@ -300,15 +328,35 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 		if len(cids) == 0 {
 			continue
 		}
-		if _, err := tx.Exec(ctx, `
+		lrows, err := tx.Query(ctx, `
 			INSERT INTO campaign_leads (contact_id, campaign_id)
 			SELECT $1, c.id
 			FROM   campaigns c
 			WHERE  c.id = ANY($2) AND c.organization_id = $3
 			ON CONFLICT (campaign_id, contact_id) DO NOTHING
-		`, ncontacts[i].ID, cids, orgID); err != nil {
+			RETURNING campaign_id
+		`, ncontacts[i].ID, cids, orgID)
+		if err != nil {
 			db.CaptureError(err, "", nil, "campaign_leads insert")
 			return nil, errx.InternalError()
+		}
+		added, err := collectLinks(lrows, ncontacts[i].ID)
+		if err != nil {
+			db.CaptureError(err, "", nil, "campaign_leads returning")
+			return nil, errx.InternalError()
+		}
+		campaignLinks = append(campaignLinks, added...)
+		// A contact created from a campaign's Leads tab is attributed to that
+		// campaign by name, resolved here rather than trusted from the client.
+		if created[i] && normalized[i].Source == models.ContactSourceCampaign && normalized[i].SourceDetail == "" && len(added) > 0 {
+			if _, err := tx.Exec(ctx, `
+				UPDATE contacts SET source_detail = cam.name
+				FROM   campaigns cam
+				WHERE  contacts.id = $1 AND cam.id = $2
+			`, ncontacts[i].ID, added[0].LinkID); err != nil {
+				db.CaptureError(err, "", nil, "source_detail from campaign")
+				return nil, errx.InternalError()
+			}
 		}
 
 		rows, err := tx.Query(ctx, `
@@ -345,16 +393,24 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 		if len(cats) == 0 {
 			continue
 		}
-		if _, err := tx.Exec(ctx, `
+		crows, err := tx.Query(ctx, `
 			INSERT INTO contact_categories (contact_id, category_id)
 			SELECT $1, cat.id
 			FROM   categories cat
 			WHERE  cat.id = ANY($2) AND cat.user_id = $3
 			ON CONFLICT (contact_id, category_id) DO NOTHING
-		`, ncontacts[i].ID, cats, userID); err != nil {
+			RETURNING category_id
+		`, ncontacts[i].ID, cats, userID)
+		if err != nil {
 			db.CaptureError(err, "", nil, "contact_categories insert")
 			return nil, errx.InternalError()
 		}
+		added, err := collectLinks(crows, ncontacts[i].ID)
+		if err != nil {
+			db.CaptureError(err, "", nil, "contact_categories returning")
+			return nil, errx.InternalError()
+		}
+		categoryLinks = append(categoryLinks, added...)
 
 		rows, err := tx.Query(ctx, `
 			SELECT cat.id, cat.title, cat.color
@@ -383,6 +439,19 @@ func (r *contactRepository) Add(ctx context.Context, userID string, orgID uuid.U
 			return nil, errx.InternalError()
 		}
 		ncontacts[i].Categories = linked
+	}
+
+	if err := logContactCreated(ctx, tx, orgID, actor, createdIDs); err != nil {
+		db.CaptureError(err, "", nil, "contact_created activity")
+		return nil, errx.InternalError()
+	}
+	if err := logCampaignLinks(ctx, tx, orgID, actor, models.ActivityCampaignAdded, campaignLinks); err != nil {
+		db.CaptureError(err, "", nil, "campaign_added activity")
+		return nil, errx.InternalError()
+	}
+	if err := logCategoryLinks(ctx, tx, orgID, actor, models.ActivityCategoryAdded, categoryLinks); err != nil {
+		db.CaptureError(err, "", nil, "category_added activity")
+		return nil, errx.InternalError()
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -1367,6 +1436,9 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		return nil, errx.InternalError()
 	}
 
+	// Membership changes, written to the activity timeline before commit.
+	var campaignsAdded, campaignsRemoved, categoriesAdded, categoriesRemoved []contactLink
+
 	// Unmarshal current campaigns
 	if len(campaignsJSON) > 0 {
 		var campaigns []struct {
@@ -1499,12 +1571,20 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 				  AND cl.campaign_id = cam.id
 				  AND cam.id = ANY($2::uuid[])
 				  AND cam.organization_id = $3
+				RETURNING cl.campaign_id
 			`
 			params := []any{contactID, toDelete, orgID}
-			if _, err = tx.Exec(ctx, query, params...); err != nil {
+			rows, err := tx.Query(ctx, query, params...)
+			if err != nil {
 				db.CaptureError(err, query, params, "exec")
 				return nil, errx.InternalError()
 			}
+			removed, err := collectLinks(rows, c.ID)
+			if err != nil {
+				db.CaptureError(err, query, params, "returning")
+				return nil, errx.InternalError()
+			}
+			campaignsRemoved = append(campaignsRemoved, removed...)
 		}
 
 		if len(toInsert) > 0 {
@@ -1514,12 +1594,20 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 				FROM campaigns cam
 				WHERE cam.id = ANY($2::uuid[]) AND cam.organization_id = $3
 				ON CONFLICT (campaign_id, contact_id) DO NOTHING
+				RETURNING campaign_id
 			`
 			params := []any{contactID, toInsert, orgID}
-			if _, err = tx.Exec(ctx, query, params...); err != nil {
+			rows, err := tx.Query(ctx, query, params...)
+			if err != nil {
 				db.CaptureError(err, query, params, "exec")
 				return nil, errx.InternalError()
 			}
+			added, err := collectLinks(rows, c.ID)
+			if err != nil {
+				db.CaptureError(err, query, params, "returning")
+				return nil, errx.InternalError()
+			}
+			campaignsAdded = append(campaignsAdded, added...)
 		}
 	}
 
@@ -1576,22 +1664,43 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		if perr != nil {
 			return nil, perr
 		}
-		// Wipe then insert; scoped to user-owned categories.
-		if _, err := tx.Exec(ctx, `DELETE FROM contact_categories WHERE contact_id = $1`, contactID); err != nil {
+		// Drop everything not in the (user-owned) wanted set, then insert the
+		// rest; RETURNING on both sides is what feeds the timeline.
+		drows, err := tx.Query(ctx, `
+			DELETE FROM contact_categories
+			WHERE contact_id = $1
+			  AND category_id NOT IN (SELECT id FROM categories WHERE id = ANY($2) AND user_id = $3)
+			RETURNING category_id
+		`, contactID, ids, userID)
+		if err != nil {
 			db.CaptureError(err, "", nil, "categories wipe")
 			return nil, errx.InternalError()
 		}
+		removed, err := collectLinks(drows, c.ID)
+		if err != nil {
+			db.CaptureError(err, "", nil, "categories wipe returning")
+			return nil, errx.InternalError()
+		}
+		categoriesRemoved = append(categoriesRemoved, removed...)
 		if len(ids) > 0 {
-			if _, err := tx.Exec(ctx, `
+			irows, err := tx.Query(ctx, `
 				INSERT INTO contact_categories (contact_id, category_id)
 				SELECT $1, cat.id
 				FROM   categories cat
 				WHERE  cat.id = ANY($2) AND cat.user_id = $3
 				ON CONFLICT (contact_id, category_id) DO NOTHING
-			`, contactID, ids, userID); err != nil {
+				RETURNING category_id
+			`, contactID, ids, userID)
+			if err != nil {
 				db.CaptureError(err, "", nil, "categories insert")
 				return nil, errx.InternalError()
 			}
+			added, err := collectLinks(irows, c.ID)
+			if err != nil {
+				db.CaptureError(err, "", nil, "categories insert returning")
+				return nil, errx.InternalError()
+			}
+			categoriesAdded = append(categoriesAdded, added...)
 		}
 		categoriesChanged = true
 	} else {
@@ -1600,16 +1709,24 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 			if perr != nil {
 				return nil, perr
 			}
-			if _, err := tx.Exec(ctx, `
+			irows, err := tx.Query(ctx, `
 				INSERT INTO contact_categories (contact_id, category_id)
 				SELECT $1, cat.id
 				FROM   categories cat
 				WHERE  cat.id = ANY($2) AND cat.user_id = $3
 				ON CONFLICT (contact_id, category_id) DO NOTHING
-			`, contactID, ids, userID); err != nil {
+				RETURNING category_id
+			`, contactID, ids, userID)
+			if err != nil {
 				db.CaptureError(err, "", nil, "categories add")
 				return nil, errx.InternalError()
 			}
+			added, err := collectLinks(irows, c.ID)
+			if err != nil {
+				db.CaptureError(err, "", nil, "categories add returning")
+				return nil, errx.InternalError()
+			}
+			categoriesAdded = append(categoriesAdded, added...)
 			categoriesChanged = true
 		}
 		if len(data.RemoveCategories) > 0 {
@@ -1617,13 +1734,21 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 			if perr != nil {
 				return nil, perr
 			}
-			if _, err := tx.Exec(ctx, `
+			drows, err := tx.Query(ctx, `
 				DELETE FROM contact_categories
 				WHERE contact_id = $1 AND category_id = ANY($2)
-			`, contactID, ids); err != nil {
+				RETURNING category_id
+			`, contactID, ids)
+			if err != nil {
 				db.CaptureError(err, "", nil, "categories remove")
 				return nil, errx.InternalError()
 			}
+			removed, err := collectLinks(drows, c.ID)
+			if err != nil {
+				db.CaptureError(err, "", nil, "categories remove returning")
+				return nil, errx.InternalError()
+			}
+			categoriesRemoved = append(categoriesRemoved, removed...)
 			categoriesChanged = true
 		}
 	}
@@ -1655,6 +1780,23 @@ func (r *contactRepository) Update(ctx context.Context, userID, contactID string
 		}
 	}
 
+	actor := actorID(userID)
+	for _, w := range []struct {
+		typ   models.ActivityType
+		links []contactLink
+		log   func(context.Context, activityWriter, uuid.UUID, *uuid.UUID, models.ActivityType, []contactLink) error
+	}{
+		{models.ActivityCampaignAdded, campaignsAdded, logCampaignLinks},
+		{models.ActivityCampaignRemoved, campaignsRemoved, logCampaignLinks},
+		{models.ActivityCategoryAdded, categoriesAdded, logCategoryLinks},
+		{models.ActivityCategoryRemoved, categoriesRemoved, logCategoryLinks},
+	} {
+		if err := w.log(ctx, tx, orgID, actor, w.typ, w.links); err != nil {
+			db.CaptureError(err, "", nil, string(w.typ)+" activity")
+			return nil, errx.InternalError()
+		}
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		db.CaptureError(err, "", nil, "commit")
 		return nil, errx.InternalError()
@@ -1680,22 +1822,45 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 			*data.Subscribe, orgID, data.Contacts)
 	}
 
-	// Campaigns are organization assets: scoping them by the caller made a
-	// teammate's "add to campaign" a silent no-op on campaigns they did not create.
+	// Membership changes run outside the batch: their RETURNING rows are what
+	// the activity timeline records. Campaigns are organization assets:
+	// scoping them by the caller made a teammate's "add to campaign" a silent
+	// no-op on campaigns they did not create.
+	actor := actorID(userID)
+	link := func(sql string, typ models.ActivityType, log func(context.Context, activityWriter, uuid.UUID, *uuid.UUID, models.ActivityType, []contactLink) error, args ...any) *errx.Error {
+		rows, err := tx.Query(ctx, sql, args...)
+		if err != nil {
+			db.CaptureError(err, sql, args, "bulk link")
+			return errx.InternalError()
+		}
+		links, err := collectLinkPairs(rows)
+		if err != nil {
+			db.CaptureError(err, sql, args, "bulk link returning")
+			return errx.InternalError()
+		}
+		if err := log(ctx, tx, orgID, actor, typ, links); err != nil {
+			db.CaptureError(err, "", nil, string(typ)+" activity")
+			return errx.InternalError()
+		}
+		return nil
+	}
 	if len(data.RemoveCampaigns) > 0 {
-		b.Queue(`DELETE FROM campaign_leads cl
+		if xerr := link(`DELETE FROM campaign_leads cl
 		         USING contacts c, campaigns cam
 		         WHERE cl.contact_id = c.id
 		           AND cl.campaign_id = cam.id
 		           AND c.organization_id = $1
 		           AND cam.organization_id = $1
 		           AND cl.contact_id = ANY($2)
-		           AND cl.campaign_id = ANY($3)`,
-			orgID, data.Contacts, data.RemoveCampaigns)
+		           AND cl.campaign_id = ANY($3)
+		         RETURNING cl.contact_id, cl.campaign_id`,
+			models.ActivityCampaignRemoved, logCampaignLinks, orgID, data.Contacts, data.RemoveCampaigns); xerr != nil {
+			return nil, xerr
+		}
 	}
 
 	if len(data.AddCampaigns) > 0 {
-		b.Queue(`INSERT INTO campaign_leads (contact_id, campaign_id)
+		if xerr := link(`INSERT INTO campaign_leads (contact_id, campaign_id)
 		         SELECT c.id, cam.id
 		         FROM contacts c
 		         CROSS JOIN campaigns cam
@@ -1703,22 +1868,28 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 		           AND c.id = ANY($2)
 		           AND cam.id = ANY($3::uuid[])
 		           AND cam.organization_id = $1
-		         ON CONFLICT DO NOTHING`,
-			orgID, data.Contacts, data.AddCampaigns)
+		         ON CONFLICT DO NOTHING
+		         RETURNING contact_id, campaign_id`,
+			models.ActivityCampaignAdded, logCampaignLinks, orgID, data.Contacts, data.AddCampaigns); xerr != nil {
+			return nil, xerr
+		}
 	}
 
 	if len(data.RemoveCategories) > 0 {
-		b.Queue(`DELETE FROM contact_categories cc
+		if xerr := link(`DELETE FROM contact_categories cc
 		         USING contacts c
 		         WHERE cc.contact_id = c.id
 		           AND c.organization_id = $1
 		           AND cc.contact_id = ANY($2)
-		           AND cc.category_id = ANY($3::uuid[])`,
-			orgID, data.Contacts, data.RemoveCategories)
+		           AND cc.category_id = ANY($3::uuid[])
+		         RETURNING cc.contact_id, cc.category_id`,
+			models.ActivityCategoryRemoved, logCategoryLinks, orgID, data.Contacts, data.RemoveCategories); xerr != nil {
+			return nil, xerr
+		}
 	}
 
 	if len(data.AddCategories) > 0 {
-		b.Queue(`INSERT INTO contact_categories (contact_id, category_id)
+		if xerr := link(`INSERT INTO contact_categories (contact_id, category_id)
 		         SELECT c.id, cat.id
 		         FROM contacts c
 		         CROSS JOIN categories cat
@@ -1726,8 +1897,11 @@ func (r *contactRepository) BulkUpdate(ctx context.Context, userID string, orgID
 		           AND c.id = ANY($2)
 		           AND cat.id = ANY($3::uuid[])
 		           AND cat.user_id = $4
-		         ON CONFLICT DO NOTHING`,
-			orgID, data.Contacts, data.AddCategories, userID)
+		         ON CONFLICT DO NOTHING
+		         RETURNING contact_id, category_id`,
+			models.ActivityCategoryAdded, logCategoryLinks, orgID, data.Contacts, data.AddCategories, userID); xerr != nil {
+			return nil, xerr
+		}
 	}
 
 	for _, p := range data.Fields {
@@ -2190,6 +2364,7 @@ func (r *contactRepository) GetDetail(ctx context.Context, userID uuid.UUID, org
 		SELECT
 			c.id, c.first_name, c.last_name, c.email, c.company, c.phone,
 			c.custom_fields, c.subscribed, c.updated_at, c.created_at,
+			c.source, c.source_detail, c.first_seen_at,
 			COALESCE(
 				(
 					SELECT json_agg(json_build_object('id', cam.id, 'name', cam.name))
@@ -2216,7 +2391,9 @@ func (r *contactRepository) GetDetail(ctx context.Context, userID uuid.UUID, org
 	err := r.DB.QueryRow(ctx, mainQuery, mainArgs...).Scan(
 		&detail.ID, &detail.FirstName, &detail.LastName, &detail.Email,
 		&detail.Company, &detail.Phone, &detail.CustomFields, &detail.Subscribed,
-		&detail.UpdatedAt, &detail.CreatedAt, &campaignsJSON, &categoriesJSON,
+		&detail.UpdatedAt, &detail.CreatedAt,
+		&detail.Source, &detail.SourceDetail, &detail.FirstSeenAt,
+		&campaignsJSON, &categoriesJSON,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -2419,6 +2596,8 @@ func (r *contactRepository) ListSentEmails(ctx context.Context, userID, contactI
 //   - deliverability_events           → bounce / complaint
 //   - suppressed_recipients           → suppression added
 //   - contact_notes                   → CRM notes
+//   - meeting_bookings                → meetings
+//   - contact_activities              → creation and campaign / category membership
 //
 // We pull up to (limit) candidates from each source ordered by time
 // DESC, then merge-sort in Go. This avoids a 5-way UNION with
@@ -2717,6 +2896,64 @@ func (r *contactRepository) ListTimeline(ctx context.Context, userID uuid.UUID, 
 			events = append(events, ev)
 		}
 		mrows.Close()
+
+		// 7. Lifecycle: creation (with its first-touch source) and campaign /
+		//    category membership changes, from contact_activities. Names were
+		//    resolved when the row was written, so a renamed or deleted
+		//    campaign still reads correctly.
+		lifeQuery := `
+			SELECT created_at, user_id, activity_type, metadata
+			FROM contact_activities
+			WHERE contact_id = $1
+			  AND organization_id = $2
+			  AND activity_type IN ('contact_created', 'campaign_added', 'campaign_removed', 'category_added', 'category_removed')
+			  AND created_at < $3
+			ORDER BY created_at DESC
+			LIMIT $4
+		`
+		lrows, err := r.DB.Query(ctx, lifeQuery, contactID, *orgID, bound, limit)
+		if err != nil {
+			db.CaptureError(err, lifeQuery, nil, "ListTimeline lifecycle")
+			return nil, errx.InternalError()
+		}
+		for lrows.Next() {
+			var ev models.ContactTimelineEvent
+			var typ string
+			var meta map[string]any
+			if err := lrows.Scan(&ev.At, &ev.UserID, &typ, &meta); err != nil {
+				lrows.Close()
+				db.CaptureError(err, "", nil, "ListTimeline lifecycle scan")
+				return nil, errx.InternalError()
+			}
+			ev.Type = models.ContactTimelineEventType(typ)
+			str := func(k string) *string {
+				if v, ok := meta[k].(string); ok && v != "" {
+					return &v
+				}
+				return nil
+			}
+			id := func(k string) *uuid.UUID {
+				if v, ok := meta[k].(string); ok {
+					if u, perr := uuid.Parse(v); perr == nil {
+						return &u
+					}
+				}
+				return nil
+			}
+			switch ev.Type {
+			case models.TimelineContactCreated:
+				ev.Source = str("source")
+				ev.SourceDetail = str("source_detail")
+			case models.TimelineCampaignAdded, models.TimelineCampaignRemoved:
+				ev.CampaignID = id("campaign_id")
+				ev.CampaignName = str("campaign_name")
+			case models.TimelineCategoryAdded, models.TimelineCategoryRemoved:
+				ev.CategoryID = id("category_id")
+				ev.CategoryTitle = str("category_title")
+			}
+			events = append(events, ev)
+		}
+		lrows.Close()
 	}
 
 	// Merge sort: newest first.

--- a/internal/repository/pg_contact_activity.go
+++ b/internal/repository/pg_contact_activity.go
@@ -1,0 +1,130 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// activityWriter is the slice of pgx.Tx the lifecycle loggers need, so they
+// run inside the mutation's own transaction and a rolled-back link never
+// leaves a stray "added to campaign" event behind.
+type activityWriter interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+}
+
+// contactLink is one (contact, campaign-or-category) membership change.
+type contactLink struct {
+	ContactID uuid.UUID
+	LinkID    uuid.UUID
+}
+
+// actorID turns the caller id the repository receives into the nullable
+// users reference contact_activities stores.
+func actorID(userID string) *uuid.UUID {
+	id, err := uuid.Parse(userID)
+	if err != nil {
+		return nil
+	}
+	return &id
+}
+
+// logContactCreated records the contact_created lifecycle event for freshly
+// inserted rows, carrying the first-touch source they were stamped with.
+func logContactCreated(ctx context.Context, tx activityWriter, orgID uuid.UUID, userID *uuid.UUID, contactIDs []uuid.UUID) error {
+	if len(contactIDs) == 0 {
+		return nil
+	}
+	_, err := tx.Exec(ctx, `
+		INSERT INTO contact_activities (contact_id, organization_id, user_id, activity_type, metadata)
+		SELECT c.id, $1, $2, 'contact_created',
+		       jsonb_build_object('source', c.source, 'source_detail', c.source_detail)
+		FROM   contacts c
+		WHERE  c.id = ANY($3) AND c.organization_id = $1
+	`, orgID, userID, contactIDs)
+	return err
+}
+
+// logCampaignLinks records campaign_added / campaign_removed events, resolving
+// the campaign name at write time so the timeline survives a later rename or
+// deletion of the campaign.
+func logCampaignLinks(ctx context.Context, tx activityWriter, orgID uuid.UUID, userID *uuid.UUID, typ models.ActivityType, links []contactLink) error {
+	if len(links) == 0 {
+		return nil
+	}
+	contacts, targets := splitLinks(links)
+	_, err := tx.Exec(ctx, `
+		INSERT INTO contact_activities (contact_id, organization_id, user_id, activity_type, metadata)
+		SELECT l.contact_id, $1, $2, $3::activity_type,
+		       jsonb_build_object('campaign_id', cam.id, 'campaign_name', cam.name)
+		FROM   unnest($4::uuid[], $5::uuid[]) AS l(contact_id, campaign_id)
+		JOIN   campaigns cam ON cam.id = l.campaign_id
+	`, orgID, userID, string(typ), contacts, targets)
+	return err
+}
+
+// logCategoryLinks is the category twin of logCampaignLinks.
+func logCategoryLinks(ctx context.Context, tx activityWriter, orgID uuid.UUID, userID *uuid.UUID, typ models.ActivityType, links []contactLink) error {
+	if len(links) == 0 {
+		return nil
+	}
+	contacts, targets := splitLinks(links)
+	_, err := tx.Exec(ctx, `
+		INSERT INTO contact_activities (contact_id, organization_id, user_id, activity_type, metadata)
+		SELECT l.contact_id, $1, $2, $3::activity_type,
+		       jsonb_build_object('category_id', cat.id, 'category_title', cat.title)
+		FROM   unnest($4::uuid[], $5::uuid[]) AS l(contact_id, category_id)
+		JOIN   categories cat ON cat.id = l.category_id
+	`, orgID, userID, string(typ), contacts, targets)
+	return err
+}
+
+func splitLinks(links []contactLink) ([]uuid.UUID, []uuid.UUID) {
+	contacts := make([]uuid.UUID, len(links))
+	targets := make([]uuid.UUID, len(links))
+	for i, l := range links {
+		contacts[i] = l.ContactID
+		targets[i] = l.LinkID
+	}
+	return contacts, targets
+}
+
+// collectLinks drains a RETURNING (id) result into links for one contact.
+func collectLinks(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}, contactID uuid.UUID) ([]contactLink, error) {
+	defer rows.Close()
+	var out []contactLink
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, contactLink{ContactID: contactID, LinkID: id})
+	}
+	return out, rows.Err()
+}
+
+// collectLinkPairs drains a RETURNING (contact_id, id) result.
+func collectLinkPairs(rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close()
+	Err() error
+}) ([]contactLink, error) {
+	defer rows.Close()
+	var out []contactLink
+	for rows.Next() {
+		var l contactLink
+		if err := rows.Scan(&l.ContactID, &l.LinkID); err != nil {
+			return nil, err
+		}
+		out = append(out, l)
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/pg_contact_campaign_state.go
+++ b/internal/repository/pg_contact_campaign_state.go
@@ -1,0 +1,221 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/infrastructure/db"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ListCampaignStates reads every campaign the contact is a lead of, with the
+// flow's steps, this contact's progress on each, and the lead status the
+// Leads list derives. Next is left nil: it is scheduler-derived and filled by
+// the service.
+func (r *contactRepository) ListCampaignStates(ctx context.Context, orgID, contactID uuid.UUID) ([]models.ContactCampaignState, *errx.Error) {
+	campQuery := `
+		SELECT cam.id, cam.name, cam.status, c.subscribed, ` + undeliverableClause("cam.id") + `
+		FROM campaign_leads cl
+		JOIN campaigns cam ON cam.id = cl.campaign_id AND cam.organization_id = $2
+		JOIN contacts c ON c.id = cl.contact_id AND c.organization_id = $2
+		WHERE cl.contact_id = $1
+		ORDER BY cam.created_at DESC
+	`
+	rows, err := r.DB.Query(ctx, campQuery, contactID, orgID)
+	if err != nil {
+		db.CaptureError(err, campQuery, []any{contactID, orgID}, "ListCampaignStates campaigns")
+		return nil, errx.InternalError()
+	}
+	type campRow struct {
+		state         models.ContactCampaignState
+		subscribed    bool
+		undeliverable bool
+	}
+	var camps []campRow
+	for rows.Next() {
+		var cr campRow
+		if err := rows.Scan(&cr.state.CampaignID, &cr.state.CampaignName, &cr.state.CampaignStatus, &cr.subscribed, &cr.undeliverable); err != nil {
+			rows.Close()
+			db.CaptureError(err, "", nil, "ListCampaignStates campaigns scan")
+			return nil, errx.InternalError()
+		}
+		camps = append(camps, cr)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		db.CaptureError(err, "", nil, "ListCampaignStates campaigns rows")
+		return nil, errx.InternalError()
+	}
+
+	out := make([]models.ContactCampaignState, 0, len(camps))
+	for _, cr := range camps {
+		st := cr.state
+		steps, failureReason, xerr := r.campaignStepsForContact(ctx, st.CampaignID, contactID)
+		if xerr != nil {
+			return nil, xerr
+		}
+		st.Steps = steps
+		st.TotalSteps = len(steps)
+
+		var sent, replied, bounced, failed bool
+		var emailSteps, emailSent int
+		var lastAt time.Time
+		for i := range steps {
+			s := &steps[i]
+			if s.Kind == "email" {
+				emailSteps++
+			}
+			if s.SentAt != nil {
+				sent = true
+				st.CompletedSteps++
+				if s.Kind == "email" {
+					emailSent++
+				}
+				if s.SentAt.After(lastAt) {
+					lastAt = *s.SentAt
+					st.LastAction, st.LastActionAt = "Sent", s.SentAt
+					if s.Kind != "email" {
+						st.LastAction = "Ran"
+					}
+					cur := *s
+					st.CurrentStep = &cur
+				}
+			}
+			for _, ev := range []struct {
+				at    *time.Time
+				label string
+			}{
+				{s.OpenedAt, "Opened"}, {s.ClickedAt, "Clicked"}, {s.RepliedAt, "Replied"},
+				{s.BouncedAt, "Bounced"}, {s.FailedAt, "Send failed"},
+			} {
+				if ev.at != nil && ev.at.After(lastAt) {
+					lastAt = *ev.at
+					st.LastAction, st.LastActionAt = ev.label, ev.at
+				}
+			}
+			replied = replied || s.RepliedAt != nil
+			bounced = bounced || s.BouncedAt != nil
+			if s.SentAt == nil && s.FailedAt != nil && s.Attempts >= config.CampaignSendMaxAttempts {
+				failed = true
+				st.FailureReason = failureReason
+			}
+		}
+		// Same priority as leadStatusClause: unsubscribed > bounced > replied >
+		// failed > completed > active > undeliverable > pending.
+		switch {
+		case !cr.subscribed:
+			st.LeadStatus = models.LeadStatusUnsubscribed
+		case bounced:
+			st.LeadStatus = models.LeadStatusBounced
+		case replied:
+			st.LeadStatus = models.LeadStatusReplied
+		case failed:
+			st.LeadStatus = models.LeadStatusFailed
+		case sent && emailSteps > 0 && emailSent >= emailSteps:
+			st.LeadStatus = models.LeadStatusCompleted
+		case sent:
+			st.LeadStatus = models.LeadStatusActive
+		case cr.undeliverable:
+			st.LeadStatus = models.LeadStatusUndeliverable
+		default:
+			st.LeadStatus = models.LeadStatusPending
+		}
+		out = append(out, st)
+	}
+	return out, nil
+}
+
+// campaignStepsForContact returns the campaign's steps in canvas order with
+// the contact's progress folded in, plus the worker's reason for the latest
+// failed send. Labels follow the Leads list: custom name, else "Email N",
+// else the action's label.
+func (r *contactRepository) campaignStepsForContact(ctx context.Context, campaignID, contactID uuid.UUID) ([]models.ContactCampaignStep, string, *errx.Error) {
+	stepQuery := `
+		SELECT s.id, s.name, s.subject, s.kind, s.action, s.position,
+		       p.sent_at, p.opened_at, p.clicked_at, p.replied_at, p.bounced_at, p.failed_at,
+		       COALESCE(p.send_attempts, 0), p.dispatched_at, COALESCE(p.failure_reason, '')
+		FROM sequences s
+		LEFT JOIN campaign_contact_progress p
+		       ON p.campaign_id = s.campaign_id AND p.sequence_id = s.id AND p.contact_id = $2
+		WHERE s.campaign_id = $1
+		ORDER BY s.position ASC, s.created_at ASC
+	`
+	rows, err := r.DB.Query(ctx, stepQuery, campaignID, contactID)
+	if err != nil {
+		db.CaptureError(err, stepQuery, []any{campaignID, contactID}, "ListCampaignStates steps")
+		return nil, "", errx.InternalError()
+	}
+	defer rows.Close()
+	var steps []models.ContactCampaignStep
+	var failureReason string
+	var failedAt time.Time
+	emails := 0
+	for rows.Next() {
+		var s models.ContactCampaignStep
+		var name string
+		var action []byte
+		var dispatchedAt *time.Time
+		var reason string
+		if err := rows.Scan(&s.ID, &name, &s.Subject, &s.Kind, &action, &s.Position,
+			&s.SentAt, &s.OpenedAt, &s.ClickedAt, &s.RepliedAt, &s.BouncedAt, &s.FailedAt,
+			&s.Attempts, &dispatchedAt, &reason); err != nil {
+			db.CaptureError(err, "", nil, "ListCampaignStates steps scan")
+			return nil, "", errx.InternalError()
+		}
+		if s.Kind == "email" {
+			emails++
+		}
+		s.Label = stepLabel(name, s.Kind, action, emails)
+		s.InFlight = s.SentAt == nil && dispatchedAt != nil
+		if s.Kind != "email" {
+			s.Subject = ""
+		}
+		if reason != "" && s.FailedAt != nil && s.FailedAt.After(failedAt) {
+			failedAt, failureReason = *s.FailedAt, reason
+		}
+		steps = append(steps, s)
+	}
+	if err := rows.Err(); err != nil {
+		db.CaptureError(err, "", nil, "ListCampaignStates steps rows")
+		return nil, "", errx.InternalError()
+	}
+	return steps, failureReason, nil
+}
+
+// stepLabel mirrors the SQL label in the Leads search: custom name, else
+// "Email N" (Nth email step in canvas order), else the node's action.
+func stepLabel(name, kind string, action []byte, emailOrdinal int) string {
+	if n := strings.TrimSpace(name); n != "" {
+		return n
+	}
+	switch kind {
+	case "email":
+		return "Email " + itoa(emailOrdinal)
+	case "wait":
+		return "Wait"
+	case "action":
+		var cfg models.ActionConfig
+		if len(action) > 0 {
+			_ = json.Unmarshal(action, &cfg)
+		}
+		switch cfg.Type {
+		case "add_tag":
+			return "Add tag"
+		case "remove_tag":
+			return "Remove tag"
+		case "unsubscribe":
+			return "Unsubscribe"
+		case "notify":
+			return "Notify"
+		case "wait":
+			return "Wait"
+		}
+		return "Action"
+	}
+	return "Step"
+}

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -36,62 +36,10 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		}
 	}
 
-	// STEP 2: Resolve the campaign's sending mailboxes. Explicit strategy uses
-	// the campaign_senders pool (carrying per-sender rotation metadata); tags
-	// strategy keeps the existing tag-based resolution. An empty explicit pool
-	// falls back to tags so a misconfigured campaign still sends.
-	type senderMeta struct {
-		weight           int
-		rotationPosition int
-		lastSentAt       *time.Time
-		hasMeta          bool
-	}
-	accounts := []models.Email{}
-	senderMetaByID := map[uuid.UUID]senderMeta{}
-	seen := map[uuid.UUID]bool{}
-	// UNION of the explicit campaign_senders pool and the tag-resolved mailboxes
-	// (one dropdown picks both — they're no longer mutually exclusive). When the
-	// campaign selects NEITHER tags nor explicit accounts, it sends from ALL of
-	// the active mailboxes in the campaign's tenant ("all").
-	//
-	// Tenancy is the campaign's organization, never its owner: a user who belongs
-	// to two organizations must not have organization A's campaign pick up an
-	// organization B mailbox and burn B's reputation, caps and warmup state. A
-	// campaign with no organization resolves to no mailboxes, the same way the
-	// campaign task halts it rather than sending unchecked.
-	scope := repository.NewAccountScope(campaign.OrganizationID)
-	senders, serr := s.emailRepo.GetByCampaignSenders(ctx, scope, campaignID)
-	if serr != nil {
-		return time.Time{}, nil, uuid.Nil, serr
-	}
-	for _, snd := range senders {
-		accounts = append(accounts, snd.Account)
-		seen[snd.Account.ID] = true
-		senderMetaByID[snd.Account.ID] = senderMeta{
-			weight:           snd.Weight,
-			rotationPosition: snd.RotationPosition,
-			lastSentAt:       snd.LastSentAt,
-			hasMeta:          true,
-		}
-	}
-	if len(campaign.EmailTags) > 0 {
-		tagAccounts, terr := s.emailRepo.GetByTags(ctx, scope, campaign.EmailTags)
-		if terr != nil {
-			return time.Time{}, nil, uuid.Nil, terr
-		}
-		for _, ta := range tagAccounts {
-			if !seen[ta.ID] {
-				accounts = append(accounts, ta)
-				seen[ta.ID] = true
-			}
-		}
-	}
-	if len(senders) == 0 && len(campaign.EmailTags) == 0 {
-		allAccts, aerr := s.emailRepo.GetAllActiveInScope(ctx, scope)
-		if aerr != nil {
-			return time.Time{}, nil, uuid.Nil, aerr
-		}
-		accounts = allAccts
+	// STEP 2: Resolve the campaign's sending mailboxes.
+	accounts, senderMetaByID, err := s.campaignSenders(ctx, campaign)
+	if err != nil {
+		return time.Time{}, nil, uuid.Nil, err
 	}
 
 	if len(accounts) == 0 {
@@ -172,6 +120,85 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// no branches. A step is sent only if the flow reaches it; STOP/end and
 	// already-sent loops drop the contact in the finder. Conditions are evaluated
 	// at schedule time (a known, accepted race vs. last-moment engagement).
+	return s.placeCampaignSend(ctx, campaign, accounts, senderMetaByID, nextPair, false)
+}
+
+// senderMeta is a mailbox's campaign_senders rotation metadata.
+type senderMeta struct {
+	weight           int
+	rotationPosition int
+	lastSentAt       *time.Time
+	hasMeta          bool
+}
+
+// campaignSenders resolves the campaign's sending mailboxes. Explicit strategy
+// uses the campaign_senders pool (carrying per-sender rotation metadata); tags
+// strategy keeps the existing tag-based resolution. An empty explicit pool
+// falls back to tags so a misconfigured campaign still sends.
+func (s *schedulerService) campaignSenders(ctx context.Context, campaign *models.Campaign) ([]models.Email, map[uuid.UUID]senderMeta, error) {
+	campaignID := campaign.ID
+	accounts := []models.Email{}
+	senderMetaByID := map[uuid.UUID]senderMeta{}
+	seen := map[uuid.UUID]bool{}
+	// UNION of the explicit campaign_senders pool and the tag-resolved mailboxes
+	// (one dropdown picks both — they're no longer mutually exclusive). When the
+	// campaign selects NEITHER tags nor explicit accounts, it sends from ALL of
+	// the active mailboxes in the campaign's tenant ("all").
+	//
+	// Tenancy is the campaign's organization, never its owner: a user who belongs
+	// to two organizations must not have organization A's campaign pick up an
+	// organization B mailbox and burn B's reputation, caps and warmup state. A
+	// campaign with no organization resolves to no mailboxes, the same way the
+	// campaign task halts it rather than sending unchecked.
+	scope := repository.NewAccountScope(campaign.OrganizationID)
+	senders, serr := s.emailRepo.GetByCampaignSenders(ctx, scope, campaignID)
+	if serr != nil {
+		return nil, nil, serr
+	}
+	for _, snd := range senders {
+		accounts = append(accounts, snd.Account)
+		seen[snd.Account.ID] = true
+		senderMetaByID[snd.Account.ID] = senderMeta{
+			weight:           snd.Weight,
+			rotationPosition: snd.RotationPosition,
+			lastSentAt:       snd.LastSentAt,
+			hasMeta:          true,
+		}
+	}
+	if len(campaign.EmailTags) > 0 {
+		tagAccounts, terr := s.emailRepo.GetByTags(ctx, scope, campaign.EmailTags)
+		if terr != nil {
+			return nil, nil, terr
+		}
+		for _, ta := range tagAccounts {
+			if !seen[ta.ID] {
+				accounts = append(accounts, ta)
+				seen[ta.ID] = true
+			}
+		}
+	}
+	if len(senders) == 0 && len(campaign.EmailTags) == 0 {
+		allAccts, aerr := s.emailRepo.GetAllActiveInScope(ctx, scope)
+		if aerr != nil {
+			return nil, nil, aerr
+		}
+		accounts = allAccts
+	}
+	return accounts, senderMetaByID, nil
+}
+
+// placeCampaignSend runs every hard constraint and pacing rule on one
+// (contact, step) pair against the campaign's mailbox pool and returns the
+// slot, exactly as the send path uses it. preview makes it read-only (no
+// decision logs, no cached writes) so the contact drawer can ask "when would
+// this step go" through the same rules the scheduler applies.
+func (s *schedulerService) placeCampaignSend(ctx context.Context, campaign *models.Campaign, accounts []models.Email, senderMetaByID map[uuid.UUID]senderMeta, nextPair *repository.ContactSequencePair, preview bool) (time.Time, *repository.ContactSequencePair, uuid.UUID, error) {
+	campaignID := campaign.ID
+	logDecision := func(eventType, message string, metadata map[string]interface{}) {
+		if !preview {
+			s.logCampaignDecision(ctx, campaignID, eventType, message, metadata)
+		}
+	}
 
 	// STEP 3.5: Resolve the recipient ESP/provider for ESP matching. Cheap:
 	// prefer the cached contact.esp_provider, else derive from the domain
@@ -195,7 +222,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 		} else {
 			recipientProvider = providerForEmailDomain(recipientContact.Email)
 			// Opportunistically cache the derived provider (best-effort).
-			if recipientProvider != "" {
+			if recipientProvider != "" && !preview {
 				_ = s.contactRepo.SetContactESP(ctx, recipientContact.ID, recipientProvider)
 			}
 		}
@@ -259,7 +286,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// manual send gate.
 	riskState := s.orgRiskState(ctx, campaign.OrganizationID)
 	if riskState.BlocksSending() {
-		s.logCampaignDecision(ctx, campaignID, "org_suspended",
+		logDecision("org_suspended",
 			"Sending is paused for this workspace while it is under review", nil)
 		return s.deferToNextDay(campaign), nil, accounts[0].ID, ErrCampaignDeferred
 	}
@@ -479,7 +506,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// every few minutes for a condition the mailbox badge, the Advisor card and
 	// the notification already cover.
 	if len(candidates) == 0 && authGated == len(accounts) {
-		s.logCampaignDecision(ctx, campaignID, "domain_auth_gated",
+		logDecision("domain_auth_gated",
 			"No mailbox can send: every sending domain fails SPF/DMARC authentication",
 			map[string]interface{}{"gated_mailboxes": authGated, "pool_size": len(accounts)})
 		return time.Time{}, nil, uuid.Nil, ErrDomainAuthFailing
@@ -488,7 +515,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	// Every mailbox is out of cold rotation. Say so rather than letting the
 	// campaign look stalled for no visible reason; they return on their own.
 	if len(candidates) == 0 && lifecycleGated == len(accounts) {
-		s.logCampaignDecision(ctx, campaignID, "mailboxes_resting",
+		logDecision("mailboxes_resting",
 			"No mailbox is in cold rotation: all are resting or held in reserve",
 			map[string]interface{}{"resting_mailboxes": lifecycleGated, "pool_size": len(accounts)})
 		return s.deferToNextDay(campaign), nil, accounts[0].ID, ErrCampaignDeferred
@@ -511,7 +538,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			if len(matching) == 0 {
 				// No matching mailbox under budget today: defer to the next slot
 				// rather than complete or send cross-provider.
-				s.logCampaignDecision(ctx, campaignID, "provider_match_deferred",
+				logDecision("provider_match_deferred",
 					"No same-provider mailbox available; deferring to next slot",
 					map[string]interface{}{"recipient_provider": recipientProvider})
 				// Deferral, not a send: nil pair + sentinel so the caller reschedules
@@ -570,7 +597,7 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 			// ESP-strict with no matching mailbox at all: defer rather than
 			// complete or send cross-provider.
 			if campaign.ESPMatchMode == "strict" && recipientProvider != "" {
-				s.logCampaignDecision(ctx, campaignID, "provider_match_deferred",
+				logDecision("provider_match_deferred",
 					"No same-provider mailbox available tomorrow; deferring",
 					map[string]interface{}{"recipient_provider": recipientProvider})
 				// Deferral, not a send (see above).

--- a/internal/scheduler/contact_preview.go
+++ b/internal/scheduler/contact_preview.go
@@ -11,9 +11,7 @@ import (
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
-// ContactSendConstraint names the hard constraint holding a contact's next
-// step back. The caller turns it into copy; the scheduler only knows which
-// gate applied.
+// ContactSendConstraint names the gate holding a step back; the caller words it.
 type ContactSendConstraint string
 
 const (
@@ -30,31 +28,23 @@ const (
 	ConstraintCampaignEnded    ContactSendConstraint = "campaign_ended"
 )
 
-// ContactSendPreview is a read-only answer to "what happens next for this
-// contact in this campaign". Route says which step; State, ScheduledAt and
-// NotBefore say when, through the same constraints the send path applies.
+// ContactSendPreview is a read-only "what happens next" for one contact in
+// one campaign; ScheduledAt is set only when the step is due now.
 type ContactSendPreview struct {
-	Route *repository.ContactRoute
-	State models.ContactNextActionState
-	// ScheduledAt is set only when the step is due now: the slot the scheduler
-	// would give it this tick.
+	Route       *repository.ContactRoute
+	State       models.ContactNextActionState
 	ScheduledAt *time.Time
-	// NotBefore is the earliest the hard constraints allow the step.
-	NotBefore  *time.Time
-	Constraint ContactSendConstraint
+	NotBefore   *time.Time
+	Constraint  ContactSendConstraint
 }
 
-// ContactSendPreviewer is the capability the contact drawer reads; the
-// scheduler service satisfies it.
+// ContactSendPreviewer is satisfied by the scheduler service.
 type ContactSendPreviewer interface {
 	PreviewContactSend(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactSendPreview, error)
 }
 
-// PreviewContactSend derives the contact's next step and its timing without
-// writing anything: it routes the contact the way FindNextRoutedPair does and
-// places the send the way CalculateNextCampaignTime does. A campaign is one
-// self-perpetuating task, so this is the only honest source of "scheduled
-// for"; nothing per contact is stored.
+// PreviewContactSend routes and places one contact through the send path's
+// own rules without writing anything.
 func (s *schedulerService) PreviewContactSend(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactSendPreview, error) {
 	campaign, err := s.campaignRepo.GetByID(ctx, campaignID)
 	if err != nil {
@@ -81,6 +71,8 @@ func (s *schedulerService) PreviewContactSend(ctx context.Context, campaignID, c
 		pv.Constraint = ConstraintCampaignInactive
 		return pv, nil
 	}
+
+	projectRampLevel(campaign, time.Now())
 
 	accounts, meta, err := s.campaignSenders(ctx, campaign)
 	if err != nil {
@@ -146,4 +138,19 @@ func (s *schedulerService) deferralConstraint(ctx context.Context, campaign *mod
 		}
 	}
 	return ConstraintCapacity
+}
+
+// projectRampLevel applies today's ramp advance in memory, mirroring
+// campaignRepo.AdvanceRampLevel, so a preview on a new UTC day budgets with
+// the level the next real pass will persist instead of yesterday's.
+func projectRampLevel(c *models.Campaign, now time.Time) {
+	if !c.RampEnabled {
+		return
+	}
+	today := now.UTC().Truncate(24 * time.Hour)
+	if c.RampLevelDate != nil && !c.RampLevelDate.UTC().Truncate(24*time.Hour).Before(today) {
+		return
+	}
+	c.RampLevel = min(c.RampCeiling, max(c.RampLevel, c.RampStart)+c.RampIncrement)
+	c.RampLevelDate = &today
 }

--- a/internal/scheduler/contact_preview.go
+++ b/internal/scheduler/contact_preview.go
@@ -1,0 +1,149 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// ContactSendConstraint names the hard constraint holding a contact's next
+// step back. The caller turns it into copy; the scheduler only knows which
+// gate applied.
+type ContactSendConstraint string
+
+const (
+	ConstraintNone             ContactSendConstraint = ""
+	ConstraintStepWait         ContactSendConstraint = "step_wait"
+	ConstraintConditionWindow  ContactSendConstraint = "condition_window"
+	ConstraintStartDate        ContactSendConstraint = "start_date"
+	ConstraintSendingWindow    ContactSendConstraint = "sending_window"
+	ConstraintNewLeadCap       ContactSendConstraint = "new_lead_cap"
+	ConstraintCapacity         ContactSendConstraint = "capacity"
+	ConstraintCampaignInactive ContactSendConstraint = "campaign_inactive"
+	ConstraintNoMailbox        ContactSendConstraint = "no_mailbox"
+	ConstraintDomainAuth       ContactSendConstraint = "domain_auth"
+	ConstraintCampaignEnded    ContactSendConstraint = "campaign_ended"
+)
+
+// ContactSendPreview is a read-only answer to "what happens next for this
+// contact in this campaign". Route says which step; State, ScheduledAt and
+// NotBefore say when, through the same constraints the send path applies.
+type ContactSendPreview struct {
+	Route *repository.ContactRoute
+	State models.ContactNextActionState
+	// ScheduledAt is set only when the step is due now: the slot the scheduler
+	// would give it this tick.
+	ScheduledAt *time.Time
+	// NotBefore is the earliest the hard constraints allow the step.
+	NotBefore  *time.Time
+	Constraint ContactSendConstraint
+}
+
+// ContactSendPreviewer is the capability the contact drawer reads; the
+// scheduler service satisfies it.
+type ContactSendPreviewer interface {
+	PreviewContactSend(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactSendPreview, error)
+}
+
+// PreviewContactSend derives the contact's next step and its timing without
+// writing anything: it routes the contact the way FindNextRoutedPair does and
+// places the send the way CalculateNextCampaignTime does. A campaign is one
+// self-perpetuating task, so this is the only honest source of "scheduled
+// for"; nothing per contact is stored.
+func (s *schedulerService) PreviewContactSend(ctx context.Context, campaignID, contactID uuid.UUID) (*ContactSendPreview, error) {
+	campaign, err := s.campaignRepo.GetByID(ctx, campaignID)
+	if err != nil {
+		return nil, err
+	}
+	route, err := s.campaignProgressRepo.RouteContact(ctx, campaignID, contactID)
+	if err != nil {
+		return nil, err
+	}
+	pv := &ContactSendPreview{Route: route}
+
+	if route.WaitUntil != nil {
+		pv.State = models.NextActionWaiting
+		pv.NotBefore = route.WaitUntil
+		pv.Constraint = ConstraintConditionWindow
+		return pv, nil
+	}
+	if route.Target == nil || route.Excluded != "" {
+		return pv, nil
+	}
+	if campaign.Status != "active" {
+		pv.State = models.NextActionPaused
+		pv.NotBefore = route.DueAt
+		pv.Constraint = ConstraintCampaignInactive
+		return pv, nil
+	}
+
+	accounts, meta, err := s.campaignSenders(ctx, campaign)
+	if err != nil {
+		return nil, err
+	}
+	if len(accounts) == 0 {
+		pv.State = models.NextActionBlocked
+		pv.Constraint = ConstraintNoMailbox
+		return pv, nil
+	}
+
+	pair := &repository.ContactSequencePair{ContactID: contactID, SequenceID: *route.Target, IsNewLead: route.IsNewLead}
+	at, sendable, _, perr := s.placeCampaignSend(ctx, campaign, accounts, meta, pair, true)
+	switch {
+	case perr == nil && sendable != nil:
+		pv.State = models.NextActionDue
+		slot := at
+		pv.ScheduledAt = &slot
+		return pv, nil
+	case errors.Is(perr, ErrCampaignDeferred):
+		pv.State = models.NextActionWaiting
+		slot := at
+		if route.DueAt != nil && route.DueAt.After(slot) {
+			slot = *route.DueAt
+		}
+		pv.NotBefore = &slot
+		pv.Constraint = s.deferralConstraint(ctx, campaign, route)
+		return pv, nil
+	case errors.Is(perr, ErrCampaignEnded):
+		pv.State = models.NextActionBlocked
+		pv.Constraint = ConstraintCampaignEnded
+		return pv, nil
+	case errors.Is(perr, ErrDomainAuthFailing):
+		pv.State = models.NextActionBlocked
+		pv.Constraint = ConstraintDomainAuth
+		return pv, nil
+	case errors.Is(perr, ErrNoEmailAccounts):
+		pv.State = models.NextActionBlocked
+		pv.Constraint = ConstraintCapacity
+		return pv, nil
+	}
+	return nil, perr
+}
+
+// deferralConstraint picks the gate that explains a deferred placement, in
+// the order the send path applies them: the step's own wait, the campaign
+// start date, the sending window, today's new-lead cap, and otherwise the
+// mailbox pool (daily caps, spacing, health, rest).
+func (s *schedulerService) deferralConstraint(ctx context.Context, campaign *models.Campaign, route *repository.ContactRoute) ContactSendConstraint {
+	grace := time.Now().Add(config.CampaignNotDueGraceSeconds * time.Second)
+	if route.DueAt != nil && route.DueAt.After(grace) {
+		return ConstraintStepWait
+	}
+	if campaign.StartDate != nil && campaign.StartDate.After(grace) {
+		return ConstraintStartDate
+	}
+	if nextScheduleSlot(time.Now(), effectiveWindows(campaign), loadLocation(campaign.Timezone)).After(grace) {
+		return ConstraintSendingWindow
+	}
+	if route.IsNewLead && campaign.MaxNewLeadsPerDay > 0 {
+		if n, err := s.campaignRepo.CountNewLeadsStartedToday(ctx, campaign.ID); err == nil && n >= campaign.MaxNewLeadsPerDay {
+			return ConstraintNewLeadCap
+		}
+	}
+	return ConstraintCapacity
+}

--- a/internal/scheduler/contact_preview_live_test.go
+++ b/internal/scheduler/contact_preview_live_test.go
@@ -1,0 +1,174 @@
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Live checks for the contact drawer's next-action preview (issue #255). The
+// preview must say what the send path would do, so every case here is proven
+// against the real routing and placement queries rather than a stub.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/scheduler/ -run LivePreview -v
+
+func livePreviewer(t *testing.T, s SchedulerService) ContactSendPreviewer {
+	t.Helper()
+	p, ok := s.(ContactSendPreviewer)
+	if !ok {
+		t.Fatal("scheduler service does not preview contact sends")
+	}
+	return p
+}
+
+func liveLead(t *testing.T, pool *pgxpool.Pool, campaign uuid.UUID) (step1, contact uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	if err := pool.QueryRow(ctx,
+		`SELECT id FROM sequences WHERE campaign_id = $1 AND position = 0`, campaign).Scan(&step1); err != nil {
+		t.Fatalf("load step 1: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT contact_id FROM campaign_leads WHERE campaign_id = $1`, campaign).Scan(&contact); err != nil {
+		t.Fatalf("load contact: %v", err)
+	}
+	return step1, contact
+}
+
+// A new lead in an always-open campaign is due now: the preview names the
+// entry step and carries the slot the scheduler would give it.
+func TestLivePreviewDueLeadGetsASlot(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	step1, contact := liveLead(t, pool, f.campaign)
+
+	pv, err := livePreviewer(t, liveScheduler(t, handle, pool)).PreviewContactSend(context.Background(), f.campaign, contact)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if pv.Route.Target == nil || *pv.Route.Target != step1 || !pv.Route.IsNewLead {
+		t.Fatalf("want the entry step for a new lead, got route %+v", pv.Route)
+	}
+	if pv.State != models.NextActionDue || pv.ScheduledAt == nil {
+		t.Fatalf("want a due step with a slot, got state=%q scheduled_at=%v constraint=%q", pv.State, pv.ScheduledAt, pv.Constraint)
+	}
+	if pv.ScheduledAt.Before(time.Now().Add(-time.Minute)) {
+		t.Fatalf("slot %s is in the past", pv.ScheduledAt)
+	}
+}
+
+// A follow-up inside its wait must not be promised a time: the preview reports
+// the step, the wait as the constraint, and an honest not-before.
+func TestLivePreviewFollowUpWaitIsReported(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	step1, contact := liveLead(t, pool, f.campaign)
+
+	step2 := uuid.New()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+			body_plain, body_html, wait_after, position, kind)
+		VALUES ($1, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', 3, 1, 'email')`,
+		step2, f.campaign, f.org); err != nil {
+		t.Fatalf("insert step 2: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE sequences SET conditions = jsonb_build_object('branches', jsonb_build_array(
+			jsonb_build_object('branch_id', 'live-else', 'target_step_id', $1::text)))
+		WHERE campaign_id = $2 AND position = 0`, step2.String(), f.campaign); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
+		VALUES ($1, $2, $3, NOW())`, f.campaign, contact, step1); err != nil {
+		t.Fatalf("stamp step 1 sent: %v", err)
+	}
+
+	pv, err := livePreviewer(t, liveScheduler(t, handle, pool)).PreviewContactSend(ctx, f.campaign, contact)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if pv.Route.Target == nil || *pv.Route.Target != step2 {
+		t.Fatalf("want step 2 routed next, got %+v", pv.Route)
+	}
+	if pv.State != models.NextActionWaiting || pv.Constraint != ConstraintStepWait {
+		t.Fatalf("want waiting on the step wait, got state=%q constraint=%q", pv.State, pv.Constraint)
+	}
+	if pv.ScheduledAt != nil {
+		t.Fatalf("a waiting step must not promise a slot, got %s", pv.ScheduledAt)
+	}
+	if pv.NotBefore == nil || time.Until(*pv.NotBefore) < 47*time.Hour {
+		t.Fatalf("not-before %v is too soon for a 3-day wait", pv.NotBefore)
+	}
+}
+
+// A lead whose campaign is outside its sending window right now: the preview
+// says so, and its not-before lands inside the next window instead of
+// inventing a time in the closed one.
+func TestLivePreviewSendingWindowBlocksTheStep(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	_, contact := liveLead(t, pool, f.campaign)
+
+	// A one-hour window that opens three hours from now. Near midnight the
+	// window would wrap, so it is pushed to 01:00-02:00 tomorrow instead.
+	now := time.Now().UTC()
+	startHour := (now.Hour() + 3) % 24
+	if startHour >= 23 || startHour < now.Hour() {
+		startHour = 1
+	}
+	if _, err := pool.Exec(ctx, `UPDATE campaigns SET start_time = $2, end_time = $3 WHERE id = $1`,
+		f.campaign, fmt.Sprintf("%02d:00", startHour), fmt.Sprintf("%02d:00", startHour+1)); err != nil {
+		t.Fatalf("narrow window: %v", err)
+	}
+
+	pv, err := livePreviewer(t, liveScheduler(t, handle, pool)).PreviewContactSend(ctx, f.campaign, contact)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if pv.State != models.NextActionWaiting || pv.Constraint != ConstraintSendingWindow {
+		t.Fatalf("want waiting on the sending window, got state=%q constraint=%q scheduled_at=%v", pv.State, pv.Constraint, pv.ScheduledAt)
+	}
+	if pv.ScheduledAt != nil {
+		t.Fatalf("a window-blocked step must not promise a slot, got %s", pv.ScheduledAt)
+	}
+	if pv.NotBefore == nil {
+		t.Fatal("want a not-before inside the next window")
+	}
+	until := time.Until(*pv.NotBefore)
+	if until < 90*time.Minute || until > 27*time.Hour {
+		t.Fatalf("not-before %s away does not sit in the next window", until.Round(time.Minute))
+	}
+	t.Logf("window opens in ~%s; preview says not before %s", until.Round(time.Minute), pv.NotBefore.UTC().Format(time.Kitchen))
+}
+
+// A paused campaign schedules nothing, whatever the step says.
+func TestLivePreviewPausedCampaignHasNoSlot(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	step1, contact := liveLead(t, pool, f.campaign)
+	if _, err := pool.Exec(ctx, `UPDATE campaigns SET status = 'paused' WHERE id = $1`, f.campaign); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+
+	pv, err := livePreviewer(t, liveScheduler(t, handle, pool)).PreviewContactSend(ctx, f.campaign, contact)
+	if err != nil {
+		t.Fatalf("preview: %v", err)
+	}
+	if pv.Route.Target == nil || *pv.Route.Target != step1 {
+		t.Fatalf("routing must still name the step, got %+v", pv.Route)
+	}
+	if pv.State != models.NextActionPaused || pv.Constraint != ConstraintCampaignInactive || pv.ScheduledAt != nil {
+		t.Fatalf("want paused with no slot, got state=%q constraint=%q scheduled_at=%v", pv.State, pv.Constraint, pv.ScheduledAt)
+	}
+}

--- a/internal/scheduler/contact_preview_test.go
+++ b/internal/scheduler/contact_preview_test.go
@@ -1,0 +1,35 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestProjectRampLevelMatchesDailyAdvance(t *testing.T) {
+	now := time.Date(2026, 8, 29, 12, 0, 0, 0, time.UTC)
+	yesterday := now.Add(-24 * time.Hour)
+
+	c := &models.Campaign{RampEnabled: true, RampStart: 10, RampIncrement: 5, RampCeiling: 50, RampLevel: 20, RampLevelDate: &yesterday}
+	projectRampLevel(c, now)
+	if c.RampLevel != 25 {
+		t.Fatalf("stale level must advance once: got %d", c.RampLevel)
+	}
+	projectRampLevel(c, now)
+	if c.RampLevel != 25 {
+		t.Fatalf("already advanced today must not advance again: got %d", c.RampLevel)
+	}
+
+	c = &models.Campaign{RampEnabled: true, RampStart: 10, RampIncrement: 5, RampCeiling: 12}
+	projectRampLevel(c, now)
+	if c.RampLevel != 12 {
+		t.Fatalf("first advance starts from ramp_start and clamps to the ceiling: got %d", c.RampLevel)
+	}
+
+	c = &models.Campaign{RampEnabled: false, RampLevel: 3}
+	projectRampLevel(c, now)
+	if c.RampLevel != 3 || c.RampLevelDate != nil {
+		t.Fatal("disabled ramp must be untouched")
+	}
+}

--- a/web/src/components/app/AddContacts.tsx
+++ b/web/src/components/app/AddContacts.tsx
@@ -33,6 +33,9 @@ export interface AddContact {
     campaigns: string[];
     categories?: string[];
     custom_fields: Record<string, string>;
+    // First-touch source hint: "campaign" when added from a campaign's
+    // Leads tab, else "manual". The server decides every other origin.
+    source?: "manual" | "campaign";
 }
 
 interface SelectCampaigns {
@@ -153,7 +156,10 @@ export default function AddContacts() {
                     },
                     {} as Record<string, string>
                 ),
-                campaigns: manual.campaigns.map((c) => c.id)
+                campaigns: manual.campaigns.map((c) => c.id),
+                // Opened from a campaign's Leads tab (campaigns preset) means
+                // the contact came in through that campaign.
+                source: (c?.add?.campaigns.length ?? 0) > 0 ? ("campaign" as const) : ("manual" as const),
             }
             await toast.promise(
                 addContacts.mutateAsync([data]),
@@ -241,6 +247,7 @@ export default function AddContacts() {
                 phone: primary['phone'] ?? "",
                 campaigns: (c?.add && c?.add.campaigns.length > 0) ? c.add.campaigns : campaigns.map((c) => c.id),
                 custom_fields,
+                source: (c?.add?.campaigns.length ?? 0) > 0 ? ("campaign" as const) : ("manual" as const),
             }
         })
         return entries

--- a/web/src/components/app/contacts/NewContactDialog.tsx
+++ b/web/src/components/app/contacts/NewContactDialog.tsx
@@ -62,6 +62,7 @@ export function NewContactDialog({ open, onClose, campaign }: Props) {
             campaigns: campaign ? [campaign.id] : [],
             categories,
             custom_fields: {},
+            source: campaign ? "campaign" : "manual",
         };
         try {
             await toast.promise(add.mutateAsync([contact]), {

--- a/web/src/components/app/contacts/contact-edit/ActivityTab.tsx
+++ b/web/src/components/app/contacts/contact-edit/ActivityTab.tsx
@@ -1,20 +1,23 @@
 // Activity tab — the contact 360 timeline.
 //
-// Filtering pipeline (all client-side, applied to whatever pages are
-// already in the cache):
-//   - Type chips: All / Emails / Replies / Deliverability / Notes
-//   - Free-text query against subject, content, campaign, sequence,
-//     mailbox, reason, intent
-//   - Date range [from, to] (inclusive day boundaries)
+// Layout:
+//   - Campaign panel: for each campaign the contact is in, the flow with this
+//     contact's progress, the lead status, and a scheduler-backed next action
+//   - Filters: type chips (All / Emails / Replies / Deliv. / Notes /
+//     Meetings / Campaigns / Lifecycle), free-text query, date range
+//   - Feed: collapsed rows stay to one line; click a row to expand every
+//     detail the event carries
 //
-// Pagination is server-side cursor pagination (page size 50). The
-// hook returns useInfiniteQuery state; this view auto-fetches the
-// next page when the sentinel scrolls into view. When the user
-// narrows the visible set with a filter, we lazy-prefetch a few more
-// pages so the filtered list isn't artificially short.
+// Filtering is client-side over whatever pages are in the cache.
+// Pagination is server-side cursor pagination (page size 50). The hook
+// returns useInfiniteQuery state; this view auto-fetches the next page when
+// the sentinel scrolls into view. When the user narrows the visible set
+// with a filter, we lazy-prefetch a few more pages so the filtered list
+// isn't artificially short. Both queries live under ["contacts", id], so
+// the audit spine's contact invalidation keeps them live.
 
 import React from "react";
-import { motion } from "framer-motion";
+import { AnimatePresence, motion } from "framer-motion";
 import { DatePicker } from "@/components/ui/DatePicker";
 import {
     AlertOctagonIcon,
@@ -23,24 +26,47 @@ import {
     CalendarClockIcon,
     CalendarPlusIcon,
     CalendarXIcon,
+    CheckIcon,
+    ChevronDownIcon,
+    ClockIcon,
     Loader2Icon,
     MailIcon,
     MailOpenIcon,
     MailWarningIcon,
+    MegaphoneIcon,
     MessageSquareIcon,
     MousePointerClickIcon,
+    OctagonXIcon,
+    PauseIcon,
     ReplyIcon,
     SearchIcon,
     StickyNoteIcon,
+    TagIcon,
+    UserPlusIcon,
     XIcon,
 } from "lucide-react";
 import useContactTimeline from "@/lib/api/hooks/app/contacts/useContactTimeline";
+import useContactCampaignStates from "@/lib/api/hooks/app/contacts/useContactCampaignStates";
 import type ContactTimelineEvent from "@/lib/api/models/app/contacts/ContactTimelineEvent";
 import type { ContactTimelineEventType } from "@/lib/api/models/app/contacts/ContactTimelineEvent";
+import type ContactCampaignState from "@/lib/api/models/app/contacts/ContactCampaignState";
+import type {
+    ContactCampaignStep,
+    ContactNextAction,
+} from "@/lib/api/models/app/contacts/ContactCampaignState";
+import type { LeadStatus } from "@/lib/api/models/app/contacts/Contact";
 import useClickOutside from "@/hooks/useClickOutside";
 import { fmtAbsolute, fmtRelative } from "./format";
 
-type FilterId = "all" | "emails" | "replies" | "deliv" | "notes" | "meetings";
+type FilterId =
+    | "all"
+    | "emails"
+    | "replies"
+    | "deliv"
+    | "notes"
+    | "meetings"
+    | "campaigns"
+    | "lifecycle";
 
 const FILTERS: { id: FilterId; label: string }[] = [
     { id: "all", label: "All" },
@@ -49,6 +75,8 @@ const FILTERS: { id: FilterId; label: string }[] = [
     { id: "deliv", label: "Deliv." },
     { id: "notes", label: "Notes" },
     { id: "meetings", label: "Meetings" },
+    { id: "campaigns", label: "Campaigns" },
+    { id: "lifecycle", label: "Lifecycle" },
 ];
 
 const EMAIL_TYPES: ContactTimelineEventType[] = [
@@ -62,6 +90,18 @@ const MEETING_TYPES: ContactTimelineEventType[] = [
     "meeting_booked",
     "meeting_rescheduled",
     "meeting_canceled",
+];
+
+const CAMPAIGN_TYPES: ContactTimelineEventType[] = [
+    "campaign_added",
+    "campaign_removed",
+];
+
+const LIFECYCLE_TYPES: ContactTimelineEventType[] = [
+    "contact_created",
+    "category_added",
+    "category_removed",
+    ...CAMPAIGN_TYPES,
 ];
 
 export default function ActivityTab({ contactId }: { contactId: string }) {
@@ -136,6 +176,8 @@ export default function ActivityTab({ contactId }: { contactId: string }) {
 
     return (
         <div className="space-y-3">
+            <CampaignPanel contactId={contactId} />
+
             <SearchBar value={query} onChange={setQuery} />
 
             <div className="flex items-center gap-2 flex-wrap">
@@ -201,6 +243,356 @@ export default function ActivityTab({ contactId }: { contactId: string }) {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Campaign panel
+// ---------------------------------------------------------------------------
+
+function CampaignPanel({ contactId }: { contactId: string }) {
+    const { data, isLoading, error } = useContactCampaignStates(contactId);
+    const states = data?.data ?? [];
+
+    if (isLoading) {
+        return (
+            <div className="rounded-md border border-slate-200 bg-white px-3 py-2.5 space-y-1.5">
+                <div className="h-2.5 w-1/3 bg-slate-100 rounded animate-pulse" />
+                <div className="h-2 w-2/3 bg-slate-100/80 rounded animate-pulse" />
+            </div>
+        );
+    }
+    if (error || states.length === 0) return null;
+
+    return (
+        <section>
+            <h2 className="text-[10px] uppercase tracking-[0.14em] font-semibold text-slate-500 mb-2">
+                Campaigns
+            </h2>
+            <div className="space-y-2">
+                {states.map((s) => (
+                    <CampaignCard key={s.campaign_id} state={s} />
+                ))}
+            </div>
+        </section>
+    );
+}
+
+function CampaignCard({ state }: { state: ContactCampaignState }) {
+    const [open, setOpen] = React.useState(false);
+    const current = state.current_step;
+
+    return (
+        <div className="rounded-md border border-slate-200 bg-white overflow-hidden">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                className="w-full text-left px-3 py-2.5 hover:bg-slate-50/70 transition-colors"
+            >
+                <div className="flex items-center gap-2 min-w-0">
+                    <MegaphoneIcon className="w-3.5 h-3.5 text-slate-400 shrink-0" />
+                    <span className="text-[12.5px] font-medium text-slate-900 truncate">
+                        {state.campaign_name}
+                    </span>
+                    <LeadStatusPill status={state.lead_status} />
+                    {state.campaign_status !== "active" && (
+                        <span className="text-[10.5px] text-slate-400">
+                            {campaignStatusLabel(state.campaign_status)}
+                        </span>
+                    )}
+                    <span className="ml-auto text-[10.5px] text-slate-400 tabular-nums shrink-0">
+                        {state.completed_steps}/{state.total_steps} steps
+                    </span>
+                    <ChevronDownIcon
+                        className={`w-3.5 h-3.5 text-slate-400 shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
+                    />
+                </div>
+
+                <StepRail steps={state.steps} />
+
+                <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-1.5">
+                    <PanelFact
+                        label="Current step"
+                        value={current ? current.label : "Not started"}
+                    />
+                    <PanelFact
+                        label="Last action"
+                        value={
+                            state.last_action && state.last_action_at ? (
+                                <span title={fmtAbsolute(state.last_action_at)}>
+                                    {state.last_action} ·{" "}
+                                    {fmtRelative(state.last_action_at)}
+                                </span>
+                            ) : (
+                                "Nothing yet"
+                            )
+                        }
+                    />
+                    <div className="sm:col-span-2">
+                        <NextActionFact
+                            next={state.next}
+                            endedReason={state.ended_reason}
+                            failureReason={state.failure_reason}
+                        />
+                    </div>
+                </div>
+            </button>
+
+            <AnimatePresence initial={false}>
+                {open && (
+                    <motion.div
+                        key="steps"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+                        className="overflow-hidden"
+                    >
+                        <div className="border-t border-slate-100">
+                            {state.steps.map((s) => (
+                                <StepRow
+                                    key={s.id}
+                                    step={s}
+                                    isNext={!!state.next?.step_id && state.next.step_id === s.id}
+                                />
+                            ))}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}
+
+function PanelFact({
+    label,
+    value,
+}: {
+    label: string;
+    value: React.ReactNode;
+}) {
+    return (
+        <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.12em] text-slate-400 font-medium">
+                {label}
+            </div>
+            <div className="text-[11.5px] text-slate-700 truncate">{value}</div>
+        </div>
+    );
+}
+
+// The next action, worded by how firm its timing is: a due step carries the
+// scheduler's slot, a waiting one carries the constraint and an earliest
+// time, a paused or blocked one only the reason. Never a made-up timestamp.
+function NextActionFact({
+    next,
+    endedReason,
+    failureReason,
+}: {
+    next?: ContactNextAction | null;
+    endedReason?: string;
+    failureReason?: string;
+}) {
+    if (!next) {
+        return (
+            <PanelFact
+                label="Next"
+                value={
+                    <span className="text-slate-500">
+                        {endedReason || "Nothing scheduled"}
+                        {failureReason ? ` · ${failureReason}` : ""}
+                    </span>
+                }
+            />
+        );
+    }
+    const Icon =
+        next.state === "due"
+            ? ClockIcon
+            : next.state === "paused"
+              ? PauseIcon
+              : next.state === "blocked"
+                ? OctagonXIcon
+                : ClockIcon;
+    const tone =
+        next.state === "due"
+            ? "bg-sky-50 text-sky-700"
+            : next.state === "blocked"
+              ? "bg-red-50 text-red-700"
+              : next.state === "paused"
+                ? "bg-slate-100 text-slate-600"
+                : "bg-amber-50 text-amber-700";
+    const stateLabel =
+        next.state === "due"
+            ? "Due"
+            : next.state === "waiting"
+              ? "Waiting"
+              : next.state === "paused"
+                ? "Paused"
+                : "Blocked";
+
+    return (
+        <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.12em] text-slate-400 font-medium">
+                Next
+            </div>
+            <div className="text-[11.5px] text-slate-700 flex items-center gap-1.5 flex-wrap">
+                <span className="font-medium text-slate-900">{next.step_label}</span>
+                {next.subject && (
+                    <span className="text-slate-500 truncate">· {next.subject}</span>
+                )}
+                <span
+                    className={`inline-flex items-center gap-1 h-4 px-1.5 rounded text-[10.5px] font-medium ${tone}`}
+                >
+                    <Icon className="w-3 h-3" />
+                    {stateLabel}
+                </span>
+                {next.state === "due" && next.scheduled_at && (
+                    <span title="The slot the scheduler would give this step on its next pass. Leads queued ahead can still push it later.">
+                        next slot {fmtAbsolute(next.scheduled_at)}
+                    </span>
+                )}
+                {next.state !== "due" && next.not_before && (
+                    <span title={fmtAbsolute(next.not_before)}>
+                        not before {fmtAbsolute(next.not_before)}
+                    </span>
+                )}
+            </div>
+            {next.constraint && (
+                <div className="text-[11px] text-slate-500 mt-0.5">{next.constraint}</div>
+            )}
+        </div>
+    );
+}
+
+// One dot per step: filled when sent, amber while in flight, red on a
+// bounce or exhausted failure, hollow otherwise.
+function StepRail({ steps }: { steps: ContactCampaignStep[] }) {
+    if (steps.length === 0) return null;
+    return (
+        <div className="mt-2 flex items-center gap-1">
+            {steps.map((s, i) => {
+                const st = stepState(s);
+                const dot =
+                    st === "sent"
+                        ? "bg-sky-600 border-sky-600"
+                        : st === "in_flight"
+                          ? "bg-amber-400 border-amber-400"
+                          : st === "failed"
+                            ? "bg-red-500 border-red-500"
+                            : "bg-white border-slate-300";
+                return (
+                    <React.Fragment key={s.id}>
+                        {i > 0 && (
+                            <span
+                                className={`h-px flex-1 min-w-2 ${st === "sent" || st === "in_flight" ? "bg-sky-300" : "bg-slate-200"}`}
+                            />
+                        )}
+                        <span
+                            title={`${s.label}${s.sent_at ? ` · sent ${fmtAbsolute(s.sent_at)}` : ""}`}
+                            className={`w-2.5 h-2.5 rounded-full border shrink-0 ${dot}`}
+                        />
+                    </React.Fragment>
+                );
+            })}
+        </div>
+    );
+}
+
+type StepState = "sent" | "in_flight" | "failed" | "pending";
+
+function stepState(s: ContactCampaignStep): StepState {
+    if (s.sent_at) return "sent";
+    if (s.in_flight) return "in_flight";
+    if (s.failed_at) return "failed";
+    return "pending";
+}
+
+function StepRow({ step, isNext }: { step: ContactCampaignStep; isNext: boolean }) {
+    const st = stepState(step);
+    const facts: string[] = [];
+    if (step.sent_at) facts.push(`sent ${fmtRelative(step.sent_at)}`);
+    if (step.opened_at) facts.push("opened");
+    if (step.clicked_at) facts.push("clicked");
+    if (step.replied_at) facts.push("replied");
+    if (step.bounced_at) facts.push("bounced");
+    if (!step.sent_at && step.failed_at)
+        facts.push(`failed ${step.attempts ?? 0}x`);
+    if (st === "in_flight") facts.push("sending");
+    if (isNext) facts.push("next");
+
+    return (
+        <div className="px-3 py-1.5 border-b last:border-b-0 border-slate-100 flex items-center gap-2 text-[11.5px]">
+            <span
+                className={`w-4 h-4 rounded-full inline-flex items-center justify-center shrink-0 ${
+                    st === "sent"
+                        ? "bg-sky-600 text-white"
+                        : st === "failed"
+                          ? "bg-red-500 text-white"
+                          : st === "in_flight"
+                            ? "bg-amber-400 text-white"
+                            : "border border-slate-300 text-transparent"
+                }`}
+            >
+                <CheckIcon className="w-2.5 h-2.5" />
+            </span>
+            <span
+                className={`truncate ${st === "pending" && !isNext ? "text-slate-500" : "text-slate-900"}`}
+            >
+                {step.label}
+                {step.subject && (
+                    <span className="text-slate-400"> · {step.subject}</span>
+                )}
+            </span>
+            <span className="ml-auto text-[10.5px] text-slate-400 shrink-0">
+                {facts.join(" · ")}
+            </span>
+        </div>
+    );
+}
+
+function LeadStatusPill({ status }: { status: LeadStatus }) {
+    const map: Record<LeadStatus, { label: string; cls: string }> = {
+        pending: { label: "Queued", cls: "bg-slate-100 text-slate-600" },
+        active: { label: "Processing", cls: "bg-sky-50 text-sky-700" },
+        completed: { label: "Done", cls: "bg-emerald-50 text-emerald-700" },
+        replied: { label: "Replied", cls: "bg-emerald-50 text-emerald-700" },
+        bounced: { label: "Bounced", cls: "bg-red-50 text-red-700" },
+        failed: { label: "Failed", cls: "bg-red-50 text-red-700" },
+        unsubscribed: { label: "Unsubscribed", cls: "bg-slate-100 text-slate-600" },
+        undeliverable: { label: "Undeliverable", cls: "bg-amber-50 text-amber-700" },
+    };
+    const m = map[status] ?? { label: status, cls: "bg-slate-100 text-slate-600" };
+    return (
+        <span
+            className={`inline-flex h-4 items-center px-1.5 rounded text-[10.5px] font-medium shrink-0 ${m.cls}`}
+        >
+            {m.label}
+        </span>
+    );
+}
+
+function campaignStatusLabel(status: string): string {
+    switch (status) {
+        case "paused":
+            return "paused";
+        case "paused_guardrail":
+            return "auto-paused";
+        case "paused_no_accounts":
+            return "paused, no accounts";
+        case "paused_trial_expired":
+            return "paused, trial expired";
+        case "completed":
+            return "finished";
+        case "draft":
+            return "not started";
+        default:
+            return status.replace(/_/g, " ");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Filters
+// ---------------------------------------------------------------------------
+
 function applyFilters(
     events: ContactTimelineEvent[],
     f: { type: FilterId; query: string; from: string; to: string },
@@ -229,6 +621,12 @@ function applyFilters(
             case "meetings":
                 if (!MEETING_TYPES.includes(e.type)) return false;
                 break;
+            case "campaigns":
+                if (!CAMPAIGN_TYPES.includes(e.type)) return false;
+                break;
+            case "lifecycle":
+                if (!LIFECYCLE_TYPES.includes(e.type)) return false;
+                break;
             case "all":
                 break;
         }
@@ -240,6 +638,9 @@ function applyFilters(
                 e.step_name,
                 e.email_account_email,
                 e.email_account_name,
+                e.category_title,
+                e.source,
+                e.source_detail,
                 e.reason,
                 e.intent,
             ]
@@ -489,6 +890,12 @@ function SkeletonList() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// Feed rows
+// ---------------------------------------------------------------------------
+
+// Collapsed: icon, label, subject, a one-line meta. Expanded (click): every
+// field the event carries, as a label/value grid.
 function EventRow({
     event,
     highlight,
@@ -496,38 +903,132 @@ function EventRow({
     event: ContactTimelineEvent;
     highlight: string;
 }) {
-    const { Icon, label } = visualFor(event.type);
+    const [open, setOpen] = React.useState(false);
+    const { Icon, label } = visualFor(event);
+    const details = detailsFor(event);
+
     return (
-        <div className="px-3 py-2 border-b last:border-b-0 border-slate-100">
-            <div className="flex items-start gap-2.5">
-                <Icon className="w-3.5 h-3.5 text-slate-400 mt-0.5 shrink-0" />
-                <div className="min-w-0 flex-1">
-                    <div className="flex items-baseline gap-1.5 min-w-0">
-                        <span className="text-[12px] font-medium text-slate-900 shrink-0">
-                            {label}
-                        </span>
-                        {event.subject && (
-                            <span className="text-[11.5px] text-slate-600 truncate">
-                                · <Highlight text={event.subject} q={highlight} />
+        <div className="border-b last:border-b-0 border-slate-100">
+            <button
+                type="button"
+                onClick={() => setOpen((v) => !v)}
+                aria-expanded={open}
+                className="w-full text-left px-3 py-2 hover:bg-slate-50/70 transition-colors"
+            >
+                <div className="flex items-start gap-2.5">
+                    <Icon className="w-3.5 h-3.5 text-slate-400 mt-0.5 shrink-0" />
+                    <div className="min-w-0 flex-1">
+                        <div className="flex items-baseline gap-1.5 min-w-0">
+                            <span className="text-[12px] font-medium text-slate-900 shrink-0">
+                                {label}
                             </span>
-                        )}
+                            {event.subject && (
+                                <span className="text-[11.5px] text-slate-600 truncate">
+                                    · <Highlight text={event.subject} q={highlight} />
+                                </span>
+                            )}
+                        </div>
+                        <EventMeta event={event} highlight={highlight} />
                     </div>
-                    <EventMeta event={event} highlight={highlight} />
+                    <span
+                        className="text-[10.5px] text-slate-400 tabular-nums shrink-0 mt-0.5"
+                        title={fmtAbsolute(event.at)}
+                    >
+                        {fmtRelative(event.at)}
+                    </span>
+                    <ChevronDownIcon
+                        className={`w-3.5 h-3.5 text-slate-300 shrink-0 mt-0.5 transition-transform ${open ? "rotate-180" : ""}`}
+                    />
                 </div>
-                <span
-                    className="text-[10.5px] text-slate-400 tabular-nums shrink-0 mt-0.5"
-                    title={fmtAbsolute(event.at)}
-                >
-                    {fmtRelative(event.at)}
-                </span>
-            </div>
-            {event.content && (
-                <div className="text-[11.5px] text-slate-700 mt-1.5 ml-6 whitespace-pre-wrap break-words border-l-2 border-slate-100 pl-2">
-                    <Highlight text={event.content} q={highlight} />
-                </div>
-            )}
+                {event.content && !open && (
+                    <div className="text-[11.5px] text-slate-700 mt-1.5 ml-6 whitespace-pre-wrap break-words border-l-2 border-slate-100 pl-2 line-clamp-3">
+                        <Highlight text={event.content} q={highlight} />
+                    </div>
+                )}
+            </button>
+            <AnimatePresence initial={false}>
+                {open && (
+                    <motion.div
+                        key="details"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.18, ease: [0.32, 0.72, 0, 1] }}
+                        className="overflow-hidden"
+                    >
+                        <div className="mx-3 mb-2.5 ml-9 rounded-md border border-slate-200 bg-slate-50/60 px-2.5 py-2 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+                            {details.map(([k, v]) => (
+                                <React.Fragment key={k}>
+                                    <span className="text-slate-400 uppercase tracking-[0.1em] text-[10px] font-medium pt-px">
+                                        {k}
+                                    </span>
+                                    <span className="text-slate-700 min-w-0 break-words whitespace-pre-wrap">
+                                        {typeof v === "string" ? (
+                                            <Highlight text={v} q={highlight} />
+                                        ) : (
+                                            v
+                                        )}
+                                    </span>
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
         </div>
     );
+}
+
+// Every detail an event carries, in the order a reader wants them.
+function detailsFor(e: ContactTimelineEvent): [string, React.ReactNode][] {
+    const out: [string, React.ReactNode][] = [];
+    const add = (k: string, v?: React.ReactNode | null) => {
+        if (v !== undefined && v !== null && v !== "") out.push([k, v]);
+    };
+    add("When", fmtAbsolute(e.at));
+    if (e.type === "contact_created") {
+        add("Source", sourceLabel(e.source));
+        add("Detail", e.source_detail);
+    }
+    add("Campaign", e.campaign_name);
+    add("Step", e.step_name);
+    add("Subject", e.subject);
+    if (e.email_account_email) {
+        add(
+            "Mailbox",
+            e.email_account_name
+                ? `${e.email_account_name} <${e.email_account_email}>`
+                : e.email_account_email,
+        );
+    }
+    add("Category", e.category_title);
+    add("Intent", e.intent);
+    if (e.type === "deliverability" || e.type === "suppressed") {
+        add("Type", e.source);
+        add("Provider", e.provider && e.provider !== "manual" ? e.provider : null);
+    }
+    if (e.type.startsWith("meeting_")) {
+        add("Scheduled for", e.scheduled_for ? fmtAbsolute(e.scheduled_for) : null);
+        add("Calendar", providerLabel(e.source));
+        add("State", e.meeting_state);
+        if (e.join_url && e.type !== "meeting_canceled") {
+            add(
+                "Join",
+                <a
+                    href={e.join_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-sky-600 hover:text-sky-700 font-medium"
+                >
+                    {e.join_url}
+                </a>,
+            );
+        }
+    }
+    add("Reason", e.reason);
+    add("Content", e.content);
+    if (e.task_id) add("Task", <span className="font-mono">{e.task_id}</span>);
+    return out;
 }
 
 function EventMeta({
@@ -548,12 +1049,12 @@ function EventMeta({
                   minute: "2-digit",
               })
             : null;
-        const providerLabel = event.source === "cal_com" ? "Cal.com" : event.source === "calendly" ? "Calendly" : event.source;
+        const provider = providerLabel(event.source);
         return (
             <div className="text-[11px] text-slate-500 mt-0.5 flex gap-1.5 flex-wrap items-center">
                 {when && <span>for {when}</span>}
-                {when && providerLabel && <span className="text-slate-300">·</span>}
-                {providerLabel && <span>via {providerLabel}</span>}
+                {when && provider && <span className="text-slate-300">·</span>}
+                {provider && <span>via {provider}</span>}
                 {event.reason && (
                     <>
                         <span className="text-slate-300">·</span>
@@ -567,6 +1068,7 @@ function EventMeta({
                             href={event.join_url}
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={(e) => e.stopPropagation()}
                             className="text-sky-600 hover:text-sky-700 font-medium"
                         >
                             Join
@@ -579,43 +1081,71 @@ function EventMeta({
 
     const parts: React.ReactNode[] = [];
 
-    if (event.email_account_email) {
-        parts.push(
-            <span key="mailbox" className="font-mono">
-                from{" "}
-                <Highlight text={event.email_account_email} q={highlight} />
-            </span>,
-        );
-    }
-    if (event.campaign_name) {
-        parts.push(
-            <span key="campaign">
-                in <Highlight text={event.campaign_name} q={highlight} />
-            </span>,
-        );
-    }
-    if (event.step_name) {
-        parts.push(
-            <span key="sequence">
-                step <Highlight text={event.step_name} q={highlight} />
-            </span>,
-        );
-    }
-    if (event.intent) {
-        parts.push(<span key="intent">intent: {event.intent}</span>);
-    }
-    if (event.provider && event.provider !== "manual") {
-        parts.push(<span key="provider">via {event.provider}</span>);
-    }
-    if (event.source) {
-        parts.push(<span key="source">type: {event.source}</span>);
-    }
-    if (event.reason) {
-        parts.push(
-            <span key="reason" className="text-slate-700">
-                <Highlight text={event.reason} q={highlight} />
-            </span>,
-        );
+    // Lifecycle rows name the thing that changed, not the sending context.
+    if (event.type === "contact_created") {
+        if (event.source_detail) {
+            parts.push(
+                <span key="detail">
+                    <Highlight text={event.source_detail} q={highlight} />
+                </span>,
+            );
+        }
+    } else if (CAMPAIGN_TYPES.includes(event.type)) {
+        if (event.campaign_name) {
+            parts.push(
+                <span key="campaign">
+                    <Highlight text={event.campaign_name} q={highlight} />
+                </span>,
+            );
+        }
+    } else if (event.type === "category_added" || event.type === "category_removed") {
+        if (event.category_title) {
+            parts.push(
+                <span key="category" className="inline-flex items-center gap-1">
+                    <TagIcon className="w-3 h-3 text-slate-400" />
+                    <Highlight text={event.category_title} q={highlight} />
+                </span>,
+            );
+        }
+    } else {
+        if (event.email_account_email) {
+            parts.push(
+                <span key="mailbox" className="font-mono">
+                    from{" "}
+                    <Highlight text={event.email_account_email} q={highlight} />
+                </span>,
+            );
+        }
+        if (event.campaign_name) {
+            parts.push(
+                <span key="campaign">
+                    in <Highlight text={event.campaign_name} q={highlight} />
+                </span>,
+            );
+        }
+        if (event.step_name) {
+            parts.push(
+                <span key="sequence">
+                    step <Highlight text={event.step_name} q={highlight} />
+                </span>,
+            );
+        }
+        if (event.intent) {
+            parts.push(<span key="intent">intent: {event.intent}</span>);
+        }
+        if (event.provider && event.provider !== "manual") {
+            parts.push(<span key="provider">via {event.provider}</span>);
+        }
+        if (event.source) {
+            parts.push(<span key="source">type: {event.source}</span>);
+        }
+        if (event.reason) {
+            parts.push(
+                <span key="reason" className="text-slate-700">
+                    <Highlight text={event.reason} q={highlight} />
+                </span>,
+            );
+        }
     }
 
     if (parts.length === 0) return null;
@@ -651,11 +1181,42 @@ function Highlight({ text, q }: { text: string; q: string }) {
     );
 }
 
-function visualFor(type: ContactTimelineEventType): {
+function providerLabel(source?: string | null): string | null {
+    if (!source) return null;
+    if (source === "cal_com") return "Cal.com";
+    if (source === "calendly") return "Calendly";
+    return source;
+}
+
+// The first-touch source as a person would say it.
+export function sourceLabel(source?: string | null): string {
+    switch (source) {
+        case "manual":
+            return "Added manually";
+        case "campaign":
+            return "Added from a campaign";
+        case "import":
+            return "Imported from a file";
+        case "sheet_sync":
+            return "Synced from Google Sheets";
+        case "api":
+            return "Created via the API";
+        case "ai_assistant":
+            return "Created by the AI assistant";
+        case "unknown":
+        case undefined:
+        case null:
+            return "Unknown";
+        default:
+            return source;
+    }
+}
+
+function visualFor(e: ContactTimelineEvent): {
     Icon: typeof MailIcon;
     label: string;
 } {
-    switch (type) {
+    switch (e.type) {
         case "email_sent":
             return { Icon: MailIcon, label: "Email sent" };
         case "email_opened":
@@ -680,8 +1241,37 @@ function visualFor(type: ContactTimelineEventType): {
             return { Icon: CalendarClockIcon, label: "Meeting rescheduled" };
         case "meeting_canceled":
             return { Icon: CalendarXIcon, label: "Meeting canceled" };
+        case "contact_created":
+            return { Icon: UserPlusIcon, label: createdLabel(e.source) };
+        case "campaign_added":
+            return { Icon: MegaphoneIcon, label: "Added to campaign" };
+        case "campaign_removed":
+            return { Icon: MegaphoneIcon, label: "Removed from campaign" };
+        case "category_added":
+            return { Icon: TagIcon, label: "Added to category" };
+        case "category_removed":
+            return { Icon: TagIcon, label: "Removed from category" };
         default:
-            return { Icon: MailIcon, label: type };
+            return { Icon: MailIcon, label: e.type };
+    }
+}
+
+function createdLabel(source?: string | null): string {
+    switch (source) {
+        case "import":
+            return "Imported";
+        case "sheet_sync":
+            return "Synced from sheet";
+        case "api":
+            return "Created via API";
+        case "campaign":
+            return "Added from campaign";
+        case "ai_assistant":
+            return "Created by AI assistant";
+        case "manual":
+            return "Created manually";
+        default:
+            return "Contact created";
     }
 }
 

--- a/web/src/components/app/contacts/contact-edit/ActivityTab.tsx
+++ b/web/src/components/app/contacts/contact-edit/ActivityTab.tsx
@@ -1011,16 +1011,17 @@ function detailsFor(e: ContactTimelineEvent): [string, React.ReactNode][] {
         add("Scheduled for", e.scheduled_for ? fmtAbsolute(e.scheduled_for) : null);
         add("Calendar", providerLabel(e.source));
         add("State", e.meeting_state);
-        if (e.join_url && e.type !== "meeting_canceled") {
+        const joinUrl = safeHttpUrl(e.join_url);
+        if (joinUrl && e.type !== "meeting_canceled") {
             add(
                 "Join",
                 <a
-                    href={e.join_url}
+                    href={joinUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-sky-600 hover:text-sky-700 font-medium"
                 >
-                    {e.join_url}
+                    {joinUrl}
                 </a>,
             );
         }
@@ -1050,6 +1051,7 @@ function EventMeta({
               })
             : null;
         const provider = providerLabel(event.source);
+        const joinUrl = safeHttpUrl(event.join_url);
         return (
             <div className="text-[11px] text-slate-500 mt-0.5 flex gap-1.5 flex-wrap items-center">
                 {when && <span>for {when}</span>}
@@ -1061,11 +1063,11 @@ function EventMeta({
                         <span className="text-slate-700">{event.reason}</span>
                     </>
                 )}
-                {event.type !== "meeting_canceled" && event.join_url && (
+                {event.type !== "meeting_canceled" && joinUrl && (
                     <>
                         <span className="text-slate-300">·</span>
                         <a
-                            href={event.join_url}
+                            href={joinUrl}
                             target="_blank"
                             rel="noopener noreferrer"
                             onClick={(e) => e.stopPropagation()}
@@ -1179,6 +1181,18 @@ function Highlight({ text, q }: { text: string; q: string }) {
             {text.slice(idx + ql.length)}
         </>
     );
+}
+
+// Meeting join links come from a scheduling provider's webhook and are stored
+// verbatim, so only http(s) may become an href; anything else is not linked.
+function safeHttpUrl(raw?: string | null): string | null {
+    if (!raw) return null;
+    try {
+        const u = new URL(raw);
+        return u.protocol === "https:" || u.protocol === "http:" ? u.href : null;
+    } catch {
+        return null;
+    }
 }
 
 function providerLabel(source?: string | null): string | null {

--- a/web/src/components/app/contacts/contact-edit/OverviewTab.tsx
+++ b/web/src/components/app/contacts/contact-edit/OverviewTab.tsx
@@ -19,6 +19,7 @@ import {
 import type ContactDetail from "@/lib/api/models/app/contacts/ContactDetail";
 import type Contact from "@/lib/api/models/app/contacts/Contact";
 import { fmtAbsolute, fmtRelative } from "./format";
+import { sourceLabel } from "./ActivityTab";
 
 export default function OverviewTab({
     contact,
@@ -177,6 +178,25 @@ export default function OverviewTab({
                     />
                 </div>
             </Section>
+
+            {detail && (
+                <Section title="Source">
+                    <div className="rounded-md border border-slate-200 bg-white overflow-hidden">
+                        <ProfileRow
+                            label="Came from"
+                            value={
+                                detail.source_detail
+                                    ? `${sourceLabel(detail.source)} · ${detail.source_detail}`
+                                    : sourceLabel(detail.source)
+                            }
+                        />
+                        <ProfileRow
+                            label="First seen"
+                            value={fmtAbsolute(detail.first_seen_at)}
+                        />
+                    </div>
+                </Section>
+            )}
 
             {Object.keys(contact.custom_fields || {}).length > 0 && (
                 <Section title="Custom fields">

--- a/web/src/lib/api/client/app/contacts/listContactCampaignStates.ts
+++ b/web/src/lib/api/client/app/contacts/listContactCampaignStates.ts
@@ -1,0 +1,12 @@
+import type { ContactCampaignStatesResult } from "@/lib/api/models/app/contacts/ContactCampaignState";
+import Request from "../../Request";
+
+export default async function listContactCampaignStates(
+    contactId: string,
+): Promise<ContactCampaignStatesResult> {
+    return await Request<ContactCampaignStatesResult>({
+        method: "GET",
+        url: `/contacts/${contactId}/campaigns`,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/hooks/app/contacts/useContactCampaignStates.ts
+++ b/web/src/lib/api/hooks/app/contacts/useContactCampaignStates.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import listContactCampaignStates from "@/lib/api/client/app/contacts/listContactCampaignStates";
+
+// Per-campaign state for the contact drawer. Keyed under ["contacts", id] so
+// the audit spine's contact invalidation (and the send/open/reply events'
+// per-contact invalidation) refresh it live; no polling.
+export default function useContactCampaignStates(contactId: string, enabled = true) {
+    return useQuery({
+        queryKey: ["contacts", contactId, "campaign-state"],
+        queryFn: () => listContactCampaignStates(contactId),
+        enabled: enabled && !!contactId,
+        staleTime: 15_000,
+    });
+}

--- a/web/src/lib/api/models/app/contacts/AddContact.ts
+++ b/web/src/lib/api/models/app/contacts/AddContact.ts
@@ -8,4 +8,8 @@ export default interface AddContact {
     categories?: string[];
 
     custom_fields: Record<string, string>;
+
+    // First-touch source hint. The dashboard may say "manual" or "campaign"
+    // (added from a campaign's Leads tab); the server decides everything else.
+    source?: "manual" | "campaign";
 }

--- a/web/src/lib/api/models/app/contacts/ContactCampaignState.ts
+++ b/web/src/lib/api/models/app/contacts/ContactCampaignState.ts
@@ -1,0 +1,65 @@
+import type { LeadStatus } from "./Contact";
+
+// One campaign a contact belongs to, as the Activity tab's campaign panel
+// shows it: the flow with this contact's progress, the derived lead status,
+// and a scheduler-backed next action.
+export interface ContactCampaignStep {
+    id: string;
+    label: string;
+    kind: string;
+    position: number;
+    subject?: string;
+
+    sent_at?: string | null;
+    opened_at?: string | null;
+    clicked_at?: string | null;
+    replied_at?: string | null;
+    bounced_at?: string | null;
+    failed_at?: string | null;
+    attempts?: number;
+    in_flight?: boolean;
+}
+
+// due: the step is due and the scheduler produced a slot for it.
+// waiting: a hard constraint holds it back; not_before is the earliest.
+// paused: the campaign is not active.
+// blocked: the campaign cannot send at all right now.
+export type ContactNextActionState = "due" | "waiting" | "paused" | "blocked";
+
+export interface ContactNextAction {
+    // Absent while a condition window is open: the next step depends on how
+    // the contact responds.
+    step_id?: string | null;
+    step_label: string;
+    kind?: string;
+    subject?: string;
+
+    state: ContactNextActionState;
+    // Only when due now; contacts ahead in the queue can still push it later.
+    scheduled_at?: string | null;
+    not_before?: string | null;
+    constraint?: string;
+}
+
+export default interface ContactCampaignState {
+    campaign_id: string;
+    campaign_name: string;
+    campaign_status: string;
+    lead_status: LeadStatus;
+    failure_reason?: string;
+
+    steps: ContactCampaignStep[];
+    completed_steps: number;
+    total_steps: number;
+
+    current_step?: ContactCampaignStep | null;
+    last_action?: string;
+    last_action_at?: string | null;
+
+    next?: ContactNextAction | null;
+    ended_reason?: string;
+}
+
+export interface ContactCampaignStatesResult {
+    data: ContactCampaignState[];
+}

--- a/web/src/lib/api/models/app/contacts/ContactDetail.ts
+++ b/web/src/lib/api/models/app/contacts/ContactDetail.ts
@@ -22,7 +22,23 @@ export interface ContactSuppression {
     created_at: string;
 }
 
+// Where a contact first came from. Mirrors the backend CHECK; "unknown" is
+// what rows created before attribution existed carry.
+export type ContactSource =
+    | "unknown"
+    | "manual"
+    | "campaign"
+    | "import"
+    | "sheet_sync"
+    | "api"
+    | "ai_assistant";
+
 export default interface ContactDetail extends Contact {
     engagement: ContactEngagement;
     suppression?: ContactSuppression | null;
+
+    // First-touch attribution; never changes after creation.
+    source: ContactSource;
+    source_detail: string;
+    first_seen_at: string;
 }

--- a/web/src/lib/api/models/app/contacts/ContactTimelineEvent.ts
+++ b/web/src/lib/api/models/app/contacts/ContactTimelineEvent.ts
@@ -10,7 +10,15 @@ export type ContactTimelineEventType =
     | "note"
     | "meeting_booked"
     | "meeting_rescheduled"
-    | "meeting_canceled";
+    | "meeting_canceled"
+    // Lifecycle (from contact_activities). contact_created carries the
+    // first-touch source, which is how "imported" and "created via API"
+    // are told apart.
+    | "contact_created"
+    | "campaign_added"
+    | "campaign_removed"
+    | "category_added"
+    | "category_removed";
 
 export default interface ContactTimelineEvent {
     type: ContactTimelineEventType;
@@ -38,6 +46,11 @@ export default interface ContactTimelineEvent {
     scheduled_for?: string | null;
     join_url?: string | null;
     meeting_state?: string | null;
+
+    // Lifecycle events.
+    category_id?: string | null;
+    category_title?: string | null;
+    source_detail?: string | null;
 
     user_id?: string | null;
 }


### PR DESCRIPTION
Implements the derivable half of #255. Website visit tracking is explicitly out of scope here and ships separately.

## What this closes from #255

- [x] **Contact source attribution** (section 2, the part this product can record): every contact carries a first-touch `source` (`manual`, `campaign`, `import`, `sheet_sync`, `api`, `ai_assistant`), a `source_detail` (file name, campaign, sheet, API key name) and `first_seen_at`. Stamped at every creation site: Add contact / Add lead in the dashboard, the file import wizard, Google Sheets sync, API-key requests (always `api`, named after the key; a body may not claim otherwise), and the AI assistant. An upsert onto an existing contact keeps the original source. Existing rows are stamped `unknown`, not guessed. Shown on the Overview tab and as the first timeline event.
- [x] **Complete activity timeline** (section 3, the events that exist here): contact created (with its source, which is how "imported" and "created via API" are told apart), added to / removed from a campaign, added to / removed from a category, merged into `GET /contacts/:id/timeline` alongside the existing send/open/click/reply/bounce/deliverability/suppression/note/meeting events. Names are resolved at write time so a renamed or deleted campaign does not rewrite history.
- [x] **Campaign activity for one contact** (sections 4 and 6): a panel at the top of the Activity tab lists each campaign the contact is in with the flow drawn step by step (sent / opened / clicked / replied / bounced / failed / in flight), the lead status, completed/total steps, current step, last action and time, and the next action.
- [x] **Scheduled time for the next action** (sections 4 and 5), done honestly: a campaign is one self-perpetuating task, so nothing per contact is stored. `GET /contacts/:id/campaigns` asks the scheduler for a read-only preview that runs the contact through the *same* routing (`RouteContact`, sharing the `campaignRouter` extracted from `FindNextRoutedPair`) and the *same* placement (`placeCampaignSend`, extracted from `CalculateNextCampaignTime`, with a `preview` flag that suppresses decision logs and cache writes). No pacing rule is reimplemented in a handler. The result is one of `due` (carries the slot the scheduler would give it; leads ahead in the queue can still push it later), `waiting` (carries the earliest allowed time and the constraint: `Waiting 3 days after Email 1`, `Outside the campaign's sending window`, `Today's new-lead limit is reached`, mailbox capacity), `paused`, or `blocked` (no mailbox, domain auth failing, past end date). An undecided branch condition says the next step depends on their response.
- [x] **Detailed email events** (section 7, within what is tracked): every row expands to show campaign, step, subject, mailbox, reason, intent, provider, category, source detail, meeting details.
- [x] Filter chips for the new families (**Campaigns**, **Lifecycle**) next to the existing ones, plus the existing search and date range; search now also matches categories and sources.
- [x] Realtime: both new queries live under `["contacts", id]`, so the audit spine's contact invalidation (and the existing send/open/reply per-contact invalidation) refreshes them without a page reload.

## Not in this PR (non-goals)

- No website / page-hit tracking, no JS tracker, no device/browser/geo capture, no UTM capture (section 1, and the website-derived parts of section 2). That is the follow-up PR.
- No forms and no form-submission events.
- No Mautic-style segments: this product has categories, and category membership is what the timeline records.
- No "upcoming actions list" beyond the next step (section 5's multi-step projection). Projecting several steps ahead would mean predicting future engagement and future mailbox capacity; the panel shows the whole flow with what has happened and the one next action the scheduler can actually vouch for.
- Email open device/browser/location (section 7) is not tracked by the pixel today and is not added here.

## Data model

- Migration `000106_contact_source`: three columns on `contacts` with a CHECK on `source`, backfill of `first_seen_at` from `created_at`, and two new `activity_type` enum values. Adding columns needs no `orgtransfer` change (rows travel as jsonb and the importer intersects against the destination catalog); confirmed against `internal/app/orgtransfer/spec.go`, and no new table was added. `contact_activities` was already registered there.
- Lifecycle events reuse the existing org-scoped `contact_activities` table rather than a second event table; they are written inside the same transaction as the membership change (`RETURNING` on every link insert/delete, so an `ON CONFLICT DO NOTHING` no-op logs nothing).

## Tests

- `TestLiveContactTimelineLifecycleEvents` / `TestLiveContactSourceCampaignResolvesName` (repository): creation, upsert-does-not-recreate, campaign/category add and remove via `Update` and `BulkUpdate`, name resolution, ordering, invalid source refused.
- `TestLivePreviewDueLeadGetsASlot`, `TestLivePreviewFollowUpWaitIsReported`, `TestLivePreviewSendingWindowBlocksTheStep`, `TestLivePreviewPausedCampaignHasNoSlot` (scheduler): the preview against real routing and placement, including a contact whose next step is blocked by a sending window.
- Existing `TestLiveFollowUpWaitIsHonored`, `TestLiveWaitingFollowUpDoesNotBlockOtherLeads`, the consumer send-result suite and `TestLiveEveryQueryPrepares` still pass on the refactored routing.

Verified: `make fmt`, `make lint` (with `check-migrations`), `pnpm typecheck` + `pnpm lint` in `web/`, `pnpm types:check` + `pnpm lint` + `pnpm build` in `docs/`, and all `TestLive*` in the touched packages against the dev Postgres.

## Docs

`guides/contacts-crm.mdx` (source attribution, activity timeline), `guides/campaigns.mdx` (what one lead is doing next, and the meaning of due / waiting / paused / blocked), `api/endpoints.mdx` (new route), `api/reference/contacts.mdx` (new event types and fields, contact source fields, the new endpoint, the activities enum).

Closes the derivable acceptance criteria of #255 as listed above; the website-tracking criteria remain open for the follow-up.