### PR TITLE
fix: keep host node_modules out of the Docker build context so the forms image builds (#292)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,14 +11,17 @@
 .vscode
 .agentd
 
-# Frontend bits — the web service bind-mounts ./web directly, so we
-# never want the heavyweight frontend tree to land in the Go build
-# context.
-web/node_modules
-web/.vite
+# Frontend trees: the Go images never need them, and a host node_modules
+# copied over the forms image's own install makes pnpm abort the build (#292).
+**/node_modules
+**/.vite
 web/dist
 web/build
 web/coverage
+forms/dist
+admin/dist
+site/dist
+site/.astro
 
 # Compiled host binaries that would shadow / inflate the context.
 bin

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -5,6 +5,8 @@
 # the heavy pnpm build runs only once.
 FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 WORKDIR /app
+# No TTY in a build: CI=true makes pnpm reinstall instead of prompting.
+ENV CI=true
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/deploy/docker/forms.Dockerfile
+++ b/deploy/docker/forms.Dockerfile
@@ -9,6 +9,8 @@
 # $TARGETARCH (no QEMU).
 FROM --platform=$BUILDPLATFORM node:22-alpine AS appbuilder
 WORKDIR /app
+# No TTY in a build: CI=true makes pnpm reinstall instead of prompting.
+ENV CI=true
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 COPY forms/package.json forms/pnpm-lock.yaml forms/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile

--- a/docs/content/docs/development/troubleshooting.mdx
+++ b/docs/content/docs/development/troubleshooting.mdx
@@ -64,6 +64,7 @@ Newer builds return the invite-only refusal with its own machine code, `registra
 |---|---|
 | `no space left on device`, often from a random service mid-compile | Docker is out of disk. Free space with `docker builder prune -af` and `docker image prune -af`, check the host has about 10 GB free, then re-run `make up` |
 | `failed to authorize: ... EOF` while pulling a base image | A transient registry blip. Re-run `make up`; completed layers are cached |
+| `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY` while building the `forms` image | A `forms/node_modules` from a native `make forms` or `make dev` was shipped into the Docker build context and overwrote the image's own install, and pnpm will not recreate it without a terminal. Current checkouts keep every `node_modules` out of the context and run pnpm in CI mode; on an older checkout, `rm -rf forms/node_modules` and re-run `make up` |
 | `failed to xattr /path/._something: operation not permitted` on macOS | The checkout is on a filesystem without native extended attributes (exFAT, NTFS or a network share), so macOS writes `._*` sidecar files that BuildKit cannot read. Run `dot_clean -m .` then `find . -name '._*' -delete` and re-run. Cloning to an APFS volume avoids it |
 
 ## The stack is up but something is wrong

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -5,6 +5,8 @@
 # heavy pnpm build runs only once.
 FROM --platform=$BUILDPLATFORM node:22-alpine AS build
 WORKDIR /app
+# No TTY in a build: CI=true makes pnpm reinstall instead of prompting.
+ENV CI=true
 RUN corepack enable && corepack prepare pnpm@11.9.0 --activate
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
Fixes #292.

## Cause

`make up` fails on the `forms` image with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. The issue attributes it to pnpm's dependency check after `COPY forms/ .`, but a clean checkout passes that check: the unmodified Dockerfile builds fine from a clean context.

The real trigger is the build context. The forms image builds from the repo root, and the root `.dockerignore` only excluded `web/node_modules`. Any `forms/node_modules` left by a native `make forms`, `make run` or `make dev` is shipped into the context, and `COPY forms/ .` overwrites the image's fresh install with one whose `.modules.yaml` points at the host's pnpm store. pnpm then wants to purge and recreate `node_modules`, cannot confirm without a TTY, and exits 1. Reproduced exactly by installing forms deps on the host and rebuilding.

## Changes

- `.dockerignore`: exclude every `node_modules` and `.vite` directory, plus the `forms`, `admin` and `site` build outputs. None of the root-context images need them.
- `deploy/docker/forms.Dockerfile`: `ENV CI=true` in the app build stage, so pnpm reinstalls instead of prompting if the install ever looks stale again.
- `web/Dockerfile`, `admin/Dockerfile`: same `CI=true` line. They have their own ignore files so they were not failing, but they run the identical pnpm path.
- `docs/content/docs/development/troubleshooting.mdx`: a row for the symptom with the workaround for older checkouts.

The alternative of copying source before `pnpm install` was not adopted: it would drop the cached install layer on every source change.

## Verification

All with a host `forms/node_modules` present in the checkout:

- forms app stage with the full fix: builds, no reinstall
- forms app stage with the old ignore rules and only `CI=true`: pnpm logs `Recreating /app/node_modules` and the build completes
- full forms, web and admin images: build end to end
- `pnpm lint` and `pnpm types:check` in `docs/`: pass (two pre-existing warnings in untouched files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container builds by enabling non-interactive dependency installation.
  * Updated container build exclusions to reduce unnecessary files and generated output in build contexts.

* **Documentation**
  * Added troubleshooting guidance for dependency cleanup issues encountered while building the forms container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->