### PR TITLE
Fix the tracking image build: static/tracking.js is not in the build context

### DIFF
--- a/tracking/Dockerfile
+++ b/tracking/Dockerfile
@@ -18,6 +18,8 @@ RUN apk add --no-cache musl-dev && \
 WORKDIR /app
 COPY Cargo.toml Cargo.lock* ./
 COPY src ./src
+# include_str! reads static/tracking.js at compile time, so it must be in the context.
+COPY static ./static
 
 # The binary is copied out of the (cache-mounted) target dir before the mount is
 # released, so the runtime stage can COPY it.


### PR DESCRIPTION
`Build and Push` has failed on `main` for every commit since the website-visitor-tracking merge (#259), on both architectures:

```
error: couldn't read `src/../static/tracking.js`: No such file or directory (os error 2)
 --> src/handlers.rs:300:27
```

`handlers.rs:300` serves the website tracker with `include_str!("../static/tracking.js")`, which is resolved at compile time. The tracking image builds from `context: ./tracking` and the Dockerfile copies only `Cargo.toml`, `Cargo.lock*` and `src`, so the file the macro needs was never in the context.

The CI cargo job stayed green throughout because it builds from the full checkout, where `tracking/static/` is present. Only the image build sees the trimmed context, which is why this landed on `main` with a green PR.

Fix is one `COPY static ./static` before the build. The runtime stage still copies only the binary, so embedding the script with `include_str!` remains the right call: there is no static directory in the final image to read from at runtime.

Verified by reconstructing the exact layout the builder stage sees (`Cargo.toml`, `Cargo.lock`, `src/`, `static/`) and confirming `src/../static/tracking.js` resolves. `tracking/` has no `.dockerignore`, so nothing re-excludes it.