### PR TITLE
feat: surface the segment ID in the dashboard and docs for segment API integrators

### DIFF
--- a/docs/content/docs/api/reference/contacts.mdx
+++ b/docs/content/docs/api/reference/contacts.mdx
@@ -982,7 +982,7 @@ Auth: **Scope** `READ_CRM` · **Org permission** `view_contacts`
 
 ## Segments
 
-Segments are saved contact audiences: a list of conditions plus per-contact manual overrides. Membership is evaluated live on every read, so a segment never needs rebuilding. Every segment endpoint takes the contact scopes, except enrolling into a campaign, which writes leads and takes `WRITE_CAMPAIGNS`. Every endpoint here addresses a segment by its `id`; besides `GET /segments`, the dashboard shows it on the segment page header (click to copy) and in the row menu of the Segments tab.
+Segments are saved contact audiences: a list of conditions plus per-contact manual overrides. Membership is evaluated live on every read, so a segment never needs rebuilding. Every segment endpoint takes the contact scopes, except enrolling into a campaign, which writes leads and takes `WRITE_CAMPAIGNS`. Endpoints that operate on an existing segment address it by its `id`; besides `GET /segments`, the dashboard shows that ID on the segment page header (click to copy) and in the row menu of the Segments tab.
 
 A segment object:
 

--- a/docs/content/docs/api/reference/contacts.mdx
+++ b/docs/content/docs/api/reference/contacts.mdx
@@ -982,7 +982,7 @@ Auth: **Scope** `READ_CRM` · **Org permission** `view_contacts`
 
 ## Segments
 
-Segments are saved contact audiences: a list of conditions plus per-contact manual overrides. Membership is evaluated live on every read, so a segment never needs rebuilding. Every segment endpoint takes the contact scopes, except enrolling into a campaign, which writes leads and takes `WRITE_CAMPAIGNS`.
+Segments are saved contact audiences: a list of conditions plus per-contact manual overrides. Membership is evaluated live on every read, so a segment never needs rebuilding. Every segment endpoint takes the contact scopes, except enrolling into a campaign, which writes leads and takes `WRITE_CAMPAIGNS`. Every endpoint here addresses a segment by its `id`; besides `GET /segments`, the dashboard shows it on the segment page header (click to copy) and in the row menu of the Segments tab.
 
 A segment object:
 

--- a/docs/content/docs/guides/segments.mdx
+++ b/docs/content/docs/guides/segments.mdx
@@ -52,6 +52,12 @@ Sequences can pin as well: the **Add to segment** and **Remove from segment** ac
 - **Duplicate**: the segment menu copies a definition to start a variation from.
 - **Search and export**: the contact search and export accept `segment_ids`, so anything that takes a contact filter can be scoped to a segment.
 
+## Segments in the API
+
+Everything above can be driven from the [API](/api/reference/contacts/#segments): list, create, update and delete segments, pin contacts in or out, look up a contact's segments, and enrol a segment into a campaign. Contact search and export take `segment_ids` to scope any contact query to a segment, so an external system (a signup form, a CRM sync) can keep a segment current and let campaigns pick it up from there.
+
+API calls address a segment by its ID. It is shown at the bottom of the segment page header (click it to copy), in the **Copy segment ID** entry of a segment's row menu on the Segments tab, and in every segment the API returns. Reads take the `READ_CONTACTS` key scope, writes `WRITE_CONTACTS`, and enrolling into a campaign `WRITE_CAMPAIGNS`.
+
 <Callout type="info" title="Segments and categories">
 Categories are labels you put on a contact. Segments are rules that read those labels (and everything else) to decide who belongs. Use a category to mark a fact about a contact, and a segment to describe an audience.
 </Callout>
@@ -68,4 +74,5 @@ Categories are labels you put on a contact. Segments are rules that read those l
   <Card title="Contacts and CRM" href="/guides/contacts-crm/" />
   <Card title="Campaigns" href="/guides/campaigns/" />
   <Card title="Analytics" href="/guides/analytics/" />
+  <Card title="Segments API reference" href="/api/reference/contacts/#segments" />
 </Cards>

--- a/web/src/app/app/contacts/segments/[id]/page.tsx
+++ b/web/src/app/app/contacts/segments/[id]/page.tsx
@@ -149,16 +149,22 @@ function SegmentIdChip({ id }: { id: string }) {
         }
     }
     return (
-        <button
-            type="button"
-            onClick={copy}
-            title="Copy segment ID"
-            className="mt-1 inline-flex items-center gap-1.5 max-w-full font-mono text-[10.5px] text-slate-400 hover:text-slate-700 transition-colors"
-        >
-            <span className="uppercase tracking-[0.14em] font-sans font-medium text-[9.5px]">ID</span>
-            <span className="truncate">{id}</span>
-            {copied ? <CheckIcon className="w-3 h-3 text-emerald-600 shrink-0" /> : <CopyIcon className="w-3 h-3 shrink-0" />}
-        </button>
+        <>
+            <button
+                type="button"
+                onClick={copy}
+                aria-label={copied ? "Segment ID copied" : "Copy segment ID"}
+                title="Copy segment ID"
+                className="mt-1 inline-flex items-center gap-1.5 max-w-full font-mono text-[10.5px] text-slate-400 hover:text-slate-700 transition-colors"
+            >
+                <span className="uppercase tracking-[0.14em] font-sans font-medium text-[9.5px]">ID</span>
+                <span className="truncate">{id}</span>
+                {copied ? <CheckIcon className="w-3 h-3 text-emerald-600 shrink-0" /> : <CopyIcon className="w-3 h-3 shrink-0" />}
+            </button>
+            <span className="sr-only" role="status" aria-live="polite">
+                {copied ? "Segment ID copied" : ""}
+            </span>
+        </>
     );
 }
 

--- a/web/src/app/app/contacts/segments/[id]/page.tsx
+++ b/web/src/app/app/contacts/segments/[id]/page.tsx
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeftIcon, ChevronDownIcon, MegaphoneIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { ArrowLeftIcon, CheckIcon, ChevronDownIcon, CopyIcon, MegaphoneIcon, PencilIcon, Trash2Icon } from "lucide-react";
 import toast from "react-hot-toast";
 
 import ContactsTable from "@/components/app/contacts/ContactsTable";
@@ -94,6 +94,7 @@ function SegmentDetail() {
                         </div>
                         {s.description && <p className="text-[12px] text-slate-500 mt-0.5">{s.description}</p>}
                         <ConditionSummary conditions={s.conditions} match={s.match} specs={fields.data ?? []} included={s.included_count} excluded={s.excluded_count} />
+                        <SegmentIdChip id={s.id} />
                     </div>
                     <div className="flex items-center gap-1.5 shrink-0">
                         <button
@@ -131,6 +132,33 @@ function SegmentDetail() {
             <SegmentEditor open={editorOpen} onClose={() => setEditorOpen(false)} segment={s} />
             <AddSegmentToCampaignDialog open={campaignOpen} onClose={() => setCampaignOpen(false)} segment={s} />
         </div>
+    );
+}
+
+// The segment's ID, click to copy: it is what the API takes (segments CRUD,
+// members, contact search segment_ids), so integrators need it at hand.
+function SegmentIdChip({ id }: { id: string }) {
+    const [copied, setCopied] = React.useState(false);
+    async function copy() {
+        try {
+            await navigator.clipboard.writeText(id);
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+        } catch {
+            toast.error("Could not copy");
+        }
+    }
+    return (
+        <button
+            type="button"
+            onClick={copy}
+            title="Copy segment ID"
+            className="mt-1 inline-flex items-center gap-1.5 max-w-full font-mono text-[10.5px] text-slate-400 hover:text-slate-700 transition-colors"
+        >
+            <span className="uppercase tracking-[0.14em] font-sans font-medium text-[9.5px]">ID</span>
+            <span className="truncate">{id}</span>
+            {copied ? <CheckIcon className="w-3 h-3 text-emerald-600 shrink-0" /> : <CopyIcon className="w-3 h-3 shrink-0" />}
+        </button>
     );
 }
 

--- a/web/src/app/app/contacts/segments/page.tsx
+++ b/web/src/app/app/contacts/segments/page.tsx
@@ -92,6 +92,16 @@ function SegmentsList() {
         setEditorOpen(true);
     }
 
+    // The ID is what the segments API takes; copying needs no write permission.
+    async function copyId(s: Segment) {
+        try {
+            await navigator.clipboard.writeText(s.id);
+            toast.success("Segment ID copied");
+        } catch {
+            toast.error("Could not copy");
+        }
+    }
+
     function askDelete(s: Segment) {
         confirm.show(`Delete the segment "${s.name}"? Contacts themselves are kept.`, async () => {
             try {
@@ -202,6 +212,7 @@ function SegmentsList() {
                                         <PopoverMenuItem onSelect={guarded(() => openEdit(s))}>Edit conditions</PopoverMenuItem>
                                         <PopoverMenuItem onSelect={campaignGuarded(() => setCampaignFor(s))}>Add to campaign</PopoverMenuItem>
                                         <PopoverMenuItem onSelect={guarded(() => duplicate(s))}>Duplicate</PopoverMenuItem>
+                                        <PopoverMenuItem onSelect={() => copyId(s)}>Copy segment ID</PopoverMenuItem>
                                         <PopoverMenuSeparator />
                                         <PopoverMenuItem onSelect={guarded(() => askDelete(s))}>Delete</PopoverMenuItem>
                                     </PopoverMenuContent>


### PR DESCRIPTION
Fixes #275

## What the issue asked for, and what was actually missing

Issue #275 asks for a segment ID and add/update/delete support on the segment API. The API half already shipped with #270 and I verified all of it live against the running backend, with both a JWT session and an API key (`READ_CONTACTS`/`WRITE_CONTACTS` scopes):

- `POST /v1/segments`, `GET /v1/segments`, `GET /v1/segments/:id`, `PATCH /v1/segments/:id`, `DELETE /v1/segments/:id` all work and every response carries the segment `id`
- membership management works end to end: `POST /v1/segments/:id/members` with `include` / `exclude` / `auto`, `GET /v1/contacts/:id/segments`, and `POST /v1/contacts/search` scoped by `segment_ids` — i.e. the "form signup adds the contact to my Platform User segment" integration from #277 is already possible today
- it is all documented under [API reference / contacts / Segments](https://docs.warmbly.com/api/reference/contacts/#segments)

What was genuinely missing is the piece the screenshot shows: the dashboard never displays a segment's ID anywhere, so an integrator has no way to find the ID the API needs short of scraping it from the URL or calling `GET /segments` first.

## Changes

- **Segment page header** (`web`): a click-to-copy ID chip below the condition summary (copy icon flips to a check, matching the CloudLinkCard pattern)
- **Segments list row menu** (`web`): a **Copy segment ID** entry (no write guard — reading the ID only needs view access)
- **Docs, segments guide**: a new *Segments in the API* section explaining that segments are fully manageable via the API (CRUD, members, enrolment, `segment_ids` scoping), where to find the ID, and which key scopes apply; plus a card linking to the API reference
- **Docs, API reference**: one sentence in the Segments intro noting where the dashboard shows the ID

## Verification

- live CRUD + membership flow exercised against the dev backend with both auth modes (created, listed, patched, member-pinned, searched by `segment_ids`, cleared, deleted; test data cleaned up)
- `pnpm typecheck` + `pnpm lint` in `web/`: clean (pre-existing warnings only)
- `pnpm types:check`, `pnpm lint`, and `pnpm build` in `docs/`: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added options to copy segment IDs from the segments list and individual segment pages.
  * Added success feedback and error notifications for copy actions.
  * Segment ID copying is available without write permission.

* **Documentation**
  * Expanded segment documentation with API management, filtering, enrollment, pinning, ID locations, and required access scopes.
  * Clarified how segment endpoints use segment IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->