### PR TITLE
feat: one-time email campaign preset with send estimate, one-time status wording, plain-text send fix and campaign tab mobile padding (#288)

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1300,6 +1300,10 @@ func main() {
 		if aware, ok := campaignService.(campaign.ProgressAware); ok {
 			aware.WireProgress(campaignProgressRepository)
 		}
+		// The wizard's audience-versus-pool estimate counts segment members.
+		if aware, ok := campaignService.(campaign.SegmentAware); ok {
+			aware.WireSegments(segmentService)
+		}
 		// Delete drops attachment objects and duplicate copies them, so the
 		// campaign service needs the store the attachment handler writes to.
 		if aware, ok := campaignService.(campaign.AttachmentAware); ok {

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -43,6 +43,7 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 |--------|------|----------------|
 | GET | `/campaigns` | `READ_CAMPAIGNS` |
 | GET | `/campaigns-overview` | `READ_CAMPAIGNS` |
+| POST | `/campaigns-estimate` | `READ_CAMPAIGNS` |
 | POST | `/campaigns` | `WRITE_CAMPAIGNS` |
 | GET | `/campaigns/:id` | `READ_CAMPAIGNS` |
 | PATCH | `/campaigns/:id` | `WRITE_CAMPAIGNS` |

--- a/docs/content/docs/api/reference/campaigns.mdx
+++ b/docs/content/docs/api/reference/campaigns.mdx
@@ -18,6 +18,7 @@ Search and page through the organization's campaigns. **Scope** `READ_CAMPAIGNS`
 | `q` | query | string | Free-text filter on campaign name. Optional. |
 | `folder` | query | string | Restrict to a single folder id. Optional. |
 | `status` | query | string | Status bucket filter: `draft`, `active`, `paused` (matches every paused variant), or `completed`. Any other value returns `400`. Optional. |
+| `kind` | query | string | `sequence` or `one_time`. Any other value returns `400`. Optional. |
 | `cursor` | query | string | Opaque cursor from the previous page's `pagination.next_cursor`. Optional. |
 | `limit` | query | string | Page size. Optional. |
 
@@ -35,6 +36,7 @@ A `data` plus `pagination` envelope. `next_cursor` is the campaign id to resume 
       "name": "Q3 outbound",
       "description": "",
       "status": "active",
+      "kind": "sequence",
       "stop_on_reply": true,
       "open_tracking": true,
       "link_tracking": true,
@@ -83,7 +85,7 @@ A `data` plus `pagination` envelope. `next_cursor` is the campaign id to resume 
 
 `GET /campaigns-overview`
 
-Status-bucket counts plus per-folder totals for the organization, used to drive campaign browsing UIs. `paused` sums every paused variant (`paused`, `paused_no_accounts`, `paused_trial_expired`). The path has no campaign id, so it lives beside `/campaigns` rather than under it. **Scope** `READ_CAMPAIGNS` · **Org permission** `view_campaigns`.
+Status-bucket counts plus per-folder totals for the organization, used to drive campaign browsing UIs. `paused` sums every paused variant (`paused`, `paused_no_accounts`, `paused_trial_expired`); `one_time` counts campaigns of that kind whatever their status. The path has no campaign id, so it lives beside `/campaigns` rather than under it. **Scope** `READ_CAMPAIGNS` · **Org permission** `view_campaigns`.
 
 ### Response
 
@@ -94,9 +96,42 @@ Status-bucket counts plus per-folder totals for the organization, used to drive 
   "paused": 2,
   "draft": 4,
   "completed": 3,
+  "one_time": 2,
   "folders": [
     { "folder_id": "6b9c1c8e-1f2a-4d3b-8c7e-9a0b1c2d3e4f", "total": 5 }
   ]
+}
+```
+
+## Estimate a send
+
+`POST /campaigns-estimate`
+
+Project an audience against a sender pool before a campaign exists: how many contacts the segments resolve to, how many mailboxes would send, the pool's daily ceiling under the campaign limit, and the day the last send is expected to land. Nothing is written, so it needs no `Idempotency-Key`. The dashboard's one-time email wizard shows this on its last step. **Scope** `READ_CAMPAIGNS` · **Org permission** `view_campaigns`.
+
+### Request body
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `segment_ids` | string[] | yes | Segments making up the audience (at most 20). A contact in several of them is counted once. |
+| `email_tag_ids` | string[] | no | Mailbox tags that resolve the pool. Omit or send `[]` for every active mailbox in the workspace. |
+| `daily_limit` | integer | no | Per-mailbox campaign cap to apply (defaults to `50`). Each mailbox counts the smaller of this and its own cap. |
+| `days` | integer (0-127) | no | Weekday bitmask of sending days, bit 0 = Monday. Defaults to weekdays. |
+| `timezone` | string | no | IANA timezone the days are counted in. Defaults to UTC. |
+| `start_date` | string (RFC 3339) | no | When sending begins. Omit for now. |
+
+### Response
+
+`sending_days` and `estimated_finish_at` are `null` when the audience is empty, the pool has no capacity, or the send would take longer than two years. Today only contributes what the pool has not already sent (`remaining_today`).
+
+```json
+{
+  "recipients": 1000,
+  "mailboxes": 4,
+  "daily_capacity": 200,
+  "remaining_today": 140,
+  "sending_days": 5,
+  "estimated_finish_at": "2026-09-09T00:00:00+02:00"
 }
 ```
 
@@ -112,10 +147,11 @@ Create a campaign. Only `name` is required, every other field is optional and ap
 | --- | --- | --- | --- |
 | `name` | string | yes | Campaign name. |
 | `description` | string | no | Free-text description. |
+| `kind` | string | no | `sequence` (default) or `one_time`. A one-time email accepts at most one entry in `steps` here and refuses further email steps later; it is otherwise a normal campaign. Fixed at creation. |
 | `stop_on_reply` | boolean | no | Stop sending to a contact once they reply. |
 | `open_tracking` | boolean | no | Insert the open pixel. |
 | `link_tracking` | boolean | no | Rewrite links through the tracking ticket service. |
-| `text_only` | boolean | no | Send plain text only. |
+| `text_only` | boolean | no | Send plain text only: no HTML part, and open and click tracking are off regardless of their flags. |
 | `daily_limit` | integer | no | Per-campaign daily send cap. |
 | `unsubscribe_header` | boolean | no | Add the RFC 8058 one-click unsubscribe header. |
 | `risky_emails` | boolean | no | Allow sending to risky/unverified addresses. |

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -11,9 +11,23 @@ You need at least one active mailbox and a contact list. Warm new mailboxes befo
 
 ## Create a campaign
 
-**Campaigns** > **New campaign** opens a four-step wizard: **Basics** (name, description), **Schedule** (timezone, sending days, hours), **Sending** (mailbox tags, daily limit per mailbox, stop on reply, open and click tracking, unsubscribe header), and **First email** (subject, body, optional follow-ups). Follow-ups added here are connected in order, each waiting the number of days you set after the previous step; open the Steps tab to rearrange, branch, or change the waits. Only a name is required; the first email can be skipped and written in the full editor on the Steps tab, and everything else can be changed later from settings. Closing a wizard with unsaved edits asks before discarding them.
+**Campaigns** > **New campaign** opens a wizard that first asks what you are sending: a **sequence** or a [one-time email](#one-time-emails). For a sequence the steps are **Basics** (name, description), **Schedule** (timezone, sending days, hours), **Sending** (mailbox tags, daily limit per mailbox, stop on reply, open and click tracking, unsubscribe header), and **First email** (subject, body, optional follow-ups). Follow-ups added here are connected in order, each waiting the number of days you set after the previous step; open the Steps tab to rearrange, branch, or change the waits. Only a name is required; the first email can be skipped and written in the full editor on the Steps tab, and everything else can be changed later from settings. Closing a wizard with unsaved edits asks before discarding them.
 
 The campaign starts as a **draft**. Nothing sends until you start it.
+
+## One-time emails
+
+A one-time email is a campaign with a single message and no follow-ups: an announcement, an update, a single ask to a segment. It is still a campaign underneath, so it sends through your mailbox pool with the same rotation, per-mailbox daily caps, spacing, suppression, tracking and analytics as a sequence. What changes is the flow and the wording.
+
+Pick **One-time email** on the wizard's first step. The steps are then **Basics**, **Email** (subject and body, both required), **Audience** (one or more [segments](/guides/segments/); every current member becomes a lead, and a contact in several of them is emailed once), **Sending** (mailbox tags, daily limit, tracking, unsubscribe header) and **Send**. The last step chooses **Send now** or **Schedule for later** with a date and time, sets the sending days and window, and shows an estimate: how many recipients the segments resolve to, how many mailboxes will send, the pool's daily ceiling, and the day the last send is expected to land. The estimate is the earliest finish under the daily caps, not a promise. A thousand contacts on one mailbox at the default cap is a multi-week send, and the wizard says so before you confirm.
+
+Confirming creates the campaign, links the segments (so the campaign keeps enrolling contacts who join them later, exactly like [linking a segment](/guides/segments/#linking-a-segment-to-a-campaign)), and starts it. A scheduled one waits for its date, then sends inside the window. If the start is refused, for example because the segments are empty or the list fails the [launch check](#the-launch-check-on-your-list), the email is kept as a draft and its page explains why.
+
+In the campaigns list a one-time email carries a **One-time** badge and reads **draft**, **scheduled** (started, waiting for its date), **sending** or **sent**; the **Type** filter shows only sequences or only one-time emails. The Overview tab reports opens, clicks, replies and bounces the same way it does for a sequence. Adding a second email step to a one-time email is refused: create a sequence when you want a reminder later.
+
+## Plain text only
+
+**Settings** > **Plain text only** sends the campaign without an HTML part. Recipients get the plain-text body with the mailbox's plain-text signature, and because open pixels and wrapped links need HTML, open and click tracking are off for that campaign whatever their toggles say. Test emails respect it too, so what lands in your own inbox is what recipients get.
 
 ## Senders and rotation
 

--- a/docs/content/docs/guides/segments.mdx
+++ b/docs/content/docs/guides/segments.mdx
@@ -51,6 +51,7 @@ Sequences can pin too: the **Add to segment** and **Remove from segment** action
 - **Browse**: a segment page lists its current members with the same table, filters, detail drawer and bulk actions as the contacts page.
 - **Add to campaign**: enrols every current member as a lead of the campaign you pick, from the segment page or with **From segment** on a campaign's Leads tab. Contacts already in that campaign are skipped, and a running campaign wakes up to schedule the new leads. This is a snapshot: contacts who join the segment later are not added until you run it again. To keep a campaign fed automatically, [link the segment](#linking-a-segment-to-a-campaign) instead.
 - **Link to campaign**: attaches the segment to a campaign as a live audience, so contacts who join the segment later become leads on their own. See [below](#linking-a-segment-to-a-campaign).
+- **One-time email**: send one message to the segment without building a sequence. **Campaigns** > **New campaign** > **One-time email** picks the segments, shows how many contacts they resolve to and how long the mailbox pool needs, and sends now or on a date. See [one-time emails](/guides/campaigns/#one-time-emails).
 - **Filter**: the contact list's filter bar has a **Segment** pill, and the same scope carries into an export.
 - **Duplicate**: the segment menu copies a definition to start a variation from.
 - **Search and export**: the contact search and export accept `segment_ids`, so anything that takes a contact filter can be scoped to a segment.

--- a/internal/api/handler/campaign.go
+++ b/internal/api/handler/campaign.go
@@ -134,9 +134,36 @@ func (h *Handler) SearchCampaigns(c *gin.Context) {
 	cursor := c.Query("cursor")
 	folder := c.Query("folder")
 	status := c.Query("status")
+	kind := c.Query("kind")
 	limit := c.Query("limit")
 
-	resp, err := h.CampaignService.Search(c.Request.Context(), orgID.String(), query, cursor, folder, status, limit)
+	resp, err := h.CampaignService.Search(c.Request.Context(), orgID.String(), query, cursor, folder, status, kind, limit)
+	if err != nil {
+		errx.JSON(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// EstimateCampaign projects an audience against a sender pool before a
+// campaign exists: recipients, daily capacity and the day the last send
+// lands. Read-only.
+// POST /campaigns-estimate
+func (h *Handler) EstimateCampaign(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.ErrNoOrganization)
+		return
+	}
+
+	var data models.CampaignEstimate
+	if err := c.ShouldBindJSON(&data); err != nil {
+		errx.JSON(c, errx.ErrInvalid)
+		return
+	}
+
+	resp, err := h.CampaignService.Estimate(c.Request.Context(), *orgID, &data)
 	if err != nil {
 		errx.JSON(c, err)
 		return

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -462,7 +462,7 @@ func Run(
 
 			// Audience-versus-pool projection for the campaign wizard (no
 			// campaign id yet). Read-level: it writes nothing.
-			protected.POST("/campaigns-estimate", m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.EstimateCampaign)
+			protected.POST("/campaigns-estimate", m.RateLimitMiddleware(models.RateLimitRead), m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.EstimateCampaign)
 
 			campaigns := protected.Group("/campaigns")
 			campaigns.Use(m.RateLimitMiddleware(models.RateLimitWrite))

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -460,6 +460,10 @@ func Run(
 			// lives one level up).
 			protected.GET("/campaigns-overview", m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.GetCampaignsOverview)
 
+			// Audience-versus-pool projection for the campaign wizard (no
+			// campaign id yet). Read-level: it writes nothing.
+			protected.POST("/campaigns-estimate", m.RequireOrganization(), m.RequireAccess(models.PermViewCampaigns, models.APIPermReadCampaigns), h.EstimateCampaign)
+
 			campaigns := protected.Group("/campaigns")
 			campaigns.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 			{

--- a/internal/app/aitools/tools_campaigns.go
+++ b/internal/app/aitools/tools_campaigns.go
@@ -69,6 +69,7 @@ func (d Deps) registerCampaignTools(r *Registry) {
 		InputSchema: objectSchema(map[string]any{
 			"name":        strProp("Campaign name (required)."),
 			"description": strProp("Optional description."),
+			"kind":        strProp("Optional: 'sequence' (default, follow-ups allowed) or 'one_time' (a single message, at most one step)."),
 			"steps": arrProp("Optional email steps to seed the sequence.", objectSchema(map[string]any{
 				"subject":   strProp("Email subject (may contain {{merge}} vars)."),
 				"body":      strProp("Email body text (may contain {{merge}} vars)."),
@@ -368,7 +369,7 @@ func (d Deps) listCampaigns(ctx context.Context, inv Invocation, args json.RawMe
 	if limit <= 0 || limit > 50 {
 		limit = 20
 	}
-	res, xerr := d.Campaigns.Search(ctx, inv.OrgID.String(), in.Query, "", "", in.Status, fmt.Sprintf("%d", limit))
+	res, xerr := d.Campaigns.Search(ctx, inv.OrgID.String(), in.Query, "", "", in.Status, "", fmt.Sprintf("%d", limit))
 	if xerr != nil {
 		return "", fromErrx(xerr)
 	}
@@ -413,8 +414,9 @@ func (d Deps) getCampaignStats(ctx context.Context, inv Invocation, args json.Ra
 
 func (d Deps) createCampaignDraft(ctx context.Context, inv Invocation, args json.RawMessage) (string, error) {
 	in, err := decodeArgs[struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
+		Name        string  `json:"name"`
+		Description string  `json:"description"`
+		Kind        *string `json:"kind"`
 		Steps       []struct {
 			Subject  string `json:"subject"`
 			Body     string `json:"body"`
@@ -425,6 +427,9 @@ func (d Deps) createCampaignDraft(ctx context.Context, inv Invocation, args json
 		return "", err
 	}
 	if in.Name == "" {
+		return "", ErrInvalidArgs
+	}
+	if in.Kind != nil && *in.Kind != "" && !models.ValidCampaignKind(*in.Kind) {
 		return "", ErrInvalidArgs
 	}
 
@@ -442,6 +447,7 @@ func (d Deps) createCampaignDraft(ctx context.Context, inv Invocation, args json
 	camp, xerr := d.Campaigns.Create(ctx, inv.UserID.String(), &orgID, &models.CreateCampaign{
 		Name:        in.Name,
 		Description: in.Description,
+		Kind:        in.Kind,
 		Sequences:   seqs,
 	})
 	if xerr != nil {

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -932,9 +932,10 @@ func (s *campaignService) Estimate(ctx context.Context, orgID uuid.UUID, in *mod
 		out.DailyCapacity += lim
 		sent, err := s.taskRepo.CountCampaignEmailsSentToday(ctx, acct.ID)
 		if err != nil {
-			// A counter blip must not blank the whole estimate; today then
-			// reads as untouched, which is the optimistic side.
-			sent = 0
+			// A counter blip must not blank the whole estimate, but it must
+			// not flatter it either: a mailbox whose sends today are unknown
+			// contributes nothing to today and only counts from tomorrow.
+			continue
 		}
 		out.RemainingToday += max(0, lim-sent)
 	}

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -15,6 +15,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/dailythrottle"
 	"github.com/warmbly/warmbly/internal/app/listgate"
+	"github.com/warmbly/warmbly/internal/app/tz"
+	"github.com/warmbly/warmbly/internal/bitmask"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
@@ -86,7 +88,7 @@ func (s *campaignService) Get(ctx context.Context, orgID, id string) (*models.Ca
 	return resp, nil
 }
 
-func (s *campaignService) Search(ctx context.Context, orgID, query, cursor, folder, status, limit string) (*models.CampaignsResult, *errx.Error) {
+func (s *campaignService) Search(ctx context.Context, orgID, query, cursor, folder, status, kind, limit string) (*models.CampaignsResult, *errx.Error) {
 	cursorId, err := paging.DecodeCursor(cursor)
 	if err != nil {
 		return nil, err
@@ -104,8 +106,11 @@ func (s *campaignService) Search(ctx context.Context, orgID, query, cursor, fold
 	default:
 		return nil, errx.New(errx.BadRequest, "invalid status filter: must be draft, active, paused, or completed")
 	}
+	if kind != "" && !models.ValidCampaignKind(kind) {
+		return nil, errx.New(errx.BadRequest, "invalid kind filter: must be sequence or one_time")
+	}
 
-	resp, xerr := s.campaignRepository.Search(ctx, orgID, query, cursorId, folderId, status, limitN)
+	resp, xerr := s.campaignRepository.Search(ctx, orgID, query, cursorId, folderId, status, kind, limitN)
 	if xerr != nil {
 		return nil, errx.InternalError()
 	}
@@ -856,4 +861,130 @@ func modelOrgID(orgID *uuid.UUID) string {
 		return ""
 	}
 	return orgID.String()
+}
+
+// estimateHorizonDays bounds the finish-date walk; an audience that needs
+// longer than this reports no finish date rather than a meaningless one.
+const estimateHorizonDays = 2 * 366
+
+// Estimate projects an audience against a sender pool. It applies the same
+// cap rule as the scheduler (the smaller of the mailbox cap and the campaign
+// limit, per mailbox, per day) but none of its pacing, so the result is the
+// earliest the last send can land, not a promise.
+func (s *campaignService) Estimate(ctx context.Context, orgID uuid.UUID, in *models.CampaignEstimate) (*models.CampaignEstimateResult, *errx.Error) {
+	out := &models.CampaignEstimateResult{}
+
+	if len(in.SegmentIDs) > models.CampaignSegmentsMax {
+		return nil, errx.New(errx.BadRequest, fmt.Sprintf("a campaign can link at most %d segments", models.CampaignSegmentsMax))
+	}
+	seen := map[string]bool{}
+	segmentIDs := make([]string, 0, len(in.SegmentIDs))
+	for _, raw := range in.SegmentIDs {
+		if _, err := uuid.Parse(raw); err != nil {
+			return nil, errx.New(errx.BadRequest, "invalid segment id")
+		}
+		if seen[raw] {
+			continue
+		}
+		seen[raw] = true
+		segmentIDs = append(segmentIDs, raw)
+	}
+	// One preview over "in any of these segments" counts each contact once
+	// however many of the segments they belong to.
+	if len(segmentIDs) > 0 && s.segments != nil {
+		n, xerr := s.segments.Preview(ctx, orgID, &models.SegmentPreview{
+			Match:      models.SegmentMatchAny,
+			Conditions: []models.SegmentCondition{{Field: "segment", Operator: models.SegOpIn, Values: segmentIDs}},
+		})
+		if xerr != nil {
+			return nil, xerr
+		}
+		out.Recipients = n
+	}
+
+	dailyLimit := config.CampaignLimitDefault
+	if in.DailyLimit != nil {
+		if xerr := validate.CampaignDailyLimit(*in.DailyLimit); xerr != nil {
+			return nil, xerr
+		}
+		dailyLimit = *in.DailyLimit
+	}
+
+	// Same pool resolution as the scheduler: tags when given, otherwise
+	// every active mailbox in the workspace.
+	scope := repository.NewAccountScope(&orgID)
+	var accounts []models.Email
+	var xerr *errx.Error
+	if len(in.EmailTagIDs) > 0 {
+		accounts, xerr = s.emailRepo.GetByTags(ctx, scope, in.EmailTagIDs)
+	} else {
+		accounts, xerr = s.emailRepo.GetAllActiveInScope(ctx, scope)
+	}
+	if xerr != nil {
+		return nil, xerr
+	}
+	out.Mailboxes = len(accounts)
+	for _, acct := range accounts {
+		lim := min(acct.CampaignLimit, dailyLimit)
+		if lim < 0 {
+			lim = 0
+		}
+		out.DailyCapacity += lim
+		sent, err := s.taskRepo.CountCampaignEmailsSentToday(ctx, acct.ID)
+		if err != nil {
+			// A counter blip must not blank the whole estimate; today then
+			// reads as untouched, which is the optimistic side.
+			sent = 0
+		}
+		out.RemainingToday += max(0, lim-sent)
+	}
+	if out.Recipients == 0 || out.DailyCapacity == 0 {
+		return out, nil
+	}
+
+	// Walk calendar days from the start, spending each sending day's
+	// capacity, until the audience is covered. Today only has what the pool
+	// has not already sent.
+	days := bitmask.DefaultDays()
+	if in.Days != nil && *in.Days != 0 {
+		days = *in.Days
+	}
+	loc := time.UTC
+	if in.Timezone != nil && tz.Valid(*in.Timezone) {
+		if l, err := time.LoadLocation(*in.Timezone); err == nil {
+			loc = l
+		}
+	}
+	now := time.Now().In(loc)
+	start := now
+	if in.StartDate != nil && in.StartDate.After(now) {
+		start = in.StartDate.In(loc)
+	}
+	startDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, loc)
+	startsToday := startDay.Equal(time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, loc))
+	remaining := out.Recipients
+	sendingDays := 0
+	for i := 0; i < estimateHorizonDays; i++ {
+		d := startDay.AddDate(0, 0, i)
+		// Mask bit 0 is Monday; time.Weekday starts at Sunday.
+		if days&(1<<((int(d.Weekday())+6)%7)) == 0 {
+			continue
+		}
+		capacity := out.DailyCapacity
+		if i == 0 && startsToday {
+			capacity = out.RemainingToday
+		}
+		if capacity <= 0 {
+			continue
+		}
+		sendingDays++
+		remaining -= capacity
+		if remaining <= 0 {
+			finish := d
+			out.SendingDays = &sendingDays
+			out.EstimatedFinishAt = &finish
+			break
+		}
+	}
+	return out, nil
 }

--- a/internal/app/campaign/service.go
+++ b/internal/app/campaign/service.go
@@ -20,8 +20,12 @@ const campaignCooldownSeconds = 60
 type CampaignService interface {
 	Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error)
 	Get(ctx context.Context, userID, id string) (*models.Campaign, *errx.Error)
-	Search(ctx context.Context, userID, query, cursor, folder, status, limit string) (*models.CampaignsResult, *errx.Error)
+	Search(ctx context.Context, userID, query, cursor, folder, status, kind, limit string) (*models.CampaignsResult, *errx.Error)
 	Overview(ctx context.Context, orgID string) (*models.CampaignsOverview, *errx.Error)
+	// Estimate projects how many contacts a set of segments reaches and how
+	// many sending days a mailbox pool needs under the per-mailbox caps.
+	// Read-only; the wizard shows it before a one-time email is created.
+	Estimate(ctx context.Context, orgID uuid.UUID, in *models.CampaignEstimate) (*models.CampaignEstimateResult, *errx.Error)
 	Update(ctx context.Context, userID, id string, data *models.UpdateCampaign) (*models.Campaign, *errx.Error)
 	// Delete removes an organization's campaign outright. A running campaign
 	// is stopped as part of it: its pending tasks are cancelled in the same
@@ -78,6 +82,24 @@ type campaignService struct {
 	// campaignProgressRepo counts the leads verification refused, so a start
 	// with nothing left to send can say why. Optional/nil-safe.
 	campaignProgressRepo repository.CampaignProgressRepository
+	// segments counts an audience for Estimate. Optional: without it an
+	// estimate reports zero recipients.
+	segments SegmentCounter
+}
+
+// SegmentCounter is the slice of the segment service Estimate needs.
+// Satisfied structurally by segment.Service.
+type SegmentCounter interface {
+	Preview(ctx context.Context, orgID uuid.UUID, in *models.SegmentPreview) (int, *errx.Error)
+}
+
+// SegmentAware lets main hand the campaign service the segment counter.
+type SegmentAware interface {
+	WireSegments(c SegmentCounter)
+}
+
+func (s *campaignService) WireSegments(c SegmentCounter) {
+	s.segments = c
 }
 
 // WireAudience attaches the launch-time list gate.

--- a/internal/infrastructure/db/migrations/000122_campaign_kind.down.sql
+++ b/internal/infrastructure/db/migrations/000122_campaign_kind.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE campaigns DROP COLUMN IF EXISTS kind;

--- a/internal/infrastructure/db/migrations/000122_campaign_kind.up.sql
+++ b/internal/infrastructure/db/migrations/000122_campaign_kind.up.sql
@@ -1,0 +1,5 @@
+-- A campaign is either a multi-step sequence or a one-time email: one message
+-- to an audience, no follow-ups. Both send through the same pacer; the kind
+-- only changes what the editor allows and how status reads in the list.
+ALTER TABLE campaigns ADD COLUMN kind text NOT NULL DEFAULT 'sequence'
+    CHECK (kind IN ('sequence', 'one_time'));

--- a/internal/models/campaign.go
+++ b/internal/models/campaign.go
@@ -86,6 +86,19 @@ func (w *ScheduleWindows) Scan(src any) error {
 	return nil
 }
 
+// Campaign kinds. A sequence is the multi-step default; a one-time email is
+// one message to an audience with no follow-ups. Both send through the same
+// pacer and caps; the kind is fixed at creation.
+const (
+	CampaignKindSequence = "sequence"
+	CampaignKindOneTime  = "one_time"
+)
+
+// ValidCampaignKind reports whether k is a known campaign kind.
+func ValidCampaignKind(k string) bool {
+	return k == CampaignKindSequence || k == CampaignKindOneTime
+}
+
 type Campaign struct {
 	ID             uuid.UUID  `json:"id"`
 	UserID         string     `json:"user_id"`
@@ -94,6 +107,7 @@ type Campaign struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Status      string `json:"status"`
+	Kind        string `json:"kind"`
 
 	StopOnReply       bool `json:"stop_on_reply"`
 	OpenTracking      bool `json:"open_tracking"`
@@ -211,7 +225,34 @@ type CampaignsOverview struct {
 	Paused    int64                 `json:"paused"`
 	Draft     int64                 `json:"draft"`
 	Completed int64                 `json:"completed"`
+	OneTime   int64                 `json:"one_time"`
 	Folders   []CampaignFolderCount `json:"folders"`
+}
+
+// CampaignEstimate is the request for POST /campaigns-estimate: how many
+// contacts a set of segments resolves to and how long a sender pool needs
+// to reach them under the per-mailbox caps. Nothing is written.
+type CampaignEstimate struct {
+	SegmentIDs  []string   `json:"segment_ids"`
+	EmailTagIDs []string   `json:"email_tag_ids,omitempty"`
+	DailyLimit  *int       `json:"daily_limit,omitempty"`
+	Days        *uint8     `json:"days,omitempty"`
+	Timezone    *string    `json:"timezone,omitempty"`
+	StartDate   *time.Time `json:"start_date,omitempty"`
+}
+
+// CampaignEstimateResult is the projection. DailyCapacity is the pool's
+// per-day ceiling under the campaign limit; RemainingToday subtracts what the
+// mailboxes already sent today. SendingDays is how many sending days the
+// audience needs and EstimatedFinishAt the calendar day the last send lands
+// on, both nil when the pool has no capacity.
+type CampaignEstimateResult struct {
+	Recipients        int        `json:"recipients"`
+	Mailboxes         int        `json:"mailboxes"`
+	DailyCapacity     int        `json:"daily_capacity"`
+	RemainingToday    int        `json:"remaining_today"`
+	SendingDays       *int       `json:"sending_days"`
+	EstimatedFinishAt *time.Time `json:"estimated_finish_at"`
 }
 
 type CampaignFolderCount struct {
@@ -294,6 +335,9 @@ func (u *UpdateCampaign) TouchesSchedule() bool {
 type CreateCampaign struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	// Kind defaults to "sequence". A "one_time" campaign accepts a single
+	// email step here and refuses further ones later.
+	Kind *string `json:"kind,omitempty"`
 
 	// Sending rules / tracking
 	StopOnReply       *bool `json:"stop_on_reply,omitempty"`

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -36,7 +36,7 @@ type CampaignRepository interface {
 	// Search filters by name substring, folder id, and status bucket
 	// ("draft" | "active" | "paused" | "completed"; paused matches every
 	// paused_* variant; empty means all).
-	Search(ctx context.Context, userID, query string, cursor, folder *string, status string, limit int32) (*models.CampaignsResult, error)
+	Search(ctx context.Context, userID, query string, cursor, folder *string, status, kind string, limit int32) (*models.CampaignsResult, error)
 	// Overview returns status-bucket counts plus per-folder totals for the
 	// campaigns browser sidebar.
 	Overview(ctx context.Context, orgID string) (*models.CampaignsOverview, error)
@@ -144,7 +144,8 @@ const CAMPAIGN_SELECT = `id, name, description, status,
 		  schedule_windows,
 		  guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
 		  guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days,
-		  guardrail_tripped_at, guardrail_reason`
+		  guardrail_tripped_at, guardrail_reason,
+		  kind`
 
 func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) error {
 	var dest []any = []any{
@@ -163,6 +164,7 @@ func getCampaign(rows db.Scannable, campaign *models.Campaign, extra ...any) err
 		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
 		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
 		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
+		&campaign.Kind,
 	}
 	dest = append(dest, extra...)
 	return rows.Scan(
@@ -186,6 +188,7 @@ const CAMPAIGN_SELECT_FULL = `
 	c.guardrail_enabled, c.guardrail_bounce_rate_max, c.guardrail_complaint_rate_max,
 	c.guardrail_reply_rate_min, c.guardrail_min_sample, c.guardrail_window_days,
 	c.guardrail_tripped_at, c.guardrail_reason,
+	c.kind,
 	COALESCE(array_agg(cet.tag_id) FILTER (WHERE cet.tag_id IS NOT NULL), '{}') AS email_tag_ids,
 	COALESCE(array_agg(cec.folder_id) FILTER (WHERE cec.folder_id IS NOT NULL), '{}') AS email_folder_ids
 `
@@ -277,6 +280,18 @@ func (r *campaignRepository) Create(ctx context.Context, userID string, orgID *u
 		if len(v.BodyPlain) > config.SequenceBodyLimit || len(v.BodyHTML) > config.SequenceBodyLimit {
 			return nil, errx.ErrSequenceBody
 		}
+	}
+
+	kind := models.CampaignKindSequence
+	if data.Kind != nil && *data.Kind != "" {
+		if !models.ValidCampaignKind(*data.Kind) {
+			return nil, errx.New(errx.BadRequest, "kind must be sequence or one_time")
+		}
+		kind = *data.Kind
+	}
+	// A one-time email is one message; follow-ups belong in a sequence.
+	if kind == models.CampaignKindOneTime && len(data.Sequences) > 1 {
+		return nil, errx.New(errx.BadRequest, "a one-time email has a single step; create a sequence campaign for follow-ups")
 	}
 
 	cc := data.CC
@@ -410,7 +425,7 @@ func (r *campaignRepository) Create(ctx context.Context, userID string, orgID *u
 			sender_strategy, rotation_mode,
 			ramp_enabled, ramp_start, ramp_increment, ramp_ceiling,
 			esp_match_mode, max_new_leads_per_day, prioritize_new_leads,
-			tracking_domain,
+			tracking_domain, kind,
 			created_at, updated_at
 		) VALUES (
 			gen_random_uuid(), $1, $2, $3, $4,
@@ -421,7 +436,7 @@ func (r *campaignRepository) Create(ctx context.Context, userID string, orgID *u
 			$20, $21,
 			$22, $23, $24, $25,
 			$26, $27, $28,
-			$29,
+			$29, $30,
 			NOW(), NOW()
 		)
 		RETURNING %s
@@ -457,6 +472,7 @@ func (r *campaignRepository) Create(ctx context.Context, userID string, orgID *u
 		maxNewLeads,        // $27
 		prioritizeNewLeads, // $28
 		trackingDomain,     // $29
+		kind,               // $30
 	}
 
 	row := tx.QueryRow(ctx, insertSQL, params...)
@@ -650,7 +666,7 @@ func (r *campaignRepository) Get(ctx context.Context, orgID, id string) (*models
 	return &campaign, nil
 }
 
-func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cursor, folder *string, status string, limit int32) (*models.CampaignsResult, error) {
+func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cursor, folder *string, status, kind string, limit int32) (*models.CampaignsResult, error) {
 	tx, err := r.DB.Begin(ctx)
 	if err != nil {
 		db.CaptureError(err, "", nil, "begin")
@@ -675,6 +691,7 @@ func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cu
 		  SELECT 1 FROM campaign_folders cf WHERE cf.campaign_id = c.id AND cf.folder_id = $4
 		 ))
 		 AND ($5 = '' OR CASE WHEN $5 = 'paused' THEN c.status::text LIKE 'paused%%' ELSE c.status::text = $5 END)
+		 AND ($6 = '' OR c.kind = $6)
 		GROUP BY c.id
 		ORDER BY created_at DESC
 		LIMIT %d`,
@@ -693,6 +710,7 @@ func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cu
 				SELECT 1 FROM campaign_folders cf WHERE cf.campaign_id = c.id AND cf.folder_id = $3
 			  ))
 			  AND ($4 = '' OR CASE WHEN $4 = 'paused' THEN c.status::text LIKE 'paused%' ELSE c.status::text = $4 END)
+			  AND ($5 = '' OR c.kind = $5)
 		`
 	}
 
@@ -702,6 +720,7 @@ func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cu
 		query,
 		folder,
 		status,
+		kind,
 	}
 
 	rows, err := tx.Query(
@@ -744,9 +763,10 @@ func (r *campaignRepository) Search(ctx context.Context, orgID, query string, cu
 			query,
 			folder,
 			status,
+			kind,
 		}
 		var tmp int64
-		err = tx.QueryRow(ctx, countSQL, orgID, query, folder, status).Scan(&tmp)
+		err = tx.QueryRow(ctx, countSQL, params...).Scan(&tmp)
 		if err != nil {
 			db.CaptureError(err, countSQL, params, "queryrow")
 			return nil, err
@@ -773,7 +793,8 @@ func (r *campaignRepository) Overview(ctx context.Context, orgID string) (*model
 			COUNT(*) FILTER (WHERE status = 'active'),
 			COUNT(*) FILTER (WHERE status::text LIKE 'paused%'),
 			COUNT(*) FILTER (WHERE status = 'draft'),
-			COUNT(*) FILTER (WHERE status = 'completed')
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE kind = 'one_time')
 		FROM campaigns
 		WHERE organization_id = $1`
 	err := r.DB.QueryRow(ctx, countsSQL, orgID).Scan(
@@ -782,6 +803,7 @@ func (r *campaignRepository) Overview(ctx context.Context, orgID string) (*model
 		&overview.Paused,
 		&overview.Draft,
 		&overview.Completed,
+		&overview.OneTime,
 	)
 	if err != nil {
 		db.CaptureError(err, countsSQL, []any{orgID}, "queryrow")
@@ -1251,6 +1273,7 @@ func (r *campaignRepository) GetByID(ctx context.Context, campaignID uuid.UUID) 
 		&campaign.GuardrailEnabled, &campaign.GuardrailBounceRateMax, &campaign.GuardrailComplaintRateMax,
 		&campaign.GuardrailReplyRateMin, &campaign.GuardrailMinSample, &campaign.GuardrailWindowDays,
 		&campaign.GuardrailTrippedAt, &campaign.GuardrailReason,
+		&campaign.Kind,
 		&campaign.EmailTags, &campaign.Folders,
 	)
 	if err != nil {

--- a/internal/repository/pg_campaign_lifecycle.go
+++ b/internal/repository/pg_campaign_lifecycle.go
@@ -104,7 +104,7 @@ func (r *campaignRepository) Duplicate(ctx context.Context, in DuplicateCampaign
 			guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
 			guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days,
 			guardrail_tripped_at, guardrail_reason,
-			last_status_change_at, updated_at, created_at
+			last_status_change_at, updated_at, created_at, kind
 		)
 		SELECT
 			$2, $3, organization_id, $4, description, 'draft',
@@ -122,7 +122,7 @@ func (r *campaignRepository) Duplicate(ctx context.Context, in DuplicateCampaign
 			guardrail_enabled, guardrail_bounce_rate_max, guardrail_complaint_rate_max,
 			guardrail_reply_rate_min, guardrail_min_sample, guardrail_window_days,
 			NULL, '',
-			NULL, NOW(), NOW()
+			NULL, NOW(), NOW(), kind
 		FROM campaigns
 		WHERE id = $1
 	`

--- a/internal/repository/pg_sequence.go
+++ b/internal/repository/pg_sequence.go
@@ -129,9 +129,12 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 	}
 	defer tx.Rollback(ctx)
 
+	// FOR UPDATE serialises step creation per campaign, so two concurrent
+	// inserts on a one-time campaign cannot both see zero email steps.
 	query := `
 		SELECT user_id, organization_id, kind
 		FROM campaigns WHERE id = $1
+		FOR UPDATE
 	`
 
 	params := []any{

--- a/internal/repository/pg_sequence.go
+++ b/internal/repository/pg_sequence.go
@@ -130,7 +130,7 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 	defer tx.Rollback(ctx)
 
 	query := `
-		SELECT user_id, organization_id
+		SELECT user_id, organization_id, kind
 		FROM campaigns WHERE id = $1
 	`
 
@@ -140,11 +140,12 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 
 	var ownerID string
 	var orgID uuid.UUID
+	var kind string
 	err = tx.QueryRow(
 		ctx,
 		query,
 		params...,
-	).Scan(&ownerID, &orgID)
+	).Scan(&ownerID, &orgID, &kind)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, errx.ErrNotFound
@@ -155,6 +156,19 @@ func (r *sequenceRepository) Create(ctx context.Context, userID string, campaign
 
 	if ownerID != userID {
 		return nil, errx.ErrForbidden
+	}
+
+	// A one-time email is a single message: a second email step would turn
+	// it into a sequence without the list, status wording or docs saying so.
+	if kind == models.CampaignKindOneTime {
+		var emailSteps int
+		if err := tx.QueryRow(ctx, `SELECT COUNT(*) FROM sequences WHERE campaign_id = $1 AND kind = 'email'`, campaignID).Scan(&emailSteps); err != nil {
+			db.CaptureError(err, "", params, "queryrow")
+			return nil, errx.InternalError()
+		}
+		if emailSteps > 0 {
+			return nil, errx.New(errx.BadRequest, "a one-time email has a single message; create a sequence campaign for follow-ups")
+		}
 	}
 
 	// Get the next position for this campaign's sequences

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -512,6 +512,16 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		}
 	}
 
+	// STEP 10.6: A plain-text campaign ships no HTML part at all. Tracking
+	// below only rewrites HTML, so dropping it here is what makes the
+	// setting's "disables tracking" promise true.
+	if campaign.TextOnly {
+		if bodyPlain == "" && bodyHTML != "" {
+			bodyPlain = ExtractPlainTextFromHTML(bodyHTML)
+		}
+		bodyHTML = ""
+	}
+
 	// STEP 10.75: Score the copy the recipient will actually receive, after
 	// merge fields, spintax, A/B and AI blocks have resolved. Advisory: it
 	// warns once per step and never blocks or delays the send.
@@ -575,8 +585,10 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	messageID := generateMessageID(account.Email)
 
 	// STEP 15: Build tracking info (worker receives the already-resolved host).
+	// A plain-text send carries none: there is no HTML for a pixel or a
+	// wrapped link to live in.
 	var tracking *models.TrackingInfo
-	if campaign.OpenTracking || campaign.LinkTracking {
+	if !campaign.TextOnly && (campaign.OpenTracking || campaign.LinkTracking) {
 		tracking = &models.TrackingInfo{
 			OpenTracking:   campaign.OpenTracking,
 			LinkTracking:   campaign.LinkTracking,

--- a/internal/tasks/test_email.go
+++ b/internal/tasks/test_email.go
@@ -44,6 +44,11 @@ func (s *tasksService) SendTestEmail(ctx context.Context, userID string, account
 	if bodyPlain == "" && bodyHTML != "" {
 		bodyPlain = ExtractPlainTextFromHTML(bodyHTML)
 	}
+	// The test shows what the campaign will send: plain-text campaigns get
+	// no HTML part here either.
+	if campaign.TextOnly {
+		bodyHTML = ""
+	}
 
 	// Prepend [TEST] to subject
 	subject = "[TEST] " + subject

--- a/internal/tasks/test_email.go
+++ b/internal/tasks/test_email.go
@@ -54,8 +54,12 @@ func (s *tasksService) SendTestEmail(ctx context.Context, userID string, account
 	subject = "[TEST] " + subject
 
 	// Add signature if enabled
+	// Same guard as the campaign send path: a plain-text test must not grow
+	// an HTML part back through the signature.
 	if account.SignatureSync {
-		bodyHTML = AddSignature(bodyHTML, account.SignatureHTML, true)
+		if bodyHTML != "" {
+			bodyHTML = AddSignature(bodyHTML, account.SignatureHTML, true)
+		}
 		bodyPlain = AddSignature(bodyPlain, account.SignaturePlain, false)
 	}
 

--- a/web/src/app/app/api-keys/_components/KeyDetailDrawer.tsx
+++ b/web/src/app/app/api-keys/_components/KeyDetailDrawer.tsx
@@ -213,7 +213,7 @@ function Inner({ apiKey, onClose }: { apiKey: APIKey; onClose: () => void }) {
                             {apiKey.description && (
                                 <p className="text-[12px] text-slate-500 mt-0.5 leading-relaxed">{apiKey.description}</p>
                             )}
-                            <div className="mt-2 grid grid-cols-3 gap-3 text-[10.5px]">
+                            <div className="mt-2 grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3 text-[10.5px]">
                                 <MiniField label="Created" value={fmtRelative(apiKey.created_at)} />
                                 <MiniField label="Last used" value={apiKey.last_used_at ? fmtRelative(apiKey.last_used_at) : "never"} />
                                 <MiniField label="Last IP" value={apiKey.last_request_ip || "—"} mono />

--- a/web/src/app/app/campaigns/[id]/layout.tsx
+++ b/web/src/app/app/campaigns/[id]/layout.tsx
@@ -10,9 +10,11 @@ import {
     Loader2Icon,
     PauseIcon,
     PlayIcon,
+    SendIcon,
     Settings2Icon,
     UsersIcon,
 } from "lucide-react";
+import { campaignDisplayLabel, isOneTimeCampaign } from "@/components/app/campaigns/status";
 import useCampaign from "@/lib/api/hooks/app/campaigns/useCampaign";
 import useStartCampaign from "@/lib/api/hooks/app/campaigns/useStartCampaign";
 import useStopCampaign from "@/lib/api/hooks/app/campaigns/useStopCampaign";
@@ -73,7 +75,7 @@ export default function CampaignLayout() {
 
     if (campaignData.isLoading) {
         return (
-            <div className="px-5 pt-5 space-y-4">
+            <div className="px-3 sm:px-5 pt-4 sm:pt-5 space-y-4">
                 <div className="space-y-2">
                     <div className="h-6 w-56 bg-slate-100 rounded-md animate-pulse" />
                     <div className="h-3 w-40 bg-slate-100 rounded animate-pulse" />
@@ -126,7 +128,7 @@ export default function CampaignLayout() {
     return (
         <CampaignContext.Provider value={campaign}>
             <div className="flex flex-col min-h-full bg-white">
-                <div className="px-5 pt-4 pb-3 flex items-start gap-3">
+                <div className="px-3 sm:px-5 pt-3 sm:pt-4 pb-3 flex items-start gap-3">
                     <div className="min-w-0">
                         <Link
                             to="/app/campaigns"
@@ -135,13 +137,24 @@ export default function CampaignLayout() {
                             <ArrowLeftIcon className="w-3 h-3" />
                             Campaigns
                         </Link>
-                        <div className="flex items-center gap-2">
-                            <h1 className="text-[18px] font-semibold text-slate-900 truncate">{campaign.name}</h1>
+                        {/* min-w-0 lets the name truncate instead of pushing the
+                            pills off a narrow screen; the pills wrap under it. */}
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                            <h1 className="min-w-0 max-w-full text-[18px] font-semibold text-slate-900 truncate">{campaign.name}</h1>
                             <span
                                 className={`shrink-0 inline-flex items-center h-5 px-2 rounded-md border text-[10px] uppercase tracking-[0.12em] font-medium ${pill}`}
                             >
-                                {status === "paused_undeliverable" ? "needs verification" : status}
+                                {campaignDisplayLabel(campaign)}
                             </span>
+                            {isOneTimeCampaign(campaign) && (
+                                <span
+                                    title="One-time email: a single message, no follow-ups"
+                                    className="shrink-0 inline-flex items-center gap-1 h-5 px-2 rounded-md bg-sky-50 text-sky-700 text-[10px] uppercase tracking-[0.12em] font-medium"
+                                >
+                                    <SendIcon className="w-2.5 h-2.5" />
+                                    One-time
+                                </span>
+                            )}
                             <ResourceViewers resource={`campaign:${campaign.id}`} className="shrink-0" />
                         </div>
                         <p className="text-[11px] text-slate-400 font-mono mt-1 truncate">{campaign.id}</p>
@@ -205,7 +218,10 @@ export default function CampaignLayout() {
                     })}
                 </div>
 
-                <div className="p-5">
+                {/* Leads renders a full-bleed Page (its own topbar, stat strip
+                    and table gutters), so padding it again wastes a fifth of a
+                    phone screen and stops its hairlines short of the edge. */}
+                <div className={pathname.replace(/\/$/, "").endsWith("/leads") ? "" : "p-3 sm:p-5"}>
                     <Outlet />
                 </div>
             </div>

--- a/web/src/app/app/campaigns/page.tsx
+++ b/web/src/app/app/campaigns/page.tsx
@@ -34,6 +34,7 @@ import {
     PlayIcon,
     PlusIcon,
     RefreshCcwIcon,
+    SendIcon,
     Settings2Icon,
 } from "lucide-react";
 import {
@@ -48,9 +49,10 @@ import {
 } from "@/components/layout/Page";
 import { SearchInput } from "@/components/ui/field";
 import {
-    CAMPAIGN_STATUS_LABEL,
+    campaignDisplayLabel,
     campaignStatusBucket as statusBucket,
     campaignStatusTone as statusTone,
+    isOneTimeCampaign,
 } from "@/components/app/campaigns/status";
 import {
     PopoverMenu,
@@ -63,14 +65,19 @@ import {
 } from "@/components/ui/popover-menu";
 
 type StatusFilter = "all" | "active" | "paused" | "draft" | "completed";
+type KindFilter = "all" | "sequence" | "one_time";
 type SortMode = "newest" | "oldest" | "name";
+
+const KIND_LABEL: Record<KindFilter, string> = {
+    all: "All types",
+    sequence: "Sequences",
+    one_time: "One-time emails",
+};
 
 // Per-state label + leading mark for a campaign row. "active" renders the
 // animated dot-grid loader; every other state is a 14px lucide icon so the
 // fixed-width leading slot keeps each row's name aligned. The label/tone maps
 // live in components/app/campaigns/status so pickers share them.
-const STATUS_LABEL = CAMPAIGN_STATUS_LABEL;
-
 function CampaignStatusMark({ status }: { status: string }) {
     const tone = statusTone(status);
     if (status === "active") {
@@ -243,6 +250,7 @@ export default function CampaignsPage() {
     const [folder, setFolder] = useState<string>("");
     const [query, setQuery] = useState<string>("");
     const [status, setStatus] = useState<StatusFilter>("all");
+    const [kind, setKind] = useState<KindFilter>("all");
     const [sort, setSort] = useState<SortMode>("newest");
     const [newOpen, setNewOpen] = useState<boolean>(false);
     const [launchTarget, setLaunchTarget] = useState<Campaign | null>(null);
@@ -287,9 +295,11 @@ export default function CampaignsPage() {
     const activeFolder = folders.find((f) => f.id === folder);
 
     const filtered = useMemo(() => {
-        const base = status === "all"
-            ? campaigns
-            : campaigns.filter((c) => statusBucket(c.status) === status);
+        const base = campaigns.filter(
+            (c) =>
+                (status === "all" || statusBucket(c.status) === status) &&
+                (kind === "all" || (c.kind ?? "sequence") === kind),
+        );
         const sorted = [...base];
         if (sort === "newest") {
             sorted.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
@@ -299,7 +309,7 @@ export default function CampaignsPage() {
             sorted.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? ""));
         }
         return sorted;
-    }, [campaigns, status, sort]);
+    }, [campaigns, status, kind, sort]);
 
     const counts = useMemo(() => {
         const stats = { total: campaigns.length, active: 0, paused: 0, draft: 0, completed: 0 };
@@ -422,6 +432,23 @@ export default function CampaignsPage() {
                 <PopoverMenu align="end">
                     <PopoverMenuTrigger asChild>
                         <SelectButton
+                            icon={<SendIcon className="w-3.5 h-3.5" />}
+                            label={KIND_LABEL[kind]}
+                        />
+                    </PopoverMenuTrigger>
+                    <PopoverMenuContent minWidth={180}>
+                        <PopoverMenuLabel>Type</PopoverMenuLabel>
+                        {(Object.keys(KIND_LABEL) as KindFilter[]).map((k) => (
+                            <PopoverMenuItem key={k} selected={kind === k} onSelect={() => setKind(k)}>
+                                {KIND_LABEL[k]}
+                            </PopoverMenuItem>
+                        ))}
+                    </PopoverMenuContent>
+                </PopoverMenu>
+
+                <PopoverMenu align="end">
+                    <PopoverMenuTrigger asChild>
+                        <SelectButton
                             icon={<FilterIcon className="w-3.5 h-3.5" />}
                             label={
                                 sort === "newest"
@@ -503,7 +530,7 @@ export default function CampaignsPage() {
                     <div className="divide-y divide-slate-200/60">
                         {filtered.map((c) => {
                             const cstatus = c.status ?? "draft";
-                            const stateLabel = STATUS_LABEL[cstatus] ?? cstatus;
+                            const stateLabel = campaignDisplayLabel(c);
                             const StateIcon =
                                 cstatus === "active" ? PauseIcon : PlayIcon;
                             return (
@@ -523,6 +550,15 @@ export default function CampaignsPage() {
                                     <span className="font-mono text-[10.5px] text-slate-400 tabular-nums shrink-0 hidden sm:inline">
                                         {c.id.slice(0, 8)}
                                     </span>
+                                    {isOneTimeCampaign(c) && (
+                                        <span
+                                            title="One-time email: a single message, no follow-ups"
+                                            className="inline-flex items-center gap-1 h-[18px] px-1.5 rounded-full bg-sky-50 text-sky-700 text-[10px] font-medium uppercase tracking-[0.1em] shrink-0"
+                                        >
+                                            <SendIcon className="w-2.5 h-2.5" />
+                                            One-time
+                                        </span>
+                                    )}
                                     <AdvisorRowFlag findings={advisor.get(c.id)} subject={c.name} />
                                     <CampaignFolderChips campaign={c} folders={folders} />
                                     {c.description && (

--- a/web/src/app/app/settings/sending/page.tsx
+++ b/web/src/app/app/settings/sending/page.tsx
@@ -166,7 +166,7 @@ function SendingSettings() {
 
                                 <Row label="Delivery hours" align="start">
                                     <div className="w-full sm:w-[320px]">
-                                        <div className="grid grid-cols-6 gap-1">
+                                        <div className="grid grid-cols-4 sm:grid-cols-6 gap-1">
                                             {HOURS.map((h) => {
                                                 const on = hours.includes(h);
                                                 return (

--- a/web/src/app/app/templates/page.tsx
+++ b/web/src/app/app/templates/page.tsx
@@ -137,7 +137,7 @@ export default function TemplatesPage() {
             </div>
 
             <SectionBar label={query.isPending ? "Loading…" : `${list.length} templates`} />
-            <PageBody className="px-5 py-5">
+            <PageBody className="px-3 py-4 sm:px-5 sm:py-5">
                 {query.isPending ? (
                     <SkeletonRows />
                 ) : list.length === 0 ? (

--- a/web/src/components/app/campaigns/NewCampaignDialog.tsx
+++ b/web/src/components/app/campaigns/NewCampaignDialog.tsx
@@ -1377,16 +1377,27 @@ function EstimatePanel({
             </>
         );
         tone = "warn";
+    } else if (sendingDays === null || finish === null) {
+        // The backend leaves both null when the audience is not covered
+        // inside its two-year horizon, which must not read as "one day".
+        headline = "Longer than this estimate can project";
+        detail = (
+            <>
+                {recipients.toLocaleString()} recipients at up to {dailyCapacity.toLocaleString()} a day would take
+                years.{" "}
+                <button type="button" onClick={onEditPool} className="underline underline-offset-2 hover:text-slate-900">
+                    Add mailboxes or raise the daily limit
+                </button>
+                , or narrow the audience.
+            </>
+        );
+        tone = "warn";
     } else {
-        const days = sendingDays ?? 0;
+        const days = sendingDays;
         headline =
             days <= 1
-                ? finish
-                    ? `Finishes ${startsAt ? "on" : "today,"} ${fmtDate(finish)}`
-                    : "Finishes in one sending day"
-                : finish
-                  ? `About ${days} sending days, finishing around ${fmtDate(finish)}`
-                  : `More than ${days} sending days`;
+                ? `Finishes ${startsAt ? "on" : "today,"} ${fmtDate(finish)}`
+                : `About ${days} sending days, finishing around ${fmtDate(finish)}`;
         detail = (
             <>
                 {recipients.toLocaleString()} recipient{recipients === 1 ? "" : "s"} across {mailboxes} mailbox

--- a/web/src/components/app/campaigns/NewCampaignDialog.tsx
+++ b/web/src/components/app/campaigns/NewCampaignDialog.tsx
@@ -1,9 +1,12 @@
 // Multi-step new-campaign wizard.
 //
-// Four steps (basics, schedule, sending, first email) with directional slide
-// transitions and a numbered stepper, ending in a single atomic create call.
-// Only the name and the first email are enforced; every other step ships a
-// safe default and can be changed later on the campaign detail page.
+// Two flows share one dialog. A sequence (basics, schedule, sending, first
+// email) ends in a single atomic create call and leaves a draft. A one-time
+// email (basics, email, audience, sending, send) creates the campaign, links
+// the chosen segments so their members become leads, and starts it, either
+// now or on the scheduled date. Both use directional slide transitions and a
+// numbered stepper; a step cannot be left until it is complete, and the
+// reason shows in the footer instead of a silently disabled button.
 
 import React from "react";
 import { AnimatePresence, motion } from "framer-motion";
@@ -13,6 +16,7 @@ import {
     CheckIcon,
     ChevronLeftIcon,
     ChevronRightIcon,
+    ListChecksIcon,
     Loader2Icon,
     MailIcon,
     MegaphoneIcon,
@@ -20,16 +24,23 @@ import {
     PlusIcon,
     SendIcon,
     Trash2Icon,
+    UsersIcon,
     XIcon,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { useNavigate } from "react-router-dom";
 import useCreateCampaign from "@/lib/api/hooks/app/campaigns/useCreateCampaign";
+import useStartCampaign from "@/lib/api/hooks/app/campaigns/useStartCampaign";
+import useCampaignEstimate from "@/lib/api/hooks/app/campaigns/useCampaignEstimate";
+import { useSetCampaignSegments } from "@/lib/api/hooks/app/segments";
+import type { CampaignKind } from "@/lib/api/models/app/campaigns/Campaign";
 import { Label, NumberInput, TextInput } from "@/components/ui/field";
 import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
 import { TimePicker } from "@/components/ui/TimePicker";
+import { DateTimePicker } from "@/components/ui/DateTimePicker";
 import WeekdayBitmask from "@/components/app/campaigns/schedule/WeekdayBitmask";
 import TagSelector from "@/components/app/popup/select/TagSelector";
+import { SegmentMultiPicker } from "@/components/app/segments/SegmentPickers";
 import { Toggle } from "@/components/app/campaigns/preferences/components/CampaignPreferenceBoolBox";
 import { useUserProfile } from "@/hooks/context/user";
 import { useConfirm } from "@/hooks/context/confirm";
@@ -56,14 +67,29 @@ const EVERY_DAY_MASK = 0b1111111;
 const NAME_MIN = 3;
 const NAME_MAX = 50;
 
-const STEPS = [
-    { label: "Basics", icon: MegaphoneIcon },
-    { label: "Schedule", icon: CalendarClockIcon },
-    { label: "Sending", icon: SendIcon },
-    { label: "First email", icon: MailIcon },
-] as const;
-type Step = 0 | 1 | 2 | 3;
-const LAST_STEP = (STEPS.length - 1) as Step;
+type StepKey = "basics" | "schedule" | "sending" | "email" | "audience" | "send";
+type StepDef = { key: StepKey; label: string; icon: typeof MegaphoneIcon };
+
+const SEQUENCE_STEPS: readonly StepDef[] = [
+    { key: "basics", label: "Basics", icon: MegaphoneIcon },
+    { key: "schedule", label: "Schedule", icon: CalendarClockIcon },
+    { key: "sending", label: "Sending", icon: SendIcon },
+    { key: "email", label: "First email", icon: MailIcon },
+];
+
+// A one-time email asks for the message before the audience, and ends on the
+// send step where the estimate can see everything it depends on.
+const ONE_TIME_STEPS: readonly StepDef[] = [
+    { key: "basics", label: "Basics", icon: MegaphoneIcon },
+    { key: "email", label: "Email", icon: MailIcon },
+    { key: "audience", label: "Audience", icon: UsersIcon },
+    { key: "sending", label: "Sending", icon: SendIcon },
+    { key: "send", label: "Send", icon: CalendarClockIcon },
+];
+
+function stepsFor(kind: CampaignKind): readonly StepDef[] {
+    return kind === "one_time" ? ONE_TIME_STEPS : SEQUENCE_STEPS;
+}
 
 let seqCounter = 0;
 const newSequence = (wait: number): SequenceDraft => ({
@@ -73,7 +99,10 @@ const newSequence = (wait: number): SequenceDraft => ({
     wait_after: wait,
 });
 
+type SendMode = "now" | "later";
+
 type Draft = {
+    kind: CampaignKind;
     name: string;
     description: string;
     timezone: string;
@@ -87,9 +116,15 @@ type Draft = {
     linkTracking: boolean;
     unsubHeader: boolean;
     sequences: SequenceDraft[];
+    // One-time only.
+    segmentIds: string[];
+    sendMode: SendMode;
+    // Local "yyyy-MM-ddTHH:mm", the DateTimePicker's shape.
+    scheduledAt: string;
 };
 
 const initialDraft = (timezone: string): Draft => ({
+    kind: "sequence",
     name: "",
     description: "",
     timezone,
@@ -103,33 +138,63 @@ const initialDraft = (timezone: string): Draft => ({
     linkTracking: true,
     unsubHeader: true,
     sequences: [newSequence(0)],
+    segmentIds: [],
+    sendMode: "now",
+    scheduledAt: "",
 });
 
+function scheduledDate(d: Draft): Date | null {
+    if (d.sendMode !== "later" || !d.scheduledAt) return null;
+    const date = new Date(d.scheduledAt);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
 // One human-readable reason a step cannot be left yet, or null when it can.
-function stepIssue(step: Step, d: Draft): string | null {
-    if (step === 0) {
-        const n = d.name.trim().length;
-        if (n < NAME_MIN) return `Name needs at least ${NAME_MIN} characters`;
-        if (n > NAME_MAX) return `Name is ${NAME_MAX} characters max`;
-        return null;
+function stepIssue(key: StepKey, d: Draft): string | null {
+    switch (key) {
+        case "basics": {
+            const n = d.name.trim().length;
+            if (n < NAME_MIN) return `Name needs at least ${NAME_MIN} characters`;
+            if (n > NAME_MAX) return `Name is ${NAME_MAX} characters max`;
+            return null;
+        }
+        case "schedule":
+            if (d.days === 0) return "Pick at least one sending day";
+            if (d.startTime && d.endTime && d.startTime >= d.endTime) return "End time must be after the start time";
+            return null;
+        case "email": {
+            const first = d.sequences[0];
+            if (!first) return null;
+            const hasSubject = first.subject.trim().length > 0;
+            const hasBody = first.body_plain.trim().length > 0;
+            // A one-time email is the whole campaign, so it cannot be skipped.
+            if (d.kind === "one_time") {
+                if (!hasSubject) return "Give the email a subject line";
+                if (!hasBody) return "Write the email's body";
+                return null;
+            }
+            // A sequence's first email may be skipped entirely (written later
+            // on the Steps tab), but a half-written one must be finished.
+            if (hasBody && !hasSubject) return "Give the first email a subject line";
+            if (hasSubject && !hasBody) return "Write the first email's body";
+            return null;
+        }
+        case "audience":
+            if (d.segmentIds.length === 0) return "Pick at least one segment";
+            return null;
+        case "send": {
+            if (d.days === 0) return "Pick at least one sending day";
+            if (d.startTime && d.endTime && d.startTime >= d.endTime) return "End time must be after the start time";
+            if (d.sendMode === "later") {
+                const at = scheduledDate(d);
+                if (!at) return "Pick a date and time to send";
+                if (at.getTime() < Date.now()) return "The scheduled time has already passed";
+            }
+            return null;
+        }
+        default:
+            return null;
     }
-    if (step === 1) {
-        if (d.days === 0) return "Pick at least one sending day";
-        if (d.startTime && d.endTime && d.startTime >= d.endTime) return "End time must be after the start time";
-        return null;
-    }
-    if (step === 3) {
-        // The first email may be skipped entirely (written later on the Steps
-        // tab), but a half-written one must be finished.
-        const first = d.sequences[0];
-        if (!first) return null;
-        const hasSubject = first.subject.trim().length > 0;
-        const hasBody = first.body_plain.trim().length > 0;
-        if (hasBody && !hasSubject) return "Give the first email a subject line";
-        if (hasSubject && !hasBody) return "Write the first email's body";
-        return null;
-    }
-    return null;
 }
 
 function daysLabel(mask: number): string {
@@ -147,46 +212,77 @@ function fmt12(hhmm: string): string {
     return `${h12}:${String(m).padStart(2, "0")} ${h < 12 ? "AM" : "PM"}`;
 }
 
+function fmtDate(d: Date): string {
+    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function fmtDateTime(d: Date): string {
+    return d.toLocaleString("en-US", { month: "short", day: "numeric", hour: "numeric", minute: "2-digit" });
+}
+
 export function NewCampaignDialog({ open, onClose }: Props) {
     const navigate = useNavigate();
     const profile = useUserProfile();
     const confirm = useConfirm();
     const create = useCreateCampaign();
+    const linkSegments = useSetCampaignSegments();
+    const start = useStartCampaign();
     const defaultTimezone = profile?.timezones?.[0]?.name || "Europe/London";
 
-    const [step, setStep] = React.useState<Step>(0);
+    const [step, setStep] = React.useState(0);
     const [direction, setDirection] = React.useState<1 | -1>(1);
     const [draft, setDraft] = React.useState<Draft>(() => initialDraft(defaultTimezone));
     // Set when the user tries to leave a step that is not ready; shows the reason.
     const [nudged, setNudged] = React.useState(false);
+    // The one-time flow is three calls; the footer stays busy across all of them.
+    const [submitting, setSubmitting] = React.useState(false);
+
+    const steps = stepsFor(draft.kind);
+    const lastStep = steps.length - 1;
+    const current = steps[Math.min(step, lastStep)];
 
     const patch = React.useCallback((p: Partial<Draft>) => setDraft((d) => ({ ...d, ...p })), []);
+
+    const setKind = React.useCallback(
+        (kind: CampaignKind) =>
+            setDraft((d) => {
+                if (d.kind === kind) return d;
+                return {
+                    ...d,
+                    kind,
+                    // A one-time email is exactly one message.
+                    sequences: kind === "one_time" ? d.sequences.slice(0, 1) : d.sequences,
+                };
+            }),
+        [],
+    );
 
     React.useEffect(() => {
         if (!open) {
             setStep(0);
             setDirection(1);
             setNudged(false);
+            setSubmitting(false);
             setDraft(initialDraft(defaultTimezone));
         }
     }, [open, defaultTimezone]);
 
-    const issue = stepIssue(step, draft);
+    const issue = stepIssue(current.key, draft);
     React.useEffect(() => {
         if (!issue) setNudged(false);
     }, [issue]);
 
     // A step is reachable when every step before it is complete.
     const canReach = React.useCallback(
-        (target: Step) => {
-            for (let i = 0; i < target; i++) if (stepIssue(i as Step, draft)) return false;
+        (target: number) => {
+            for (let i = 0; i < target; i++) if (stepIssue(steps[i].key, draft)) return false;
             return true;
         },
-        [draft],
+        [draft, steps],
     );
 
     const goTo = React.useCallback(
-        (target: Step) => {
+        (target: number) => {
             if (target === step) return;
             if (target > step && !canReach(target)) {
                 setNudged(true);
@@ -199,34 +295,45 @@ export function NewCampaignDialog({ open, onClose }: Props) {
         [step, canReach],
     );
 
+    const goToKey = React.useCallback(
+        (key: StepKey) => {
+            const idx = steps.findIndex((s) => s.key === key);
+            if (idx >= 0) goTo(idx);
+        },
+        [steps, goTo],
+    );
+
     const next = React.useCallback(() => {
         if (issue) {
             setNudged(true);
             return;
         }
-        if (step < LAST_STEP) goTo((step + 1) as Step);
-    }, [issue, step, goTo]);
+        if (step < lastStep) goTo(step + 1);
+    }, [issue, step, lastStep, goTo]);
 
     const dirty =
         draft.name.trim() !== "" ||
         draft.description.trim() !== "" ||
         draft.emailTagIds.length > 0 ||
+        draft.segmentIds.length > 0 ||
         draft.sequences.some((s) => s.subject.trim() !== "" || s.body_plain.trim() !== "");
 
+    const isPending = create.isPending || submitting;
+
     const requestClose = React.useCallback(() => {
-        if (create.isPending) return;
+        if (isPending) return;
         if (dirty) {
             confirm.show("Discard this campaign draft?", async () => onClose());
             return;
         }
         onClose();
-    }, [create.isPending, dirty, confirm, onClose]);
+    }, [isPending, dirty, confirm, onClose]);
 
     React.useEffect(() => {
         if (!open) return;
         const onKey = (e: KeyboardEvent) => {
             if (e.key !== "Escape") return;
-            // An open dropdown (timezone, tags) or the discard confirm owns this Escape.
+            // An open dropdown (timezone, tags, segments, date) or the discard confirm owns this Escape.
             if (document.querySelector("[data-floating], [role='alertdialog']")) return;
             e.preventDefault();
             requestClose();
@@ -235,46 +342,90 @@ export function NewCampaignDialog({ open, onClose }: Props) {
         return () => document.removeEventListener("keydown", onKey);
     }, [open, requestClose]);
 
-    async function submit() {
-        if (create.isPending) return;
-        for (const s of [0, 1, 2, 3] as Step[]) {
-            if (stepIssue(s, draft)) {
-                setDirection(s > step ? 1 : -1);
-                setStep(s);
-                setNudged(true);
-                return;
-            }
-        }
-        const steps = draft.sequences
+    function buildSteps() {
+        return draft.sequences
             .filter((s) => s.subject.trim().length > 0 || s.body_plain.trim().length > 0)
             .map((s, i) => ({
-                name: `Step ${i + 1}`,
+                name: draft.kind === "one_time" ? "Email" : `Step ${i + 1}`,
                 subject: s.subject.trim(),
                 body_plain: s.body_plain,
                 body_html: `<div>${escapeHtml(s.body_plain).replace(/\n/g, "<br/>")}</div>`,
                 wait_after: i === 0 ? 0 : Math.max(0, s.wait_after),
             }));
+    }
+
+    async function submit() {
+        if (isPending) return;
+        for (let i = 0; i < steps.length; i++) {
+            if (stepIssue(steps[i].key, draft)) {
+                setDirection(i > step ? 1 : -1);
+                setStep(i);
+                setNudged(true);
+                return;
+            }
+        }
+        const base = {
+            name: draft.name.trim(),
+            description: draft.description.trim(),
+            timezone: draft.timezone,
+            days: draft.days,
+            start_time: draft.startTime,
+            end_time: draft.endTime,
+            daily_limit: draft.dailyLimit,
+            open_tracking: draft.openTracking,
+            link_tracking: draft.linkTracking,
+            unsubscribe_header: draft.unsubHeader,
+            email_tag_ids: draft.emailTagIds,
+            steps: buildSteps(),
+        };
+
+        if (draft.kind === "sequence") {
+            try {
+                const created = await create.mutateAsync({ ...base, kind: "sequence", stop_on_reply: draft.stopOnReply });
+                toast.success("Campaign created. Add contacts, then launch it.");
+                onClose();
+                if (created?.id) navigate(`/app/campaigns/${created.id}`);
+            } catch (err) {
+                toast.error(buildError(err as AppError));
+            }
+            return;
+        }
+
+        // One-time: create, link the audience (which enrols its members as
+        // leads), then start. A scheduled start date parks the campaign until
+        // then; the scheduler does the waiting, not the browser.
+        const at = scheduledDate(draft);
+        setSubmitting(true);
+        let createdID: string | null = null;
         try {
             const created = await create.mutateAsync({
-                name: draft.name.trim(),
-                description: draft.description.trim(),
-                timezone: draft.timezone,
-                days: draft.days,
-                start_time: draft.startTime,
-                end_time: draft.endTime,
-                daily_limit: draft.dailyLimit,
-                stop_on_reply: draft.stopOnReply,
-                open_tracking: draft.openTracking,
-                link_tracking: draft.linkTracking,
-                unsubscribe_header: draft.unsubHeader,
-                email_tag_ids: draft.emailTagIds,
-                steps,
+                ...base,
+                kind: "one_time",
+                // No follow-ups exist to stop, and a reply should still not
+                // re-send the one message, so the flag stays on.
+                stop_on_reply: true,
+                start_date: at ? at.toISOString() : undefined,
             });
-            toast.success("Campaign created. Add contacts, then launch it.");
+            createdID = created.id;
+            await linkSegments.mutateAsync({ campaignId: created.id, segmentIds: draft.segmentIds });
+            await start.mutateAsync({ id: created.id });
+            toast.success(at ? `Scheduled for ${fmtDateTime(at)}.` : "Sending now.");
             onClose();
-            if (created?.id) navigate(`/app/campaigns/${created.id}`);
+            navigate(`/app/campaigns/${created.id}`);
         } catch (err) {
-            toast.error(buildError(err as AppError));
+            // Past the create call the campaign exists as a draft: say so and
+            // hand over to the campaign page, where the launch dialog can
+            // explain a refused start (an empty segment, a risky list).
+            const message = buildError(err as AppError);
+            if (createdID) {
+                toast.error(`${message} The email was saved as a draft; start it from its page.`);
+                onClose();
+                navigate(`/app/campaigns/${createdID}`);
+            } else {
+                toast.error(message);
+            }
+        } finally {
+            setSubmitting(false);
         }
     }
 
@@ -294,7 +445,7 @@ export function NewCampaignDialog({ open, onClose }: Props) {
                         key="card"
                         role="dialog"
                         aria-modal="true"
-                        aria-label="New campaign"
+                        aria-label={draft.kind === "one_time" ? "New one-time email" : "New campaign"}
                         initial={{ y: 8, opacity: 0, scale: 0.985 }}
                         animate={{ y: 0, opacity: 1, scale: 1 }}
                         exit={{ y: 8, opacity: 0, scale: 0.985 }}
@@ -302,13 +453,13 @@ export function NewCampaignDialog({ open, onClose }: Props) {
                         onMouseDown={(e) => e.stopPropagation()}
                         className="w-full max-w-[720px] rounded-lg bg-white border border-slate-200 shadow-[0_24px_48px_-12px_rgba(15,23,42,0.18),0_8px_16px_-8px_rgba(15,23,42,0.1)] overflow-hidden flex flex-col max-h-[88dvh]"
                     >
-                        <Header onClose={requestClose} />
-                        <Stepper step={step} canReach={canReach} goTo={goTo} />
+                        <Header kind={draft.kind} onClose={requestClose} />
+                        <Stepper steps={steps} step={step} canReach={canReach} goTo={goTo} />
 
                         <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
                             <AnimatePresence mode="wait" initial={false} custom={direction}>
                                 <motion.div
-                                    key={step}
+                                    key={`${draft.kind}-${current.key}`}
                                     custom={direction}
                                     variants={paneVariants}
                                     initial="enter"
@@ -317,21 +468,40 @@ export function NewCampaignDialog({ open, onClose }: Props) {
                                     transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
                                     className="px-5 py-5 min-h-[340px]"
                                 >
-                                    {step === 0 && <BasicsStep draft={draft} patch={patch} onEnter={next} />}
-                                    {step === 1 && <ScheduleStep draft={draft} patch={patch} />}
-                                    {step === 2 && <SendingStep draft={draft} patch={patch} />}
-                                    {step === 3 && <EmailsStep draft={draft} patch={patch} goTo={goTo} />}
+                                    {current.key === "basics" && (
+                                        <BasicsStep draft={draft} patch={patch} setKind={setKind} onEnter={next} />
+                                    )}
+                                    {current.key === "schedule" && <ScheduleStep draft={draft} patch={patch} />}
+                                    {current.key === "sending" && <SendingStep draft={draft} patch={patch} />}
+                                    {current.key === "email" && <EmailsStep draft={draft} patch={patch} goToKey={goToKey} />}
+                                    {current.key === "audience" && <AudienceStep draft={draft} patch={patch} />}
+                                    {current.key === "send" && <SendStep draft={draft} patch={patch} goToKey={goToKey} />}
                                 </motion.div>
                             </AnimatePresence>
                         </div>
 
                         <Footer
                             step={step}
+                            lastStep={lastStep}
+                            submitLabel={
+                                draft.kind === "one_time"
+                                    ? draft.sendMode === "later"
+                                        ? "Schedule"
+                                        : "Send now"
+                                    : "Create campaign"
+                            }
+                            submitIcon={
+                                draft.kind === "one_time"
+                                    ? draft.sendMode === "later"
+                                        ? CalendarClockIcon
+                                        : SendIcon
+                                    : PlusIcon
+                            }
                             issue={nudged ? issue : null}
-                            onBack={() => goTo((step - 1) as Step)}
+                            onBack={() => goTo(step - 1)}
                             onNext={next}
                             onSubmit={submit}
-                            isPending={create.isPending}
+                            isPending={isPending}
                         />
                     </motion.div>
                 </motion.div>
@@ -346,15 +516,18 @@ const paneVariants = {
     exit: (dir: 1 | -1) => ({ x: dir * -28, opacity: 0 }),
 };
 
-function Header({ onClose }: { onClose: () => void }) {
+function Header({ kind, onClose }: { kind: CampaignKind; onClose: () => void }) {
+    const Icon = kind === "one_time" ? SendIcon : MegaphoneIcon;
     return (
         <div className="h-12 px-4 border-b border-slate-200 flex items-center gap-2.5 shrink-0">
             <div className="size-5 rounded bg-slate-100 text-slate-600 flex items-center justify-center">
-                <MegaphoneIcon className="w-3 h-3" />
+                <Icon className="w-3 h-3" />
             </div>
             <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">New</span>
             <div className="h-4 w-px bg-slate-200" />
-            <span className="text-[12.5px] text-slate-900 font-medium">Campaign</span>
+            <span className="text-[12.5px] text-slate-900 font-medium">
+                {kind === "one_time" ? "One-time email" : "Campaign"}
+            </span>
             <button
                 type="button"
                 onClick={onClose}
@@ -368,26 +541,27 @@ function Header({ onClose }: { onClose: () => void }) {
 }
 
 function Stepper({
+    steps,
     step,
     canReach,
     goTo,
 }: {
-    step: Step;
-    canReach: (s: Step) => boolean;
-    goTo: (s: Step) => void;
+    steps: readonly StepDef[];
+    step: number;
+    canReach: (s: number) => boolean;
+    goTo: (s: number) => void;
 }) {
     return (
         <div className="px-4 sm:px-5 h-11 border-b border-slate-100 flex items-center shrink-0 bg-slate-50/40">
-            {STEPS.map((s, i) => {
-                const idx = i as Step;
-                const active = idx === step;
-                const done = idx < step;
-                const reachable = idx <= step || canReach(idx);
+            {steps.map((s, i) => {
+                const active = i === step;
+                const done = i < step;
+                const reachable = i <= step || canReach(i);
                 return (
-                    <React.Fragment key={s.label}>
+                    <React.Fragment key={s.key}>
                         <button
                             type="button"
-                            onClick={() => goTo(idx)}
+                            onClick={() => goTo(i)}
                             disabled={!reachable}
                             aria-current={active ? "step" : undefined}
                             className={cn(
@@ -441,7 +615,7 @@ function Stepper({
                                 {s.label}
                             </span>
                         </button>
-                        {i < STEPS.length - 1 && (
+                        {i < steps.length - 1 && (
                             <span className="relative flex-1 h-px mx-1 sm:mx-2 bg-slate-200 min-w-3 overflow-hidden">
                                 <motion.span
                                     initial={false}
@@ -461,20 +635,26 @@ function Stepper({
 
 function Footer({
     step,
+    lastStep,
+    submitLabel,
+    submitIcon: SubmitIcon,
     issue,
     onBack,
     onNext,
     onSubmit,
     isPending,
 }: {
-    step: Step;
+    step: number;
+    lastStep: number;
+    submitLabel: string;
+    submitIcon: typeof PlusIcon;
     issue: string | null;
     onBack: () => void;
     onNext: () => void;
     onSubmit: () => void;
     isPending: boolean;
 }) {
-    const isLast = step === LAST_STEP;
+    const isLast = step === lastStep;
     return (
         <div className="px-3 min-h-12 py-1.5 sm:py-0 sm:h-12 border-t border-slate-200 flex items-center gap-1.5 shrink-0 bg-slate-50/30">
             {step > 0 ? (
@@ -526,8 +706,8 @@ function Footer({
                         disabled={isPending}
                         className="h-7 px-2.5 rounded-md bg-sky-600 hover:bg-sky-700 text-white text-[12px] font-medium inline-flex items-center gap-1.5 transition-colors disabled:opacity-60 shrink-0"
                     >
-                        {isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <PlusIcon className="w-3 h-3" />}
-                        Create campaign
+                        {isPending ? <Loader2Icon className="w-3 h-3 animate-spin" /> : <SubmitIcon className="w-3 h-3" />}
+                        {submitLabel}
                     </button>
                 )}
             </div>
@@ -544,23 +724,86 @@ function StepIntro({ title, hint }: { title: string; hint: string }) {
     );
 }
 
+function KindCard({
+    selected,
+    icon: Icon,
+    title,
+    description,
+    onSelect,
+}: {
+    selected: boolean;
+    icon: typeof MegaphoneIcon;
+    title: string;
+    description: string;
+    onSelect: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={onSelect}
+            className={cn(
+                "text-left rounded-md border px-3 py-2.5 flex items-start gap-2.5 transition-colors outline-none focus-visible:ring-2 focus-visible:ring-sky-100",
+                selected
+                    ? "border-sky-400 bg-sky-50/60 ring-1 ring-inset ring-sky-400"
+                    : "border-slate-200 hover:border-slate-300 hover:bg-slate-50",
+            )}
+        >
+            <span
+                className={cn(
+                    "size-6 rounded-md inline-flex items-center justify-center shrink-0 mt-0.5",
+                    selected ? "bg-sky-600 text-white" : "bg-slate-100 text-slate-600",
+                )}
+            >
+                <Icon className="w-3.5 h-3.5" />
+            </span>
+            <span className="min-w-0">
+                <span className="block text-[12.5px] text-slate-900 font-medium">{title}</span>
+                <span className="block text-[11px] text-slate-500 mt-0.5 leading-relaxed">{description}</span>
+            </span>
+        </button>
+    );
+}
+
 function BasicsStep({
     draft,
     patch,
+    setKind,
     onEnter,
 }: {
     draft: Draft;
     patch: (p: Partial<Draft>) => void;
+    setKind: (k: CampaignKind) => void;
     onEnter: () => void;
 }) {
     const len = draft.name.trim().length;
     return (
-        <div className="max-w-[520px]">
-            <StepIntro title="What is this campaign?" hint="A name your team will recognise in the list. Only the name is required." />
+        <div className="max-w-[560px]">
+            <StepIntro
+                title="What are you sending?"
+                hint="A sequence follows up over days; a one-time email goes out once to a segment. Both send through your mailbox pool at its daily caps."
+            />
             <div className="space-y-4">
+                <div role="radiogroup" aria-label="Campaign type" className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <KindCard
+                        selected={draft.kind === "sequence"}
+                        icon={ListChecksIcon}
+                        title="Sequence"
+                        description="Several emails with waits, branches and follow-ups. Add contacts and launch when ready."
+                        onSelect={() => setKind("sequence")}
+                    />
+                    <KindCard
+                        selected={draft.kind === "one_time"}
+                        icon={SendIcon}
+                        title="One-time email"
+                        description="One message to a segment, sent now or on a date, with no follow-ups."
+                        onSelect={() => setKind("one_time")}
+                    />
+                </div>
                 <div>
                     <div className="flex items-baseline justify-between">
-                        <Label>Campaign name</Label>
+                        <Label>{draft.kind === "one_time" ? "Email name" : "Campaign name"}</Label>
                         <span
                             className={cn(
                                 "text-[10.5px] tabular-nums",
@@ -579,7 +822,7 @@ function BasicsStep({
                                 onEnter();
                             }
                         }}
-                        placeholder="Q3 outbound, SaaS founders"
+                        placeholder={draft.kind === "one_time" ? "September product update" : "Q3 outbound, SaaS founders"}
                         autoFocus
                         className="w-full"
                     />
@@ -598,13 +841,99 @@ function BasicsStep({
     );
 }
 
-function ScheduleStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
+function TimezoneField({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
     const profile = useUserProfile();
     const timezoneOptions = React.useMemo<SelectOption[]>(
         () => (profile?.timezones || []).map((tz) => ({ value: tz.name, label: tz.display_name })),
         [profile?.timezones],
     );
+    return (
+        <div>
+            <Label>Timezone</Label>
+            <SelectMenu
+                value={draft.timezone}
+                onChange={(v) => patch({ timezone: v })}
+                options={timezoneOptions}
+                fullWidth
+                placeholder="Select a timezone"
+                aria-label="Sending timezone"
+            />
+        </div>
+    );
+}
+
+function SendingWindowFields({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
     const windowInvalid = draft.startTime >= draft.endTime;
+    return (
+        <>
+            <div>
+                <div className="flex items-baseline justify-between">
+                    <Label>Sending days</Label>
+                    <div className="flex items-center gap-1 text-[10.5px]">
+                        <button
+                            type="button"
+                            onClick={() => patch({ days: WEEKDAYS_MASK })}
+                            className={cn(
+                                "px-1.5 h-5 rounded transition-colors",
+                                draft.days === WEEKDAYS_MASK
+                                    ? "bg-sky-50 text-sky-700"
+                                    : "text-slate-400 hover:text-slate-700 hover:bg-slate-100",
+                            )}
+                        >
+                            Weekdays
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => patch({ days: EVERY_DAY_MASK })}
+                            className={cn(
+                                "px-1.5 h-5 rounded transition-colors",
+                                draft.days === EVERY_DAY_MASK
+                                    ? "bg-sky-50 text-sky-700"
+                                    : "text-slate-400 hover:text-slate-700 hover:bg-slate-100",
+                            )}
+                        >
+                            Every day
+                        </button>
+                    </div>
+                </div>
+                <div className="mt-1">
+                    <WeekdayBitmask weekdays={WEEKDAYS} value={draft.days} setValue={(v) => patch({ days: v })} />
+                </div>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+                <div>
+                    <Label>From</Label>
+                    <TimePicker
+                        value={draft.startTime}
+                        onChange={(v) => patch({ startTime: v })}
+                        stepMinutes={30}
+                        fullWidth
+                        placeholder="Start"
+                    />
+                </div>
+                <div>
+                    <Label>Until</Label>
+                    <TimePicker
+                        value={draft.endTime}
+                        onChange={(v) => patch({ endTime: v })}
+                        stepMinutes={30}
+                        fullWidth
+                        placeholder="End"
+                    />
+                </div>
+            </div>
+
+            <p className={cn("text-[11.5px] leading-relaxed", windowInvalid ? "text-amber-700" : "text-slate-500")}>
+                {windowInvalid
+                    ? "The window ends before it starts. Pick an end time after the start time."
+                    : `${daysLabel(draft.days)}, ${fmt12(draft.startTime)} to ${fmt12(draft.endTime)}.`}
+            </p>
+        </>
+    );
+}
+
+function ScheduleStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
     return (
         <div className="max-w-[560px]">
             <StepIntro
@@ -612,87 +941,15 @@ function ScheduleStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft
                 hint="Sends stay inside this window in the campaign timezone and spread out across it."
             />
             <div className="space-y-5">
-                <div>
-                    <Label>Timezone</Label>
-                    <SelectMenu
-                        value={draft.timezone}
-                        onChange={(v) => patch({ timezone: v })}
-                        options={timezoneOptions}
-                        fullWidth
-                        placeholder="Select a timezone"
-                        aria-label="Sending timezone"
-                    />
-                </div>
-
-                <div>
-                    <div className="flex items-baseline justify-between">
-                        <Label>Sending days</Label>
-                        <div className="flex items-center gap-1 text-[10.5px]">
-                            <button
-                                type="button"
-                                onClick={() => patch({ days: WEEKDAYS_MASK })}
-                                className={cn(
-                                    "px-1.5 h-5 rounded transition-colors",
-                                    draft.days === WEEKDAYS_MASK
-                                        ? "bg-sky-50 text-sky-700"
-                                        : "text-slate-400 hover:text-slate-700 hover:bg-slate-100",
-                                )}
-                            >
-                                Weekdays
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => patch({ days: EVERY_DAY_MASK })}
-                                className={cn(
-                                    "px-1.5 h-5 rounded transition-colors",
-                                    draft.days === EVERY_DAY_MASK
-                                        ? "bg-sky-50 text-sky-700"
-                                        : "text-slate-400 hover:text-slate-700 hover:bg-slate-100",
-                                )}
-                            >
-                                Every day
-                            </button>
-                        </div>
-                    </div>
-                    <div className="mt-1">
-                        <WeekdayBitmask weekdays={WEEKDAYS} value={draft.days} setValue={(v) => patch({ days: v })} />
-                    </div>
-                </div>
-
-                <div className="grid grid-cols-2 gap-3">
-                    <div>
-                        <Label>From</Label>
-                        <TimePicker
-                            value={draft.startTime}
-                            onChange={(v) => patch({ startTime: v })}
-                            stepMinutes={30}
-                            fullWidth
-                            placeholder="Start"
-                        />
-                    </div>
-                    <div>
-                        <Label>Until</Label>
-                        <TimePicker
-                            value={draft.endTime}
-                            onChange={(v) => patch({ endTime: v })}
-                            stepMinutes={30}
-                            fullWidth
-                            placeholder="End"
-                        />
-                    </div>
-                </div>
-
-                <p className={cn("text-[11.5px] leading-relaxed", windowInvalid ? "text-amber-700" : "text-slate-500")}>
-                    {windowInvalid
-                        ? "The window ends before it starts. Pick an end time after the start time."
-                        : `${daysLabel(draft.days)}, ${fmt12(draft.startTime)} to ${fmt12(draft.endTime)}.`}
-                </p>
+                <TimezoneField draft={draft} patch={patch} />
+                <SendingWindowFields draft={draft} patch={patch} />
             </div>
         </div>
     );
 }
 
 function SendingStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
+    const oneTime = draft.kind === "one_time";
     return (
         <div className="max-w-[560px]">
             <StepIntro
@@ -729,12 +986,14 @@ function SendingStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>
                 </div>
 
                 <div className="border border-slate-200 rounded-md divide-y divide-slate-100 overflow-hidden">
-                    <SwitchRow
-                        label="Stop on reply"
-                        description="Pause follow-ups for a contact once they respond."
-                        value={draft.stopOnReply}
-                        onChange={(v) => patch({ stopOnReply: v })}
-                    />
+                    {!oneTime && (
+                        <SwitchRow
+                            label="Stop on reply"
+                            description="Pause follow-ups for a contact once they respond."
+                            value={draft.stopOnReply}
+                            onChange={(v) => patch({ stopOnReply: v })}
+                        />
+                    )}
                     <SwitchRow
                         label="Track opens"
                         description="Insert a transparent pixel to measure inbox impressions."
@@ -791,38 +1050,45 @@ function SwitchRow({
 function EmailsStep({
     draft,
     patch,
-    goTo,
+    goToKey,
 }: {
     draft: Draft;
     patch: (p: Partial<Draft>) => void;
-    goTo: (s: Step) => void;
+    goToKey: (k: StepKey) => void;
 }) {
+    const oneTime = draft.kind === "one_time";
     const update = (i: number, p: Partial<SequenceDraft>) =>
         patch({ sequences: draft.sequences.map((s, idx) => (idx === i ? { ...s, ...p } : s)) });
 
     return (
         <div className="max-w-[640px]">
             <StepIntro
-                title="What does the first email say?"
-                hint="Optional. Skip this to write it in the full editor on the Steps tab afterwards."
+                title={oneTime ? "What does the email say?" : "What does the first email say?"}
+                hint={
+                    oneTime
+                        ? "This is the whole send. You can polish it in the full editor on the Steps tab afterwards."
+                        : "Optional. Skip this to write it in the full editor on the Steps tab afterwards."
+                }
             />
 
-            <div className="mb-4 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-slate-500">
-                <button type="button" onClick={() => goTo(1)} className="hover:text-slate-900 hover:underline underline-offset-2">
-                    {daysLabel(draft.days)}, {fmt12(draft.startTime)} to {fmt12(draft.endTime)}
-                </button>
-                <span className="text-slate-300">·</span>
-                <button type="button" onClick={() => goTo(2)} className="hover:text-slate-900 hover:underline underline-offset-2">
-                    {draft.dailyLimit}/day per mailbox
-                </button>
-                <span className="text-slate-300">·</span>
-                <button type="button" onClick={() => goTo(2)} className="hover:text-slate-900 hover:underline underline-offset-2">
-                    {draft.emailTagIds.length === 0
-                        ? "all mailboxes"
-                        : `${draft.emailTagIds.length} tag${draft.emailTagIds.length === 1 ? "" : "s"}`}
-                </button>
-                <PencilLineIcon className="w-3 h-3 text-slate-300 ml-0.5" />
-            </div>
+            {!oneTime && (
+                <div className="mb-4 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px] text-slate-500">
+                    <button type="button" onClick={() => goToKey("schedule")} className="hover:text-slate-900 hover:underline underline-offset-2">
+                        {daysLabel(draft.days)}, {fmt12(draft.startTime)} to {fmt12(draft.endTime)}
+                    </button>
+                    <span className="text-slate-300">·</span>
+                    <button type="button" onClick={() => goToKey("sending")} className="hover:text-slate-900 hover:underline underline-offset-2">
+                        {draft.dailyLimit}/day per mailbox
+                    </button>
+                    <span className="text-slate-300">·</span>
+                    <button type="button" onClick={() => goToKey("sending")} className="hover:text-slate-900 hover:underline underline-offset-2">
+                        {draft.emailTagIds.length === 0
+                            ? "all mailboxes"
+                            : `${draft.emailTagIds.length} tag${draft.emailTagIds.length === 1 ? "" : "s"}`}
+                    </button>
+                    <PencilLineIcon className="w-3 h-3 text-slate-300 ml-0.5" />
+                </div>
+            )}
 
             <div className="space-y-3">
                 <AnimatePresence initial={false}>
@@ -841,7 +1107,7 @@ function EmailsStep({
                                     {i + 1}
                                 </span>
                                 <span className="text-[12px] text-slate-900 font-medium">
-                                    {i === 0 ? "First email" : `Follow-up ${i}`}
+                                    {oneTime ? "Email" : i === 0 ? "First email" : `Follow-up ${i}`}
                                 </span>
                                 {i > 0 && (
                                     <div className="flex items-center gap-1.5 ml-1">
@@ -898,20 +1164,260 @@ function EmailsStep({
                     ))}
                 </AnimatePresence>
 
-                <button
-                    type="button"
-                    onClick={() => patch({ sequences: [...draft.sequences, newSequence(3)] })}
-                    className="w-full h-8 rounded-md border border-dashed border-slate-200 text-[12px] text-slate-500 hover:text-slate-900 hover:border-slate-300 hover:bg-slate-50 inline-flex items-center justify-center gap-1.5 transition-colors"
-                >
-                    <PlusIcon className="w-3 h-3" />
-                    Add a follow-up
-                </button>
+                {oneTime ? (
+                    <p className="text-[11px] text-slate-500 leading-relaxed">
+                        No follow-ups here by design. Want a reminder a few days later? Create a sequence instead.
+                    </p>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={() => patch({ sequences: [...draft.sequences, newSequence(3)] })}
+                        className="w-full h-8 rounded-md border border-dashed border-slate-200 text-[12px] text-slate-500 hover:text-slate-900 hover:border-slate-300 hover:bg-slate-50 inline-flex items-center justify-center gap-1.5 transition-colors"
+                    >
+                        <PlusIcon className="w-3 h-3" />
+                        Add a follow-up
+                    </button>
+                )}
 
                 <p className="text-[10.5px] text-slate-400 leading-relaxed">
                     Personalise with <code className="font-mono">{"{{.FirstName}}"}</code>,{" "}
                     <code className="font-mono">{"{{.Company}}"}</code>, custom fields like{" "}
                     <code className="font-mono">{"{{.role}}"}</code>, and conditionals like{" "}
                     <code className="font-mono">{"{{if .Company}}...{{end}}"}</code>. HTML is generated for you.
+                </p>
+            </div>
+        </div>
+    );
+}
+
+function AudienceStep({ draft, patch }: { draft: Draft; patch: (p: Partial<Draft>) => void }) {
+    const estimate = useCampaignEstimate({ segment_ids: draft.segmentIds });
+    const recipients = estimate.data?.recipients;
+    return (
+        <div className="max-w-[560px]">
+            <StepIntro
+                title="Who receives it?"
+                hint="Every current member of the segments you pick becomes a lead. Suppressed and unsubscribed contacts are skipped at send time."
+            />
+            <div className="space-y-4">
+                <div>
+                    <Label>Segments</Label>
+                    <SegmentMultiPicker value={draft.segmentIds} onChange={(next) => patch({ segmentIds: next })} />
+                    <p className="text-[11px] text-slate-400 mt-1">
+                        Contacts in more than one segment are counted, and emailed, once.
+                    </p>
+                </div>
+                <div className="rounded-md border border-slate-200 px-3 py-2.5 flex items-center gap-3">
+                    <span className="size-7 rounded-md bg-slate-100 text-slate-600 inline-flex items-center justify-center shrink-0">
+                        <UsersIcon className="w-3.5 h-3.5" />
+                    </span>
+                    <div className="min-w-0">
+                        <p className="text-[12.5px] text-slate-900 font-medium tabular-nums">
+                            {draft.segmentIds.length === 0
+                                ? "No segment picked yet"
+                                : estimate.isPending
+                                  ? "Counting…"
+                                  : estimate.isError
+                                    ? "Could not count recipients"
+                                    : `${(recipients ?? 0).toLocaleString()} recipient${recipients === 1 ? "" : "s"}`}
+                        </p>
+                        <p className="text-[11px] text-slate-500 mt-0.5">
+                            {recipients === 0 && !estimate.isPending && draft.segmentIds.length > 0
+                                ? "These segments have no contacts right now, so there is nothing to send."
+                                : "Live membership, as of now."}
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function SendStep({
+    draft,
+    patch,
+    goToKey,
+}: {
+    draft: Draft;
+    patch: (p: Partial<Draft>) => void;
+    goToKey: (k: StepKey) => void;
+}) {
+    const at = scheduledDate(draft);
+    const estimate = useCampaignEstimate({
+        segment_ids: draft.segmentIds,
+        email_tag_ids: draft.emailTagIds,
+        daily_limit: draft.dailyLimit,
+        days: draft.days,
+        timezone: draft.timezone,
+        start_date: at ? at.toISOString() : undefined,
+    });
+    const e = estimate.data;
+    const finish = e?.estimated_finish_at ? new Date(e.estimated_finish_at) : null;
+
+    return (
+        <div className="max-w-[560px]">
+            <StepIntro
+                title="When should it go?"
+                hint="Send now starts the moment you confirm. Either way it keeps to the sending window and the daily cap of every mailbox."
+            />
+            <div className="space-y-5">
+                <div role="radiogroup" aria-label="Send timing" className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    <KindCard
+                        selected={draft.sendMode === "now"}
+                        icon={SendIcon}
+                        title="Send now"
+                        description="Start as soon as it is created."
+                        onSelect={() => patch({ sendMode: "now" })}
+                    />
+                    <KindCard
+                        selected={draft.sendMode === "later"}
+                        icon={CalendarClockIcon}
+                        title="Schedule for later"
+                        description="Pick the date and time sending begins."
+                        onSelect={() => patch({ sendMode: "later" })}
+                    />
+                </div>
+
+                <AnimatePresence initial={false}>
+                    {draft.sendMode === "later" && (
+                        <motion.div
+                            key="when"
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: "auto" }}
+                            exit={{ opacity: 0, height: 0 }}
+                            transition={{ duration: 0.16 }}
+                            className="overflow-hidden"
+                        >
+                            <Label>Start sending at</Label>
+                            <DateTimePicker
+                                value={draft.scheduledAt}
+                                onChange={(v) => patch({ scheduledAt: v })}
+                                stepMinutes={15}
+                                datePlaceholder="Pick a date"
+                            />
+                            <p className="text-[11px] text-slate-400 mt-1">In your local time.</p>
+                        </motion.div>
+                    )}
+                </AnimatePresence>
+
+                <TimezoneField draft={draft} patch={patch} />
+                <SendingWindowFields draft={draft} patch={patch} />
+
+                <EstimatePanel
+                    loading={estimate.isPending && draft.segmentIds.length > 0}
+                    error={estimate.isError}
+                    recipients={e?.recipients ?? 0}
+                    mailboxes={e?.mailboxes ?? 0}
+                    dailyCapacity={e?.daily_capacity ?? 0}
+                    sendingDays={e?.sending_days ?? null}
+                    finish={finish}
+                    startsAt={at}
+                    onEditPool={() => goToKey("sending")}
+                    onEditAudience={() => goToKey("audience")}
+                />
+            </div>
+        </div>
+    );
+}
+
+function EstimatePanel({
+    loading,
+    error,
+    recipients,
+    mailboxes,
+    dailyCapacity,
+    sendingDays,
+    finish,
+    startsAt,
+    onEditPool,
+    onEditAudience,
+}: {
+    loading: boolean;
+    error: boolean;
+    recipients: number;
+    mailboxes: number;
+    dailyCapacity: number;
+    sendingDays: number | null;
+    finish: Date | null;
+    startsAt: Date | null;
+    onEditPool: () => void;
+    onEditAudience: () => void;
+}) {
+    let headline: string;
+    let detail: React.ReactNode;
+    let tone: "neutral" | "warn" = "neutral";
+
+    if (loading) {
+        headline = "Working out the timing…";
+        detail = "Counting the audience against the mailbox pool.";
+    } else if (error) {
+        headline = "Could not estimate the timing";
+        detail = "The send still works; this only affects the preview.";
+    } else if (recipients === 0) {
+        headline = "Nothing to send yet";
+        detail = (
+            <>
+                The chosen segments have no contacts.{" "}
+                <button type="button" onClick={onEditAudience} className="underline underline-offset-2 hover:text-slate-900">
+                    Change the audience
+                </button>
+                .
+            </>
+        );
+        tone = "warn";
+    } else if (mailboxes === 0 || dailyCapacity === 0) {
+        headline = "No mailbox can send this";
+        detail = (
+            <>
+                The sender pool resolves to no active mailbox.{" "}
+                <button type="button" onClick={onEditPool} className="underline underline-offset-2 hover:text-slate-900">
+                    Change the pool
+                </button>{" "}
+                or connect a mailbox first.
+            </>
+        );
+        tone = "warn";
+    } else {
+        const days = sendingDays ?? 0;
+        headline =
+            days <= 1
+                ? finish
+                    ? `Finishes ${startsAt ? "on" : "today,"} ${fmtDate(finish)}`
+                    : "Finishes in one sending day"
+                : finish
+                  ? `About ${days} sending days, finishing around ${fmtDate(finish)}`
+                  : `More than ${days} sending days`;
+        detail = (
+            <>
+                {recipients.toLocaleString()} recipient{recipients === 1 ? "" : "s"} across {mailboxes} mailbox
+                {mailboxes === 1 ? "" : "es"} at up to {dailyCapacity.toLocaleString()} a day.
+                {days > 1 && " One-time means one message per contact, not one day: the daily caps still pace it."}
+            </>
+        );
+        if (days > 7) tone = "warn";
+    }
+
+    return (
+        <div
+            className={cn(
+                "rounded-md border px-3 py-2.5 flex items-start gap-3",
+                tone === "warn" ? "border-amber-200 bg-amber-50/60" : "border-slate-200",
+            )}
+        >
+            <span
+                className={cn(
+                    "size-7 rounded-md inline-flex items-center justify-center shrink-0",
+                    tone === "warn" ? "bg-amber-100 text-amber-700" : "bg-slate-100 text-slate-600",
+                )}
+            >
+                {loading ? <Loader2Icon className="w-3.5 h-3.5 animate-spin" /> : <CalendarClockIcon className="w-3.5 h-3.5" />}
+            </span>
+            <div className="min-w-0">
+                <p className={cn("text-[12.5px] font-medium", tone === "warn" ? "text-amber-900" : "text-slate-900")}>
+                    {headline}
+                </p>
+                <p className={cn("text-[11px] mt-0.5 leading-relaxed", tone === "warn" ? "text-amber-800" : "text-slate-500")}>
+                    {detail}
                 </p>
             </div>
         </div>

--- a/web/src/components/app/campaigns/sequences/nodes/AIVariableNode.tsx
+++ b/web/src/components/app/campaigns/sequences/nodes/AIVariableNode.tsx
@@ -261,7 +261,7 @@ function AIVariableConfigBody({
     };
 
     return (
-        <div className="flex max-h-[calc(100dvh-4rem)] min-h-[340px]">
+        <div className="flex flex-col md:flex-row max-h-[calc(100dvh-4rem)] min-h-[340px]">
             {/* LEFT — the instruction, in the same editor used everywhere else */}
             <div className="flex min-w-0 flex-1 flex-col">
                 <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 pb-4 pt-5">
@@ -359,7 +359,9 @@ function AIVariableConfigBody({
             </div>
 
             {/* RIGHT — the live sample */}
-            <div className="flex w-[300px] shrink-0 flex-col border-l border-slate-200 bg-slate-50/60 p-4">
+            {/* The sample sits beside the form on desktop and under it on a
+                phone, where a 300px column would leave the form no room. */}
+            <div className="flex w-full max-h-[32dvh] md:max-h-none md:w-[300px] shrink-0 flex-col border-t md:border-t-0 md:border-l border-slate-200 bg-slate-50/60 p-4">
                 <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-slate-400">
                     Sample for Alex Rivera at Acme
                 </span>

--- a/web/src/components/app/campaigns/status.ts
+++ b/web/src/components/app/campaigns/status.ts
@@ -47,3 +47,30 @@ export function campaignStatusLabel(status?: string): string {
 export function campaignStatusTone(status: string): string {
     return CAMPAIGN_STATUS_TONE[status] ?? CAMPAIGN_STATUS_TONE.draft;
 }
+
+// The subset of a campaign the display helpers need, so list rows, pickers
+// and the detail header can all pass their own shape.
+export interface CampaignStatusSubject {
+    status?: string;
+    kind?: string;
+    start_date?: Date | string | null;
+}
+
+export function isOneTimeCampaign(c: Pick<CampaignStatusSubject, "kind">): boolean {
+    return c.kind === "one_time";
+}
+
+// A one-time email reads as a message, not a sequence: draft, scheduled
+// (active but waiting on its start date), sending, sent. Paused variants keep
+// their sequence wording since the reasons are the same.
+export function campaignDisplayLabel(c: CampaignStatusSubject): string {
+    const status = c.status ?? "draft";
+    if (!isOneTimeCampaign(c)) return campaignStatusLabel(status);
+    if (status === "completed") return "sent";
+    if (status === "active") {
+        const start = c.start_date ? new Date(c.start_date) : null;
+        if (start && !Number.isNaN(start.getTime()) && start.getTime() > Date.now()) return "scheduled";
+        return "sending";
+    }
+    return campaignStatusLabel(status);
+}

--- a/web/src/components/layout/Page.tsx
+++ b/web/src/components/layout/Page.tsx
@@ -219,7 +219,7 @@ export function Stat({
         </>
     );
     const cls = cn(
-        "group px-5 py-4 transition-colors",
+        "group px-5 py-3 md:py-4 transition-colors",
         !last && "border-r border-slate-200",
         (href || onClick) && "hover:bg-slate-50 cursor-pointer",
     );

--- a/web/src/lib/api/client/app/campaigns/createCampaign.ts
+++ b/web/src/lib/api/client/app/campaigns/createCampaign.ts
@@ -1,4 +1,5 @@
 import type Campaign from "@/lib/api/models/app/campaigns/Campaign";
+import type { CampaignKind } from "@/lib/api/models/app/campaigns/Campaign";
 import Request from "../../Request";
 
 // Wire shape for POST /campaigns. Everything other than `name` is optional;
@@ -7,6 +8,8 @@ import Request from "../../Request";
 export interface CreateCampaignInput {
     name: string;
     description?: string;
+    // Defaults to "sequence". A "one_time" campaign takes at most one step.
+    kind?: CampaignKind;
 
     // Sending rules / tracking
     stop_on_reply?: boolean;

--- a/web/src/lib/api/client/app/campaigns/estimateCampaign.ts
+++ b/web/src/lib/api/client/app/campaigns/estimateCampaign.ts
@@ -1,0 +1,35 @@
+import Request from "../../Request";
+
+// Wire shape for POST /campaigns-estimate: an audience (segments) against a
+// sender pool (tags, or every active mailbox when empty) under a per-mailbox
+// daily limit and a weekday mask. Read-only; nothing is created.
+export interface CampaignEstimateInput {
+    segment_ids: string[];
+    email_tag_ids?: string[];
+    daily_limit?: number;
+    days?: number;
+    timezone?: string;
+    // RFC 3339. Omit to start now.
+    start_date?: string;
+}
+
+export interface CampaignEstimateResult {
+    recipients: number;
+    mailboxes: number;
+    // Pool ceiling per sending day under the campaign limit.
+    daily_capacity: number;
+    // What the pool can still send today.
+    remaining_today: number;
+    // Null when the pool has no capacity or the audience is empty.
+    sending_days: number | null;
+    estimated_finish_at: string | null;
+}
+
+export default async function estimateCampaign(input: CampaignEstimateInput): Promise<CampaignEstimateResult> {
+    return await Request<CampaignEstimateResult>({
+        method: "POST",
+        url: `/campaigns-estimate`,
+        data: input,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/hooks/app/campaigns/useCampaignEstimate.ts
+++ b/web/src/lib/api/hooks/app/campaigns/useCampaignEstimate.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import estimateCampaign, { type CampaignEstimateInput } from "@/lib/api/client/app/campaigns/estimateCampaign";
+
+// Audience-versus-pool projection for the campaign wizard. Keyed on the whole
+// input so every edit (segment, tag, limit, days, start) re-asks; disabled
+// until at least one segment is chosen because the answer is zero before that.
+export default function useCampaignEstimate(input: CampaignEstimateInput, enabled = true) {
+    return useQuery({
+        queryKey: ["campaigns", "estimate", input],
+        queryFn: () => estimateCampaign(input),
+        enabled: enabled && input.segment_ids.length > 0,
+        staleTime: 30_000,
+        placeholderData: (prev) => prev,
+    });
+}

--- a/web/src/lib/api/models/app/campaigns/Campaign.ts
+++ b/web/src/lib/api/models/app/campaigns/Campaign.ts
@@ -1,11 +1,16 @@
 import type Sequence from "./sequences/Sequence";
 
+export type CampaignKind = "sequence" | "one_time";
+
 export default interface Campaign {
     id: string;
 
     name: string;
     description: string;
     status: string;
+    // "sequence" (multi-step, the default) or "one_time" (a single message
+    // to an audience, no follow-ups). Fixed at creation.
+    kind: CampaignKind;
 
     stop_on_reply: boolean;
     open_tracking: boolean;


### PR DESCRIPTION
Closes #296. Scoped implementation of #288 for a cold email service, plus a mobile padding fix for the campaign detail tabs.

## One-time email campaign preset
- `campaigns.kind` (`sequence` | `one_time`, migration 000122). `kind` on `POST /campaigns`, `GET /campaigns?kind=`, and an `one_time` count on `/campaigns-overview`. Fixed at creation; a one-time campaign takes at most one email step and refuses more later.
- `POST /campaigns-estimate`: deduplicated recipients across segments, mailbox pool under the per-mailbox caps, remaining capacity today, sending days and finish date. Read-only.
- Wizard: Sequence / One-time email picker on the first step. One-time runs Basics, Email (required), Audience (segments, live count), Sending, Send (now or scheduled, sending days and window, estimate panel), then creates, links segments and starts. A refused start leaves a draft and lands on the campaign page with the reason.
- Campaigns list: One-time badge, Type filter, and draft / scheduled / sending / sent wording (also on the detail header).
- `text_only` is now honoured by the send path and the test-email path: no HTML part, no tracking pixel or wrapped links.
- Docs: campaigns guide (one-time emails, plain text), segments guide, API reference for campaigns, endpoint scope map. AI `create_campaign_draft` tool accepts `kind`.

## Mobile
- Campaign detail tabs no longer stack a 20px wrapper on top of the Leads page's own chrome; other tabs use a 12px gutter below `sm`. Campaign name truncates instead of pushing pills off screen. Stat strip cells are shorter on phones. Templates body, API key meta row, delivery hours grid and the AI variable dialog's sample pane collapse or stack on narrow screens.

## Verification
`make lint` (check-migrations, golangci-lint) clean; `pnpm typecheck` and `pnpm lint` clean in `web/`; `pnpm types:check` and `pnpm lint` clean in `docs/`. Exercised the new endpoints against a seeded database with the seeded API key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Create and send one-time email campaigns alongside multi-step sequences.
  - Select audiences, preview recipient and mailbox capacity, schedule delivery, and view estimated completion times.
  - Filter campaigns by type and see one-time campaign counts and status labels.
  - One-time campaigns support segment linking and immediate or scheduled sending.
  - Estimates now warn when the full delivery timeline cannot be projected.

- **Bug Fixes**
  - Text-only campaigns and test emails no longer include HTML or tracking metadata.

- **Documentation**
  - Updated API and campaign guides with one-time campaign setup, constraints, scheduling, analytics, and tracking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->