### PR TITLE
Self-hosted update indicator and one-click updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -460,6 +460,35 @@ BILLING_PROVIDER=none
 # WORKER_INSTALLER_PATH=
 
 
+# === Updates ==================================================================
+#
+# The admin panel's top bar shows the running version and turns into an
+# "Update available" pill when a newer release exists. The backend checks
+# GitHub Releases on the interval below; the check is one unauthenticated API
+# read and can be turned off. Full page: https://docs.warmbly.com/development/updates/
+# UPDATE_CHECK_ENABLED=true
+# UPDATE_CHECK_INTERVAL=30m          # minimum 5m
+# UPDATE_CHANNEL=stable              # stable | dev (dev also offers prereleases)
+# RELEASES_GITHUB_REPO=warmbly/warmbly   # point a fork's instance at the fork
+# RELEASES_GITHUB_TOKEN=             # optional; only raises the API rate limit
+#
+# "Update and restart" in that pill needs the updater: a sidecar that pulls this
+# checkout, rebuilds the images and recreates the containers, then waits for the
+# backend to answer again. It holds the docker socket (root on this host), so it
+# runs only under the "updater" compose profile. `make up` enables the profile;
+# for a plain `docker compose up`, uncomment the next line. Comment it out to
+# update by hand with `git pull && make up` instead.
+# COMPOSE_PROFILES=updater
+#
+# The backend reaches it at UPDATER_URL with UPDATER_TOKEN (defaults to
+# INTERNAL_API_TOKEN). UPDATER_URL=none makes the panel report-only.
+# UPDATER_URL=http://updater:8095
+# UPDATER_TOKEN=
+# UPDATER_FETCH_INTERVAL=30m         # how often the updater git-fetches for the "commits behind" count
+# UPDATER_PRUNE=true                 # docker image prune after a successful update
+# UPDATER_ALLOW_DIRTY=false          # let an update run over local modifications in the checkout
+# WARMBLY_REPO_DIR=                  # the checkout's absolute path; defaults to $PWD at compose time
+
 # === Tracking service (Rust, open/click) ======================================
 #
 # The shipped docker-compose.yml pins the listen address, so these two only take

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -132,6 +132,10 @@ jobs:
           context: .
           file: deploy/docker/${{ matrix.service }}.Dockerfile
           push: true
+          build-args: |
+            VERSION=dev-${{ github.sha }}
+            COMMIT=${{ github.sha }}
+            BUILT_AT=${{ github.event.head_commit.timestamp }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,10 @@ jobs:
           context: .
           file: deploy/docker/${{ matrix.service }}.Dockerfile
           push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+            COMMIT=${{ github.sha }}
+            BUILT_AT=${{ github.event.head_commit.timestamp }}
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.ref_name }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:v${{ needs.validate-tag.outputs.minor }}

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,21 @@ export PATH := $(GO_BIN):$(PATH)
 # fresh clones without any environment setup.
 COMPOSE := docker compose -p warmbly
 
+# Build identity stamped into the Go images (shown in the admin panel's top bar
+# and read by the update check). Empty outside a git checkout, which the
+# binaries report as "dev".
+export WARMBLY_BUILD_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null)
+export WARMBLY_BUILD_COMMIT ?= $(shell git rev-parse HEAD 2>/dev/null)
+export WARMBLY_BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# The updater sidecar (one-click "Update and restart" from the admin panel)
+# holds the docker socket, so it lives behind a compose profile. `make up`
+# turns it on; UPDATER=false leaves it off.
+UPDATER ?= true
+ifeq ($(UPDATER),true)
+UP_PROFILES := --profile updater
+endif
+
 GOLANGCI_LINT_VERSION ?= v1.64.8
 PROTOC_GEN_GO_VERSION ?= v1.36.11
 PROTOC_GEN_GO_GRPC_VERSION ?= v1.6.1
@@ -23,7 +38,7 @@ PROTO_DIR := internal/tasks/proto
 PROTO_GEN_FILES := $(PROTO_DIR)/tasks.pb.go
 
 .PHONY: poollink-dev poollink-dev-down poollink-dev-reset setup-tools fmt lint check-migrations proto check-proto \
-        up claim doctor cli seed-demo seed seed-plan sandbox sandbox-seed sandbox-simulate reset logs status stop down test-seed \
+        up upgrade claim doctor cli seed-demo seed seed-plan sandbox sandbox-seed sandbox-simulate reset logs status stop down test-seed \
         restart restart-go restart-all infra infra-down app app-down app-logs \
         backend forms forms-web consumer worker run dev tracking realtime web \
         admin site docs grant-admin revoke-admin gen-key db-reset db-wipe migrate
@@ -79,7 +94,7 @@ ADMIN_URL = http://$(WEB_HOST):5174
 # everything detached. Dashboard :5173, admin :5174, API :8080.
 up:
 	@command -v docker >/dev/null || { echo "docker is required: https://docs.docker.com/get-docker/"; exit 1; }
-	$(COMPOSE) up -d --build
+	$(COMPOSE) $(UP_PROFILES) up -d --build
 	@echo ""
 	@echo "Warmbly is starting. The first run builds the images once."
 	@echo ""
@@ -87,6 +102,12 @@ up:
 	@echo "  Dashboard: $(DASHBOARD_URL)     Admin: $(ADMIN_URL)"
 	@echo "  Health:    make doctor               Logs:  make logs"
 	@echo "  Demo data: make seed-demo            Guide: https://docs.warmbly.com/development/first-run/"
+
+# The by-hand equivalent of "Update and restart" in the admin panel: move the
+# checkout forward, rebuild, recreate what changed. Migrations apply on boot.
+upgrade:
+	git pull --ff-only
+	@$(MAKE) --no-print-directory up
 
 # Report how to get into this instance, and end on a command that works.
 #

--- a/admin/src/app/dashboard/AuditPage.tsx
+++ b/admin/src/app/dashboard/AuditPage.tsx
@@ -27,7 +27,7 @@ const KNOWN_ACTIONS = [
 ];
 
 const KNOWN_TARGETS = [
-    "worker", "aws_credentials", "worker_profile", "release",
+    "worker", "aws_credentials", "worker_profile", "release", "instance",
     "user", "email_account", "campaign", "plan",
 ];
 

--- a/admin/src/app/dashboard/HealthPage.tsx
+++ b/admin/src/app/dashboard/HealthPage.tsx
@@ -2,14 +2,25 @@
 // as decided by the running backend. The endpoint returns only checks that
 // are not ok, so an empty response is a real all-clear and not a stub.
 
-import { Link } from "react-router-dom";
-import { AlertTriangle, CheckCircle2, Info, RefreshCw, XCircle } from "lucide-react";
+import { useState } from "react";
+import { Link, useSearchParams } from "react-router-dom";
+import {
+    AlertTriangle,
+    ArrowUpCircle,
+    CheckCircle2,
+    Info,
+    Loader2,
+    RefreshCw,
+    XCircle,
+} from "lucide-react";
 import { PageHeader } from "@/components/layout/PageHeader";
 import { ErrorState } from "@/components/ErrorState";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { InstanceFindings } from "./InstanceHealthPanel";
+import { UpdateDialog } from "@/components/layout/UpdateDialog";
 import { useInstanceHealth } from "@/hooks/useInstanceHealth";
+import { buildLabel, isUpdating, useUpdateState } from "@/hooks/useUpdateState";
 import type { InstanceHealthSummary } from "@/lib/api/client/admin/instance";
 
 export default function HealthPage() {
@@ -42,6 +53,8 @@ export default function HealthPage() {
                     {healthQ.isFetching ? "Checking..." : "Run checks"}
                 </Button>
             </PageHeader>
+
+            <UpdateCard />
 
             {healthQ.isLoading && (
                 <div className="space-y-3">
@@ -85,6 +98,61 @@ export default function HealthPage() {
                     )}
                 </>
             )}
+        </div>
+    );
+}
+
+// Version and update status, above the findings: the same facts as the pill
+// in the top bar, on the page an operator opens to ask "is this instance ok".
+function UpdateCard() {
+    const updateQ = useUpdateState();
+    // ?update=1 is how the dashboard's version pill deep-links an admin
+    // straight into the dialog.
+    const [params] = useSearchParams();
+    const [open, setOpen] = useState(params.get("update") === "1");
+    const state = updateQ.data;
+    if (!state) return null;
+
+    const updating = isUpdating(state);
+    const available = state.update_available;
+    const tone = updating
+        ? "border-sky-200 bg-sky-50/60"
+        : available
+          ? "border-amber-200 bg-amber-50/60"
+          : "border-border bg-white";
+
+    return (
+        <div className={`mb-5 flex flex-wrap items-center gap-3 rounded-lg border p-3 ${tone}`}>
+            {updating ? (
+                <Loader2 className="size-4 shrink-0 animate-spin text-sky-600" />
+            ) : available ? (
+                <ArrowUpCircle className="size-4 shrink-0 text-amber-600" />
+            ) : (
+                <CheckCircle2 className="size-4 shrink-0 text-emerald-600" />
+            )}
+            <div className="min-w-0 flex-1 text-[13px]">
+                <span className="font-semibold text-foreground">
+                    {updating
+                        ? "Updating this instance"
+                        : available
+                          ? `${state.latest?.tag && state.reason === "release" ? state.latest.tag : "A newer version"} is available`
+                          : "Up to date"}
+                </span>
+                <span className="text-muted-foreground">
+                    {" "}
+                    running {buildLabel(state)}
+                    {state.updater.checkout && !state.updater.checkout.detached
+                        ? ` on ${state.updater.checkout.branch}`
+                        : ""}
+                    {state.checked_at
+                        ? `, checked ${new Date(state.checked_at).toLocaleTimeString()}`
+                        : ""}
+                </span>
+            </div>
+            <Button size="sm" variant={available ? "default" : "outline"} onClick={() => setOpen(true)}>
+                {updating ? "Progress" : available ? "Update" : "Details"}
+            </Button>
+            <UpdateDialog open={open} onOpenChange={setOpen} />
         </div>
     );
 }

--- a/admin/src/components/layout/Topbar.tsx
+++ b/admin/src/components/layout/Topbar.tsx
@@ -1,9 +1,11 @@
-// Sticky top bar. Holds the env pill, a search slot (unused for now —
-// reserved for the cmd-K palette we'll add later), and the user menu.
+// Sticky top bar. Holds the env pill, the version pill (which becomes the
+// update indicator), a search slot (unused for now, reserved for the cmd-K
+// palette we'll add later), and the user menu.
 // The 3px admin stripe sits *above* this bar in AppShell so it's the
 // first thing the eye lands on.
 
 import { EnvPill } from "./EnvPill";
+import { UpdatePill } from "./UpdatePill";
 import { UserMenu } from "./UserMenu";
 
 export function Topbar() {
@@ -12,6 +14,7 @@ export function Topbar() {
             <div className="h-full flex items-center gap-3 px-4">
                 <div className="flex items-center gap-2">
                     <EnvPill />
+                    <UpdatePill />
                     <span className="text-xs text-muted-foreground hidden sm:inline">
                         Connected to <code className="text-foreground font-mono">/admin/*</code>
                     </span>

--- a/admin/src/components/layout/UpdateDialog.tsx
+++ b/admin/src/components/layout/UpdateDialog.tsx
@@ -91,11 +91,19 @@ export function UpdateDialog({ open, onOpenChange }: Props) {
         return "idle";
     }, [state, started, jobQ.isError, stateQ.isError]);
 
-    // Leaving the confirmation open across a phase change would let a stale
-    // click start a second update.
+    const canApply =
+        canManage &&
+        state?.updater.status === "ok" &&
+        !!state?.update_available &&
+        !state?.updater.checkout?.dirty &&
+        phase === "idle";
+
+    // Leaving the confirmation open once the update can no longer start
+    // (a phase change, or the checkout turning dirty) would let a stale
+    // click start a job that fails.
     useEffect(() => {
-        if (phase !== "idle") setConfirming(false);
-    }, [phase]);
+        if (!canApply) setConfirming(false);
+    }, [canApply]);
 
     const checkMut = useMutation({
         mutationFn: checkForUpdates,
@@ -110,7 +118,12 @@ export function UpdateDialog({ open, onOpenChange }: Props) {
     });
 
     const applyMut = useMutation({
-        mutationFn: () => applyUpdate("latest"),
+        mutationFn: () => {
+            // The state keeps refreshing while the confirmation is open; a
+            // checkout that turned dirty meanwhile must not start a job.
+            if (!canApply) return Promise.reject(new Error("The update can no longer start; check the status above."));
+            return applyUpdate("latest");
+        },
         onSuccess: (job: UpdateJob) => {
             markUpdateStarted(state?.running.version ?? "", state?.running.commit ?? job.from_commit);
             setConfirming(false);
@@ -124,12 +137,6 @@ export function UpdateDialog({ open, onOpenChange }: Props) {
     const updater = state?.updater;
     const checkout = updater?.checkout;
     const job = updater?.job ?? updater?.last_job;
-    const canApply =
-        canManage &&
-        updater?.status === "ok" &&
-        !!state?.update_available &&
-        !checkout?.dirty &&
-        phase === "idle";
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>

--- a/admin/src/components/layout/UpdateDialog.tsx
+++ b/admin/src/components/layout/UpdateDialog.tsx
@@ -125,7 +125,11 @@ export function UpdateDialog({ open, onOpenChange }: Props) {
     const checkout = updater?.checkout;
     const job = updater?.job ?? updater?.last_job;
     const canApply =
-        canManage && updater?.status === "ok" && !!state?.update_available && phase === "idle";
+        canManage &&
+        updater?.status === "ok" &&
+        !!state?.update_available &&
+        !checkout?.dirty &&
+        phase === "idle";
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>

--- a/admin/src/components/layout/UpdateDialog.tsx
+++ b/admin/src/components/layout/UpdateDialog.tsx
@@ -1,0 +1,487 @@
+// The update dialog behind the version pill: what is running, what is newest,
+// and the one button that pulls, rebuilds and restarts through the updater.
+// While a job runs it shows the steps and the live log; when the backend goes
+// away for the restart it says so and keeps polling until it is back.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+    AlertTriangle,
+    Check,
+    CheckCircle2,
+    ExternalLink,
+    GitBranch,
+    Loader2,
+    RefreshCw,
+    RotateCw,
+    XCircle,
+} from "lucide-react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { docsUrl } from "@/lib/docs";
+import { cn } from "@/lib/utils";
+import { useAdminPerm } from "@/hooks/useAdminPerm";
+import { AdminPerm } from "@/lib/auth/permissions";
+import {
+    UPDATE_JOB_KEY,
+    UPDATE_STATE_KEY,
+    buildLabel,
+    isUpdating,
+    useUpdateJob,
+    useUpdateState,
+} from "@/hooks/useUpdateState";
+import {
+    applyUpdate,
+    checkForUpdates,
+    type UpdateJob,
+    type UpdateState,
+} from "@/lib/api/client/admin/updates";
+import { markUpdateStarted, readUpdateStarted } from "@/lib/updateSession";
+
+const DOCS_UPDATES = "/development/updates/";
+
+const STEPS: Record<string, string[]> = {
+    compose: ["fetch", "checkout", "build", "restart", "prune", "wait"],
+    command: ["fetch", "checkout", "command", "wait"],
+};
+
+const STEP_LABELS: Record<string, string> = {
+    fetch: "Fetch",
+    checkout: "Pull",
+    build: "Build",
+    restart: "Restart",
+    prune: "Clean up",
+    command: "Run script",
+    wait: "Wait for backend",
+    starting: "Starting",
+};
+
+type Phase = "idle" | "running" | "restarting" | "done" | "failed";
+
+interface Props {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function UpdateDialog({ open, onOpenChange }: Props) {
+    const qc = useQueryClient();
+    const canManage = useAdminPerm(AdminPerm.ManageSettings);
+    const stateQ = useUpdateState();
+    const jobQ = useUpdateJob(open);
+    const state: UpdateState | undefined = jobQ.data ?? stateQ.data;
+    const [confirming, setConfirming] = useState(false);
+    const started = readUpdateStarted();
+
+    const phase: Phase = useMemo(() => {
+        if (isUpdating(state)) return "running";
+        if (started && (jobQ.isError || stateQ.isError)) return "restarting";
+        const last = state?.updater.last_job;
+        if (started && last && last.status !== "running") {
+            return last.status === "succeeded" ? "done" : "failed";
+        }
+        return "idle";
+    }, [state, started, jobQ.isError, stateQ.isError]);
+
+    // Leaving the confirmation open across a phase change would let a stale
+    // click start a second update.
+    useEffect(() => {
+        if (phase !== "idle") setConfirming(false);
+    }, [phase]);
+
+    const checkMut = useMutation({
+        mutationFn: checkForUpdates,
+        onSuccess: (data) => {
+            qc.setQueryData(UPDATE_STATE_KEY, data);
+            qc.setQueryData(UPDATE_JOB_KEY, data);
+            toast.success(
+                data.update_available ? "A newer version is available" : "This instance is up to date",
+            );
+        },
+        onError: (err: Error) => toast.error(err.message || "Could not check for updates"),
+    });
+
+    const applyMut = useMutation({
+        mutationFn: () => applyUpdate("latest"),
+        onSuccess: (job: UpdateJob) => {
+            markUpdateStarted(state?.running.version ?? "", state?.running.commit ?? job.from_commit);
+            setConfirming(false);
+            toast.success("Update started");
+            void qc.invalidateQueries({ queryKey: UPDATE_STATE_KEY });
+            void qc.invalidateQueries({ queryKey: UPDATE_JOB_KEY });
+        },
+        onError: (err: Error) => toast.error(err.message || "Could not start the update"),
+    });
+
+    const updater = state?.updater;
+    const checkout = updater?.checkout;
+    const job = updater?.job ?? updater?.last_job;
+    const canApply =
+        canManage && updater?.status === "ok" && !!state?.update_available && phase === "idle";
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="sm:max-w-xl">
+                <DialogHeader>
+                    <DialogTitle>Updates</DialogTitle>
+                    <DialogDescription>
+                        {state
+                            ? `Running ${buildLabel(state)}${state.running.commit ? ` (${state.running.commit.slice(0, 7)})` : ""}.`
+                            : "Reading the running version."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                {phase === "idle" && state && (
+                    <div className="space-y-3">
+                        <Overview state={state} />
+                        {updater?.status !== "ok" && <UpdaterNotice state={state} />}
+                        {checkout?.dirty && (
+                            <Notice tone="warning">
+                                The checkout has local modifications. The updater refuses to move it
+                                until they are committed or stashed, or `UPDATER_ALLOW_DIRTY=true`.
+                            </Notice>
+                        )}
+                        {job && job.status === "failed" && !started && (
+                            <Notice tone="error">
+                                The last update failed at step {STEP_LABELS[job.step] ?? job.step}:{" "}
+                                {job.error}
+                            </Notice>
+                        )}
+                        {confirming && (
+                            <div className="animate-in fade-in slide-in-from-bottom-1 duration-200">
+                            <Notice tone="warning">
+                                <div className="font-medium text-foreground">
+                                    This pulls the checkout, rebuilds the images and restarts every
+                                    service.
+                                </div>
+                                <div className="mt-1">
+                                    Sending and syncing pause for a few minutes and resume on their own;
+                                    nothing in flight is lost. Migrations apply when the backend comes
+                                    back. This panel reconnects by itself.
+                                </div>
+                            </Notice>
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {(phase === "running" || phase === "restarting") && (
+                    <Progress state={state} job={job} restarting={phase === "restarting"} />
+                )}
+
+                {phase === "done" && state && (
+                    <div className="space-y-3 animate-in fade-in zoom-in-95 duration-300">
+                        <div className="flex items-start gap-3 rounded-lg border border-emerald-200 bg-emerald-50 p-3">
+                            <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600 animate-in zoom-in-50 duration-300" />
+                            <div className="text-[13px] leading-relaxed text-emerald-800">
+                                <div className="font-semibold">Updated to {buildLabel(state)}</div>
+                                Every service is back and sending has resumed. Reload to pick up the
+                                new admin panel.
+                            </div>
+                        </div>
+                        {job?.log && <LogPanel lines={job.log} />}
+                    </div>
+                )}
+
+                {phase === "failed" && (
+                    <div className="space-y-3 animate-in fade-in duration-200">
+                        <Notice tone="error">
+                            <div className="font-semibold text-foreground">The update failed</div>
+                            {job?.error ?? "See the log below."} The previous version is still running
+                            unless the restart step had already begun.
+                        </Notice>
+                        {job?.log && <LogPanel lines={job.log} />}
+                    </div>
+                )}
+
+                <DialogFooter className="gap-2 sm:justify-between">
+                    <a
+                        href={docsUrl(DOCS_UPDATES)}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-xs font-medium text-[var(--admin-accent-strong)] hover:underline"
+                    >
+                        How updates work
+                        <ExternalLink className="size-3" />
+                    </a>
+                    <div className="flex flex-wrap items-center gap-2">
+                        {phase === "idle" && canManage && (
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => checkMut.mutate()}
+                                disabled={checkMut.isPending}
+                            >
+                                <RefreshCw className={cn("size-4", checkMut.isPending && "animate-spin")} />
+                                {checkMut.isPending ? "Checking..." : "Check now"}
+                            </Button>
+                        )}
+                        {phase === "idle" && canApply && !confirming && (
+                            <Button size="sm" onClick={() => setConfirming(true)}>
+                                <RotateCw className="size-4" />
+                                Update and restart
+                            </Button>
+                        )}
+                        {phase === "idle" && confirming && (
+                            <>
+                                <Button size="sm" variant="ghost" onClick={() => setConfirming(false)}>
+                                    Cancel
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    onClick={() => applyMut.mutate()}
+                                    disabled={applyMut.isPending}
+                                >
+                                    {applyMut.isPending ? (
+                                        <Loader2 className="size-4 animate-spin" />
+                                    ) : (
+                                        <RotateCw className="size-4" />
+                                    )}
+                                    Update now
+                                </Button>
+                            </>
+                        )}
+                        {(phase === "done" || phase === "failed") && (
+                            <Button size="sm" onClick={() => window.location.reload()}>
+                                Reload
+                            </Button>
+                        )}
+                        {(phase === "running" || phase === "restarting") && (
+                            <Button size="sm" variant="ghost" onClick={() => onOpenChange(false)}>
+                                Keep running in the background
+                            </Button>
+                        )}
+                    </div>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+function Overview({ state }: { state: UpdateState }) {
+    const { latest, updater } = state;
+    const checkout = updater.checkout;
+    return (
+        <dl className="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-2 text-[13px]">
+            <dt className="text-muted-foreground">Latest release</dt>
+            <dd>
+                {latest ? (
+                    <span className="inline-flex flex-wrap items-center gap-2">
+                        <span className="font-medium">{latest.tag}</span>
+                        {latest.published_at && (
+                            <span className="text-muted-foreground">
+                                {new Date(latest.published_at).toLocaleDateString()}
+                            </span>
+                        )}
+                        {latest.html_url && (
+                            <a
+                                href={latest.html_url}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="inline-flex items-center gap-1 text-xs font-medium text-[var(--admin-accent-strong)] hover:underline"
+                            >
+                                Release notes
+                                <ExternalLink className="size-3" />
+                            </a>
+                        )}
+                    </span>
+                ) : state.check_error ? (
+                    <span className="text-amber-700">Could not read releases: {state.check_error}</span>
+                ) : state.enabled ? (
+                    <span className="text-muted-foreground">No release found for {state.repo}</span>
+                ) : (
+                    <span className="text-muted-foreground">Release check is off</span>
+                )}
+            </dd>
+
+            <dt className="text-muted-foreground">Status</dt>
+            <dd>
+                {state.update_available ? (
+                    <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-700">
+                        Update available
+                    </Badge>
+                ) : (
+                    <Badge variant="outline" className="border-emerald-300 bg-emerald-50 text-emerald-700">
+                        Up to date
+                    </Badge>
+                )}
+                {state.checked_at && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                        checked {new Date(state.checked_at).toLocaleTimeString()}, every{" "}
+                        {state.interval}
+                    </span>
+                )}
+            </dd>
+
+            {checkout && (
+                <>
+                    <dt className="text-muted-foreground">Checkout</dt>
+                    <dd className="flex flex-wrap items-center gap-2">
+                        <span className="inline-flex items-center gap-1 font-mono text-xs">
+                            <GitBranch className="size-3.5 text-muted-foreground" />
+                            {checkout.detached ? "pinned" : checkout.branch}@{checkout.commit.slice(0, 7)}
+                        </span>
+                        {!checkout.detached && (
+                            <span className="text-muted-foreground">
+                                {checkout.behind > 0
+                                    ? `${checkout.behind} commit${checkout.behind === 1 ? "" : "s"} behind`
+                                    : "matches the remote"}
+                            </span>
+                        )}
+                        {checkout.fetch_error && (
+                            <span className="text-amber-700">fetch failed: {checkout.fetch_error}</span>
+                        )}
+                    </dd>
+                </>
+            )}
+
+            <dt className="text-muted-foreground">Updater</dt>
+            <dd>
+                {updater.status === "ok" && (
+                    <span>
+                        ready
+                        <span className="text-muted-foreground"> ({updater.mode} mode)</span>
+                    </span>
+                )}
+                {updater.status === "off" && <span className="text-muted-foreground">not configured</span>}
+                {updater.status === "unreachable" && <span className="text-amber-700">unreachable</span>}
+            </dd>
+        </dl>
+    );
+}
+
+function UpdaterNotice({ state }: { state: UpdateState }) {
+    const u = state.updater;
+    if (u.status === "unreachable") {
+        return (
+            <Notice tone="warning">
+                <div className="font-medium text-foreground">The updater is not answering</div>
+                {u.error} Until it does, update by hand:
+                <Cmd>git pull && make up</Cmd>
+            </Notice>
+        );
+    }
+    return (
+        <Notice tone="info">
+            <div className="font-medium text-foreground">This panel can only report</div>
+            No updater is configured, so apply updates from a shell on the host:
+            <Cmd>git pull && make up</Cmd>
+            To get the button, enable the updater compose profile (`make up` does) or run the
+            updater unit on a bare-metal host.
+        </Notice>
+    );
+}
+
+function Progress({
+    state,
+    job,
+    restarting,
+}: {
+    state: UpdateState | undefined;
+    job: UpdateJob | undefined;
+    restarting: boolean;
+}) {
+    const mode = state?.updater.mode ?? "compose";
+    const steps = STEPS[mode] ?? STEPS.compose;
+    const current = restarting ? "wait" : (job?.step ?? "starting");
+    const currentIdx = Math.max(0, steps.indexOf(current));
+    const percent = Math.round(((currentIdx + 0.5) / steps.length) * 100);
+    return (
+        <div className="space-y-3 animate-in fade-in duration-200">
+            <div className="flex items-start gap-3 rounded-lg border border-sky-200 bg-sky-50/60 p-3">
+                <Loader2 className="mt-0.5 size-4 shrink-0 animate-spin text-sky-600" />
+                <div className="min-w-0 flex-1 text-[13px] leading-relaxed text-sky-900">
+                    <div className="flex items-center justify-between gap-3">
+                        <span className="font-semibold">
+                            {restarting ? "Restarting services" : `Updating: ${STEP_LABELS[current] ?? current}`}
+                        </span>
+                        <span className="text-xs tabular-nums text-sky-700">{percent}%</span>
+                    </div>
+                    <div className="mt-1.5 h-1.5 overflow-hidden rounded-full bg-sky-100">
+                        <div
+                            className="h-full rounded-full bg-sky-500 transition-[width] duration-500 ease-out"
+                            style={{ width: `${percent}%` }}
+                        />
+                    </div>
+                    <div className="mt-1.5 text-xs text-sky-800/80">
+                        {restarting
+                            ? "The backend is coming back up. This panel reconnects on its own; keep the tab open or come back later, the result is kept."
+                            : "You can close this dialog; the pill in the top bar keeps following the job."}
+                    </div>
+                </div>
+            </div>
+            <ol className="flex flex-wrap gap-1.5">
+                {steps.map((s, i) => {
+                    const done = currentIdx > i || (restarting && s !== "wait");
+                    const active = s === current;
+                    return (
+                        <li
+                            key={s}
+                            className={cn(
+                                "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]",
+                                done && "border-emerald-200 bg-emerald-50 text-emerald-700",
+                                active && "border-sky-300 bg-sky-50 text-sky-700",
+                                !done && !active && "border-border text-muted-foreground",
+                            )}
+                        >
+                            {done ? (
+                                <Check className="size-3" />
+                            ) : active ? (
+                                <Loader2 className="size-3 animate-spin" />
+                            ) : null}
+                            {STEP_LABELS[s] ?? s}
+                        </li>
+                    );
+                })}
+            </ol>
+            {job?.log && job.log.length > 0 && <LogPanel lines={job.log} />}
+        </div>
+    );
+}
+
+function LogPanel({ lines }: { lines: string[] }) {
+    const ref = useRef<HTMLPreElement>(null);
+    useEffect(() => {
+        const el = ref.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [lines.length]);
+    return (
+        <pre
+            ref={ref}
+            className="max-h-64 overflow-auto rounded-md border border-border bg-zinc-950 p-3 text-[11px] leading-relaxed text-zinc-200"
+        >
+            {lines.join("\n")}
+        </pre>
+    );
+}
+
+function Notice({ tone, children }: { tone: "info" | "warning" | "error"; children: React.ReactNode }) {
+    const styles = {
+        info: "border-sky-200 bg-sky-50/60 text-sky-900",
+        warning: "border-amber-200 bg-amber-50/60 text-amber-900",
+        error: "border-red-200 bg-red-50/60 text-red-900",
+    }[tone];
+    const Icon = tone === "error" ? XCircle : AlertTriangle;
+    return (
+        <div className={cn("flex items-start gap-3 rounded-lg border p-3 text-[13px] leading-relaxed", styles)}>
+            <Icon className="mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0 flex-1">{children}</div>
+        </div>
+    );
+}
+
+function Cmd({ children }: { children: string }) {
+    return (
+        <code className="mt-1.5 mb-1.5 block rounded bg-white/70 px-2 py-1 font-mono text-[12px] text-foreground">
+            {children}
+        </code>
+    );
+}

--- a/admin/src/components/layout/UpdatePill.tsx
+++ b/admin/src/components/layout/UpdatePill.tsx
@@ -1,0 +1,98 @@
+// The version pill in the top bar. Quiet when the instance is current, amber
+// when a newer version exists, a spinner while an update runs or the backend
+// restarts. It also closes the loop after a restart: once the backend answers
+// with a new build it says "Updated to vX" and refreshes every query.
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { ArrowUpCircle, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useAdminPerm } from "@/hooks/useAdminPerm";
+import { AdminPerm } from "@/lib/auth/permissions";
+import { buildLabel, isUpdating, useUpdateState } from "@/hooks/useUpdateState";
+import { clearUpdateStarted, readUpdateStarted } from "@/lib/updateSession";
+import { UpdateDialog } from "./UpdateDialog";
+
+export function UpdatePill() {
+    const canRead = useAdminPerm(AdminPerm.ViewAnalytics);
+    const stateQ = useUpdateState({ enabled: canRead });
+    const qc = useQueryClient();
+    const [open, setOpen] = useState(false);
+    const state = stateQ.data;
+    const updating = isUpdating(state);
+    const started = readUpdateStarted();
+    // The poll fails while the backend restarts; an update this browser
+    // started is the only reason to read that as "restarting" rather than down.
+    const restarting = !!started && stateQ.isError;
+
+    // The backend is back after an update this browser started: report the
+    // outcome once, then refresh everything so no page shows stale data.
+    useEffect(() => {
+        if (!started || !state || updating) return;
+        const last = state.updater.last_job;
+        const moved =
+            (state.running.commit && state.running.commit !== started.fromCommit) ||
+            (state.running.version && state.running.version !== started.fromVersion);
+        if (last?.status === "failed") {
+            clearUpdateStarted();
+            toast.error(`The update failed: ${last.error ?? "see the update dialog"}`);
+            return;
+        }
+        if (moved || last?.status === "succeeded") {
+            clearUpdateStarted();
+            toast.success(`Updated to ${buildLabel(state)}`);
+            void qc.invalidateQueries();
+        }
+    }, [started, state, updating, qc]);
+
+    if (!canRead || (!state && !restarting)) return null;
+
+    let tone = "border-border bg-white text-muted-foreground hover:text-foreground";
+    let label = buildLabel(state);
+    let icon: React.ReactNode = null;
+    let title = "Up to date";
+
+    if (restarting) {
+        tone = "border-sky-200 bg-sky-50 text-sky-700";
+        label = "Restarting";
+        icon = <Loader2 className="size-3 animate-spin" />;
+        title = "The backend is restarting after an update";
+    } else if (updating) {
+        tone = "border-sky-200 bg-sky-50 text-sky-700";
+        label = "Updating";
+        icon = <Loader2 className="size-3 animate-spin" />;
+        title = `Update in progress: ${state?.updater.job?.step ?? ""}`;
+    } else if (state?.update_available) {
+        tone = "border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100";
+        label = state.latest?.tag && state.reason === "release" ? `Update to ${state.latest.tag}` : "Update available";
+        icon = (
+            <span className="relative flex size-3.5 items-center justify-center">
+                <span className="absolute inline-flex size-full rounded-full bg-amber-400 opacity-60 animate-ping" />
+                <ArrowUpCircle className="relative size-3.5" />
+            </span>
+        );
+        title = `A newer version is available; running ${buildLabel(state)}`;
+    } else if (state?.updater.status === "unreachable") {
+        tone = "border-amber-200 bg-white text-amber-700";
+        title = "The updater is not answering";
+    }
+
+    return (
+        <>
+            <button
+                type="button"
+                onClick={() => setOpen(true)}
+                title={title}
+                className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] font-medium transition-colors",
+                    tone,
+                )}
+            >
+                {icon}
+                {label}
+            </button>
+            <UpdateDialog open={open} onOpenChange={setOpen} />
+        </>
+    );
+}

--- a/admin/src/hooks/useUpdateState.ts
+++ b/admin/src/hooks/useUpdateState.ts
@@ -1,0 +1,45 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUpdateState, type UpdateState } from "@/lib/api/client/admin/updates";
+
+export const UPDATE_STATE_KEY = ["admin", "instance", "update"] as const;
+export const UPDATE_JOB_KEY = ["admin", "instance", "update", "job"] as const;
+
+// One cache entry feeds the top-bar pill, the Setup and health card and the
+// dialog. It polls every minute, and every few seconds while a job runs, so
+// the pill follows an update started from another tab or before a reload.
+export function useUpdateState(options?: { enabled?: boolean }) {
+    return useQuery({
+        queryKey: UPDATE_STATE_KEY,
+        queryFn: () => getUpdateState(false),
+        refetchInterval: (query) => (isUpdating(query.state.data) ? 3_000 : 60_000),
+        // While the backend restarts every request fails; keep the last state
+        // on screen instead of flashing an error.
+        retry: false,
+        enabled: options?.enabled ?? true,
+    });
+}
+
+// The dialog's view of a running job, with the log. Polled only while open.
+export function useUpdateJob(enabled: boolean) {
+    return useQuery({
+        queryKey: UPDATE_JOB_KEY,
+        queryFn: () => getUpdateState(true),
+        refetchInterval: (query) => (isUpdating(query.state.data) ? 2_000 : 15_000),
+        retry: false,
+        enabled,
+    });
+}
+
+export function isUpdating(state: UpdateState | undefined): boolean {
+    return state?.updater.job?.status === "running";
+}
+
+// A short, stable label for the running build: the tag when there is one,
+// otherwise the commit.
+export function buildLabel(state: UpdateState | undefined): string {
+    if (!state) return "";
+    const v = state.running.version;
+    if (v && v !== "dev") return v;
+    const c = state.running.commit ?? state.updater.checkout?.commit ?? "";
+    return c ? `dev ${c.slice(0, 7)}` : "dev";
+}

--- a/admin/src/lib/api/client/admin/updates.ts
+++ b/admin/src/lib/api/client/admin/updates.ts
@@ -1,0 +1,98 @@
+// /admin/instance/update : what is running, what is newest, and the button
+// that applies it through the host-side updater.
+
+import { Request } from "@/lib/api/client";
+
+export interface RunningBuild {
+    version: string;
+    commit?: string;
+    built_at?: string;
+}
+
+export interface LatestRelease {
+    tag: string;
+    name?: string;
+    html_url?: string;
+    published_at?: string;
+    channel: string;
+}
+
+export interface UpdaterCheckout {
+    branch: string;
+    detached: boolean;
+    commit: string;
+    describe: string;
+    remote_commit: string;
+    behind: number;
+    dirty: boolean;
+    fetched_at: string;
+    fetch_error?: string;
+}
+
+export type UpdateJobStatus = "running" | "succeeded" | "failed";
+
+export interface UpdateJob {
+    id: string;
+    status: UpdateJobStatus;
+    target: string;
+    step: string;
+    started_at: string;
+    finished_at?: string;
+    error?: string;
+    from_commit: string;
+    to_commit?: string;
+    // Absent on the top-bar poll; present when fetched with log=1.
+    log?: string[] | null;
+}
+
+export type UpdaterStatus = "off" | "ok" | "unreachable";
+
+export interface UpdaterView {
+    configured: boolean;
+    status: UpdaterStatus;
+    error?: string;
+    mode?: "compose" | "command";
+    repo_dir?: string;
+    checkout?: UpdaterCheckout;
+    job?: UpdateJob;
+    last_job?: UpdateJob;
+}
+
+export interface UpdateState {
+    running: RunningBuild;
+    latest?: LatestRelease;
+    update_available: boolean;
+    reason?: "release" | "commits";
+    checked_at?: string;
+    check_error?: string;
+    enabled: boolean;
+    interval: string;
+    channel: string;
+    repo: string;
+    updater: UpdaterView;
+}
+
+export function getUpdateState(withLog = false): Promise<UpdateState> {
+    return Request({
+        method: "GET",
+        url: withLog ? "/admin/instance/update?log=1" : "/admin/instance/update",
+        authorization: true,
+    });
+}
+
+export function checkForUpdates(): Promise<UpdateState> {
+    return Request({
+        method: "POST",
+        url: "/admin/instance/update/check",
+        authorization: true,
+    });
+}
+
+export function applyUpdate(target = "latest"): Promise<UpdateJob> {
+    return Request({
+        method: "POST",
+        url: "/admin/instance/update/apply",
+        data: { target },
+        authorization: true,
+    });
+}

--- a/admin/src/lib/updateSession.ts
+++ b/admin/src/lib/updateSession.ts
@@ -1,0 +1,44 @@
+// Remembers that this browser started an update, across the backend restart
+// and a page reload, so the top bar can say "Updated to vX" (or that it
+// failed) once the backend answers again instead of silently going quiet.
+
+const KEY = "warmbly.admin.update.started";
+
+export interface StartedUpdate {
+    fromVersion: string;
+    fromCommit: string;
+    startedAt: number;
+}
+
+export function markUpdateStarted(fromVersion: string, fromCommit: string) {
+    try {
+        const v: StartedUpdate = { fromVersion, fromCommit, startedAt: Date.now() };
+        sessionStorage.setItem(KEY, JSON.stringify(v));
+    } catch {
+        /* storage unavailable: the dialog still tracks the job while open */
+    }
+}
+
+export function readUpdateStarted(): StartedUpdate | null {
+    try {
+        const raw = sessionStorage.getItem(KEY);
+        if (!raw) return null;
+        const v = JSON.parse(raw) as StartedUpdate;
+        // An entry older than an hour is a job nobody is waiting on any more.
+        if (Date.now() - v.startedAt > 60 * 60_000) {
+            sessionStorage.removeItem(KEY);
+            return null;
+        }
+        return v;
+    } catch {
+        return null;
+    }
+}
+
+export function clearUpdateStarted() {
+    try {
+        sessionStorage.removeItem(KEY);
+    } catch {
+        /* ignore */
+    }
+}

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -96,6 +96,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/twofa"
 	"github.com/warmbly/warmbly/internal/app/tz"
 	"github.com/warmbly/warmbly/internal/app/unibox"
+	"github.com/warmbly/warmbly/internal/app/updates"
 	"github.com/warmbly/warmbly/internal/app/user"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
@@ -234,6 +235,7 @@ func main() {
 	var workerRepoForHandler repository.WorkerRepository
 	var credentialsRepository repository.CredentialsRepository
 	var releasesService *releases.Service
+	var updatesService *updates.Service
 
 	// Notifications
 	var emailNotificationService notify.EmailNotificationService
@@ -1124,6 +1126,22 @@ func main() {
 		)
 		releasesService.RunBootCheck(ctx)
 
+		// Update indicator and one-click update. The release check is on by
+		// default (one GitHub API read per interval); applying an update needs
+		// the host-side updater (UPDATER_URL), which the compose stack ships as
+		// the "updater" profile.
+		updateInterval, _ := time.ParseDuration(getenvDefault("UPDATE_CHECK_INTERVAL", "30m"))
+		updatesService = updates.New(updates.Config{
+			Enabled:      getenvDefault("UPDATE_CHECK_ENABLED", "true") != "false",
+			Interval:     updateInterval,
+			Channel:      getenvDefault("UPDATE_CHANNEL", "stable"),
+			GithubRepo:   getenvDefault("RELEASES_GITHUB_REPO", "warmbly/warmbly"),
+			GithubToken:  os.Getenv("RELEASES_GITHUB_TOKEN"),
+			UpdaterURL:   os.Getenv("UPDATER_URL"),
+			UpdaterToken: getenvDefault("UPDATER_TOKEN", os.Getenv("INTERNAL_API_TOKEN")),
+		})
+		updatesService.Start(ctx)
+
 		eventsPublisher := events.NewPublisher(bus, s3, codecImpl, cipherService)
 
 		// apiCfg.Hostname is the bind address, not a reachable base. Building
@@ -1848,6 +1866,7 @@ func main() {
 		Policy:    authPolicy,
 		DB:        instanceChecksDB,
 		Cache:     authCache,
+		Updates:   updatesService,
 	})
 
 	h := &handler.Handler{
@@ -1928,6 +1947,7 @@ func main() {
 		WorkerRepo:         workerRepoForHandler,
 		CredentialsRepo:    credentialsRepository,
 		ReleasesService:    releasesService,
+		UpdatesService:     updatesService,
 
 		// Notifications
 		EmailNotificationService: emailNotificationService,

--- a/cmd/updater/main.go
+++ b/cmd/updater/main.go
@@ -1,0 +1,108 @@
+// The updater is the host-side agent behind "Update and restart" in the admin
+// panel. It moves the checkout forward, rebuilds and restarts the stack, and
+// reports progress to the backend. See docs/content/docs/development/updates.mdx.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/updater"
+	"github.com/warmbly/warmbly/internal/version"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.LUTC)
+
+	repoDir := getenv("UPDATER_REPO_DIR", "")
+	if repoDir == "" {
+		if wd, err := os.Getwd(); err == nil {
+			repoDir = wd
+		}
+	}
+	cfg := updater.Config{
+		Mode:             updater.Mode(getenv("UPDATER_MODE", string(updater.ModeCompose))),
+		RepoDir:          repoDir,
+		Remote:           getenv("UPDATER_REMOTE", "origin"),
+		Command:          os.Getenv("UPDATER_COMMAND"),
+		ComposeProject:   getenv("UPDATER_COMPOSE_PROJECT", "warmbly"),
+		ComposeProfiles:  getenv("UPDATER_COMPOSE_PROFILES", "updater"),
+		BackendHealthURL: getenv("UPDATER_BACKEND_HEALTH_URL", "http://backend:8080/health"),
+		StateDir:         getenv("UPDATER_STATE_DIR", "/var/lib/warmbly-updater"),
+		FetchInterval:    duration("UPDATER_FETCH_INTERVAL", 30*time.Minute),
+		Prune:            boolean("UPDATER_PRUNE", true),
+		AllowDirty:       boolean("UPDATER_ALLOW_DIRTY", false),
+		Version:          version.String(),
+	}
+	if cfg.Mode != updater.ModeCompose && cfg.Mode != updater.ModeCommand {
+		log.Fatalf("updater: UPDATER_MODE must be compose or command, got %q", cfg.Mode)
+	}
+
+	runner, err := updater.NewRunner(cfg)
+	if err != nil {
+		log.Fatalf("updater: %v", err)
+	}
+	// The updater shares the backend's internal token unless given its own.
+	token := getenv("UPDATER_TOKEN", os.Getenv("INTERNAL_API_TOKEN"))
+	server, err := updater.NewServer(runner, token)
+	if err != nil {
+		log.Fatalf("updater: %v", err)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	runner.Start(ctx)
+
+	addr := getenv("UPDATER_ADDR", ":8095")
+	srv := &http.Server{Addr: addr, Handler: server.Handler(), ReadHeaderTimeout: 10 * time.Second}
+	go func() {
+		<-ctx.Done()
+		runner.Stop()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	}()
+	log.Printf("updater: %s mode, checkout %s, listening on %s (version %s)", cfg.Mode, cfg.RepoDir, addr, cfg.Version)
+	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("updater: %v", err)
+	}
+}
+
+func getenv(key, def string) string {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		return v
+	}
+	return def
+}
+
+func duration(key string, def time.Duration) time.Duration {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d < time.Minute {
+		return def
+	}
+	return d
+}
+
+func boolean(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}

--- a/cmd/warmblyctl/status.go
+++ b/cmd/warmblyctl/status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/instancecheck"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/version"
 )
 
 // errChecksFailed is how `make doctor` fails a script. The findings are already
@@ -41,6 +42,9 @@ type instanceStatus struct {
 
 	Checks  []instancecheck.Finding `json:"checks"`
 	Summary instancecheck.Summary   `json:"summary"`
+
+	Version string `json:"version"`
+	Commit  string `json:"commit,omitempty"`
 }
 
 func runStatus(ctx context.Context, args []string) error {
@@ -120,6 +124,9 @@ func collectStatus(ctx context.Context, c *conn) (*instanceStatus, error) {
 
 		AppURL:       config.AppBaseURL(),
 		AppURLSource: appURLSource(),
+
+		Version: version.String(),
+		Commit:  version.ShortCommit(),
 	}
 	state.NextSteps = nextSteps(state)
 	state.Checks, state.Summary = runChecks(ctx, c)
@@ -133,7 +140,13 @@ func printStatus(s *instanceStatus) {
 	}
 	mail := fmt.Sprintf("%s (%s; %s)", s.MailTransport, mailEffect(s.MailTransport, s.MailDelivers), s.MailTransportSource)
 
+	build := s.Version
+	if s.Commit != "" {
+		build += " (" + s.Commit + ")"
+	}
+
 	fmt.Println("Instance")
+	fmt.Printf("  Version           %s\n", build)
 	fmt.Printf("  Accounts          %d\n", s.Accounts)
 	fmt.Printf("  Claimed           %s\n", claimed)
 	fmt.Printf("  Platform admins   %d\n", s.AdminCount)

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -15,6 +15,8 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG GO_TAGS=""
 ARG TARGETOS TARGETARCH
+# Build identity shown in the admin panel; see internal/version.
+ARG VERSION="" COMMIT="" BUILT_AT=""
 RUN apk add --no-cache git ca-certificates && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache gcc musl-dev librdkafka-dev; fi
 
@@ -27,10 +29,10 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
     if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
-    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/backend ./cmd/backend; \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/seed ./cmd/seed; \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/migrate ./cmd/migrate; \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/warmblyctl ./cmd/warmblyctl
+    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/backend ./cmd/backend; \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/seed ./cmd/seed; \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/migrate ./cmd/migrate; \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/warmblyctl ./cmd/warmblyctl
 
 # Runtime stage
 FROM alpine:3.23

--- a/deploy/docker/consumer.Dockerfile
+++ b/deploy/docker/consumer.Dockerfile
@@ -7,6 +7,8 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG GO_TAGS=""
 ARG TARGETOS TARGETARCH
+# Build identity shown in the admin panel; see internal/version.
+ARG VERSION="" COMMIT="" BUILT_AT=""
 RUN apk add --no-cache git ca-certificates && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache gcc musl-dev librdkafka-dev; fi
 
@@ -19,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
     if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
-    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/consumer ./cmd/consumer
+    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/consumer ./cmd/consumer
 
 # Runtime stage
 FROM alpine:3.23

--- a/deploy/docker/forms.Dockerfile
+++ b/deploy/docker/forms.Dockerfile
@@ -20,6 +20,8 @@ RUN pnpm build
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG TARGETOS TARGETARCH
+# Build identity shown in the admin panel; see internal/version.
+ARG VERSION="" COMMIT="" BUILT_AT=""
 RUN apk add --no-cache git ca-certificates
 
 WORKDIR /app
@@ -29,7 +31,7 @@ RUN --mount=type=cache,target=/go/pkg/mod go mod download
 COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/forms ./cmd/forms
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/forms ./cmd/forms
 
 # Runtime stage
 FROM alpine:3.23

--- a/deploy/docker/updater.Dockerfile
+++ b/deploy/docker/updater.Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+#
+# The updater is the host-side agent behind "Update and restart" in the admin
+# panel: it pulls the checkout, rebuilds the images and recreates the
+# containers. It needs git and the docker CLI with the compose plugin, and the
+# docker socket mounted at runtime (see the updater service in
+# docker-compose.yml). Builder runs on $BUILDPLATFORM and cross-compiles.
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
+
+ARG TARGETOS TARGETARCH
+ARG VERSION="" COMMIT="" BUILT_AT=""
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/updater ./cmd/updater
+
+# Runtime: the official docker CLI image already carries the compose plugin.
+FROM docker:27-cli
+
+RUN apk add --no-cache git ca-certificates tzdata && mkdir -p /var/lib/warmbly-updater
+
+COPY --from=builder /out/updater /app/updater
+
+# Runs as root on purpose: it holds the docker socket, and chowns what git
+# wrote back to the checkout's owner after every update.
+EXPOSE 8095
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s \
+  CMD wget --no-verbose --tries=1 --spider http://127.0.0.1:8095/health || exit 1
+
+ENTRYPOINT ["/app/updater"]

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -7,6 +7,8 @@ FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
 ARG GO_TAGS=""
 ARG TARGETOS TARGETARCH
+# Build identity shown in the admin panel; see internal/version.
+ARG VERSION="" COMMIT="" BUILT_AT=""
 RUN apk add --no-cache git ca-certificates && \
     if echo "$GO_TAGS" | grep -qw kafka; then apk add --no-cache gcc musl-dev librdkafka-dev; fi
 
@@ -19,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
     if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
-    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/worker ./cmd/worker
+    CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT" -o /out/worker ./cmd/worker
 
 # Runtime stage
 FROM alpine:3.23

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -12,6 +12,7 @@ them is [Deploying without Docker](https://docs.warmbly.com/development/bare-met
 | `warmbly-tracking.service` | `/opt/warmbly/bin/tracking` | `/etc/warmbly/warmbly.env` |
 | `warmbly-realtime.service` | `/opt/warmbly/realtime/bin/realtime start` | `/etc/warmbly/warmbly.env` |
 | `warmbly-worker.service` | `/opt/warmbly/bin/worker` | `/etc/warmbly/worker.env` |
+| `warmbly-updater.service` | `/opt/warmbly/bin/updater` | `/etc/warmbly/updater.env` |
 
 Every unit runs as the unprivileged `warmbly` user, may write only under
 `/var/lib/warmbly` (blob storage), and restarts on failure. Copy them to
@@ -21,3 +22,9 @@ Every unit runs as the unprivileged `warmbly` user, may write only under
 
 `deploy/config/env.example` is the template for `warmbly.env`; the worker env
 file is what `POST /api/v1/workers/enroll` returns for an enrollment token.
+
+`warmbly-updater.service` is the exception to the unprivileged rule: it runs as
+the user who owns the checkout (`deploy` in the unit; change it) and drives
+`scripts/upgrade-bare-metal.sh`, which uses sudo for the install and restart
+steps. `updater.env` holds only `UPDATER_TOKEN` (the backend's
+`INTERNAL_API_TOKEN`). See [Updates](https://docs.warmbly.com/development/updates/).

--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -25,6 +25,10 @@ file is what `POST /api/v1/workers/enroll` returns for an enrollment token.
 
 `warmbly-updater.service` is the exception to the unprivileged rule: it runs as
 the user who owns the checkout (`deploy` in the unit; change it) and drives
-`scripts/upgrade-bare-metal.sh`, which uses sudo for the install and restart
-steps. `updater.env` holds only `UPDATER_TOKEN` (the backend's
-`INTERNAL_API_TOKEN`). See [Updates](https://docs.warmbly.com/development/updates/).
+`scripts/upgrade-bare-metal.sh`, which builds unprivileged and then runs
+`warmbly-install-release.sh` (installed root-owned at
+`/usr/local/sbin/warmbly-install-release`) through sudo. That installer takes no
+arguments, touches only fixed paths and refuses symlinks, and is the single
+command to allow in sudoers. `updater.env` holds only `UPDATER_TOKEN` (the
+backend's `INTERNAL_API_TOKEN`). See
+[Updates](https://docs.warmbly.com/development/updates/).

--- a/deploy/systemd/warmbly-install-release.sh
+++ b/deploy/systemd/warmbly-install-release.sh
@@ -22,7 +22,15 @@ HEALTH=http://127.0.0.1:8080/health
 
 log() { printf '==> %s\n' "$*"; }
 regular() { [[ -f "$1" && ! -L "$1" ]]; }
-plain_dir() { [[ -d "$1" && ! -L "$1" ]]; }
+# A directory qualifies only when nothing inside it is a symlink either: the
+# checkout's owner must not be able to point root at a file elsewhere.
+plain_dir() {
+  [[ -d "$1" && ! -L "$1" ]] || return 1
+  if find "$1" -type l -print -quit | grep -q .; then
+    log "refusing $1: it contains a symlink"
+    return 1
+  fi
+}
 has_unit() { systemctl list-unit-files "warmbly-$1.service" --no-legend 2>/dev/null | grep -q .; }
 
 log "installing binaries"
@@ -54,7 +62,7 @@ for app in web admin; do
     [[ -f "$PREFIX/$app/config.js" ]] && cp "$PREFIX/$app/config.js" "$cfg"
     rm -rf "$PREFIX/$app"
     cp -r --no-dereference "$SRC/$app/dist" "$PREFIX/$app"
-    [[ -s "$cfg" ]] && cp "$cfg" "$PREFIX/$app/config.js"
+    [[ -s "$cfg" ]] && cp --remove-destination "$cfg" "$PREFIX/$app/config.js"
     rm -f "$cfg"
     chown -R root:root "$PREFIX/$app"
     chmod -R a+rX "$PREFIX/$app"
@@ -71,8 +79,9 @@ fi
 log "restarting backend"
 systemctl restart warmbly-backend
 healthy=0
-for _ in $(seq 1 60); do
-  if curl -fsS "$HEALTH" >/dev/null 2>&1; then healthy=1; break; fi
+deadline=$((SECONDS + 120))
+while [[ $SECONDS -lt $deadline ]]; do
+  if curl -fsS --connect-timeout 2 --max-time 5 "$HEALTH" >/dev/null 2>&1; then healthy=1; break; fi
   sleep 2
 done
 if [[ "$healthy" -ne 1 ]]; then

--- a/deploy/systemd/warmbly-install-release.sh
+++ b/deploy/systemd/warmbly-install-release.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# The privileged half of a bare-metal upgrade: install the artifacts that
+# scripts/upgrade-bare-metal.sh built under /opt/warmbly/src/out and friends,
+# then restart the units, backend first. It takes no arguments and touches only
+# fixed paths, so it is the one command the checkout's owner may run through
+# sudo without a password. Install it root-owned and not writable by that user:
+#
+#   sudo install -o root -g root -m 0755 deploy/systemd/warmbly-install-release.sh /usr/local/sbin/warmbly-install-release
+#   deploy ALL=(root) NOPASSWD: /usr/local/sbin/warmbly-install-release      # visudo
+#
+# A symlink under the build output is refused: a caller who owns the checkout
+# must not be able to make root read or install a file from somewhere else.
+set -euo pipefail
+
+SRC=/opt/warmbly/src
+PREFIX=/opt/warmbly
+HEALTH=http://127.0.0.1:8080/health
+
+[[ "$(id -u)" -eq 0 ]] || { echo "run through sudo" >&2; exit 1; }
+[[ $# -eq 0 ]] || { echo "takes no arguments" >&2; exit 2; }
+
+log() { printf '==> %s\n' "$*"; }
+regular() { [[ -f "$1" && ! -L "$1" ]]; }
+plain_dir() { [[ -d "$1" && ! -L "$1" ]]; }
+has_unit() { systemctl list-unit-files "warmbly-$1.service" --no-legend 2>/dev/null | grep -q .; }
+
+log "installing binaries"
+for bin in backend forms consumer worker migrate warmblyctl updater; do
+  f="$SRC/out/$bin"
+  if regular "$f"; then
+    install -o root -g root -m 0755 "$f" "$PREFIX/bin/$bin"
+  fi
+done
+ln -sf "$PREFIX/bin/warmblyctl" /usr/local/bin/warmblyctl
+
+if has_unit tracking && regular "$SRC/tracking/target/release/tracking"; then
+  install -o root -g root -m 0755 "$SRC/tracking/target/release/tracking" "$PREFIX/bin/tracking"
+fi
+
+if has_unit realtime && plain_dir "$SRC/realtime/_build/prod/rel/realtime"; then
+  log "installing realtime"
+  rm -rf "$PREFIX/realtime"
+  cp -r --no-dereference "$SRC/realtime/_build/prod/rel/realtime" "$PREFIX/realtime"
+  chown -R warmbly:warmbly "$PREFIX/realtime"
+fi
+
+# The runtime config.js is written by hand on a bare-metal install and a
+# rebuilt dist/ would drop it, so it is kept across the copy.
+for app in web admin; do
+  if plain_dir "$SRC/$app/dist" && plain_dir "$PREFIX/$app"; then
+    log "installing $app"
+    cfg="$(mktemp)"
+    [[ -f "$PREFIX/$app/config.js" ]] && cp "$PREFIX/$app/config.js" "$cfg"
+    rm -rf "$PREFIX/$app"
+    cp -r --no-dereference "$SRC/$app/dist" "$PREFIX/$app"
+    [[ -s "$cfg" ]] && cp "$cfg" "$PREFIX/$app/config.js"
+    rm -f "$cfg"
+    chown -R root:root "$PREFIX/$app"
+    chmod -R a+rX "$PREFIX/$app"
+  fi
+done
+if plain_dir "$SRC/forms/dist" && plain_dir "$PREFIX/forms"; then
+  log "installing forms"
+  rm -rf "$PREFIX/forms/dist"
+  cp -r --no-dereference "$SRC/forms/dist" "$PREFIX/forms/dist"
+  chown -R root:root "$PREFIX/forms/dist"
+  chmod -R a+rX "$PREFIX/forms/dist"
+fi
+
+log "restarting backend"
+systemctl restart warmbly-backend
+healthy=0
+for _ in $(seq 1 60); do
+  if curl -fsS "$HEALTH" >/dev/null 2>&1; then healthy=1; break; fi
+  sleep 2
+done
+if [[ "$healthy" -ne 1 ]]; then
+  log "the backend did not answer at $HEALTH within two minutes; the other services were not restarted"
+  exit 1
+fi
+
+rest=()
+for svc in forms consumer tracking realtime worker; do
+  has_unit "$svc" && rest+=("warmbly-$svc")
+done
+if [[ ${#rest[@]} -gt 0 ]]; then
+  log "restarting ${rest[*]}"
+  systemctl restart "${rest[@]}"
+fi
+log "installed"

--- a/deploy/systemd/warmbly-updater.service
+++ b/deploy/systemd/warmbly-updater.service
@@ -7,8 +7,9 @@ Wants=network-online.target
 [Service]
 Type=simple
 # Runs as the user who owns the checkout, so git writes stay theirs. The
-# upgrade script escalates for the install and restart steps through sudo;
-# grant that user the sudoers line from the docs.
+# upgrade script builds unprivileged and then runs the fixed-path installer
+# (/usr/local/sbin/warmbly-install-release, root-owned) through sudo; that
+# installer is the only command to allow in sudoers. See the docs.
 User=deploy
 Group=deploy
 EnvironmentFile=/etc/warmbly/updater.env

--- a/deploy/systemd/warmbly-updater.service
+++ b/deploy/systemd/warmbly-updater.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=Warmbly updater (one-click update from the admin panel)
+Documentation=https://docs.warmbly.com/development/updates/
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Runs as the user who owns the checkout, so git writes stay theirs. The
+# upgrade script escalates for the install and restart steps through sudo;
+# grant that user the sudoers line from the docs.
+User=deploy
+Group=deploy
+EnvironmentFile=/etc/warmbly/updater.env
+WorkingDirectory=/opt/warmbly/src
+Environment=UPDATER_MODE=command
+Environment=UPDATER_REPO_DIR=/opt/warmbly/src
+Environment=UPDATER_COMMAND=/opt/warmbly/src/scripts/upgrade-bare-metal.sh
+Environment=UPDATER_BACKEND_HEALTH_URL=http://127.0.0.1:8080/health
+Environment=UPDATER_STATE_DIR=/var/lib/warmbly-updater
+Environment=UPDATER_ADDR=127.0.0.1:8095
+ExecStart=/opt/warmbly/bin/updater
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -298,6 +298,10 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/backend.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
     ports: ["8080:8080"]
     environment:
       <<: *selfhost-env
@@ -340,6 +344,16 @@ services:
       WEBAUTHN_RP_ORIGINS: ${WEBAUTHN_RP_ORIGINS:-}
       # Worker image the orchestrator installs on remote machines.
       WORKER_IMAGE: ${WORKER_IMAGE:-}
+      # Update indicator: polls GitHub Releases and shows a newer version in the
+      # admin panel's top bar. Applying it goes through the updater service
+      # below; unset UPDATER_URL to keep the panel report-only.
+      UPDATE_CHECK_ENABLED: ${UPDATE_CHECK_ENABLED:-true}
+      UPDATE_CHECK_INTERVAL: ${UPDATE_CHECK_INTERVAL:-30m}
+      UPDATE_CHANNEL: ${UPDATE_CHANNEL:-stable}
+      RELEASES_GITHUB_REPO: ${RELEASES_GITHUB_REPO:-warmbly/warmbly}
+      RELEASES_GITHUB_TOKEN: ${RELEASES_GITHUB_TOKEN:-}
+      UPDATER_URL: ${UPDATER_URL:-http://updater:8095}
+      UPDATER_TOKEN: ${UPDATER_TOKEN:-${INTERNAL_API_TOKEN:-local-dev-internal-token}}
     volumes:
       - blobs:/data/blobs
     depends_on:
@@ -360,6 +374,10 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/forms.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
     ports: ["${FORMS_PORT:-8090}:8090"]
     environment:
       GIN_MODE: release
@@ -386,6 +404,10 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/consumer.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
     environment:
       <<: *selfhost-env
       ENCRYPTED_KEYS_PROVIDER: postgres
@@ -403,6 +425,10 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/worker.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
     environment:
       <<: *selfhost-env
       # Dovecot in the sandbox profile uses a self-signed cert. Set
@@ -525,6 +551,39 @@ services:
     depends_on:
       backend: { condition: service_healthy }
 
+  # One-click updates from the admin panel (the version pill in the top bar).
+  # Pulls this checkout, rebuilds the images and recreates the containers when
+  # the backend asks, then waits for the backend to answer again. It holds the
+  # docker socket, which is root on this host, so it only runs under the
+  # "updater" profile: `make up` enables it, and COMPOSE_PROFILES=updater in
+  # .env does the same for a plain `docker compose up`. Leave the profile off
+  # to update by hand with `git pull && make up`.
+  updater:
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: deploy/docker/updater.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
+    environment:
+      UPDATER_TOKEN: ${UPDATER_TOKEN:-${INTERNAL_API_TOKEN:-local-dev-internal-token}}
+      # The checkout is mounted at its host path so the compose file's relative
+      # paths resolve identically inside and outside the container.
+      UPDATER_REPO_DIR: ${WARMBLY_REPO_DIR:-${PWD}}
+      UPDATER_COMPOSE_PROJECT: warmbly
+      UPDATER_BACKEND_HEALTH_URL: http://backend:8080/health
+      UPDATER_FETCH_INTERVAL: ${UPDATER_FETCH_INTERVAL:-30m}
+      UPDATER_PRUNE: ${UPDATER_PRUNE:-true}
+      UPDATER_ALLOW_DIRTY: ${UPDATER_ALLOW_DIRTY:-false}
+    working_dir: ${WARMBLY_REPO_DIR:-${PWD}}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${WARMBLY_REPO_DIR:-${PWD}}:${WARMBLY_REPO_DIR:-${PWD}}
+      - updater_state:/var/lib/warmbly-updater
+    profiles: ["updater"]
+
   # ─── one-shots ────────────────────────────────────────────────────────
 
   # Optional demo seed. Run explicitly: docker compose --profile seed run --rm seed
@@ -549,3 +608,4 @@ volumes:
   nats_data:
   blobs:
   worker_state:
+  updater_state:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -346,7 +346,10 @@ services:
       WORKER_IMAGE: ${WORKER_IMAGE:-}
       # Update indicator: polls GitHub Releases and shows a newer version in the
       # admin panel's top bar. Applying it goes through the updater service
-      # below; unset UPDATER_URL to keep the panel report-only.
+      # below. The address is always set because a profile cannot be tested
+      # here; with the profile off the host does not resolve and the backend
+      # reports the updater as not running (report-only), never as broken.
+      # UPDATER_URL=none in .env turns the button off explicitly.
       UPDATE_CHECK_ENABLED: ${UPDATE_CHECK_ENABLED:-true}
       UPDATE_CHECK_INTERVAL: ${UPDATE_CHECK_INTERVAL:-30m}
       UPDATE_CHANNEL: ${UPDATE_CHANNEL:-stable}
@@ -591,6 +594,10 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/backend.Dockerfile
+      args:
+        VERSION: ${WARMBLY_BUILD_VERSION:-}
+        COMMIT: ${WARMBLY_BUILD_COMMIT:-}
+        BUILT_AT: ${WARMBLY_BUILD_TIME:-}
     entrypoint: ["/app/seed"]
     environment:
       <<: *selfhost-env

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -327,6 +327,7 @@ These never accept an API key. They depend on a human-bound session: billing flo
 
 - `POST /auth/login`, `/auth/login/confirm`, `/auth/register`, `/auth/register/confirm`, `/auth/refresh`, `/auth/reset-password`, `/auth/reset-password/confirm`
 - `GET /auth/config` (public deployment capabilities: which sign-in methods this backend has enabled, whether a login code step follows, whether signups are open, whether the instance still needs claiming)
+- `GET /auth/instance` (JWT only: the running Warmbly version of a self-hosted instance and whether a newer release exists, for the dashboard's version pill; a hosted deployment answers `self_hosted: false` and nothing else)
 
 `POST /auth/register` accepts an optional `invite` field carrying an invitation token. On a deployment running `DISABLE_REGISTRATION=invite_only` it is what permits the signup, and the account is created inside the inviting organization rather than in a new one. The token must resolve to a live invitation whose email equals the submitted address, otherwise the request is refused with `invitation_invalid`. Omitting it on a closed deployment returns `registration_invite_only` or `registration_closed`. See [error codes](/api/error-codes/#registration-and-invitation-refusals).
 

--- a/docs/content/docs/development/bare-metal.mdx
+++ b/docs/content/docs/development/bare-metal.mdx
@@ -562,16 +562,15 @@ Because the worker is not in a container, the admin panel's SSH-driven day-two a
 
 ## Upgrading
 
-Rebuild the artifacts that changed, then restart. Migrations are forward-only and apply on backend boot, so bring the backend up before the rest:
+`scripts/upgrade-bare-metal.sh` is the build steps above in order: build every artifact this host runs, install it, restart the backend first (migrations are forward-only and apply on its boot), then the rest, keeping each frontend's `config.js` across the copy. Run it as the user who owns the checkout:
 
 ```bash
-cd /opt/warmbly/src && sudo git pull                     # or checkout a newer tag
-# repeat the build steps for the services that changed, then:
-sudo systemctl restart warmbly-backend
-sudo systemctl restart warmbly-forms warmbly-consumer warmbly-tracking warmbly-realtime warmbly-worker
+cd /opt/warmbly/src && scripts/upgrade-bare-metal.sh --pull    # git pull --ff-only, build, install, restart
 ```
 
-Frontend rebuilds overwrite `config.js` when you copy `dist/` over, so rewrite it afterwards (or keep the two files somewhere and copy them back). A build script that does all of it in order is worth writing the second time you upgrade.
+To pin a release instead of following the branch, check the tag out first (`git checkout vX.Y.Z`) and run it without `--pull`.
+
+The admin panel can run the same script for you. The version pill in its top bar shows when a newer release exists, and with the updater unit installed, **Update and restart** in it pulls, runs the script and reports back. [Updates](/development/updates/#without-docker) has the unit, the sudoers line it needs and the backend variable that points at it.
 
 ## Backups
 

--- a/docs/content/docs/development/bare-metal.mdx
+++ b/docs/content/docs/development/bare-metal.mdx
@@ -566,8 +566,12 @@ Because the worker is not in a container, the admin panel's SSH-driven day-two a
 
 ```bash
 sudo install -o root -g root -m 0755 /opt/warmbly/src/deploy/systemd/warmbly-install-release.sh /usr/local/sbin/warmbly-install-release
+echo "$USER ALL=(root) NOPASSWD: /usr/local/sbin/warmbly-install-release" | sudo tee /etc/sudoers.d/warmbly-upgrade >/dev/null
+sudo chmod 0440 /etc/sudoers.d/warmbly-upgrade
 cd /opt/warmbly/src && scripts/upgrade-bare-metal.sh --pull    # git pull --ff-only, build, install, restart
 ```
+
+The sudoers line is what lets the script call the installer without a password prompt; it allows that one root-owned command and nothing else.
 
 To pin a release instead of following the branch, check the tag out first (`git checkout vX.Y.Z`) and run it without `--pull`.
 

--- a/docs/content/docs/development/bare-metal.mdx
+++ b/docs/content/docs/development/bare-metal.mdx
@@ -562,9 +562,10 @@ Because the worker is not in a container, the admin panel's SSH-driven day-two a
 
 ## Upgrading
 
-`scripts/upgrade-bare-metal.sh` is the build steps above in order: build every artifact this host runs, install it, restart the backend first (migrations are forward-only and apply on its boot), then the rest, keeping each frontend's `config.js` across the copy. Run it as the user who owns the checkout:
+`scripts/upgrade-bare-metal.sh` is the build steps above in order: build every artifact this host runs as the checkout's owner, then run the root-owned installer `warmbly-install-release` through sudo, which installs them, restarts the backend first (migrations are forward-only and apply on its boot), then the rest, keeping each frontend's `config.js` across the copy. Install that one script root-owned once, then run the upgrade as the user who owns the checkout:
 
 ```bash
+sudo install -o root -g root -m 0755 /opt/warmbly/src/deploy/systemd/warmbly-install-release.sh /usr/local/sbin/warmbly-install-release
 cd /opt/warmbly/src && scripts/upgrade-bare-metal.sh --pull    # git pull --ff-only, build, install, restart
 ```
 

--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -381,6 +381,20 @@ Delayed sends run through the local poller, so the backend must be running for s
 | `SENTRY_DSN` | Error reporting. Optional in every environment, including `prod` | unset |
 | `APNS_KEY` or `APNS_KEY_PATH`, `APNS_KEY_ID`, `APNS_TEAM_ID`, `APNS_TOPIC` | Mobile push on backend and consumer. Partial configuration disables push with a warning, never a crash | unset |
 
+## Updates
+
+| Variable | What it does | Default | Restart needed |
+|---|---|---|---|
+| `UPDATE_CHECK_ENABLED` | Polls GitHub Releases for a newer Warmbly and shows it in the admin panel's top bar and on Setup and health | `true` | yes |
+| `UPDATE_CHECK_INTERVAL` | How often the release check runs. Minimum `5m` | `30m` | yes |
+| `UPDATE_CHANNEL` | `stable` follows releases; `dev` also offers prereleases | `stable` | yes |
+| `RELEASES_GITHUB_REPO` | The `owner/repo` whose releases count as Warmbly versions. Point a fork's instance at the fork | `warmbly/warmbly` | yes |
+| `RELEASES_GITHUB_TOKEN` | Optional GitHub token; only raises the API rate limit | unset | yes |
+| `UPDATER_URL` | The host-side updater that applies an update (pull, rebuild, restart). Unset, or `none`, leaves the panel report-only | `http://updater:8095` under compose | yes |
+| `UPDATER_TOKEN` | The bearer token the backend presents to the updater | `INTERNAL_API_TOKEN` | yes |
+
+The updater's own variables (`UPDATER_MODE`, `UPDATER_COMMAND`, `UPDATER_REPO_DIR` and the rest) are on [Updates](/development/updates/#configuration); it is a separate process and its environment is not on the configuration page.
+
 ## Forms service
 
 The public face of hosted forms (`cmd/forms`): it serves the React (TanStack) form app built from `forms/`, the per-form page shells, the embed loader and public submissions, on its own port so form traffic never touches the API origin. It reads its own environment; none of these appear in the admin panel except `FORM_IP_RATE_LIMIT`.

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -747,8 +747,12 @@ To move a worker fleet onto a new release, update `WORKER_IMAGE` and use "Pull l
 
 ## Upgrading and backups
 
+The admin panel tells you when a newer version exists: the version pill in its top bar turns amber, and **Update and restart** in it pulls the checkout, rebuilds, restarts what changed and reconnects once the backend is back. `make up` starts the updater that makes the button work. The whole flow, what it does and how to run it without Docker, is on [Updates](/development/updates/).
+
+By hand it is the same two steps:
+
 ```bash
-git pull && make up          # migrations apply on backend boot
+make upgrade                 # git pull --ff-only, then make up; migrations apply on backend boot
 ```
 
 Upgrading is safe with data in place: migrations are forward-only and apply on backend boot.

--- a/docs/content/docs/development/instance-health.mdx
+++ b/docs/content/docs/development/instance-health.mdx
@@ -61,6 +61,7 @@ Two neighbouring endpoints round out the surface, both under **Instance** in the
 |---|---|---|
 | `GET /admin/instance/config` | `manage_settings` | Every configuration entry with its resolved value, source and restart requirement. Sensitive keys return a fingerprint, never a value |
 | `GET /admin/instance/limits` | `view_analytics` | The effective sending, warmup and rate limits this build compiles in |
+| `GET /admin/instance/update` | `view_analytics` | The running build, the newest release, and the updater's state. Backs the version pill in the top bar; see [Updates](/development/updates/) |
 
 ## Security and secrets
 
@@ -163,6 +164,16 @@ Platform mail is sent from a domain that differs from the dashboard's. Mailbox p
 ### login_code_demoted
 
 `AUTH_LOGIN_CODE=always` was demoted to `new_device` at boot because the transport does not deliver. Otherwise nobody could ever complete a login. See [login codes](/development/accounts-and-access/#login-codes).
+
+## Updates
+
+### update_available
+
+A newer Warmbly exists: a release on the configured channel is newer than the running build, or the checkout is behind its branch. The message names both versions and how to apply it. With the updater running, the version pill in the top bar has an **Update and restart** button; without it, `git pull && make up`. See [Updates](/development/updates/).
+
+### updater_unreachable
+
+`UPDATER_URL` is set but nothing answers there, so the update button cannot work. Start the updater (the `updater` compose profile, or the systemd unit on a bare-metal host), fix the address, or remove the variable to update by hand. See [enabling the updater](/development/updates/#enabling-the-updater).
 
 ## Accounts and access
 

--- a/docs/content/docs/development/meta.json
+++ b/docs/content/docs/development/meta.json
@@ -11,6 +11,7 @@
     "warmblyctl",
     "configuration",
     "instance-health",
+    "updates",
     "troubleshooting",
     "---Development---",
     "local-development",

--- a/docs/content/docs/development/updates.mdx
+++ b/docs/content/docs/development/updates.mdx
@@ -1,0 +1,163 @@
+---
+title: Updates
+description: How a self-hosted instance learns about a new Warmbly version, what the indicator in the admin panel means, and how Update and restart pulls, rebuilds and restarts the stack for you.
+---
+
+A self-hosted Warmbly checks for a newer version on its own and shows it in the admin panel. Applying it is one button when the updater runs next to the stack: the checkout is pulled, every image is rebuilt, the services that changed are recreated, and the panel reconnects once the backend answers again. Nothing in flight is lost: sending and syncing pause for the restart and resume from the database on the other side.
+
+## The indicator
+
+The top bar of the **admin panel** (`:5174`) carries a version pill next to the environment label. It reads the running backend's build identity, so it shows exactly what is deployed, not what the checkout says.
+
+| Pill | Means |
+|---|---|
+| `v1.4.0` (grey) | Up to date. Click it for the details and a manual check |
+| `Update to v1.5.0` (amber) | A newer release exists on the configured channel |
+| `Update available` (amber) | The checkout is behind its branch (an install that tracks `main`) |
+| `Updating` (blue, spinning) | An update job is running; the pill follows it from any tab |
+| `Restarting` (blue, spinning) | The backend is coming back after an update |
+
+The same facts sit at the top of **Instance > Setup and health**, and an available update is also a finding there (`update_available`, info severity), so a page that only lists findings still tells you.
+
+## In the dashboard
+
+Every member of a self-hosted workspace sees the same version pill in the **dashboard** header, next to the plan badge: the running version in grey, or "Update to vX.Y.Z" in amber with a pulsing dot once a newer release exists. It is there so nobody has to ask which version the server runs, and so the people who cannot update still know one is waiting.
+
+Who can act on it follows platform admin access, not workspace roles:
+
+- **Members** see a badge. Its tooltip names the version and says to ask a platform admin.
+- **Platform admins** click it and get the update dialog: the running and available versions with the release notes, the checkout and updater state, a "Check now" button, and **Update and restart**. That button leads to a confirmation pane that spells out what the update does (pull, rebuild and restart, sending pauses and resumes, migrations apply, the tab reconnects) before anything runs.
+
+While the update runs the dialog shows a progress bar, the step list with the live step highlighted, and the log behind a toggle. When the backend goes away for the restart the dialog says it is reconnecting and keeps polling; the pill in the header turns into a spinner so the job stays visible with the dialog closed, and a reload picks it back up. When the new backend answers, the dialog shows the result and reloads the dashboard after a short countdown, or, if the dialog was closed, a toast reports the new version and every list refreshes.
+
+The dashboard reads `GET /auth/instance` for the version (any member) and the admin endpoints below for the rest (platform admins only, the same permission gates as the admin panel).
+
+## What counts as newer
+
+Two signals, and either one lights the pill:
+
+- **A release.** The newest release of `RELEASES_GITHUB_REPO` on `UPDATE_CHANNEL` (`stable`, or `dev` to include prereleases) is compared with the running build's version. A build stamped `v1.4.0-3-gabc1234` (three commits past the `v1.4.0` tag) is treated as newer than `v1.4.0` and older than `v1.4.1`, so an instance built from `main` is not nagged about the release it already contains.
+- **Commits.** When the updater runs, it fetches the remote on `UPDATER_FETCH_INTERVAL` and reports how far the checkout is behind its branch. Any distance counts as an update on an install that tracks a branch.
+
+A build that carries no version (an image built without the build arguments, reported as `dev`) cannot be compared with a release, and only the commit distance applies.
+
+The version comes from the binary itself: the Dockerfiles and `make up` stamp the tag, commit and build time in (`internal/version`), CI does the same for published images, and `warmblyctl status` prints it as the first line.
+
+## Update and restart
+
+The button appears when the updater is reachable and something newer exists. It needs the `manage_settings` admin permission, and every press is an audit row (`upgrade` on `instance`).
+
+What happens, in the order the dialog shows it:
+
+1. **Fetch.** `git fetch --tags --prune` on the checkout.
+2. **Pull.** On a branch, a fast-forward merge of the remote branch. On a checkout pinned to a tag, a checkout of the newest release. A checkout with local modifications is refused rather than merged over; commit or stash them, or set `UPDATER_ALLOW_DIRTY=true`.
+3. **Build.** `docker compose build` for every service, with the version stamped in.
+4. **Restart.** `docker compose up -d --no-build` for every service the checkout defines plus everything running, minus the updater itself. Compose recreates only the containers whose image or configuration changed, so Postgres, Redis and NATS stay up, and the backend applies migrations as it boots.
+5. **Clean up.** `docker image prune -f`, unless `UPDATER_PRUNE=false`.
+6. **Wait for backend.** The updater polls `/health` until it answers, for up to six minutes, and marks the job as succeeded or failed.
+
+If the updater's own image changed, it recreates itself last, after the outcome is already on disk, so the new updater reports the finished job.
+
+The dialog streams the log. Close it and the pill keeps following the job; reload the page and the pill picks the job up again. When the backend answers with a new build, a toast says which version is now running and every list refreshes.
+
+Migrations are forward-only, so an update never needs to be rolled back to be safe with data in place. Read [backing up](/development/deployment-guide/#backing-up) anyway: a backup before an update is the one you are glad to have.
+
+<Callout type="warn" title="The updater holds the docker socket">
+Inside the compose stack the updater mounts `/var/run/docker.sock`, which is root on the host. That is why it lives behind the `updater` compose profile and answers only to a bearer token the backend holds, on the compose network, with no published port. The backend gates the button on an admin permission and audits it. If any of that is more trust than the host should extend, leave the profile off and update by hand.
+</Callout>
+
+## Enabling the updater
+
+### Docker Compose
+
+`make up` starts the stack with the `updater` profile, so a stock install already has the button. For a plain `docker compose up`, put this in `.env`:
+
+```bash
+COMPOSE_PROFILES=updater
+```
+
+The service mounts the checkout at its own host path (`WARMBLY_REPO_DIR`, `$PWD` by default) so the compose file's relative paths resolve the same way inside the container, and shares `INTERNAL_API_TOKEN` with the backend as `UPDATER_TOKEN`. Nothing else to configure.
+
+Files git writes as root are given back to the checkout's owner after each pull, so your own `git pull` on the host keeps working.
+
+To update by hand instead: `make upgrade` (a fast-forward pull, then `make up`). To leave the button out entirely, start with `make up UPDATER=false` and set `UPDATER_URL=none` in `.env`; the panel then only reports.
+
+### Without Docker
+
+On a [bare-metal install](/development/bare-metal/) the updater is a systemd unit that runs `scripts/upgrade-bare-metal.sh` after pulling. The script is the documented upgrade procedure as a script: build every artifact this host runs, install it, restart the backend first, then the rest, keeping each frontend's `config.js` across the copy.
+
+```bash
+cd /opt/warmbly/src
+go build -o out/updater ./cmd/updater && sudo install -m 0755 out/updater /opt/warmbly/bin/
+sudo install -m 0644 deploy/systemd/warmbly-updater.service /etc/systemd/system/
+printf 'UPDATER_TOKEN=%s\n' "$(grep ^INTERNAL_API_TOKEN= /etc/warmbly/warmbly.env | cut -d= -f2-)" | sudo tee /etc/warmbly/updater.env >/dev/null
+sudo chmod 0600 /etc/warmbly/updater.env
+sudo systemctl daemon-reload && sudo systemctl enable --now warmbly-updater
+```
+
+The unit runs as the user who owns the checkout (`deploy` as shipped; edit it), and the script uses `sudo` for the install and restart steps, so that user needs a sudoers line for exactly those commands:
+
+```
+deploy ALL=(root) NOPASSWD: /usr/bin/install, /bin/cp, /bin/rm, /bin/chown, /bin/chmod, /bin/systemctl, /bin/ln
+```
+
+Then point the backend at it in `warmbly.env` and restart it:
+
+```bash
+UPDATER_URL=http://127.0.0.1:8095
+```
+
+The same script works by hand: `scripts/upgrade-bare-metal.sh --pull`.
+
+## Configuration
+
+Backend:
+
+| Variable | What it does | Default |
+|---|---|---|
+| `UPDATE_CHECK_ENABLED` | Polls GitHub Releases and shows a newer version in the panel | `true` |
+| `UPDATE_CHECK_INTERVAL` | How often the release check runs; minimum `5m` | `30m` |
+| `UPDATE_CHANNEL` | `stable` follows releases; `dev` also offers prereleases | `stable` |
+| `RELEASES_GITHUB_REPO` | The `owner/repo` whose releases are Warmbly versions. Point a fork's instance at the fork | `warmbly/warmbly` |
+| `RELEASES_GITHUB_TOKEN` | Optional; only raises the GitHub API rate limit | unset |
+| `UPDATER_URL` | The updater. Unset, or `none`, leaves the panel report-only | `http://updater:8095` under compose |
+| `UPDATER_TOKEN` | Bearer token presented to the updater | `INTERNAL_API_TOKEN` |
+
+Updater:
+
+| Variable | What it does | Default |
+|---|---|---|
+| `UPDATER_TOKEN` | The token it accepts; falls back to `INTERNAL_API_TOKEN`. Refuses to start without one | unset |
+| `UPDATER_MODE` | `compose` rebuilds and recreates the compose project; `command` runs `UPDATER_COMMAND` | `compose` |
+| `UPDATER_COMMAND` | The build-and-restart command for `command` mode | unset |
+| `UPDATER_REPO_DIR` | The checkout | working directory |
+| `UPDATER_REMOTE` | The git remote to fetch and pull from | `origin` |
+| `UPDATER_COMPOSE_PROJECT` | The `-p` the stack was started with | `warmbly` |
+| `UPDATER_COMPOSE_PROFILES` | Extra profiles on every compose call, so its own image is rebuilt | `updater` |
+| `UPDATER_BACKEND_HEALTH_URL` | Polled after the restart until it answers | `http://backend:8080/health` |
+| `UPDATER_FETCH_INTERVAL` | How often it fetches for the commits-behind count | `30m` |
+| `UPDATER_PRUNE` | `docker image prune -f` after a successful update | `true` |
+| `UPDATER_ALLOW_DIRTY` | Update over local modifications in the checkout | `false` |
+| `UPDATER_STATE_DIR` | Where the last job is kept across restarts | `/var/lib/warmbly-updater` |
+| `UPDATER_ADDR` | Listen address | `:8095` |
+
+## Endpoints
+
+| Endpoint | Auth | Returns |
+|---|---|---|
+| `GET /admin/instance/update` | platform admin, `view_analytics` | Running build, latest release, whether an update is available, updater and job state. `?log=1` includes the job log |
+| `POST /admin/instance/update/check` | platform admin, `manage_settings` | Runs both checks now and returns the state |
+| `POST /admin/instance/update/apply` | platform admin, `manage_settings` | Starts an update job (`{"target": "latest"}` or a release tag) and returns it. The backend restarts as part of it |
+
+The updater's own API (`GET /status`, `POST /check`, `POST /update`) is bearer-authenticated and meant for the backend only.
+
+## Findings
+
+Two [instance health](/development/instance-health/) checks belong to this page:
+
+- `update_available` (info): a newer version exists, with the version and how to apply it.
+- `updater_unreachable` (warning): `UPDATER_URL` is set but nothing answers there, so the button cannot work. Start the updater, fix the address, or remove the variable to update by hand.
+
+## Workers on other machines
+
+This page is about the control plane. Remote workers installed from the panel keep their own daily self-update timer and the **Pull latest and restart** action on the worker's page; see [day-2 operations](/development/deployment-guide/#day-2-operations).

--- a/docs/content/docs/development/updates.mdx
+++ b/docs/content/docs/development/updates.mdx
@@ -98,8 +98,9 @@ sudo systemctl daemon-reload && sudo systemctl enable --now warmbly-updater
 
 The unit runs as the user who owns the checkout (`deploy` as shipped; edit it). The only root step is the installer, so that user needs exactly one sudoers line, and nothing broader:
 
-```
-deploy ALL=(root) NOPASSWD: /usr/local/sbin/warmbly-install-release
+```bash
+echo "deploy ALL=(root) NOPASSWD: /usr/local/sbin/warmbly-install-release" | sudo tee /etc/sudoers.d/warmbly-upgrade >/dev/null
+sudo chmod 0440 /etc/sudoers.d/warmbly-upgrade
 ```
 
 The installer is root-owned and not writable by that user, takes no arguments, reads only from fixed paths under the checkout and refuses symlinks there, so owning the checkout does not become owning the host. The binaries it installs run as the unprivileged `warmbly` user either way.

--- a/docs/content/docs/development/updates.mdx
+++ b/docs/content/docs/development/updates.mdx
@@ -84,24 +84,27 @@ To update by hand instead: `make upgrade` (a fast-forward pull, then `make up`).
 
 ### Without Docker
 
-On a [bare-metal install](/development/bare-metal/) the updater is a systemd unit that runs `scripts/upgrade-bare-metal.sh` after pulling. The script is the documented upgrade procedure as a script: build every artifact this host runs, install it, restart the backend first, then the rest, keeping each frontend's `config.js` across the copy.
+On a [bare-metal install](/development/bare-metal/) the updater is a systemd unit that runs `scripts/upgrade-bare-metal.sh` after pulling. The script builds every artifact this host runs as the checkout's owner, then hands off to one privileged installer, `warmbly-install-release`, which copies the artifacts into `/opt/warmbly`, keeps each frontend's `config.js`, restarts the backend first and the rest once it answers.
 
 ```bash
 cd /opt/warmbly/src
 go build -o out/updater ./cmd/updater && sudo install -m 0755 out/updater /opt/warmbly/bin/
+sudo install -o root -g root -m 0755 deploy/systemd/warmbly-install-release.sh /usr/local/sbin/warmbly-install-release
 sudo install -m 0644 deploy/systemd/warmbly-updater.service /etc/systemd/system/
 printf 'UPDATER_TOKEN=%s\n' "$(grep ^INTERNAL_API_TOKEN= /etc/warmbly/warmbly.env | cut -d= -f2-)" | sudo tee /etc/warmbly/updater.env >/dev/null
 sudo chmod 0600 /etc/warmbly/updater.env
 sudo systemctl daemon-reload && sudo systemctl enable --now warmbly-updater
 ```
 
-The unit runs as the user who owns the checkout (`deploy` as shipped; edit it), and the script uses `sudo` for the install and restart steps, so that user needs a sudoers line for exactly those commands:
+The unit runs as the user who owns the checkout (`deploy` as shipped; edit it). The only root step is the installer, so that user needs exactly one sudoers line, and nothing broader:
 
 ```
-deploy ALL=(root) NOPASSWD: /usr/bin/install, /bin/cp, /bin/rm, /bin/chown, /bin/chmod, /bin/systemctl, /bin/ln
+deploy ALL=(root) NOPASSWD: /usr/local/sbin/warmbly-install-release
 ```
 
-Then point the backend at it in `warmbly.env` and restart it:
+The installer is root-owned and not writable by that user, takes no arguments, reads only from fixed paths under the checkout and refuses symlinks there, so owning the checkout does not become owning the host. The binaries it installs run as the unprivileged `warmbly` user either way.
+
+Then point the backend at the updater in `warmbly.env` and restart it:
 
 ```bash
 UPDATER_URL=http://127.0.0.1:8095

--- a/internal/api/handler/admin_updates.go
+++ b/internal/api/handler/admin_updates.go
@@ -1,0 +1,80 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/updates"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/version"
+)
+
+// The update surface behind the admin panel's top bar: what is running, what
+// is newest, and the one button that applies it through the host-side updater.
+//
+//   GET  /admin/instance/update        state; ?log=1 keeps the job log
+//   POST /admin/instance/update/check  refresh GitHub and the updater now
+//   POST /admin/instance/update/apply  start an update job
+
+// AdminUpdateState returns the cached release check plus a live read of the
+// updater. Cheap enough for the top bar to poll.
+func (h *Handler) AdminUpdateState(c *gin.Context) {
+	if h.UpdatesService == nil {
+		c.JSON(http.StatusOK, updates.State{Running: version.Current(), Updater: updates.UpdaterView{Status: "off"}})
+		return
+	}
+	withLog := c.Query("log") == "1"
+	c.JSON(http.StatusOK, h.UpdatesService.State(c.Request.Context(), withLog))
+}
+
+// AdminUpdateCheck re-runs both checks immediately.
+func (h *Handler) AdminUpdateCheck(c *gin.Context) {
+	if h.UpdatesService == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "Update checks are not available on this deployment."))
+		return
+	}
+	h.audit(c, models.AuditActionCheckReleases, models.AuditEntityInstance, nil, nil)
+	c.JSON(http.StatusOK, h.UpdatesService.Check(c.Request.Context()))
+}
+
+type applyUpdateBody struct {
+	// Target is "latest" (default) or a release tag.
+	Target string `json:"target"`
+}
+
+// AdminUpdateApply starts an update job on the updater and returns it. The
+// backend restarts as part of the job, so the caller polls the state endpoint
+// until it answers again with a new version.
+func (h *Handler) AdminUpdateApply(c *gin.Context) {
+	if h.UpdatesService == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "Updates are not available on this deployment."))
+		return
+	}
+	var body applyUpdateBody
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&body); err != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid request body"))
+			return
+		}
+	}
+	job, err := h.UpdatesService.Apply(c.Request.Context(), body.Target)
+	if err != nil {
+		switch {
+		case errors.Is(err, updates.ErrUpdaterNotConfigured), errors.Is(err, updates.ErrNothingToApply):
+			errx.JSON(c, errx.New(errx.BadRequest, err.Error()))
+		default:
+			errx.JSON(c, errx.New(errx.Conflict, err.Error()))
+		}
+		return
+	}
+	jobID, _ := uuid.Parse(job.ID)
+	h.audit(c, models.AuditActionUpgrade, models.AuditEntityInstance, &jobID, map[string]string{
+		"target":      job.Target,
+		"from_commit": job.FromCommit,
+		"running":     version.String(),
+	})
+	c.JSON(http.StatusAccepted, job)
+}

--- a/internal/api/handler/auth_instance.go
+++ b/internal/api/handler/auth_instance.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/version"
+)
+
+// InstanceVersion answers GET /v1/auth/instance for any signed-in member of a
+// self-hosted instance: which Warmbly this is and whether a newer one exists.
+// It carries no updater detail and no log; applying the update lives in the
+// admin panel. Hosted deployments answer self_hosted=false and nothing else,
+// so the dashboard has nothing to show there.
+type instanceVersionResponse struct {
+	SelfHosted      bool                   `json:"self_hosted"`
+	Version         string                 `json:"version,omitempty"`
+	Commit          string                 `json:"commit,omitempty"`
+	UpdateAvailable bool                   `json:"update_available"`
+	Latest          *instanceLatestRelease `json:"latest,omitempty"`
+	CheckedAt       *time.Time             `json:"checked_at,omitempty"`
+}
+
+type instanceLatestRelease struct {
+	Tag         string    `json:"tag"`
+	HTMLURL     string    `json:"html_url,omitempty"`
+	PublishedAt time.Time `json:"published_at,omitempty"`
+}
+
+func (h *Handler) InstanceVersion(c *gin.Context) {
+	if !config.SelfHosted() {
+		c.JSON(http.StatusOK, instanceVersionResponse{SelfHosted: false})
+		return
+	}
+	resp := instanceVersionResponse{
+		SelfHosted: true,
+		Version:    version.String(),
+		Commit:     version.ShortCommit(),
+	}
+	if h.UpdatesService != nil {
+		st := h.UpdatesService.State(c.Request.Context(), false)
+		resp.UpdateAvailable = st.UpdateAvailable
+		if st.Latest != nil {
+			resp.Latest = &instanceLatestRelease{Tag: st.Latest.Tag, HTMLURL: st.Latest.HTMLURL, PublishedAt: st.Latest.PublishedAt}
+		}
+		if !st.CheckedAt.IsZero() {
+			t := st.CheckedAt
+			resp.CheckedAt = &t
+		}
+	}
+	c.JSON(http.StatusOK, resp)
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -60,6 +60,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/tz"
 	"github.com/warmbly/warmbly/internal/app/unibox"
 	"github.com/warmbly/warmbly/internal/app/unsublink"
+	"github.com/warmbly/warmbly/internal/app/updates"
 	"github.com/warmbly/warmbly/internal/app/user"
 	"github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
@@ -161,6 +162,8 @@ type Handler struct {
 	WorkerRepo         repository.WorkerRepository
 	CredentialsRepo    repository.CredentialsRepository
 	ReleasesService    *releases.Service
+	// UpdatesService backs the admin panel's update indicator and button.
+	UpdatesService *updates.Service
 
 	// Notifications
 	EmailNotificationService notify.EmailNotificationService

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -316,6 +316,10 @@ func Run(
 		protectedAuth.DELETE("/sessions", h.SessionRevokeOthers)
 		protectedAuth.DELETE("/sessions/:id", h.SessionRevoke)
 
+		// The instance's version and whether an update exists, for the
+		// dashboard's version pill. Any member may read it; applying an update
+		// stays behind the admin permissions on /admin/instance/update.
+		protectedAuth.GET("/instance", h.InstanceVersion)
 		protectedAuth.GET("/me", h.GetUser)
 		protectedAuth.PATCH("/me", h.UpdateUserProfile)
 		protectedAuth.PATCH("/me/onboarding", h.CompleteOnboarding)
@@ -1453,6 +1457,11 @@ func Run(
 		adminRoutes.GET("/instance/limits", middleware.RequireAdminPermission(models.AdminPermViewAnalytics), h.AdminInstanceLimits)
 		adminRoutes.GET("/instance/settings", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminGetInstanceSettings)
 		adminRoutes.PUT("/instance/settings", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminPutInstanceSettings)
+		// Updates: the top-bar indicator polls the state; applying one goes
+		// through the host-side updater and restarts this process.
+		adminRoutes.GET("/instance/update", middleware.RequireAdminPermission(models.AdminPermViewAnalytics), h.AdminUpdateState)
+		adminRoutes.POST("/instance/update/check", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminUpdateCheck)
+		adminRoutes.POST("/instance/update/apply", middleware.RequireAdminPermission(models.AdminPermManageSettings), h.AdminUpdateApply)
 
 		// Analytics Dashboard
 		adminRoutes.GET("/analytics/overview", middleware.RequireAdminPermission(models.AdminPermViewAnalytics), h.AdminGetPlatformOverview)

--- a/internal/app/instancecheck/checks_updates.go
+++ b/internal/app/instancecheck/checks_updates.go
@@ -1,0 +1,58 @@
+package instancecheck
+
+import (
+	"context"
+	"fmt"
+)
+
+const docsUpdates = "/development/updates/"
+
+func updateChecks() []check {
+	return []check{
+		{id: "update_available", run: checkUpdateAvailable},
+		{id: "updater_unreachable", run: checkUpdaterUnreachable},
+	}
+}
+
+// checkUpdateAvailable is the health-page twin of the top-bar indicator, so an
+// operator who only reads findings still learns a newer Warmbly exists.
+func checkUpdateAvailable(ctx context.Context, d Deps, _ Input) *Finding {
+	if d.Updates == nil {
+		return nil
+	}
+	st := d.Updates.State(ctx, false)
+	if !st.UpdateAvailable {
+		return nil
+	}
+	var msg string
+	switch {
+	case st.Reason == "release" && st.Latest != nil:
+		msg = fmt.Sprintf("Warmbly %s is available and this instance runs %s. ", st.Latest.Tag, st.Running.Version)
+	case st.Updater.Checkout != nil:
+		msg = fmt.Sprintf("The checkout is %d commits behind %s. ", st.Updater.Checkout.Behind, st.Updater.Checkout.Branch)
+	default:
+		msg = "A newer version is available. "
+	}
+	if st.Updater.Status == "ok" {
+		msg += "Open the version pill in the top bar and choose Update and restart; the stack rebuilds, restarts and resumes on its own."
+	} else {
+		msg += "Pull the repository and restart the stack, or enable the updater to do it from this panel."
+	}
+	return result(CategoryUpdates, SeverityInfo, "An update is available", msg, docsUpdates)
+}
+
+// checkUpdaterUnreachable fires only when an updater is configured and not
+// answering; an instance that never configured one is not misconfigured.
+func checkUpdaterUnreachable(ctx context.Context, d Deps, _ Input) *Finding {
+	if d.Updates == nil {
+		return nil
+	}
+	st := d.Updates.State(ctx, false)
+	if !st.Updater.Configured || st.Updater.Status == "ok" {
+		return nil
+	}
+	return result(CategoryUpdates, SeverityWarning, "The updater is not answering",
+		"UPDATER_URL is set but the backend cannot reach the updater, so Update and restart in the panel cannot work. "+
+			st.Updater.Error+" Remove UPDATER_URL if you update by hand.",
+		docsUpdates)
+}

--- a/internal/app/instancecheck/checks_updates.go
+++ b/internal/app/instancecheck/checks_updates.go
@@ -36,7 +36,7 @@ func checkUpdateAvailable(ctx context.Context, d Deps, _ Input) *Finding {
 	if st.Updater.Status == "ok" {
 		msg += "Open the version pill in the top bar and choose Update and restart; the stack rebuilds, restarts and resumes on its own."
 	} else {
-		msg += "Pull the repository and restart the stack, or enable the updater to do it from this panel."
+		msg += "Run make upgrade on the host, or enable the updater to do it from this panel."
 	}
 	return result(CategoryUpdates, SeverityInfo, "An update is available", msg, docsUpdates)
 }
@@ -48,7 +48,7 @@ func checkUpdaterUnreachable(ctx context.Context, d Deps, _ Input) *Finding {
 		return nil
 	}
 	st := d.Updates.State(ctx, false)
-	if !st.Updater.Configured || st.Updater.Status == "ok" {
+	if st.Updater.Status != "unreachable" {
 		return nil
 	}
 	return result(CategoryUpdates, SeverityWarning, "The updater is not answering",

--- a/internal/app/instancecheck/instancecheck.go
+++ b/internal/app/instancecheck/instancecheck.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/warmbly/warmbly/internal/app/instanceconfig"
+	"github.com/warmbly/warmbly/internal/app/updates"
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/infrastructure/cache"
 	"github.com/warmbly/warmbly/internal/notify"
@@ -40,6 +41,7 @@ const (
 	CategoryAccess   = "access"
 	CategoryWorkers  = "workers"
 	CategoryData     = "data"
+	CategoryUpdates  = "updates"
 )
 
 // Finding is one thing that is wrong, plus how to fix it.
@@ -80,6 +82,8 @@ type Deps struct {
 	Policy    *config.AuthPolicy
 	DB        *pgxpool.Pool
 	Cache     *cache.Cache
+	// Updates is the release and updater state; nil skips the update checks.
+	Updates *updates.Service
 }
 
 type check struct {
@@ -101,6 +105,7 @@ func New(deps Deps) *Registry {
 	r.checks = append(r.checks, mailChecks()...)
 	r.checks = append(r.checks, accessChecks()...)
 	r.checks = append(r.checks, infraChecks()...)
+	r.checks = append(r.checks, updateChecks()...)
 	return r
 }
 

--- a/internal/app/instanceconfig/entries.go
+++ b/internal/app/instanceconfig/entries.go
@@ -26,6 +26,7 @@ const (
 	docsCaptcha    = "/development/configuration/#captcha"
 	docsSSO        = "/development/accounts-and-access/#single-sign-on"
 	docsFirstOwner = "/development/accounts-and-access/#first-owner"
+	docsUpdates    = "/development/updates/"
 )
 
 // table is the static inventory. Declaration order is display order.
@@ -772,6 +773,49 @@ var table = []Entry{
 		Effect:     "Error reporting. Optional in every environment; unset simply logs instead.",
 		DocsAnchor: docsDeployment,
 		Resolve:    envValue("SENTRY_DSN"),
+	},
+
+	// Updates.
+	{
+		Key: "UPDATE_CHECK_ENABLED", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "Polls GitHub Releases for a newer Warmbly and shows it in the admin panel's top bar and on Setup and health.",
+		DocsAnchor: docsUpdates,
+		Resolve:    boolOr("UPDATE_CHECK_ENABLED", true),
+	},
+	{
+		Key: "UPDATE_CHECK_INTERVAL", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "How often the release check runs. Minimum 5m.",
+		DocsAnchor: docsUpdates,
+		Resolve:    envOr("UPDATE_CHECK_INTERVAL", "30m"),
+	},
+	{
+		Key: "UPDATE_CHANNEL", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "stable follows releases; dev also offers prereleases.",
+		DocsAnchor: docsUpdates,
+		Resolve:    envOr("UPDATE_CHANNEL", "stable"),
+	},
+	{
+		Key: "RELEASES_GITHUB_REPO", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "The owner/repo whose releases count as Warmbly versions. Point a fork's instance at the fork.",
+		DocsAnchor: docsUpdates,
+		Resolve:    envOr("RELEASES_GITHUB_REPO", "warmbly/warmbly"),
+	},
+	{
+		Key: "UPDATER_URL", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "The host-side updater that applies an update (pull, rebuild, restart). Unset leaves the panel report-only.",
+		DocsAnchor: docsUpdates,
+		Resolve:    envValue("UPDATER_URL"),
+	},
+	{
+		Key: "UPDATER_TOKEN", Group: GroupUpdates, RuntimeChangeable: ChangeBootOnly,
+		Effect:     "The bearer token the backend presents to the updater. Falls back to INTERNAL_API_TOKEN.",
+		DocsAnchor: docsUpdates, WhenUnset: SourceDerived,
+		Resolve: func(*Runtime) string {
+			if v := trimmed("UPDATER_TOKEN"); v != "" {
+				return v
+			}
+			return trimmed("INTERNAL_API_TOKEN")
+		},
 	},
 }
 

--- a/internal/app/instanceconfig/instanceconfig.go
+++ b/internal/app/instanceconfig/instanceconfig.go
@@ -28,6 +28,7 @@ const (
 	GroupTracking      = "tracking"
 	GroupCaptcha       = "captcha"
 	GroupObservability = "observability"
+	GroupUpdates       = "updates"
 )
 
 // Where a resolved value came from.

--- a/internal/app/releases/github.go
+++ b/internal/app/releases/github.go
@@ -1,0 +1,89 @@
+package releases
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// Release is one GitHub release as the update surfaces read it.
+type Release struct {
+	TagName     string    `json:"tag_name"`
+	Name        string    `json:"name"`
+	Prerelease  bool      `json:"prerelease"`
+	Draft       bool      `json:"draft"`
+	PublishedAt time.Time `json:"published_at"`
+	HTMLURL     string    `json:"html_url"`
+}
+
+// FetchReleases lists the newest releases of owner/repo. token is optional and
+// only raises the unauthenticated rate limit.
+func FetchReleases(ctx context.Context, client *http.Client, repo, token string) ([]Release, error) {
+	if repo == "" {
+		return nil, errors.New("RELEASES_GITHUB_REPO not set")
+	}
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	url := "https://api.github.com/repos/" + repo + "/releases?per_page=30"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("github %d: %s", resp.StatusCode, truncate(string(body), 200))
+	}
+	var releases []Release
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return releases, nil
+}
+
+// PickChannelHeads returns the most recent published release for each channel:
+//   - stable: latest non-prerelease, non-draft
+//   - dev:    latest published (including prereleases)
+func PickChannelHeads(releases []Release) (stable, dev *Release) {
+	sort.Slice(releases, func(i, j int) bool {
+		return releases[i].PublishedAt.After(releases[j].PublishedAt)
+	})
+	for i := range releases {
+		r := &releases[i]
+		if r.Draft {
+			continue
+		}
+		if dev == nil {
+			dev = r
+		}
+		if !r.Prerelease && stable == nil {
+			stable = r
+		}
+		if dev != nil && stable != nil {
+			break
+		}
+	}
+	return
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/internal/app/releases/service.go
+++ b/internal/app/releases/service.go
@@ -20,10 +20,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -110,13 +108,13 @@ func (s *Service) CheckGitHub(ctx context.Context) (changed []ProfileUpdate, err
 		return nil, errors.New("releases not enabled")
 	}
 
-	releases, err := s.fetchReleases(ctx)
+	releases, err := FetchReleases(ctx, s.http, s.cfg.GithubRepo, s.cfg.GithubToken)
 	if err != nil {
 		s.recordError(err.Error())
 		return nil, err
 	}
 
-	stable, dev := pickChannelHeads(releases)
+	stable, dev := PickChannelHeads(releases)
 
 	now := time.Now()
 	s.stateMu.Lock()
@@ -132,7 +130,7 @@ func (s *Service) CheckGitHub(ctx context.Context) (changed []ProfileUpdate, err
 	s.stateMu.Unlock()
 
 	for _, channel := range []models.ReleaseChannel{models.ReleaseChannelStable, models.ReleaseChannelDev} {
-		var target *githubRelease
+		var target *Release
 		switch channel {
 		case models.ReleaseChannelStable:
 			target = stable
@@ -292,7 +290,7 @@ func (s *Service) imageFor(tag string) string {
 	return repo + ":" + tag
 }
 
-func (s *Service) channelView(name string, r *githubRelease) ChannelView {
+func (s *Service) channelView(name string, r *Release) ChannelView {
 	return ChannelView{
 		Channel:     name,
 		Tag:         r.TagName,
@@ -300,72 +298,6 @@ func (s *Service) channelView(name string, r *githubRelease) ChannelView {
 		PublishedAt: r.PublishedAt,
 		HTMLURL:     r.HTMLURL,
 	}
-}
-
-// GitHub API
-
-type githubRelease struct {
-	TagName     string    `json:"tag_name"`
-	Name        string    `json:"name"`
-	Prerelease  bool      `json:"prerelease"`
-	Draft       bool      `json:"draft"`
-	PublishedAt time.Time `json:"published_at"`
-	HTMLURL     string    `json:"html_url"`
-}
-
-func (s *Service) fetchReleases(ctx context.Context) ([]githubRelease, error) {
-	if s.cfg.GithubRepo == "" {
-		return nil, errors.New("RELEASES_GITHUB_REPO not set")
-	}
-	url := "https://api.github.com/repos/" + s.cfg.GithubRepo + "/releases?per_page=30"
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-	if s.cfg.GithubToken != "" {
-		req.Header.Set("Authorization", "Bearer "+s.cfg.GithubToken)
-	}
-	resp, err := s.http.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("github %d: %s", resp.StatusCode, truncate(string(body), 200))
-	}
-	var releases []githubRelease
-	if err := json.Unmarshal(body, &releases); err != nil {
-		return nil, fmt.Errorf("decode: %w", err)
-	}
-	return releases, nil
-}
-
-// pickChannelHeads returns the most recent published release for each channel:
-//   - stable: latest non-prerelease, non-draft
-//   - dev:    latest published (including prereleases)
-func pickChannelHeads(releases []githubRelease) (stable, dev *githubRelease) {
-	sort.Slice(releases, func(i, j int) bool {
-		return releases[i].PublishedAt.After(releases[j].PublishedAt)
-	})
-	for i := range releases {
-		r := &releases[i]
-		if r.Draft {
-			continue
-		}
-		if dev == nil {
-			dev = r
-		}
-		if !r.Prerelease && stable == nil {
-			stable = r
-		}
-		if dev != nil && stable != nil {
-			break
-		}
-	}
-	return
 }
 
 // HMAC verification
@@ -381,11 +313,4 @@ func verifySignature(secret string, body []byte, header string) bool {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)
 	return hmac.Equal(got, mac.Sum(nil))
-}
-
-func truncate(s string, n int) string {
-	if len(s) <= n {
-		return s
-	}
-	return s[:n] + "..."
 }

--- a/internal/app/updates/semver.go
+++ b/internal/app/updates/semver.go
@@ -1,0 +1,98 @@
+package updates
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// parsed is a version the comparison understands: a release tag (v1.4.0), a
+// prerelease (v1.5.0-rc.1) or a git describe string (v1.4.0-3-gabc1234, which
+// is three commits past v1.4.0 and therefore newer than it).
+type parsed struct {
+	major, minor, patch int
+	pre                 string
+	ahead               int
+}
+
+var describeSuffix = regexp.MustCompile(`^(\d+)-g[0-9a-f]+(-dirty)?$`)
+
+func parseVersion(raw string) (parsed, bool) {
+	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "v"))
+	s = strings.TrimSuffix(s, "-dirty")
+	if s == "" {
+		return parsed{}, false
+	}
+	core, rest, _ := strings.Cut(s, "-")
+	parts := strings.Split(core, ".")
+	if len(parts) < 2 || len(parts) > 3 {
+		return parsed{}, false
+	}
+	var p parsed
+	nums := []*int{&p.major, &p.minor, &p.patch}
+	for i, part := range parts {
+		n, err := strconv.Atoi(part)
+		if err != nil || n < 0 {
+			return parsed{}, false
+		}
+		*nums[i] = n
+	}
+	if rest != "" {
+		if m := describeSuffix.FindStringSubmatch(rest); m != nil {
+			p.ahead, _ = strconv.Atoi(m[1])
+		} else if i := strings.LastIndex(rest, "-"); i > 0 && describeSuffix.MatchString(rest[i+1:]) {
+			// prerelease plus describe suffix, e.g. rc.1-3-gabc1234
+			p.pre = rest[:i]
+			p.ahead, _ = strconv.Atoi(describeSuffix.FindStringSubmatch(rest[i+1:])[1])
+		} else {
+			p.pre = rest
+		}
+	}
+	return p, true
+}
+
+// compare orders two parsed versions: -1 when a < b, 0 when equal, 1 when a > b.
+func compare(a, b parsed) int {
+	for _, pair := range [][2]int{{a.major, b.major}, {a.minor, b.minor}, {a.patch, b.patch}} {
+		if pair[0] != pair[1] {
+			if pair[0] < pair[1] {
+				return -1
+			}
+			return 1
+		}
+	}
+	// A prerelease sorts before its release; commits past a tag sort after it.
+	switch {
+	case a.pre != "" && b.pre == "":
+		return -1
+	case a.pre == "" && b.pre != "":
+		return 1
+	case a.pre != b.pre:
+		if a.pre < b.pre {
+			return -1
+		}
+		return 1
+	}
+	if a.ahead != b.ahead {
+		if a.ahead < b.ahead {
+			return -1
+		}
+		return 1
+	}
+	return 0
+}
+
+// newer reports whether latest is a newer version than running. The second
+// result is false when either side cannot be parsed (a "dev" build), in which
+// case the caller has to fall back to the checkout's commit distance.
+func newer(latest, running string) (isNewer, comparable bool) {
+	l, ok := parseVersion(latest)
+	if !ok {
+		return false, false
+	}
+	r, ok := parseVersion(running)
+	if !ok {
+		return false, false
+	}
+	return compare(l, r) > 0, true
+}

--- a/internal/app/updates/semver.go
+++ b/internal/app/updates/semver.go
@@ -15,7 +15,9 @@ type parsed struct {
 	ahead               int
 }
 
-var describeSuffix = regexp.MustCompile(`^(\d+)-g[0-9a-f]+(-dirty)?$`)
+// describeSuffix is git describe's "-<n>-g<sha>" tail, with whatever precedes
+// it (a prerelease such as rc.1, or nothing) captured first.
+var describeSuffix = regexp.MustCompile(`^(?:(.*)-)?(\d+)-g[0-9a-f]+$`)
 
 func parseVersion(raw string) (parsed, bool) {
 	s := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(raw), "v"))
@@ -39,11 +41,8 @@ func parseVersion(raw string) (parsed, bool) {
 	}
 	if rest != "" {
 		if m := describeSuffix.FindStringSubmatch(rest); m != nil {
-			p.ahead, _ = strconv.Atoi(m[1])
-		} else if i := strings.LastIndex(rest, "-"); i > 0 && describeSuffix.MatchString(rest[i+1:]) {
-			// prerelease plus describe suffix, e.g. rc.1-3-gabc1234
-			p.pre = rest[:i]
-			p.ahead, _ = strconv.Atoi(describeSuffix.FindStringSubmatch(rest[i+1:])[1])
+			p.pre = m[1]
+			p.ahead, _ = strconv.Atoi(m[2])
 		} else {
 			p.pre = rest
 		}

--- a/internal/app/updates/semver.go
+++ b/internal/app/updates/semver.go
@@ -41,8 +41,12 @@ func parseVersion(raw string) (parsed, bool) {
 	}
 	if rest != "" {
 		if m := describeSuffix.FindStringSubmatch(rest); m != nil {
+			ahead, err := strconv.Atoi(m[2])
+			if err != nil {
+				return parsed{}, false
+			}
 			p.pre = m[1]
-			p.ahead, _ = strconv.Atoi(m[2])
+			p.ahead = ahead
 		} else {
 			p.pre = rest
 		}

--- a/internal/app/updates/semver_test.go
+++ b/internal/app/updates/semver_test.go
@@ -1,0 +1,30 @@
+package updates
+
+import "testing"
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		latest, running  string
+		want, comparable bool
+	}{
+		{"v1.5.0", "v1.4.0", true, true},
+		{"v1.4.0", "v1.4.0", false, true},
+		{"v1.4.0", "v1.5.0", false, true},
+		{"v1.4.1", "v1.4.0-3-gabc1234", true, true},
+		{"v1.4.0", "v1.4.0-3-gabc1234", false, true},
+		{"v1.5.0", "v1.5.0-rc.1", true, true},
+		{"v1.5.0-rc.2", "v1.5.0-rc.1", true, true},
+		{"v1.5.0", "v1.5.0-rc.1-2-gabc1234", true, true},
+		{"v2.0.0", "1.9.9", true, true},
+		{"v1.5.0", "dev", false, false},
+		{"v1.5.0", "abc1234", false, false},
+		{"", "v1.5.0", false, false},
+		{"v1.5.0", "v1.4.0-dirty", true, true},
+	}
+	for _, c := range cases {
+		got, ok := newer(c.latest, c.running)
+		if got != c.want || ok != c.comparable {
+			t.Errorf("newer(%q, %q) = (%v, %v), want (%v, %v)", c.latest, c.running, got, ok, c.want, c.comparable)
+		}
+	}
+}

--- a/internal/app/updates/semver_test.go
+++ b/internal/app/updates/semver_test.go
@@ -22,6 +22,8 @@ func TestNewer(t *testing.T) {
 		{"v1.5.0", "abc1234", false, false},
 		{"", "v1.5.0", false, false},
 		{"v1.5.0", "v1.4.0-dirty", true, true},
+		// An overflowing commit distance is not a version at all.
+		{"v1.5.0", "v1.4.0-99999999999999999999-gabc1234", false, false},
 	}
 	for _, c := range cases {
 		got, ok := newer(c.latest, c.running)

--- a/internal/app/updates/semver_test.go
+++ b/internal/app/updates/semver_test.go
@@ -15,6 +15,8 @@ func TestNewer(t *testing.T) {
 		{"v1.5.0", "v1.5.0-rc.1", true, true},
 		{"v1.5.0-rc.2", "v1.5.0-rc.1", true, true},
 		{"v1.5.0", "v1.5.0-rc.1-2-gabc1234", true, true},
+		{"v1.5.0-rc.1-3-gabc1234", "v1.5.0-rc.1-2-gabc1234", true, true},
+		{"v1.5.0-rc.1", "v1.5.0-rc.1-2-gabc1234", false, true},
 		{"v2.0.0", "1.9.9", true, true},
 		{"v1.5.0", "dev", false, false},
 		{"v1.5.0", "abc1234", false, false},

--- a/internal/app/updates/service.go
+++ b/internal/app/updates/service.go
@@ -94,7 +94,21 @@ type Service struct {
 	latest    *Latest
 	checkedAt time.Time
 	checkErr  string
+
+	// The updater view is cached briefly so the member-facing version pill,
+	// the health checks and the admin poll share one read instead of each
+	// dialling the updater, and a stalled updater cannot slow every caller.
+	viewMu    sync.Mutex
+	view      UpdaterView
+	viewUntil time.Time
 }
+
+// viewTTL is how long a good updater read is served from cache; viewFailTTL
+// how long a failed one is, so an absent updater is dialled rarely.
+const (
+	viewTTL     = 2 * time.Second
+	viewFailTTL = 30 * time.Second
+)
 
 func New(cfg Config) *Service {
 	if cfg.HTTPClient == nil {
@@ -141,14 +155,38 @@ func (s *Service) Start(ctx context.Context) {
 func (s *Service) Check(ctx context.Context) State {
 	s.checkGitHub(ctx)
 	view := s.updaterStatus(ctx, http.MethodPost, "/check")
+	s.storeView(view)
 	return s.compose(view, false)
 }
 
-// State returns the cached release check plus a live read of the updater.
-// withLog keeps job logs; the top-bar poll drops them to stay small.
+// State returns the cached release check plus the updater's state, read live
+// at most every viewTTL. withLog keeps job logs; the top-bar poll drops them.
 func (s *Service) State(ctx context.Context, withLog bool) State {
+	return s.compose(s.cachedView(ctx), !withLog)
+}
+
+func (s *Service) cachedView(ctx context.Context) UpdaterView {
+	s.viewMu.Lock()
+	if time.Now().Before(s.viewUntil) {
+		v := s.view
+		s.viewMu.Unlock()
+		return v
+	}
+	s.viewMu.Unlock()
 	view := s.updaterStatus(ctx, http.MethodGet, "/status")
-	return s.compose(view, !withLog)
+	s.storeView(view)
+	return view
+}
+
+func (s *Service) storeView(view UpdaterView) {
+	ttl := viewTTL
+	if view.Status == "unreachable" || (view.Status == "off" && view.Configured) {
+		ttl = viewFailTTL
+	}
+	s.viewMu.Lock()
+	s.view = view
+	s.viewUntil = time.Now().Add(ttl)
+	s.viewMu.Unlock()
 }
 
 // Apply asks the updater to move to target: "latest" picks the tracked branch
@@ -161,8 +199,12 @@ func (s *Service) Apply(ctx context.Context, target string) (*updater.Job, error
 	switch strings.TrimSpace(target) {
 	case "", "latest", "branch":
 		view := s.updaterStatus(ctx, http.MethodGet, "/status")
+		s.storeView(view)
 		if view.Status != "ok" {
-			return nil, fmt.Errorf("updater is %s: %s", view.Status, view.Error)
+			if view.Error == "" {
+				return nil, ErrUpdaterNotConfigured
+			}
+			return nil, errors.New(view.Error)
 		}
 		if view.Checkout != nil && view.Checkout.Detached {
 			s.mu.Lock()
@@ -278,10 +320,19 @@ func (s *Service) updaterStatus(ctx context.Context, method, path string) Update
 		return UpdaterView{Status: "off"}
 	}
 	view := UpdaterView{Configured: true}
-	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	cctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 	resp, err := s.call(cctx, method, path, nil)
 	if err != nil {
+		// Under compose the backend always gets UPDATER_URL=http://updater:8095,
+		// profile or not. A host that does not resolve is the profile being
+		// off, which is report-only by choice, not a broken updater.
+		var dns *net.DNSError
+		if errors.As(err, &dns) {
+			view.Status = "off"
+			view.Error = "the updater is not running; enable the updater compose profile (make up does) to update from here"
+			return view
+		}
 		view.Status = "unreachable"
 		view.Error = describeDialError(err)
 		return view
@@ -322,10 +373,6 @@ func (s *Service) call(ctx context.Context, method, path string, body io.Reader)
 // describeDialError turns the usual "not running" failures into the sentence
 // the panel shows, instead of a raw dial string.
 func describeDialError(err error) string {
-	var dns *net.DNSError
-	if errors.As(err, &dns) {
-		return "the updater host does not resolve; it is not running (enable the updater compose profile) or UPDATER_URL is wrong"
-	}
 	if strings.Contains(err.Error(), "connection refused") {
 		return "the updater is not accepting connections; it is not running or UPDATER_URL points at the wrong port"
 	}

--- a/internal/app/updates/service.go
+++ b/internal/app/updates/service.go
@@ -15,6 +15,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -195,17 +196,19 @@ func (s *Service) Apply(ctx context.Context, target string) (*updater.Job, error
 	if s.cfg.UpdaterURL == "" {
 		return nil, ErrUpdaterNotConfigured
 	}
+	// Every target goes through the same availability check, so a missing
+	// updater is one clear answer rather than a transport error.
+	view := s.updaterStatus(ctx, http.MethodGet, "/status")
+	s.storeView(view)
+	if view.Status != "ok" {
+		if view.Error == "" {
+			return nil, ErrUpdaterNotConfigured
+		}
+		return nil, errors.New(view.Error)
+	}
 	req := updater.UpdateRequest{}
 	switch strings.TrimSpace(target) {
 	case "", "latest", "branch":
-		view := s.updaterStatus(ctx, http.MethodGet, "/status")
-		s.storeView(view)
-		if view.Status != "ok" {
-			if view.Error == "" {
-				return nil, ErrUpdaterNotConfigured
-			}
-			return nil, errors.New(view.Error)
-		}
 		if view.Checkout != nil && view.Checkout.Detached {
 			s.mu.Lock()
 			latest := s.latest
@@ -325,10 +328,11 @@ func (s *Service) updaterStatus(ctx context.Context, method, path string) Update
 	resp, err := s.call(cctx, method, path, nil)
 	if err != nil {
 		// Under compose the backend always gets UPDATER_URL=http://updater:8095,
-		// profile or not. A host that does not resolve is the profile being
-		// off, which is report-only by choice, not a broken updater.
+		// profile or not. The compose service name not resolving is the
+		// profile being off, which is report-only by choice, not a broken
+		// updater. Any other host that fails is reported as unreachable.
 		var dns *net.DNSError
-		if errors.As(err, &dns) {
+		if errors.As(err, &dns) && s.composeServiceHost() {
 			view.Status = "off"
 			view.Error = "the updater is not running; enable the updater compose profile (make up does) to update from here"
 			return view
@@ -370,9 +374,22 @@ func (s *Service) call(ctx context.Context, method, path string, body io.Reader)
 	return s.http.Do(req)
 }
 
+// composeServiceHost reports whether UPDATER_URL names the compose service.
+func (s *Service) composeServiceHost() bool {
+	u, err := url.Parse(s.cfg.UpdaterURL)
+	return err == nil && u.Hostname() == composeUpdaterHost
+}
+
+// composeUpdaterHost is the updater service's name in docker-compose.yml.
+const composeUpdaterHost = "updater"
+
 // describeDialError turns the usual "not running" failures into the sentence
 // the panel shows, instead of a raw dial string.
 func describeDialError(err error) string {
+	var dns *net.DNSError
+	if errors.As(err, &dns) {
+		return "the updater host does not resolve; check UPDATER_URL"
+	}
 	if strings.Contains(err.Error(), "connection refused") {
 		return "the updater is not accepting connections; it is not running or UPDATER_URL points at the wrong port"
 	}

--- a/internal/app/updates/service.go
+++ b/internal/app/updates/service.go
@@ -1,0 +1,333 @@
+// Package updates answers "is there a newer Warmbly than the one running, and
+// apply it". The check side polls GitHub Releases and the host-side updater on
+// an interval, so the admin panel's top bar can show an update the moment one
+// exists. The apply side hands the job to the updater (internal/updater) and
+// relays its progress; the backend itself never touches git or docker.
+package updates
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/releases"
+	"github.com/warmbly/warmbly/internal/updater"
+	"github.com/warmbly/warmbly/internal/version"
+)
+
+// Config is read from the environment by cmd/backend.
+type Config struct {
+	// Enabled turns the periodic GitHub check on. The updater status is read
+	// regardless, because a running job must be visible even with checks off.
+	Enabled  bool
+	Interval time.Duration
+	// Channel is stable (releases) or dev (prereleases included).
+	Channel     string
+	GithubRepo  string
+	GithubToken string
+	// UpdaterURL is the host-side updater; empty means updates are applied by
+	// hand and the panel only reports.
+	UpdaterURL   string
+	UpdaterToken string
+	HTTPClient   *http.Client
+}
+
+// Latest is the newest release on the configured channel.
+type Latest struct {
+	Tag         string    `json:"tag"`
+	Name        string    `json:"name,omitempty"`
+	HTMLURL     string    `json:"html_url,omitempty"`
+	PublishedAt time.Time `json:"published_at,omitempty"`
+	Channel     string    `json:"channel"`
+}
+
+// UpdaterView is what the panel knows about the host-side agent.
+type UpdaterView struct {
+	// Configured is whether UPDATER_URL is set at all.
+	Configured bool `json:"configured"`
+	// Status is off (not configured), ok, or unreachable.
+	Status   string            `json:"status"`
+	Error    string            `json:"error,omitempty"`
+	Mode     updater.Mode      `json:"mode,omitempty"`
+	RepoDir  string            `json:"repo_dir,omitempty"`
+	Checkout *updater.Checkout `json:"checkout,omitempty"`
+	Job      *updater.Job      `json:"job,omitempty"`
+	LastJob  *updater.Job      `json:"last_job,omitempty"`
+}
+
+// State is the whole answer to GET /admin/instance/update.
+type State struct {
+	Running         version.Info `json:"running"`
+	Latest          *Latest      `json:"latest,omitempty"`
+	UpdateAvailable bool         `json:"update_available"`
+	// Reason is release (a newer tag exists) or commits (the checkout is
+	// behind its branch); empty when nothing is pending.
+	Reason     string      `json:"reason,omitempty"`
+	CheckedAt  time.Time   `json:"checked_at,omitempty"`
+	CheckError string      `json:"check_error,omitempty"`
+	Enabled    bool        `json:"enabled"`
+	Interval   string      `json:"interval"`
+	Channel    string      `json:"channel"`
+	Repo       string      `json:"repo"`
+	Updater    UpdaterView `json:"updater"`
+}
+
+var (
+	ErrUpdaterNotConfigured = errors.New("no updater is configured on this instance")
+	ErrNothingToApply       = errors.New("the checkout is pinned to a tag and no release is known to move to")
+)
+
+type Service struct {
+	cfg  Config
+	http *http.Client
+
+	mu        sync.Mutex
+	latest    *Latest
+	checkedAt time.Time
+	checkErr  string
+}
+
+func New(cfg Config) *Service {
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 15 * time.Second}
+	}
+	if cfg.Interval < 5*time.Minute {
+		cfg.Interval = 30 * time.Minute
+	}
+	if cfg.Channel != "dev" {
+		cfg.Channel = "stable"
+	}
+	cfg.UpdaterURL = strings.TrimRight(strings.TrimSpace(cfg.UpdaterURL), "/")
+	// Compose substitutes its default for an empty value, so "none" is how a
+	// .env turns the updater off.
+	switch strings.ToLower(cfg.UpdaterURL) {
+	case "none", "off", "false":
+		cfg.UpdaterURL = ""
+	}
+	return &Service{cfg: cfg, http: cfg.HTTPClient}
+}
+
+// Start runs the release check now and on every interval until ctx ends.
+func (s *Service) Start(ctx context.Context) {
+	if !s.cfg.Enabled {
+		log.Printf("updates: release check disabled (UPDATE_CHECK_ENABLED=false)")
+		return
+	}
+	go func() {
+		s.checkGitHub(ctx)
+		t := time.NewTicker(s.cfg.Interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				s.checkGitHub(ctx)
+			}
+		}
+	}()
+}
+
+// Check refreshes both sources now and returns the result.
+func (s *Service) Check(ctx context.Context) State {
+	s.checkGitHub(ctx)
+	view := s.updaterStatus(ctx, http.MethodPost, "/check")
+	return s.compose(view, false)
+}
+
+// State returns the cached release check plus a live read of the updater.
+// withLog keeps job logs; the top-bar poll drops them to stay small.
+func (s *Service) State(ctx context.Context, withLog bool) State {
+	view := s.updaterStatus(ctx, http.MethodGet, "/status")
+	return s.compose(view, !withLog)
+}
+
+// Apply asks the updater to move to target: "latest" picks the tracked branch
+// or, on a pinned checkout, the newest release; anything else is a tag.
+func (s *Service) Apply(ctx context.Context, target string) (*updater.Job, error) {
+	if s.cfg.UpdaterURL == "" {
+		return nil, ErrUpdaterNotConfigured
+	}
+	req := updater.UpdateRequest{}
+	switch strings.TrimSpace(target) {
+	case "", "latest", "branch":
+		view := s.updaterStatus(ctx, http.MethodGet, "/status")
+		if view.Status != "ok" {
+			return nil, fmt.Errorf("updater is %s: %s", view.Status, view.Error)
+		}
+		if view.Checkout != nil && view.Checkout.Detached {
+			s.mu.Lock()
+			latest := s.latest
+			s.mu.Unlock()
+			if latest == nil {
+				return nil, ErrNothingToApply
+			}
+			req.Tag = latest.Tag
+		}
+	default:
+		req.Tag = strings.TrimSpace(target)
+	}
+
+	body, _ := json.Marshal(req)
+	resp, err := s.call(ctx, http.MethodPost, "/update", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusAccepted {
+		var e struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(raw, &e)
+		if e.Error == "" {
+			e.Error = fmt.Sprintf("updater answered %d", resp.StatusCode)
+		}
+		return nil, errors.New(e.Error)
+	}
+	var job updater.Job
+	if err := json.Unmarshal(raw, &job); err != nil {
+		return nil, fmt.Errorf("decode updater answer: %w", err)
+	}
+	return &job, nil
+}
+
+// internals
+
+func (s *Service) checkGitHub(ctx context.Context) {
+	cctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	rels, err := releases.FetchReleases(cctx, s.http, s.cfg.GithubRepo, s.cfg.GithubToken)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.checkedAt = time.Now()
+	if err != nil {
+		s.checkErr = err.Error()
+		log.Printf("updates: release check failed: %v", err)
+		return
+	}
+	s.checkErr = ""
+	stable, dev := releases.PickChannelHeads(rels)
+	head := stable
+	if s.cfg.Channel == "dev" && dev != nil {
+		head = dev
+	}
+	if head == nil {
+		s.latest = nil
+		return
+	}
+	s.latest = &Latest{
+		Tag: head.TagName, Name: head.Name, HTMLURL: head.HTMLURL,
+		PublishedAt: head.PublishedAt, Channel: s.cfg.Channel,
+	}
+}
+
+func (s *Service) compose(view UpdaterView, dropLogs bool) State {
+	s.mu.Lock()
+	st := State{
+		Running:    version.Current(),
+		Latest:     s.latest,
+		CheckedAt:  s.checkedAt,
+		CheckError: s.checkErr,
+		Enabled:    s.cfg.Enabled,
+		Interval:   s.cfg.Interval.String(),
+		Channel:    s.cfg.Channel,
+		Repo:       s.cfg.GithubRepo,
+		Updater:    view,
+	}
+	s.mu.Unlock()
+
+	if st.Latest != nil {
+		if isNewer, ok := newer(st.Latest.Tag, st.Running.Version); ok && isNewer {
+			st.UpdateAvailable = true
+			st.Reason = "release"
+		}
+	}
+	if !st.UpdateAvailable && view.Checkout != nil && !view.Checkout.Detached && view.Checkout.Behind > 0 {
+		st.UpdateAvailable = true
+		st.Reason = "commits"
+	}
+	if dropLogs {
+		if st.Updater.Job != nil {
+			st.Updater.Job = withoutLog(st.Updater.Job)
+		}
+		if st.Updater.LastJob != nil {
+			st.Updater.LastJob = withoutLog(st.Updater.LastJob)
+		}
+	}
+	return st
+}
+
+func withoutLog(j *updater.Job) *updater.Job {
+	c := *j
+	c.Log = nil
+	return &c
+}
+
+func (s *Service) updaterStatus(ctx context.Context, method, path string) UpdaterView {
+	if s.cfg.UpdaterURL == "" {
+		return UpdaterView{Status: "off"}
+	}
+	view := UpdaterView{Configured: true}
+	cctx, cancel := context.WithTimeout(ctx, 8*time.Second)
+	defer cancel()
+	resp, err := s.call(cctx, method, path, nil)
+	if err != nil {
+		view.Status = "unreachable"
+		view.Error = describeDialError(err)
+		return view
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		view.Status = "unreachable"
+		view.Error = fmt.Sprintf("updater answered %d; check UPDATER_TOKEN matches on both sides", resp.StatusCode)
+		return view
+	}
+	var st updater.Status
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 4<<20)).Decode(&st); err != nil {
+		view.Status = "unreachable"
+		view.Error = "could not decode the updater's answer"
+		return view
+	}
+	view.Status = "ok"
+	view.Mode = st.Mode
+	view.RepoDir = st.RepoDir
+	view.Checkout = st.Checkout
+	view.Job = st.Job
+	view.LastJob = st.LastJob
+	return view
+}
+
+func (s *Service) call(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, s.cfg.UpdaterURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.UpdaterToken)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	return s.http.Do(req)
+}
+
+// describeDialError turns the usual "not running" failures into the sentence
+// the panel shows, instead of a raw dial string.
+func describeDialError(err error) string {
+	var dns *net.DNSError
+	if errors.As(err, &dns) {
+		return "the updater host does not resolve; it is not running (enable the updater compose profile) or UPDATER_URL is wrong"
+	}
+	if strings.Contains(err.Error(), "connection refused") {
+		return "the updater is not accepting connections; it is not running or UPDATER_URL points at the wrong port"
+	}
+	return err.Error()
+}

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -65,6 +65,8 @@ const (
 	AuditEntityAWSCredentials AuditEntityType = "aws_credentials"
 	AuditEntityWorkerProfile  AuditEntityType = "worker_profile"
 	AuditEntityRelease        AuditEntityType = "release"
+	// AuditEntityInstance is the deployment itself: settings and updates.
+	AuditEntityInstance AuditEntityType = "instance"
 
 	// Org-scoped configuration & governance entities
 	AuditEntityOrganizationMember AuditEntityType = "organization_member"

--- a/internal/updater/api.go
+++ b/internal/updater/api.go
@@ -1,0 +1,73 @@
+// Package updater is the host-side agent that applies an update to a
+// self-hosted Warmbly: pull the checkout, rebuild, restart, and wait for the
+// backend to answer again. It runs next to the stack (a compose sidecar that
+// holds the docker socket, or a systemd unit on a bare-metal host) and the
+// backend drives it over a token-authenticated HTTP API that is never exposed
+// publicly. This file is the wire contract both sides compile against.
+package updater
+
+import "time"
+
+// Mode selects how the runner rebuilds and restarts after the checkout moved.
+type Mode string
+
+const (
+	// ModeCompose rebuilds the images and recreates the containers of the
+	// compose project the checkout belongs to.
+	ModeCompose Mode = "compose"
+	// ModeCommand runs an operator-provided command (a build-and-restart
+	// script) and leaves the rest to it.
+	ModeCommand Mode = "command"
+)
+
+// JobStatus is the lifecycle of one update run.
+type JobStatus string
+
+const (
+	JobRunning   JobStatus = "running"
+	JobSucceeded JobStatus = "succeeded"
+	JobFailed    JobStatus = "failed"
+)
+
+// Checkout describes the git checkout the updater manages.
+type Checkout struct {
+	Branch       string    `json:"branch"`
+	Detached     bool      `json:"detached"`
+	Commit       string    `json:"commit"`
+	Describe     string    `json:"describe"`
+	RemoteCommit string    `json:"remote_commit"`
+	Behind       int       `json:"behind"`
+	Dirty        bool      `json:"dirty"`
+	FetchedAt    time.Time `json:"fetched_at"`
+	FetchError   string    `json:"fetch_error,omitempty"`
+}
+
+// Job is one update run, with the tail of its log.
+type Job struct {
+	ID         string     `json:"id"`
+	Status     JobStatus  `json:"status"`
+	Target     string     `json:"target"`
+	Step       string     `json:"step"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	Error      string     `json:"error,omitempty"`
+	FromCommit string     `json:"from_commit"`
+	ToCommit   string     `json:"to_commit,omitempty"`
+	Log        []string   `json:"log"`
+}
+
+// Status is the updater's answer to GET /status.
+type Status struct {
+	Mode     Mode      `json:"mode"`
+	RepoDir  string    `json:"repo_dir"`
+	Version  string    `json:"version"`
+	Checkout *Checkout `json:"checkout,omitempty"`
+	Job      *Job      `json:"job,omitempty"`
+	LastJob  *Job      `json:"last_job,omitempty"`
+}
+
+// UpdateRequest is the body of POST /update. An empty Tag means: pull the
+// tracked branch when the checkout is on one, otherwise refuse.
+type UpdateRequest struct {
+	Tag string `json:"tag"`
+}

--- a/internal/updater/compose.go
+++ b/internal/updater/compose.go
@@ -1,0 +1,126 @@
+package updater
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// selfService is the compose service the updater itself runs as.
+const selfService = "updater"
+
+// composeArgs prefixes every compose invocation with the project and the
+// profiles, so the sidecar addresses the same stack the operator started.
+func (r *Runner) composeArgs(args ...string) []string {
+	out := []string{"compose", "-p", r.cfg.ComposeProject}
+	for _, p := range strings.Split(r.cfg.ComposeProfiles, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, "--profile", p)
+		}
+	}
+	return append(out, args...)
+}
+
+func (r *Runner) composeOutput(ctx context.Context, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "docker", r.composeArgs(args...)...)
+	cmd.Dir = r.cfg.RepoDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("docker compose %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// composeUpdate rebuilds every image and recreates the containers whose image
+// or configuration changed. Postgres, Redis and NATS keep running: compose
+// leaves a container alone when nothing about it changed.
+func (r *Runner) composeUpdate(ctx context.Context, job *Job) error {
+	r.step(job, "build")
+	describe := r.git.describe(ctx)
+	env := []string{
+		"WARMBLY_BUILD_VERSION=" + describe,
+		"WARMBLY_BUILD_COMMIT=" + job.ToCommit,
+		"DOCKER_CLI_HINTS=false",
+	}
+	r.logf(job, "building images (%s)", describe)
+	if err := r.exec(ctx, job, r.cfg.RepoDir, env, "docker", r.composeArgs("build")...); err != nil {
+		return err
+	}
+
+	r.step(job, "restart")
+	services, err := r.servicesToRecreate(ctx)
+	if err != nil {
+		return err
+	}
+	r.logf(job, "recreating %s", strings.Join(services, ", "))
+	args := append(r.composeArgs("up", "-d", "--no-build"), services...)
+	if err := r.exec(ctx, job, r.cfg.RepoDir, env, "docker", args...); err != nil {
+		return err
+	}
+
+	if r.cfg.Prune {
+		r.step(job, "prune")
+		if err := r.exec(ctx, job, r.cfg.RepoDir, nil, "docker", "image", "prune", "-f"); err != nil {
+			r.logf(job, "image prune failed (ignored): %v", err)
+		}
+	}
+	return nil
+}
+
+// servicesToRecreate is every service the checkout's profiles define plus
+// everything currently running, minus the updater itself. The union covers a
+// service the new version added and one the operator started by hand.
+func (r *Runner) servicesToRecreate(ctx context.Context) ([]string, error) {
+	defined, err := r.composeOutput(ctx, "config", "--services")
+	if err != nil {
+		return nil, err
+	}
+	running, _ := r.composeOutput(ctx, "ps", "--services", "--status", "running")
+	set := map[string]bool{}
+	for _, chunk := range []string{defined, running} {
+		for _, s := range strings.Split(chunk, "\n") {
+			if s = strings.TrimSpace(s); s != "" && s != selfService {
+				set[s] = true
+			}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no compose services found in %s", r.cfg.RepoDir)
+	}
+	return out, nil
+}
+
+// recreateSelf moves the updater onto the image it just built. It cannot run
+// `compose up updater` in-process (that stops this container half way), so a
+// detached one-off container from the new image does it a few seconds later.
+func (r *Runner) recreateSelf(ctx context.Context, job *Job) {
+	running, err := r.composeOutput(ctx, "ps", "-q", selfService)
+	if err != nil || running == "" {
+		return
+	}
+	currentImage, err := exec.CommandContext(ctx, "docker", "inspect", "-f", "{{.Image}}", running).Output()
+	if err != nil {
+		return
+	}
+	builtImage, err := exec.CommandContext(ctx, "docker", "image", "inspect", "-f", "{{.Id}}",
+		r.cfg.ComposeProject+"-"+selfService).Output()
+	if err != nil || strings.TrimSpace(string(currentImage)) == strings.TrimSpace(string(builtImage)) {
+		return
+	}
+	r.logf(job, "updater image changed; recreating the updater itself")
+	inner := fmt.Sprintf("sleep 3; docker %s", strings.Join(r.composeArgs("up", "-d", "--no-build", "--no-deps", selfService), " "))
+	args := r.composeArgs("run", "-d", "--rm", "--no-deps", "--entrypoint", "sh", selfService, "-c", inner)
+	cmd := exec.Command("docker", args...)
+	cmd.Dir = r.cfg.RepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		r.logf(job, "could not schedule the updater's own recreate (ignored): %s", strings.TrimSpace(string(out)))
+	}
+	r.saveState()
+}

--- a/internal/updater/git.go
+++ b/internal/updater/git.go
@@ -1,0 +1,130 @@
+package updater
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gitTimeout bounds one git invocation so a hung remote cannot pin a job.
+const gitTimeout = 3 * time.Minute
+
+type git struct {
+	dir    string
+	remote string
+}
+
+// run executes git in the checkout. safe.directory covers the compose case,
+// where the sidecar runs as root against a checkout the operator owns.
+func (g git) run(ctx context.Context, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, gitTimeout)
+	defer cancel()
+	full := append([]string{"-c", "safe.directory=*", "-C", g.dir}, args...)
+	cmd := exec.CommandContext(ctx, "git", full...)
+	var out, stderr bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return "", fmt.Errorf("git %s: %s", args[0], msg)
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func (g git) head(ctx context.Context) (string, error) {
+	return g.run(ctx, "rev-parse", "HEAD")
+}
+
+// branch returns the current branch, or "" when HEAD is detached.
+func (g git) branch(ctx context.Context) (string, error) {
+	out, err := g.run(ctx, "rev-parse", "--abbrev-ref", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	if out == "HEAD" {
+		return "", nil
+	}
+	return out, nil
+}
+
+func (g git) describe(ctx context.Context) string {
+	out, err := g.run(ctx, "describe", "--tags", "--always", "--dirty")
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+func (g git) dirty(ctx context.Context) (bool, error) {
+	out, err := g.run(ctx, "status", "--porcelain", "--untracked-files=no")
+	if err != nil {
+		return false, err
+	}
+	return out != "", nil
+}
+
+func (g git) fetch(ctx context.Context) error {
+	_, err := g.run(ctx, "fetch", "--tags", "--prune", g.remote)
+	return err
+}
+
+func (g git) remoteHead(ctx context.Context, branch string) (string, error) {
+	return g.run(ctx, "rev-parse", g.remote+"/"+branch)
+}
+
+// behind counts commits on the remote branch that HEAD does not have.
+func (g git) behind(ctx context.Context, branch string) (int, error) {
+	out, err := g.run(ctx, "rev-list", "--count", "HEAD.."+g.remote+"/"+branch)
+	if err != nil {
+		return 0, err
+	}
+	return strconv.Atoi(out)
+}
+
+func (g git) pull(ctx context.Context, branch string) error {
+	_, err := g.run(ctx, "merge", "--ff-only", g.remote+"/"+branch)
+	return err
+}
+
+func (g git) checkoutTag(ctx context.Context, tag string) error {
+	_, err := g.run(ctx, "checkout", "--detach", "refs/tags/"+tag)
+	return err
+}
+
+func (g git) tagExists(ctx context.Context, tag string) bool {
+	_, err := g.run(ctx, "rev-parse", "--verify", "-q", "refs/tags/"+tag)
+	return err == nil
+}
+
+// inspect reads the checkout state without touching the network. fetch runs
+// separately so a slow remote never delays a status answer.
+func (g git) inspect(ctx context.Context) (*Checkout, error) {
+	head, err := g.head(ctx)
+	if err != nil {
+		return nil, err
+	}
+	branch, err := g.branch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c := &Checkout{Commit: head, Branch: branch, Detached: branch == "", Describe: g.describe(ctx)}
+	if dirty, err := g.dirty(ctx); err == nil {
+		c.Dirty = dirty
+	}
+	if branch != "" {
+		if remote, err := g.remoteHead(ctx, branch); err == nil {
+			c.RemoteCommit = remote
+		}
+		if n, err := g.behind(ctx, branch); err == nil {
+			c.Behind = n
+		}
+	}
+	return c, nil
+}

--- a/internal/updater/owner_other.go
+++ b/internal/updater/owner_other.go
@@ -1,0 +1,5 @@
+//go:build !unix
+
+package updater
+
+func ownerOf(string) (uid, gid int, ok bool) { return 0, 0, false }

--- a/internal/updater/owner_unix.go
+++ b/internal/updater/owner_unix.go
@@ -1,0 +1,21 @@
+//go:build unix
+
+package updater
+
+import (
+	"os"
+	"syscall"
+)
+
+// ownerOf returns the uid and gid owning path.
+func ownerOf(path string) (uid, gid int, ok bool) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, false
+	}
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return int(st.Uid), int(st.Gid), true
+}

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -1,0 +1,474 @@
+package updater
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Config is everything the runner reads from the environment.
+type Config struct {
+	Mode    Mode
+	RepoDir string
+	Remote  string
+	// Command runs in ModeCommand after the checkout moved. It is passed to
+	// sh -c and has to build and restart everything itself.
+	Command string
+	// ComposeProject is the -p the stack was started with (the Makefile pins
+	// "warmbly"), ComposeProfiles the extra profiles to activate on top of the
+	// checkout's .env so the updater's own image is rebuilt too.
+	ComposeProject  string
+	ComposeProfiles string
+	// BackendHealthURL is polled after the restart until it answers 200.
+	BackendHealthURL string
+	StateDir         string
+	FetchInterval    time.Duration
+	Prune            bool
+	AllowDirty       bool
+	Version          string
+}
+
+// maxLogLines caps a job's retained log so the status answer stays small.
+const maxLogLines = 1500
+
+// healthWait bounds how long the restart step waits for the backend.
+const healthWait = 6 * time.Minute
+
+// Runner owns the checkout, the one job at a time, and the persisted history.
+type Runner struct {
+	cfg Config
+	git git
+
+	mu       sync.Mutex
+	checkout *Checkout
+	job      *Job
+	lastJob  *Job
+	cancel   context.CancelFunc
+}
+
+// ErrJobRunning is returned when an update is asked for while one runs.
+var ErrJobRunning = errors.New("an update is already running")
+
+func NewRunner(cfg Config) (*Runner, error) {
+	if cfg.RepoDir == "" {
+		return nil, errors.New("UPDATER_REPO_DIR is required")
+	}
+	if _, err := os.Stat(filepath.Join(cfg.RepoDir, ".git")); err != nil {
+		return nil, fmt.Errorf("%s is not a git checkout: %w", cfg.RepoDir, err)
+	}
+	if cfg.Mode == ModeCommand && strings.TrimSpace(cfg.Command) == "" {
+		return nil, errors.New("UPDATER_MODE=command needs UPDATER_COMMAND")
+	}
+	if cfg.Remote == "" {
+		cfg.Remote = "origin"
+	}
+	if cfg.ComposeProject == "" {
+		cfg.ComposeProject = "warmbly"
+	}
+	if cfg.FetchInterval <= 0 {
+		cfg.FetchInterval = 30 * time.Minute
+	}
+	r := &Runner{cfg: cfg, git: git{dir: cfg.RepoDir, remote: cfg.Remote}}
+	r.loadState()
+	return r, nil
+}
+
+// Start refreshes the checkout state now and then on the fetch interval.
+func (r *Runner) Start(ctx context.Context) {
+	go func() {
+		r.Refresh(ctx)
+		t := time.NewTicker(r.cfg.FetchInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				r.Refresh(ctx)
+			}
+		}
+	}()
+}
+
+// Refresh fetches the remote and re-reads the checkout.
+func (r *Runner) Refresh(ctx context.Context) *Checkout {
+	fetchErr := r.git.fetch(ctx)
+	c, err := r.git.inspect(ctx)
+	if err != nil {
+		log.Printf("updater: inspect checkout: %v", err)
+		c = &Checkout{}
+	}
+	c.FetchedAt = time.Now()
+	if fetchErr != nil {
+		c.FetchError = fetchErr.Error()
+	}
+	r.mu.Lock()
+	r.checkout = c
+	r.mu.Unlock()
+	return c
+}
+
+// Status is the current snapshot. The checkout is re-read without a fetch so
+// a job that just moved HEAD is reflected immediately.
+func (r *Runner) Status(ctx context.Context) Status {
+	r.mu.Lock()
+	prev := r.checkout
+	job := cloneJob(r.job)
+	last := cloneJob(r.lastJob)
+	r.mu.Unlock()
+
+	c, err := r.git.inspect(ctx)
+	if err == nil && prev != nil {
+		c.FetchedAt = prev.FetchedAt
+		c.FetchError = prev.FetchError
+	} else if err != nil {
+		c = prev
+	}
+	return Status{
+		Mode:     r.cfg.Mode,
+		RepoDir:  r.cfg.RepoDir,
+		Version:  r.cfg.Version,
+		Checkout: c,
+		Job:      job,
+		LastJob:  last,
+	}
+}
+
+// StartUpdate begins a job and returns immediately. Progress is read from
+// Status; the log is appended as the steps run.
+func (r *Runner) StartUpdate(req UpdateRequest) (*Job, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.job != nil && r.job.Status == JobRunning {
+		return nil, ErrJobRunning
+	}
+	target := strings.TrimSpace(req.Tag)
+	if target == "" {
+		target = "branch"
+	}
+	job := &Job{
+		ID:        uuid.NewString(),
+		Status:    JobRunning,
+		Target:    target,
+		Step:      "starting",
+		StartedAt: time.Now(),
+	}
+	r.job = job
+	ctx, cancel := context.WithCancel(context.Background())
+	r.cancel = cancel
+	go r.execute(ctx, job, req)
+	return cloneJob(job), nil
+}
+
+// Stop aborts a running job, used on process shutdown.
+func (r *Runner) Stop() {
+	r.mu.Lock()
+	cancel := r.cancel
+	r.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+}
+
+func (r *Runner) execute(ctx context.Context, job *Job, req UpdateRequest) {
+	err := r.runSteps(ctx, job, req)
+	r.mu.Lock()
+	now := time.Now()
+	job.FinishedAt = &now
+	if err != nil {
+		job.Status = JobFailed
+		job.Error = err.Error()
+		r.logf(job, "update failed: %v", err)
+	} else {
+		job.Status = JobSucceeded
+		r.logf(job, "update finished")
+	}
+	r.lastJob = job
+	r.job = nil
+	r.cancel = nil
+	r.mu.Unlock()
+	r.saveState()
+
+	if err == nil && r.cfg.Mode == ModeCompose {
+		// Last, because it may replace this very process: the outcome above is
+		// already on disk for the successor to report.
+		r.recreateSelf(ctx, job)
+	}
+}
+
+func (r *Runner) runSteps(ctx context.Context, job *Job, req UpdateRequest) error {
+	from, err := r.git.head(ctx)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	job.FromCommit = from
+	r.mu.Unlock()
+
+	r.step(job, "fetch")
+	r.logf(job, "fetching %s", r.cfg.Remote)
+	if err := r.git.fetch(ctx); err != nil {
+		return err
+	}
+
+	r.step(job, "checkout")
+	if dirty, err := r.git.dirty(ctx); err == nil && dirty && !r.cfg.AllowDirty {
+		return errors.New("the checkout has local modifications; commit or stash them, or set UPDATER_ALLOW_DIRTY=true")
+	}
+	tag := strings.TrimSpace(req.Tag)
+	switch {
+	case tag != "":
+		if !r.git.tagExists(ctx, tag) {
+			return fmt.Errorf("tag %s does not exist on %s", tag, r.cfg.Remote)
+		}
+		r.logf(job, "checking out %s", tag)
+		if err := r.git.checkoutTag(ctx, tag); err != nil {
+			return err
+		}
+	default:
+		branch, err := r.git.branch(ctx)
+		if err != nil {
+			return err
+		}
+		if branch == "" {
+			return errors.New("the checkout is detached (pinned to a tag); choose a release to move to")
+		}
+		r.logf(job, "fast-forwarding %s to %s/%s", branch, r.cfg.Remote, branch)
+		if err := r.git.pull(ctx, branch); err != nil {
+			return err
+		}
+	}
+	to, err := r.git.head(ctx)
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	job.ToCommit = to
+	r.mu.Unlock()
+	if to == from {
+		r.logf(job, "already at %s; rebuilding anyway", short(to))
+	} else {
+		r.logf(job, "moved %s -> %s", short(from), short(to))
+	}
+	r.restoreOwnership(ctx, job)
+
+	switch r.cfg.Mode {
+	case ModeCommand:
+		r.step(job, "command")
+		r.logf(job, "running UPDATER_COMMAND")
+		if err := r.exec(ctx, job, r.cfg.RepoDir, nil, "sh", "-c", r.cfg.Command); err != nil {
+			return err
+		}
+	default:
+		if err := r.composeUpdate(ctx, job); err != nil {
+			return err
+		}
+	}
+
+	if r.cfg.BackendHealthURL != "" {
+		r.step(job, "wait")
+		r.logf(job, "waiting for the backend at %s", r.cfg.BackendHealthURL)
+		if err := waitHealthy(ctx, r.cfg.BackendHealthURL, healthWait); err != nil {
+			return err
+		}
+		r.logf(job, "backend is answering")
+	}
+	return nil
+}
+
+// restoreOwnership gives files git wrote as root back to the checkout's owner,
+// so the operator's own git pull keeps working after the sidecar moved HEAD.
+func (r *Runner) restoreOwnership(ctx context.Context, job *Job) {
+	if os.Geteuid() != 0 {
+		return
+	}
+	uid, gid, ok := ownerOf(r.cfg.RepoDir)
+	if !ok || uid == 0 {
+		return
+	}
+	spec := fmt.Sprintf("%d:%d", uid, gid)
+	if err := r.exec(ctx, job, r.cfg.RepoDir, nil, "chown", "-R", spec, filepath.Join(r.cfg.RepoDir, ".git")); err != nil {
+		r.logf(job, "could not restore ownership of .git: %v", err)
+	}
+	// Only files git touched need it; a full recursive chown over node_modules
+	// would take longer than the build.
+	out, err := r.git.run(ctx, "diff", "--name-only", job.FromCommit, "HEAD")
+	if err != nil || out == "" {
+		return
+	}
+	args := []string{spec}
+	for _, f := range strings.Split(out, "\n") {
+		if f = strings.TrimSpace(f); f != "" {
+			args = append(args, filepath.Join(r.cfg.RepoDir, f))
+		}
+	}
+	_ = exec.CommandContext(ctx, "chown", args...).Run()
+}
+
+// exec runs a command with its output streamed into the job log.
+func (r *Runner) exec(ctx context.Context, job *Job, dir string, env []string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), env...)
+	pr, pw := io.Pipe()
+	cmd.Stdout = pw
+	cmd.Stderr = pw
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		sc := bufio.NewScanner(pr)
+		sc.Buffer(make([]byte, 64*1024), 1024*1024)
+		for sc.Scan() {
+			line := strings.TrimRight(sc.Text(), "\r")
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			r.logf(job, "%s", line)
+		}
+	}()
+	err := cmd.Run()
+	_ = pw.Close()
+	<-done
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func (r *Runner) step(job *Job, name string) {
+	r.mu.Lock()
+	job.Step = name
+	r.mu.Unlock()
+	r.saveState()
+}
+
+func (r *Runner) logf(job *Job, format string, args ...any) {
+	line := time.Now().UTC().Format("15:04:05") + " " + fmt.Sprintf(format, args...)
+	r.mu.Lock()
+	job.Log = append(job.Log, line)
+	if len(job.Log) > maxLogLines {
+		job.Log = job.Log[len(job.Log)-maxLogLines:]
+	}
+	r.mu.Unlock()
+	log.Printf("updater: %s", line)
+}
+
+// persisted state
+
+type stateFile struct {
+	LastJob *Job `json:"last_job,omitempty"`
+}
+
+func (r *Runner) statePath() string {
+	if r.cfg.StateDir == "" {
+		return ""
+	}
+	return filepath.Join(r.cfg.StateDir, "state.json")
+}
+
+func (r *Runner) loadState() {
+	p := r.statePath()
+	if p == "" {
+		return
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return
+	}
+	var st stateFile
+	if err := json.Unmarshal(b, &st); err != nil {
+		return
+	}
+	if st.LastJob != nil && st.LastJob.Status == JobRunning {
+		// The process died mid-job (most likely it recreated itself after a
+		// successful compose run, or the host rebooted). Say so rather than
+		// showing a job that runs forever.
+		now := time.Now()
+		st.LastJob.Status = JobFailed
+		st.LastJob.FinishedAt = &now
+		st.LastJob.Error = "the updater restarted before the job finished"
+	}
+	r.lastJob = st.LastJob
+}
+
+func (r *Runner) saveState() {
+	p := r.statePath()
+	if p == "" {
+		return
+	}
+	r.mu.Lock()
+	st := stateFile{LastJob: cloneJob(r.lastJob)}
+	if r.job != nil {
+		st.LastJob = cloneJob(r.job)
+	}
+	r.mu.Unlock()
+	b, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		return
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o640); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, p)
+}
+
+// helpers
+
+func cloneJob(j *Job) *Job {
+	if j == nil {
+		return nil
+	}
+	c := *j
+	c.Log = append([]string(nil), j.Log...)
+	return &c
+}
+
+func short(sha string) string {
+	if len(sha) > 12 {
+		return sha[:12]
+	}
+	return sha
+}
+
+func waitHealthy(ctx context.Context, url string, max time.Duration) error {
+	deadline := time.Now().Add(max)
+	client := &http.Client{Timeout: 3 * time.Second}
+	for {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("the backend did not answer at %s within %s; check its logs", url, max)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(3 * time.Second):
+		}
+	}
+}

--- a/internal/updater/runner.go
+++ b/internal/updater/runner.go
@@ -191,10 +191,10 @@ func (r *Runner) execute(ctx context.Context, job *Job, req UpdateRequest) {
 	if err != nil {
 		job.Status = JobFailed
 		job.Error = err.Error()
-		r.logf(job, "update failed: %v", err)
+		r.appendLocked(job, fmt.Sprintf("update failed: %v", err))
 	} else {
 		job.Status = JobSucceeded
-		r.logf(job, "update finished")
+		r.appendLocked(job, "update finished")
 	}
 	r.lastJob = job
 	r.job = nil
@@ -356,13 +356,19 @@ func (r *Runner) step(job *Job, name string) {
 }
 
 func (r *Runner) logf(job *Job, format string, args ...any) {
-	line := time.Now().UTC().Format("15:04:05") + " " + fmt.Sprintf(format, args...)
 	r.mu.Lock()
+	r.appendLocked(job, fmt.Sprintf(format, args...))
+	r.mu.Unlock()
+}
+
+// appendLocked records one log line. The caller holds r.mu; the mutex is not
+// reentrant, so the completion path in execute must use this, never logf.
+func (r *Runner) appendLocked(job *Job, msg string) {
+	line := time.Now().UTC().Format("15:04:05") + " " + msg
 	job.Log = append(job.Log, line)
 	if len(job.Log) > maxLogLines {
 		job.Log = job.Log[len(job.Log)-maxLogLines:]
 	}
-	r.mu.Unlock()
 	log.Printf("updater: %s", line)
 }
 

--- a/internal/updater/server.go
+++ b/internal/updater/server.go
@@ -1,0 +1,88 @@
+package updater
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Server is the HTTP face of the runner. Every route except /health needs
+// the bearer token; the backend is the only intended caller.
+type Server struct {
+	runner *Runner
+	token  string
+}
+
+func NewServer(runner *Runner, token string) (*Server, error) {
+	if strings.TrimSpace(token) == "" {
+		return nil, errors.New("UPDATER_TOKEN is required")
+	}
+	return &Server{runner: runner, token: token}, nil
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("GET /status", s.auth(s.status))
+	mux.HandleFunc("POST /check", s.auth(s.check))
+	mux.HandleFunc("POST /update", s.auth(s.update))
+	return mux
+}
+
+func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		got := strings.TrimSpace(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer"))
+		if subtle.ConstantTimeCompare([]byte(got), []byte(s.token)) != 1 {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *Server) status(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, s.runner.Status(r.Context()))
+}
+
+func (s *Server) check(w http.ResponseWriter, r *http.Request) {
+	s.runner.Refresh(r.Context())
+	writeJSON(w, http.StatusOK, s.runner.Status(r.Context()))
+}
+
+func (s *Server) update(w http.ResponseWriter, r *http.Request) {
+	var req UpdateRequest
+	raw, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 4096))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+		return
+	}
+	// A bare POST means "the tracked branch"; only a non-empty body is decoded.
+	if len(bytes.TrimSpace(raw)) > 0 {
+		if err := json.Unmarshal(raw, &req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid body"})
+			return
+		}
+	}
+	job, err := s.runner.StartUpdate(req)
+	if err != nil {
+		code := http.StatusInternalServerError
+		if errors.Is(err, ErrJobRunning) {
+			code = http.StatusConflict
+		}
+		writeJSON(w, code, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, job)
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,55 @@
+// Package version holds the build identity stamped into every Warmbly binary.
+//
+// The values are injected at link time (see deploy/docker/*.Dockerfile and the
+// Makefile), so a binary knows which release or commit it was built from
+// without reading the checkout. .git is excluded from the docker build context,
+// which is why runtime/debug's vcs data cannot be used instead.
+package version
+
+import (
+	"os"
+	"strings"
+)
+
+var (
+	// Version is the release tag (v1.4.0) or a git describe string
+	// (v1.4.0-3-gabc1234). Empty when the build did not stamp one.
+	Version = ""
+	// Commit is the full git sha the binary was built from.
+	Commit = ""
+	// BuiltAt is the RFC 3339 build time.
+	BuiltAt = ""
+)
+
+// String is the version to display: the stamped value, WARMBLY_VERSION from
+// the environment (the pre-existing override), or "dev".
+func String() string {
+	if v := strings.TrimSpace(Version); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("WARMBLY_VERSION")); v != "" {
+		return v
+	}
+	return "dev"
+}
+
+// ShortCommit is the first 12 characters of the commit, or empty.
+func ShortCommit() string {
+	c := strings.TrimSpace(Commit)
+	if len(c) > 12 {
+		return c[:12]
+	}
+	return c
+}
+
+// Info is the JSON shape every surface reports the running build as.
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit,omitempty"`
+	BuiltAt string `json:"built_at,omitempty"`
+}
+
+// Current returns the running build's identity.
+func Current() Info {
+	return Info{Version: String(), Commit: strings.TrimSpace(Commit), BuiltAt: strings.TrimSpace(BuiltAt)}
+}

--- a/scripts/upgrade-bare-metal.sh
+++ b/scripts/upgrade-bare-metal.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Rebuild and restart a Docker-free Warmbly install after the checkout moved.
+# This is what the updater runs in UPDATER_MODE=command (deploy/systemd/
+# warmbly-updater.service), and what you run by hand after `git pull`. It is
+# the "Upgrading" section of docs/content/docs/development/bare-metal.mdx as a
+# script: build every artifact that exists on this host, install it, restart
+# the backend first (migrations apply on its boot), then the rest.
+#
+#   scripts/upgrade-bare-metal.sh            # build + install + restart
+#   scripts/upgrade-bare-metal.sh --pull     # git pull --ff-only first
+#
+# Run it as the user who owns the checkout. Install and restart steps use sudo;
+# give that user this sudoers line (visudo) so the updater can run unattended:
+#
+#   deploy ALL=(root) NOPASSWD: /usr/bin/install, /bin/cp, /bin/rm, /bin/chown, /bin/chmod, /bin/systemctl, /bin/ln
+#
+set -euo pipefail
+
+SRC="${WARMBLY_SRC:-/opt/warmbly/src}"
+PREFIX="${WARMBLY_PREFIX:-/opt/warmbly}"
+SUDO="sudo"
+if [[ "$(id -u)" -eq 0 ]]; then SUDO=""; fi
+
+log() { printf '==> %s\n' "$*"; }
+
+if [[ "${1:-}" == "--pull" ]]; then
+  log "pulling"
+  git -C "$SRC" pull --ff-only
+fi
+
+cd "$SRC"
+VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || true)"
+BUILT_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+LDFLAGS="-s -w -X github.com/warmbly/warmbly/internal/version.Version=$VERSION -X github.com/warmbly/warmbly/internal/version.Commit=$COMMIT -X github.com/warmbly/warmbly/internal/version.BuiltAt=$BUILT_AT"
+
+# A service is built only if this host runs it: no Rust toolchain means no
+# tracking rebuild, and a unit that is not installed is skipped.
+has_unit() { systemctl list-unit-files "warmbly-$1.service" --no-legend 2>/dev/null | grep -q .; }
+
+log "building Go services ($VERSION)"
+export CGO_ENABLED=0
+mkdir -p out
+for cmd in backend forms consumer worker migrate warmblyctl updater; do
+  go build -ldflags="$LDFLAGS" -o "out/$cmd" "./cmd/$cmd"
+done
+
+if has_unit tracking && command -v cargo >/dev/null 2>&1; then
+  log "building tracking"
+  (cd tracking && cargo build --release)
+fi
+
+if has_unit realtime && command -v mix >/dev/null 2>&1; then
+  log "building realtime"
+  (cd realtime && MIX_ENV=prod mix deps.get --only prod && MIX_ENV=prod mix compile && MIX_ENV=prod mix release --overwrite)
+fi
+
+if command -v pnpm >/dev/null 2>&1; then
+  for app in web admin forms; do
+    if [[ -d "$PREFIX/$app" ]]; then
+      log "building $app"
+      (cd "$app" && pnpm install --frozen-lockfile && pnpm build)
+    fi
+  done
+fi
+
+log "installing binaries"
+$SUDO install -m 0755 out/backend out/forms out/consumer out/worker out/migrate out/warmblyctl out/updater "$PREFIX/bin/"
+$SUDO ln -sf "$PREFIX/bin/warmblyctl" /usr/local/bin/warmblyctl
+if [[ -f tracking/target/release/tracking ]] && has_unit tracking; then
+  $SUDO install -m 0755 tracking/target/release/tracking "$PREFIX/bin/tracking"
+fi
+if [[ -d realtime/_build/prod/rel/realtime ]] && has_unit realtime; then
+  $SUDO rm -rf "$PREFIX/realtime"
+  $SUDO cp -r realtime/_build/prod/rel/realtime "$PREFIX/realtime"
+  $SUDO chown -R warmbly:warmbly "$PREFIX/realtime"
+fi
+
+# Frontends: the runtime config.js is written by hand on a bare-metal install
+# and a rebuilt dist/ would drop it, so keep it across the copy.
+for app in web admin; do
+  if [[ -d "$app/dist" && -d "$PREFIX/$app" ]]; then
+    log "installing $app"
+    cfg="$(mktemp)"
+    [[ -f "$PREFIX/$app/config.js" ]] && cp "$PREFIX/$app/config.js" "$cfg"
+    $SUDO rm -rf "$PREFIX/$app"
+    $SUDO cp -r "$app/dist" "$PREFIX/$app"
+    [[ -s "$cfg" ]] && $SUDO cp "$cfg" "$PREFIX/$app/config.js"
+    rm -f "$cfg"
+    $SUDO chmod -R a+rX "$PREFIX/$app"
+  fi
+done
+if [[ -d forms/dist && -d "$PREFIX/forms" ]]; then
+  log "installing forms"
+  $SUDO rm -rf "$PREFIX/forms/dist"
+  $SUDO cp -r forms/dist "$PREFIX/forms/dist"
+fi
+
+log "restarting backend"
+$SUDO systemctl restart warmbly-backend
+for i in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:8080/health >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+
+rest=()
+for svc in forms consumer tracking realtime worker; do
+  has_unit "$svc" && rest+=("warmbly-$svc")
+done
+if [[ ${#rest[@]} -gt 0 ]]; then
+  log "restarting ${rest[*]}"
+  $SUDO systemctl restart "${rest[@]}"
+fi
+
+log "done: $VERSION"

--- a/scripts/upgrade-bare-metal.sh
+++ b/scripts/upgrade-bare-metal.sh
@@ -1,26 +1,22 @@
 #!/usr/bin/env bash
 #
-# Rebuild and restart a Docker-free Warmbly install after the checkout moved.
-# This is what the updater runs in UPDATER_MODE=command (deploy/systemd/
-# warmbly-updater.service), and what you run by hand after `git pull`. It is
-# the "Upgrading" section of docs/content/docs/development/bare-metal.mdx as a
-# script: build every artifact that exists on this host, install it, restart
-# the backend first (migrations apply on its boot), then the rest.
+# Rebuild a Docker-free Warmbly install after the checkout moved, then hand the
+# artifacts to the privileged installer. This is what the updater runs in
+# UPDATER_MODE=command (deploy/systemd/warmbly-updater.service), and what you
+# run by hand after `git pull`. It is the "Upgrading" section of
+# docs/content/docs/development/bare-metal.mdx as a script.
 #
-#   scripts/upgrade-bare-metal.sh            # build + install + restart
+#   scripts/upgrade-bare-metal.sh            # build, then install + restart
 #   scripts/upgrade-bare-metal.sh --pull     # git pull --ff-only first
 #
-# Run it as the user who owns the checkout. Install and restart steps use sudo;
-# give that user this sudoers line (visudo) so the updater can run unattended:
-#
-#   deploy ALL=(root) NOPASSWD: /usr/bin/install, /bin/cp, /bin/rm, /bin/chown, /bin/chmod, /bin/systemctl, /bin/ln
-#
+# Run it as the user who owns the checkout. Everything here runs unprivileged;
+# the only root step is the fixed-path installer, which is the single command
+# that user may run through sudo (see deploy/systemd/warmbly-install-release.sh).
 set -euo pipefail
 
 SRC="${WARMBLY_SRC:-/opt/warmbly/src}"
 PREFIX="${WARMBLY_PREFIX:-/opt/warmbly}"
-SUDO="sudo"
-if [[ "$(id -u)" -eq 0 ]]; then SUDO=""; fi
+INSTALLER="${WARMBLY_INSTALLER:-/usr/local/sbin/warmbly-install-release}"
 
 log() { printf '==> %s\n' "$*"; }
 
@@ -28,6 +24,12 @@ if [[ "${1:-}" == "--pull" ]]; then
   log "pulling"
   git -C "$SRC" pull --ff-only
 fi
+
+[[ -x "$INSTALLER" ]] || {
+  echo "$INSTALLER is missing. Install it root-owned first:" >&2
+  echo "  sudo install -o root -g root -m 0755 $SRC/deploy/systemd/warmbly-install-release.sh $INSTALLER" >&2
+  exit 1
+}
 
 cd "$SRC"
 VERSION="$(git describe --tags --always --dirty 2>/dev/null || echo dev)"
@@ -65,52 +67,11 @@ if command -v pnpm >/dev/null 2>&1; then
   done
 fi
 
-log "installing binaries"
-$SUDO install -m 0755 out/backend out/forms out/consumer out/worker out/migrate out/warmblyctl out/updater "$PREFIX/bin/"
-$SUDO ln -sf "$PREFIX/bin/warmblyctl" /usr/local/bin/warmblyctl
-if [[ -f tracking/target/release/tracking ]] && has_unit tracking; then
-  $SUDO install -m 0755 tracking/target/release/tracking "$PREFIX/bin/tracking"
-fi
-if [[ -d realtime/_build/prod/rel/realtime ]] && has_unit realtime; then
-  $SUDO rm -rf "$PREFIX/realtime"
-  $SUDO cp -r realtime/_build/prod/rel/realtime "$PREFIX/realtime"
-  $SUDO chown -R warmbly:warmbly "$PREFIX/realtime"
-fi
-
-# Frontends: the runtime config.js is written by hand on a bare-metal install
-# and a rebuilt dist/ would drop it, so keep it across the copy.
-for app in web admin; do
-  if [[ -d "$app/dist" && -d "$PREFIX/$app" ]]; then
-    log "installing $app"
-    cfg="$(mktemp)"
-    [[ -f "$PREFIX/$app/config.js" ]] && cp "$PREFIX/$app/config.js" "$cfg"
-    $SUDO rm -rf "$PREFIX/$app"
-    $SUDO cp -r "$app/dist" "$PREFIX/$app"
-    [[ -s "$cfg" ]] && $SUDO cp "$cfg" "$PREFIX/$app/config.js"
-    rm -f "$cfg"
-    $SUDO chmod -R a+rX "$PREFIX/$app"
-  fi
-done
-if [[ -d forms/dist && -d "$PREFIX/forms" ]]; then
-  log "installing forms"
-  $SUDO rm -rf "$PREFIX/forms/dist"
-  $SUDO cp -r forms/dist "$PREFIX/forms/dist"
-fi
-
-log "restarting backend"
-$SUDO systemctl restart warmbly-backend
-for i in $(seq 1 60); do
-  if curl -fsS http://127.0.0.1:8080/health >/dev/null 2>&1; then break; fi
-  sleep 2
-done
-
-rest=()
-for svc in forms consumer tracking realtime worker; do
-  has_unit "$svc" && rest+=("warmbly-$svc")
-done
-if [[ ${#rest[@]} -gt 0 ]]; then
-  log "restarting ${rest[*]}"
-  $SUDO systemctl restart "${rest[@]}"
+log "installing and restarting (sudo $INSTALLER)"
+if [[ "$(id -u)" -eq 0 ]]; then
+  "$INSTALLER"
+else
+  sudo -n "$INSTALLER"
 fi
 
 log "done: $VERSION"

--- a/web/src/components/layout/AppHeader.tsx
+++ b/web/src/components/layout/AppHeader.tsx
@@ -24,6 +24,7 @@ import OutboxIndicator from "@/components/app/unibox/compose/OutboxIndicator";
 import { NotificationBell } from "./NotificationBell";
 import { OrgSwitcher } from "./OrgSwitcher";
 import { PlanPill } from "./PlanPill";
+import { VersionPill } from "./VersionPill";
 import { CreditsMeter } from "./CreditsMeter";
 
 // Pretty labels for path segments. Anything missing falls back to the
@@ -145,6 +146,7 @@ export function AppHeader({ onMenu }: { onMenu?: () => void }) {
             <div className="flex items-center gap-2 px-2 sm:px-4 shrink-0">
                 <div className="hidden sm:flex items-center gap-2">
                     <PlanPill />
+                    <VersionPill />
                     <CreditsMeter />
                     <div className="h-4 w-px bg-slate-200/80" />
                 </div>

--- a/web/src/components/layout/UpdateDialog.tsx
+++ b/web/src/components/layout/UpdateDialog.tsx
@@ -892,8 +892,8 @@ function PrimaryButton({
     );
 }
 
-function relative(iso: string): string {
-    const diff = Date.now() - new Date(iso).getTime();
+function relative(at: Date | string): string {
+    const diff = Date.now() - new Date(at).getTime();
     const min = Math.round(diff / 60_000);
     if (min < 1) return "just now";
     if (min < 60) return `${min} min ago`;
@@ -901,5 +901,5 @@ function relative(iso: string): string {
     if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
     const d = Math.round(h / 24);
     if (d < 30) return `${d} day${d === 1 ? "" : "s"} ago`;
-    return new Date(iso).toLocaleDateString();
+    return new Date(at).toLocaleDateString();
 }

--- a/web/src/components/layout/UpdateDialog.tsx
+++ b/web/src/components/layout/UpdateDialog.tsx
@@ -1,0 +1,905 @@
+// The instance update dialog, for platform admins on a self-hosted install.
+//
+// Four panes with directional slides, like the campaign wizard: overview
+// (what runs, what is newest), confirm (what the update does), progress (the
+// updater's steps and log, then the backend restart), and the result. The pill
+// in the header keeps following the job when the dialog is closed, and a
+// reload picks the job back up from the backend.
+
+import React from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import toast from "react-hot-toast";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+    AlertTriangleIcon,
+    ArrowRightIcon,
+    ArrowUpCircleIcon,
+    CheckIcon,
+    ChevronDownIcon,
+    ChevronLeftIcon,
+    DatabaseIcon,
+    ExternalLinkIcon,
+    GitBranchIcon,
+    HammerIcon,
+    Loader2Icon,
+    RefreshCwIcon,
+    RotateCwIcon,
+    SendIcon,
+    ServerIcon,
+    ShieldCheckIcon,
+    XIcon,
+} from "lucide-react";
+import { applyInstanceUpdate, checkInstanceUpdate } from "@/lib/api/client/admin/updates";
+import {
+    INSTANCE_UPDATE_KEY,
+    INSTANCE_UPDATE_LOG_KEY,
+    isUpdateRunning,
+    runningLabel,
+    useInstanceUpdate,
+    useInstanceUpdateLog,
+} from "@/lib/api/hooks/auth/useInstanceUpdate";
+import type InstanceUpdate from "@/lib/api/models/auth/InstanceUpdate";
+import type { UpdateJob } from "@/lib/api/models/auth/InstanceUpdate";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import buildError from "@/lib/helper/buildError";
+import { markUpdateStarted, readUpdateStarted, clearUpdateStarted } from "@/lib/updateSession";
+import { cn } from "@/lib/utils";
+
+const DOCS_UPDATES = "https://docs.warmbly.com/development/updates/";
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+}
+
+type Pane = "overview" | "confirm" | "progress" | "done" | "failed";
+
+interface StepDef {
+    id: string;
+    label: string;
+    hint: string;
+    icon: React.ComponentType<{ className?: string }>;
+}
+
+const COMPOSE_STEPS: StepDef[] = [
+    { id: "fetch", label: "Fetch", hint: "Reading the remote repository", icon: GitBranchIcon },
+    { id: "checkout", label: "Pull", hint: "Moving the checkout to the new version", icon: ArrowUpCircleIcon },
+    { id: "build", label: "Build", hint: "Rebuilding every image, usually the longest step", icon: HammerIcon },
+    { id: "restart", label: "Restart", hint: "Recreating the services that changed", icon: RotateCwIcon },
+    { id: "prune", label: "Clean up", hint: "Removing images nothing uses any more", icon: DatabaseIcon },
+    { id: "wait", label: "Reconnect", hint: "Waiting for the backend to answer again", icon: ServerIcon },
+];
+
+const COMMAND_STEPS: StepDef[] = [
+    { id: "fetch", label: "Fetch", hint: "Reading the remote repository", icon: GitBranchIcon },
+    { id: "checkout", label: "Pull", hint: "Moving the checkout to the new version", icon: ArrowUpCircleIcon },
+    { id: "command", label: "Build and restart", hint: "Running the upgrade script", icon: HammerIcon },
+    { id: "wait", label: "Reconnect", hint: "Waiting for the backend to answer again", icon: ServerIcon },
+];
+
+export default function UpdateDialog({ open, onClose }: Props) {
+    const qc = useQueryClient();
+    const stateQ = useInstanceUpdate(open);
+    const logQ = useInstanceUpdateLog(open);
+    const state: InstanceUpdate | undefined = logQ.data ?? stateQ.data;
+    const started = readUpdateStarted();
+
+    const [pane, setPane] = React.useState<Pane>("overview");
+    const [direction, setDirection] = React.useState<1 | -1>(1);
+    const goTo = React.useCallback(
+        (next: Pane) => {
+            const order: Pane[] = ["overview", "confirm", "progress", "done", "failed"];
+            setDirection(order.indexOf(next) >= order.indexOf(pane) ? 1 : -1);
+            setPane(next);
+        },
+        [pane],
+    );
+
+    // The backend decides the pane while a job exists; the local state only
+    // drives overview <-> confirm.
+    const running = isUpdateRunning(state);
+    const backendDown = !!started && (logQ.isError || stateQ.isError);
+    const lastJob = state?.updater.last_job;
+    const finished = !!started && !running && !backendDown && lastJob && lastJob.status !== "running";
+
+    React.useEffect(() => {
+        if (!open) return;
+        if (running || backendDown) {
+            if (pane !== "progress") goTo("progress");
+        } else if (finished) {
+            const next: Pane = lastJob?.status === "succeeded" ? "done" : "failed";
+            if (pane !== next) goTo(next);
+        }
+    }, [open, running, backendDown, finished, lastJob?.status, pane, goTo]);
+
+    React.useEffect(() => {
+        if (!open) setPane("overview");
+    }, [open]);
+
+    React.useEffect(() => {
+        if (!open) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key !== "Escape") return;
+            if (document.querySelector("[data-floating], [role='alertdialog']")) return;
+            e.preventDefault();
+            onClose();
+        };
+        document.addEventListener("keydown", onKey);
+        return () => document.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    const check = useMutation({
+        mutationFn: checkInstanceUpdate,
+        onSuccess: (data) => {
+            qc.setQueryData(INSTANCE_UPDATE_KEY, data);
+            qc.setQueryData(INSTANCE_UPDATE_LOG_KEY, data);
+            toast.success(data.update_available ? "A newer version is available" : "This instance is up to date");
+        },
+        onError: (err: unknown) => toast.error(buildError(err as AppError)),
+    });
+
+    const apply = useMutation({
+        mutationFn: () => applyInstanceUpdate("latest"),
+        onSuccess: (job: UpdateJob) => {
+            markUpdateStarted(state?.running.version ?? "", state?.running.commit ?? job.from_commit);
+            goTo("progress");
+            void qc.invalidateQueries({ queryKey: INSTANCE_UPDATE_KEY });
+            void qc.invalidateQueries({ queryKey: INSTANCE_UPDATE_LOG_KEY });
+        },
+        onError: (err: unknown) => toast.error(buildError(err as AppError)),
+    });
+
+    const job = state?.updater.job ?? state?.updater.last_job;
+    const steps = state?.updater.mode === "command" ? COMMAND_STEPS : COMPOSE_STEPS;
+
+    return (
+        <AnimatePresence>
+            {open && (
+                <motion.div
+                    key="overlay"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: 0.15 }}
+                    onMouseDown={onClose}
+                    className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-900/30 backdrop-blur-[2px] px-4"
+                >
+                    <motion.div
+                        key="card"
+                        role="dialog"
+                        aria-modal="true"
+                        aria-label="Update Warmbly"
+                        initial={{ y: 8, opacity: 0, scale: 0.985 }}
+                        animate={{ y: 0, opacity: 1, scale: 1 }}
+                        exit={{ y: 8, opacity: 0, scale: 0.985 }}
+                        transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        className="w-full max-w-[560px] rounded-lg bg-white border border-slate-200 shadow-[0_24px_48px_-12px_rgba(15,23,42,0.18),0_8px_16px_-8px_rgba(15,23,42,0.1)] overflow-hidden flex flex-col max-h-[88dvh]"
+                    >
+                        <Header state={state} pane={pane} onClose={onClose} />
+
+                        <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+                            <AnimatePresence mode="wait" initial={false} custom={direction}>
+                                <motion.div
+                                    key={pane}
+                                    custom={direction}
+                                    variants={paneVariants}
+                                    initial="enter"
+                                    animate="center"
+                                    exit="exit"
+                                    transition={{ duration: 0.18, ease: [0.22, 1, 0.36, 1] }}
+                                    className="px-5 py-5"
+                                >
+                                    {pane === "overview" && (
+                                        <OverviewPane state={state} loading={stateQ.isLoading && !state} />
+                                    )}
+                                    {pane === "confirm" && <ConfirmPane state={state} />}
+                                    {pane === "progress" && (
+                                        <ProgressPane
+                                            steps={steps}
+                                            job={job}
+                                            backendDown={backendDown}
+                                        />
+                                    )}
+                                    {pane === "done" && (
+                                        <DonePane
+                                            state={state}
+                                            job={job}
+                                            onAcknowledge={() => clearUpdateStarted()}
+                                        />
+                                    )}
+                                    {pane === "failed" && <FailedPane job={job} />}
+                                </motion.div>
+                            </AnimatePresence>
+                        </div>
+
+                        <Footer
+                            pane={pane}
+                            state={state}
+                            checking={check.isPending}
+                            applying={apply.isPending}
+                            onCheck={() => check.mutate()}
+                            onContinue={() => goTo("confirm")}
+                            onBack={() => goTo("overview")}
+                            onApply={() => apply.mutate()}
+                            onRetry={() => {
+                                clearUpdateStarted();
+                                goTo("confirm");
+                            }}
+                            onClose={onClose}
+                        />
+                    </motion.div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}
+
+const paneVariants = {
+    enter: (dir: 1 | -1) => ({ x: dir * 28, opacity: 0 }),
+    center: { x: 0, opacity: 1 },
+    exit: (dir: 1 | -1) => ({ x: dir * -28, opacity: 0 }),
+};
+
+// header
+
+function Header({ state, pane, onClose }: { state?: InstanceUpdate; pane: Pane; onClose: () => void }) {
+    const latest = state?.latest?.tag;
+    const subtitle =
+        pane === "progress"
+            ? "Updating this instance"
+            : pane === "done"
+              ? "Update finished"
+              : pane === "failed"
+                ? "Update failed"
+                : state
+                  ? `Running ${runningLabel(state)}${latest ? ` · latest ${latest}` : ""}`
+                  : "Reading the running version";
+    return (
+        <div className="flex items-center gap-3 px-5 h-14 border-b border-slate-200 shrink-0">
+            <span className="size-8 rounded-md bg-sky-50 text-sky-700 flex items-center justify-center shrink-0">
+                <ArrowUpCircleIcon className="w-4 h-4" />
+            </span>
+            <div className="min-w-0 flex-1">
+                <div className="text-[13.5px] font-semibold text-slate-900 leading-tight">Update Warmbly</div>
+                <div className="text-[12px] text-slate-500 truncate">{subtitle}</div>
+            </div>
+            <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                className="size-7 rounded-md flex items-center justify-center text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+            >
+                <XIcon className="w-4 h-4" />
+            </button>
+        </div>
+    );
+}
+
+// panes
+
+function OverviewPane({ state, loading }: { state?: InstanceUpdate; loading: boolean }) {
+    if (loading || !state) {
+        return (
+            <div className="space-y-3">
+                <div className="h-20 rounded-md bg-slate-100 animate-pulse" />
+                <div className="h-4 w-2/3 rounded bg-slate-100 animate-pulse" />
+                <div className="h-4 w-1/2 rounded bg-slate-100 animate-pulse" />
+            </div>
+        );
+    }
+    const { latest, updater } = state;
+    const checkout = updater.checkout;
+    const available = state.update_available;
+
+    return (
+        <div className="space-y-4">
+            <div
+                className={cn(
+                    "rounded-md border p-4 flex items-center gap-4",
+                    available ? "border-amber-200 bg-amber-50/60" : "border-emerald-200 bg-emerald-50/50",
+                )}
+            >
+                <VersionBox label="Running" value={runningLabel(state)} muted={available} />
+                <ArrowRightIcon className={cn("w-4 h-4 shrink-0", available ? "text-amber-500" : "text-emerald-500")} />
+                <VersionBox
+                    label={available ? "Available" : "Latest"}
+                    value={latest?.tag ?? (checkout && !checkout.detached ? `${checkout.branch} head` : "unknown")}
+                    accent={available}
+                />
+                <div className="ml-auto text-right">
+                    <span
+                        className={cn(
+                            "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10.5px] font-semibold uppercase tracking-[0.1em]",
+                            available
+                                ? "border-amber-300 bg-white text-amber-700"
+                                : "border-emerald-300 bg-white text-emerald-700",
+                        )}
+                    >
+                        {available ? (
+                            <>
+                                <span className="size-1.5 rounded-full bg-amber-500 animate-pulse" />
+                                Update
+                            </>
+                        ) : (
+                            <>
+                                <CheckIcon className="w-3 h-3" />
+                                Current
+                            </>
+                        )}
+                    </span>
+                </div>
+            </div>
+
+            <dl className="text-[12.5px] divide-y divide-slate-100 border-y border-slate-100">
+                <Row label="Release">
+                    {latest ? (
+                        <span className="inline-flex flex-wrap items-center gap-2">
+                            <span className="font-medium text-slate-900">{latest.name || latest.tag}</span>
+                            {latest.published_at && (
+                                <span className="text-slate-500">published {relative(latest.published_at)}</span>
+                            )}
+                            {latest.html_url && (
+                                <a
+                                    href={latest.html_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                    className="inline-flex items-center gap-1 text-sky-700 hover:underline"
+                                >
+                                    Release notes
+                                    <ExternalLinkIcon className="w-3 h-3" />
+                                </a>
+                            )}
+                        </span>
+                    ) : state.check_error ? (
+                        <span className="text-amber-700">Could not read releases: {state.check_error}</span>
+                    ) : (
+                        <span className="text-slate-500">
+                            {state.enabled ? `No release found for ${state.repo}` : "Release check is off"}
+                        </span>
+                    )}
+                </Row>
+                {checkout && (
+                    <Row label="Checkout">
+                        <span className="inline-flex flex-wrap items-center gap-2">
+                            <span className="inline-flex items-center gap-1 font-mono text-[11.5px] text-slate-700">
+                                <GitBranchIcon className="w-3 h-3 text-slate-400" />
+                                {checkout.detached ? "pinned" : checkout.branch}@{checkout.commit.slice(0, 7)}
+                            </span>
+                            {!checkout.detached && (
+                                <span className="text-slate-500">
+                                    {checkout.behind > 0
+                                        ? `${checkout.behind} commit${checkout.behind === 1 ? "" : "s"} behind`
+                                        : "matches the remote"}
+                                </span>
+                            )}
+                            {checkout.dirty && <span className="text-amber-700">local changes present</span>}
+                        </span>
+                    </Row>
+                )}
+                <Row label="Updater">
+                    {updater.status === "ok" && (
+                        <span className="inline-flex items-center gap-1.5 text-slate-700">
+                            <span className="size-1.5 rounded-full bg-emerald-500" />
+                            ready
+                            <span className="text-slate-400">({updater.mode} mode)</span>
+                        </span>
+                    )}
+                    {updater.status === "off" && <span className="text-slate-500">not configured</span>}
+                    {updater.status === "unreachable" && (
+                        <span className="inline-flex items-center gap-1.5 text-amber-700">
+                            <span className="size-1.5 rounded-full bg-amber-500" />
+                            unreachable
+                        </span>
+                    )}
+                </Row>
+                <Row label="Checked">
+                    <span className="text-slate-500">
+                        {state.checked_at ? `${relative(state.checked_at)}, every ${state.interval}` : "not yet"}
+                    </span>
+                </Row>
+            </dl>
+
+            {updater.status !== "ok" && (
+                <Notice tone={updater.status === "unreachable" ? "warning" : "info"}>
+                    <div className="font-medium text-slate-900">
+                        {updater.status === "unreachable" ? "The updater is not answering" : "Updates run from a shell here"}
+                    </div>
+                    <div className="mt-0.5">
+                        {updater.status === "unreachable"
+                            ? updater.error
+                            : "No updater is configured on this instance, so apply updates on the host:"}
+                    </div>
+                    <code className="mt-1.5 block rounded bg-white/80 border border-slate-200 px-2 py-1 font-mono text-[11.5px] text-slate-800">
+                        git pull && make up
+                    </code>
+                    <a
+                        href={DOCS_UPDATES}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="mt-1.5 inline-flex items-center gap-1 text-sky-700 hover:underline"
+                    >
+                        How to enable the updater
+                        <ExternalLinkIcon className="w-3 h-3" />
+                    </a>
+                </Notice>
+            )}
+            {checkout?.dirty && updater.status === "ok" && (
+                <Notice tone="warning">
+                    The checkout has local modifications. The updater refuses to move it until they are
+                    committed or stashed.
+                </Notice>
+            )}
+        </div>
+    );
+}
+
+function ConfirmPane({ state }: { state?: InstanceUpdate }) {
+    const target = state?.latest?.tag;
+    const items = [
+        {
+            icon: GitBranchIcon,
+            title: target ? `Pull ${target} from the repository` : "Pull the latest changes from the repository",
+            text: "The checkout moves forward; nothing is overwritten that was committed.",
+        },
+        {
+            icon: HammerIcon,
+            title: "Rebuild and restart every service",
+            text: "Takes a few minutes. Postgres, Redis and NATS stay up; only what changed is recreated.",
+        },
+        {
+            icon: SendIcon,
+            title: "Sending and syncing pause, then resume",
+            text: "Nothing in flight is lost: campaigns and warmup pick up from the database when the workers are back.",
+        },
+        {
+            icon: DatabaseIcon,
+            title: "Migrations apply when the backend comes back",
+            text: "They are forward-only and safe with data in place. A backup before an update is still the one you are glad to have.",
+        },
+        {
+            icon: ShieldCheckIcon,
+            title: "You stay signed in",
+            text: "This tab reconnects on its own and reloads once the new version answers.",
+        },
+    ];
+    return (
+        <div className="space-y-4">
+            <div className="text-[13px] text-slate-700">Here is what happens when you continue.</div>
+            <ul className="space-y-2.5">
+                {items.map((it, i) => (
+                    <motion.li
+                        key={it.title}
+                        initial={{ opacity: 0, y: 6 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        transition={{ delay: 0.04 * i, duration: 0.2 }}
+                        className="flex items-start gap-3"
+                    >
+                        <span className="mt-0.5 size-7 rounded-md bg-slate-50 border border-slate-200 text-slate-600 flex items-center justify-center shrink-0">
+                            <it.icon className="w-3.5 h-3.5" />
+                        </span>
+                        <div className="min-w-0">
+                            <div className="text-[12.5px] font-medium text-slate-900">{it.title}</div>
+                            <div className="text-[12px] text-slate-500 leading-relaxed">{it.text}</div>
+                        </div>
+                    </motion.li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function ProgressPane({
+    steps,
+    job,
+    backendDown,
+}: {
+    steps: StepDef[];
+    job?: UpdateJob;
+    backendDown: boolean;
+}) {
+    const current = backendDown ? "wait" : (job?.step ?? "starting");
+    const idx = Math.max(0, steps.findIndex((s) => s.id === current));
+    const percent = backendDown
+        ? Math.round(((steps.length - 0.5) / steps.length) * 100)
+        : Math.round(((idx + 0.5) / steps.length) * 100);
+    const [showLog, setShowLog] = React.useState(false);
+    const lines = job?.log ?? [];
+
+    return (
+        <div className="space-y-4">
+            <div>
+                <div className="flex items-center justify-between text-[12px] mb-1.5">
+                    <span className="font-medium text-slate-900 inline-flex items-center gap-2">
+                        <Loader2Icon className="w-3.5 h-3.5 animate-spin text-sky-600" />
+                        {backendDown ? "Reconnecting to the backend" : (steps[idx]?.label ?? "Starting")}
+                    </span>
+                    <span className="text-slate-500 tabular-nums">{percent}%</span>
+                </div>
+                <div className="h-1.5 rounded-full bg-slate-100 overflow-hidden">
+                    <motion.div
+                        className="h-full rounded-full bg-sky-500"
+                        initial={{ width: 0 }}
+                        animate={{ width: `${percent}%` }}
+                        transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
+                    />
+                </div>
+                <div className="mt-1.5 text-[12px] text-slate-500">
+                    {backendDown
+                        ? "The services are restarting. This can take a minute; keep the tab open or come back later, the result is kept."
+                        : "You can close this and keep working. The pill in the header follows the update."}
+                </div>
+            </div>
+
+            <ol className="space-y-1">
+                {steps.map((s, i) => {
+                    const done = i < idx || (backendDown && s.id !== "wait");
+                    const active = i === idx && !done;
+                    return (
+                        <li
+                            key={s.id}
+                            className={cn(
+                                "flex items-center gap-3 rounded-md px-2 py-1.5 transition-colors",
+                                active && "bg-sky-50/70",
+                            )}
+                        >
+                            <span
+                                className={cn(
+                                    "size-6 rounded-full flex items-center justify-center shrink-0 border transition-colors",
+                                    done && "bg-emerald-500 border-emerald-500 text-white",
+                                    active && "bg-white border-sky-400 text-sky-600",
+                                    !done && !active && "bg-white border-slate-200 text-slate-300",
+                                )}
+                            >
+                                <AnimatePresence mode="wait" initial={false}>
+                                    {done ? (
+                                        <motion.span
+                                            key="done"
+                                            initial={{ scale: 0.4, opacity: 0 }}
+                                            animate={{ scale: 1, opacity: 1 }}
+                                            exit={{ scale: 0.4, opacity: 0 }}
+                                            transition={{ type: "spring", stiffness: 500, damping: 30 }}
+                                        >
+                                            <CheckIcon className="w-3.5 h-3.5" />
+                                        </motion.span>
+                                    ) : active ? (
+                                        <motion.span key="active" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                                            <Loader2Icon className="w-3.5 h-3.5 animate-spin" />
+                                        </motion.span>
+                                    ) : (
+                                        <motion.span key="idle" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                                            <s.icon className="w-3 h-3" />
+                                        </motion.span>
+                                    )}
+                                </AnimatePresence>
+                            </span>
+                            <div className="min-w-0 flex-1">
+                                <div
+                                    className={cn(
+                                        "text-[12.5px] leading-tight",
+                                        done ? "text-slate-500" : active ? "text-slate-900 font-medium" : "text-slate-400",
+                                    )}
+                                >
+                                    {s.label}
+                                </div>
+                                {active && (
+                                    <motion.div
+                                        initial={{ opacity: 0, height: 0 }}
+                                        animate={{ opacity: 1, height: "auto" }}
+                                        className="text-[11.5px] text-slate-500"
+                                    >
+                                        {backendDown && s.id === "wait" ? "Waiting for the new backend to answer" : s.hint}
+                                    </motion.div>
+                                )}
+                            </div>
+                        </li>
+                    );
+                })}
+            </ol>
+
+            <LogToggle open={showLog} onToggle={() => setShowLog((v) => !v)} count={lines.length} />
+            <AnimatePresence initial={false}>
+                {showLog && (
+                    <motion.div
+                        key="log"
+                        initial={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: "auto" }}
+                        exit={{ opacity: 0, height: 0 }}
+                        transition={{ duration: 0.18 }}
+                        className="overflow-hidden"
+                    >
+                        <LogPanel lines={lines} />
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}
+
+function DonePane({
+    state,
+    job,
+    onAcknowledge,
+}: {
+    state?: InstanceUpdate;
+    job?: UpdateJob;
+    onAcknowledge: () => void;
+}) {
+    const [seconds, setSeconds] = React.useState(8);
+    const [showLog, setShowLog] = React.useState(false);
+    React.useEffect(() => {
+        if (seconds <= 0) {
+            onAcknowledge();
+            window.location.reload();
+            return;
+        }
+        const t = setTimeout(() => setSeconds((s) => s - 1), 1000);
+        return () => clearTimeout(t);
+    }, [seconds, onAcknowledge]);
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-col items-center text-center py-2">
+                <motion.span
+                    initial={{ scale: 0.5, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ type: "spring", stiffness: 380, damping: 22 }}
+                    className="size-14 rounded-full bg-emerald-50 border border-emerald-200 text-emerald-600 flex items-center justify-center"
+                >
+                    <motion.span initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ delay: 0.15 }}>
+                        <CheckIcon className="w-7 h-7" strokeWidth={2.5} />
+                    </motion.span>
+                </motion.span>
+                <div className="mt-3 text-[15px] font-semibold text-slate-900">
+                    Updated to {state ? runningLabel(state) : "the new version"}
+                </div>
+                <div className="mt-1 text-[12.5px] text-slate-500 max-w-[36ch]">
+                    Every service is back and sending has resumed. Reloading in {seconds}s to pick up the
+                    new dashboard.
+                </div>
+                {job?.from_commit && job?.to_commit && (
+                    <div className="mt-2 font-mono text-[11px] text-slate-400">
+                        {job.from_commit.slice(0, 7)} <span className="text-slate-300">→</span> {job.to_commit.slice(0, 7)}
+                    </div>
+                )}
+            </div>
+            <LogToggle open={showLog} onToggle={() => setShowLog((v) => !v)} count={job?.log?.length ?? 0} />
+            {showLog && <LogPanel lines={job?.log ?? []} />}
+        </div>
+    );
+}
+
+function FailedPane({ job }: { job?: UpdateJob }) {
+    return (
+        <div className="space-y-4">
+            <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50/60 p-3">
+                <motion.span
+                    initial={{ scale: 0.6, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ type: "spring", stiffness: 380, damping: 22 }}
+                    className="size-8 rounded-full bg-white border border-red-200 text-red-600 flex items-center justify-center shrink-0"
+                >
+                    <XIcon className="w-4 h-4" />
+                </motion.span>
+                <div className="min-w-0 text-[12.5px] leading-relaxed text-red-900">
+                    <div className="font-semibold">The update did not finish</div>
+                    <div className="mt-0.5">{job?.error ?? "See the log below."}</div>
+                    <div className="mt-1 text-red-800/80">
+                        {job?.step && job.step !== "restart" && job.step !== "wait"
+                            ? "It stopped before anything restarted, so the previous version is still running."
+                            : "Check the services on the host before trying again."}
+                    </div>
+                </div>
+            </div>
+            <LogPanel lines={job?.log ?? []} />
+        </div>
+    );
+}
+
+// footer
+
+function Footer({
+    pane,
+    state,
+    checking,
+    applying,
+    onCheck,
+    onContinue,
+    onBack,
+    onApply,
+    onRetry,
+    onClose,
+}: {
+    pane: Pane;
+    state?: InstanceUpdate;
+    checking: boolean;
+    applying: boolean;
+    onCheck: () => void;
+    onContinue: () => void;
+    onBack: () => void;
+    onApply: () => void;
+    onRetry: () => void;
+    onClose: () => void;
+}) {
+    const canApply = !!state && state.updater.status === "ok" && state.update_available && !state.updater.checkout?.dirty;
+    return (
+        <div className="flex items-center gap-2 px-5 h-14 border-t border-slate-200 bg-slate-50/60 shrink-0">
+            <a
+                href={DOCS_UPDATES}
+                target="_blank"
+                rel="noreferrer"
+                className="text-[12px] text-slate-500 hover:text-slate-900 inline-flex items-center gap-1"
+            >
+                How updates work
+                <ExternalLinkIcon className="w-3 h-3" />
+            </a>
+            <div className="flex-1" />
+            {pane === "overview" && (
+                <>
+                    <GhostButton onClick={onCheck} disabled={checking}>
+                        <RefreshCwIcon className={cn("w-3.5 h-3.5", checking && "animate-spin")} />
+                        {checking ? "Checking" : "Check now"}
+                    </GhostButton>
+                    {canApply ? (
+                        <PrimaryButton onClick={onContinue}>
+                            Update and restart
+                            <ArrowRightIcon className="w-3.5 h-3.5" />
+                        </PrimaryButton>
+                    ) : (
+                        <PrimaryButton onClick={onClose}>Done</PrimaryButton>
+                    )}
+                </>
+            )}
+            {pane === "confirm" && (
+                <>
+                    <GhostButton onClick={onBack} disabled={applying}>
+                        <ChevronLeftIcon className="w-3.5 h-3.5" />
+                        Back
+                    </GhostButton>
+                    <PrimaryButton onClick={onApply} disabled={applying} tone="amber">
+                        {applying ? <Loader2Icon className="w-3.5 h-3.5 animate-spin" /> : <RotateCwIcon className="w-3.5 h-3.5" />}
+                        {applying ? "Starting" : "Update now"}
+                    </PrimaryButton>
+                </>
+            )}
+            {pane === "progress" && <GhostButton onClick={onClose}>Keep running in the background</GhostButton>}
+            {pane === "done" && (
+                <>
+                    <GhostButton onClick={onClose}>Later</GhostButton>
+                    <PrimaryButton onClick={() => window.location.reload()}>Reload now</PrimaryButton>
+                </>
+            )}
+            {pane === "failed" && (
+                <>
+                    <GhostButton onClick={onClose}>Close</GhostButton>
+                    <PrimaryButton onClick={onRetry}>
+                        <RotateCwIcon className="w-3.5 h-3.5" />
+                        Try again
+                    </PrimaryButton>
+                </>
+            )}
+        </div>
+    );
+}
+
+// bits
+
+function VersionBox({ label, value, accent, muted }: { label: string; value: string; accent?: boolean; muted?: boolean }) {
+    return (
+        <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">{label}</div>
+            <div
+                className={cn(
+                    "text-[15px] font-semibold tracking-tight truncate",
+                    accent ? "text-amber-800" : muted ? "text-slate-500" : "text-slate-900",
+                )}
+            >
+                {value}
+            </div>
+        </div>
+    );
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="grid grid-cols-[6rem_1fr] gap-3 py-2">
+            <dt className="text-slate-500">{label}</dt>
+            <dd className="min-w-0 text-slate-800">{children}</dd>
+        </div>
+    );
+}
+
+function Notice({ tone, children }: { tone: "info" | "warning"; children: React.ReactNode }) {
+    return (
+        <div
+            className={cn(
+                "flex items-start gap-3 rounded-md border p-3 text-[12.5px] leading-relaxed",
+                tone === "warning" ? "border-amber-200 bg-amber-50/60 text-amber-900" : "border-sky-200 bg-sky-50/60 text-sky-900",
+            )}
+        >
+            <AlertTriangleIcon className="mt-0.5 w-4 h-4 shrink-0" />
+            <div className="min-w-0 flex-1">{children}</div>
+        </div>
+    );
+}
+
+function LogToggle({ open, onToggle, count }: { open: boolean; onToggle: () => void; count: number }) {
+    return (
+        <button
+            type="button"
+            onClick={onToggle}
+            className="inline-flex items-center gap-1 text-[12px] text-slate-500 hover:text-slate-900 transition-colors"
+        >
+            <ChevronDownIcon className={cn("w-3.5 h-3.5 transition-transform", open && "rotate-180")} />
+            {open ? "Hide log" : "Show log"}
+            {count > 0 && <span className="text-slate-400 tabular-nums">({count})</span>}
+        </button>
+    );
+}
+
+function LogPanel({ lines }: { lines: string[] }) {
+    const ref = React.useRef<HTMLPreElement>(null);
+    React.useEffect(() => {
+        const el = ref.current;
+        if (el) el.scrollTop = el.scrollHeight;
+    }, [lines.length]);
+    return (
+        <pre
+            ref={ref}
+            className="max-h-56 overflow-auto rounded-md border border-slate-200 bg-slate-950 p-3 text-[11px] leading-relaxed text-slate-200"
+        >
+            {lines.length > 0 ? lines.join("\n") : "Waiting for output"}
+        </pre>
+    );
+}
+
+function GhostButton({ children, onClick, disabled }: { children: React.ReactNode; onClick: () => void; disabled?: boolean }) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className="inline-flex items-center gap-1.5 h-8 px-3 rounded-md text-[12.5px] font-medium text-slate-600 hover:text-slate-900 hover:bg-slate-200/60 transition-colors disabled:opacity-50 disabled:pointer-events-none"
+        >
+            {children}
+        </button>
+    );
+}
+
+function PrimaryButton({
+    children,
+    onClick,
+    disabled,
+    tone = "dark",
+}: {
+    children: React.ReactNode;
+    onClick: () => void;
+    disabled?: boolean;
+    tone?: "dark" | "amber";
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            className={cn(
+                "inline-flex items-center gap-1.5 h-8 px-3.5 rounded-md text-[12.5px] font-medium text-white transition-colors disabled:opacity-60 disabled:pointer-events-none",
+                tone === "amber" ? "bg-amber-600 hover:bg-amber-700" : "bg-slate-900 hover:bg-slate-800",
+            )}
+        >
+            {children}
+        </button>
+    );
+}
+
+function relative(iso: string): string {
+    const diff = Date.now() - new Date(iso).getTime();
+    const min = Math.round(diff / 60_000);
+    if (min < 1) return "just now";
+    if (min < 60) return `${min} min ago`;
+    const h = Math.round(min / 60);
+    if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
+    const d = Math.round(h / 24);
+    if (d < 30) return `${d} day${d === 1 ? "" : "s"} ago`;
+    return new Date(iso).toLocaleDateString();
+}

--- a/web/src/components/layout/VersionPill.tsx
+++ b/web/src/components/layout/VersionPill.tsx
@@ -1,0 +1,110 @@
+// VersionPill: the running Warmbly version, for self-hosted instances only.
+//
+// Everyone in the workspace sees it, so nobody has to ask which version the
+// server runs, and it turns amber when a newer release exists. Only a platform
+// admin can act on it: for them it opens the update dialog, follows a running
+// update with a spinner, and reports the outcome once the backend is back.
+// For everyone else it is a badge whose tooltip says who to ask. Hosted
+// deployments never render it.
+
+import React from "react";
+import toast from "react-hot-toast";
+import { useQueryClient } from "@tanstack/react-query";
+import { ArrowUpCircleIcon, Loader2Icon } from "lucide-react";
+import useInstanceVersion from "@/lib/api/hooks/auth/useInstanceVersion";
+import useUser from "@/lib/api/hooks/auth/useUser";
+import { isUpdateRunning, runningLabel, useInstanceUpdate } from "@/lib/api/hooks/auth/useInstanceUpdate";
+import { clearUpdateStarted, readUpdateStarted } from "@/lib/updateSession";
+import { cn } from "@/lib/utils";
+import UpdateDialog from "./UpdateDialog";
+
+export function VersionPill() {
+    const versionQ = useInstanceVersion();
+    const { data: user } = useUser();
+    const isAdmin = user?.is_admin === true;
+    const v = versionQ.data;
+    const selfHosted = !!v?.self_hosted;
+
+    const adminQ = useInstanceUpdate(isAdmin && selfHosted);
+    const admin = adminQ.data;
+    const qc = useQueryClient();
+    const [open, setOpen] = React.useState(false);
+
+    const started = readUpdateStarted();
+    const updating = isUpdateRunning(admin);
+    const restarting = !!started && (adminQ.isError || versionQ.isError);
+
+    // The backend is back after an update this browser started: say so once,
+    // then refresh everything so no page keeps stale data. The dialog handles
+    // the reload itself when it is open.
+    React.useEffect(() => {
+        if (!started || !admin || updating || open) return;
+        const last = admin.updater.last_job;
+        const moved =
+            (admin.running.commit && admin.running.commit !== started.fromCommit) ||
+            (admin.running.version && admin.running.version !== started.fromVersion);
+        if (last?.status === "failed") {
+            clearUpdateStarted();
+            toast.error(`The update failed: ${last.error ?? "open the version pill for the log"}`);
+        } else if (moved || last?.status === "succeeded") {
+            clearUpdateStarted();
+            toast.success(`Updated to ${runningLabel(admin)}`);
+            void qc.invalidateQueries();
+        }
+    }, [started, admin, updating, open, qc]);
+
+    if (!v || !selfHosted) return null;
+
+    const running = v.version && v.version !== "dev" ? v.version : v.commit ? `dev ${v.commit.slice(0, 7)}` : "dev";
+    const available = v.update_available;
+    const latest = v.latest?.tag;
+
+    let label = available ? (latest ? `Update to ${latest}` : "Update available") : running;
+    let icon: React.ReactNode = available ? (
+        <span className="relative flex size-2.5 items-center justify-center">
+            <span className="absolute inline-flex size-full rounded-full bg-amber-400 opacity-60 animate-ping" />
+            <ArrowUpCircleIcon className="relative w-3 h-3" />
+        </span>
+    ) : (
+        <span className="size-1.5 rounded-full bg-slate-400" />
+    );
+    let tone = available ? "bg-amber-50 text-amber-800 border-amber-200" : "bg-white/70 text-slate-500 border-slate-200";
+    let title = available
+        ? isAdmin
+            ? `Warmbly ${latest ?? "newer"} is available; this instance runs ${running}. Click to update.`
+            : `Warmbly ${latest ?? "newer"} is available; this instance runs ${running}. Ask a platform admin to update.`
+        : isAdmin
+          ? `Warmbly ${running}, up to date. Click for details.`
+          : `Warmbly ${running}, up to date.`;
+
+    if (isAdmin && (updating || restarting)) {
+        label = restarting ? "Reconnecting" : "Updating";
+        icon = <Loader2Icon className="w-3 h-3 animate-spin" />;
+        tone = "bg-sky-50 text-sky-700 border-sky-200";
+        title = restarting ? "The backend is restarting after an update" : `Update in progress: ${admin?.updater.job?.step ?? ""}`;
+    }
+
+    const className = cn(
+        "inline-flex items-center gap-1.5 h-6 px-2 rounded border text-[11px] font-semibold tracking-[0.02em] transition-colors",
+        tone,
+        isAdmin && (available ? "hover:bg-amber-100" : "hover:text-slate-900 hover:bg-white"),
+    );
+
+    if (!isAdmin) {
+        return (
+            <span title={title} className={cn(className, "cursor-default")}>
+                {icon}
+                {label}
+            </span>
+        );
+    }
+    return (
+        <>
+            <button type="button" onClick={() => setOpen(true)} title={title} className={className}>
+                {icon}
+                {label}
+            </button>
+            <UpdateDialog open={open} onClose={() => setOpen(false)} />
+        </>
+    );
+}

--- a/web/src/components/layout/VersionPill.tsx
+++ b/web/src/components/layout/VersionPill.tsx
@@ -18,14 +18,23 @@ import { clearUpdateStarted, readUpdateStarted } from "@/lib/updateSession";
 import { cn } from "@/lib/utils";
 import UpdateDialog from "./UpdateDialog";
 
+// Platform admin permission bits, mirroring internal/models/admin_permission.go.
+const ADMIN_VIEW_ANALYTICS = 1 << 11;
+const ADMIN_MANAGE_SETTINGS = 1 << 14;
+
 export function VersionPill() {
     const versionQ = useInstanceVersion();
     const { data: user } = useUser();
-    const isAdmin = user?.is_admin === true;
+    // Mirrors the backend gates: view_analytics reads the update state,
+    // manage_settings is what check and apply require. An admin without the
+    // latter sees the same read-only badge as a member.
+    const perms = user?.admin_permissions ?? 0;
+    const canView = (perms & ADMIN_VIEW_ANALYTICS) === ADMIN_VIEW_ANALYTICS;
+    const isAdmin = (perms & ADMIN_MANAGE_SETTINGS) === ADMIN_MANAGE_SETTINGS;
     const v = versionQ.data;
     const selfHosted = !!v?.self_hosted;
 
-    const adminQ = useInstanceUpdate(isAdmin && selfHosted);
+    const adminQ = useInstanceUpdate(canView && selfHosted);
     const admin = adminQ.data;
     const qc = useQueryClient();
     const [open, setOpen] = React.useState(false);

--- a/web/src/lib/api/client/admin/updates.ts
+++ b/web/src/lib/api/client/admin/updates.ts
@@ -1,0 +1,36 @@
+// The admin update endpoints, reachable with a dashboard session that holds
+// platform admin permissions. They live under /admin, not /v1, so each call
+// overrides the client's base URL.
+
+import { API_URL } from "@/lib/information";
+import type InstanceUpdate from "../../models/auth/InstanceUpdate";
+import type { UpdateJob } from "../../models/auth/InstanceUpdate";
+import Request from "../Request";
+
+export async function getInstanceUpdate(withLog = false): Promise<InstanceUpdate> {
+    return await Request<InstanceUpdate>({
+        method: "GET",
+        baseURL: API_URL,
+        url: withLog ? "/admin/instance/update?log=1" : "/admin/instance/update",
+        authorization: true,
+    });
+}
+
+export async function checkInstanceUpdate(): Promise<InstanceUpdate> {
+    return await Request<InstanceUpdate>({
+        method: "POST",
+        baseURL: API_URL,
+        url: "/admin/instance/update/check",
+        authorization: true,
+    });
+}
+
+export async function applyInstanceUpdate(target = "latest"): Promise<UpdateJob> {
+    return await Request<UpdateJob>({
+        method: "POST",
+        baseURL: API_URL,
+        url: "/admin/instance/update/apply",
+        data: { target },
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/client/auth/getInstanceVersion.ts
+++ b/web/src/lib/api/client/auth/getInstanceVersion.ts
@@ -1,0 +1,10 @@
+import type InstanceVersion from "../../models/auth/InstanceVersion";
+import Request from "../Request";
+
+export default async function getInstanceVersion(): Promise<InstanceVersion> {
+    return await Request<InstanceVersion>({
+        method: "GET",
+        url: "/auth/instance",
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/hooks/auth/useInstanceUpdate.ts
+++ b/web/src/lib/api/hooks/auth/useInstanceUpdate.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+import { getInstanceUpdate } from "../../client/admin/updates";
+import type InstanceUpdate from "../../models/auth/InstanceUpdate";
+
+export const INSTANCE_UPDATE_KEY = ["admin", "instance", "update"] as const;
+export const INSTANCE_UPDATE_LOG_KEY = ["admin", "instance", "update", "log"] as const;
+
+export function isUpdateRunning(state: InstanceUpdate | undefined): boolean {
+    return state?.updater.job?.status === "running";
+}
+
+// The admin's full view: polled every minute, every few seconds while a job
+// runs so the pill follows an update started elsewhere or before a reload.
+// Requests keep failing while the backend restarts; the last state stays.
+export function useInstanceUpdate(enabled: boolean) {
+    return useQuery({
+        queryKey: INSTANCE_UPDATE_KEY,
+        queryFn: () => getInstanceUpdate(false),
+        refetchInterval: (q) => (isUpdateRunning(q.state.data) ? 3_000 : 60_000),
+        retry: false,
+        enabled,
+    });
+}
+
+// With the log, polled only while the dialog is open.
+export function useInstanceUpdateLog(enabled: boolean) {
+    return useQuery({
+        queryKey: INSTANCE_UPDATE_LOG_KEY,
+        queryFn: () => getInstanceUpdate(true),
+        refetchInterval: (q) => (isUpdateRunning(q.state.data) ? 1_500 : 10_000),
+        retry: false,
+        enabled,
+    });
+}
+
+export function runningLabel(state: InstanceUpdate | undefined): string {
+    if (!state) return "";
+    const v = state.running.version;
+    if (v && v !== "dev") return v;
+    const c = state.running.commit ?? state.updater.checkout?.commit ?? "";
+    return c ? `dev ${c.slice(0, 7)}` : "dev";
+}

--- a/web/src/lib/api/hooks/auth/useInstanceVersion.ts
+++ b/web/src/lib/api/hooks/auth/useInstanceVersion.ts
@@ -1,16 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import getInstanceVersion from "../../client/auth/getInstanceVersion";
+import type { AppError } from "../../client/normalizeError";
 
 // Feeds the version pill in the header. The backend re-checks releases on its
 // own interval, so a five minute poll here is enough for the pill to turn
 // amber while the tab is open. A backend without the endpoint (an older
-// self-host) fails once and the pill stays hidden.
+// self-host) answers 404: the pill stays hidden and the poll stops. Any other
+// failure keeps polling, because the backend restarting for an update is the
+// one moment the pill must come back on its own.
 export default function useInstanceVersion() {
     return useQuery({
         queryKey: ["auth", "instance"],
         queryFn: getInstanceVersion,
         staleTime: 5 * 60_000,
-        refetchInterval: 5 * 60_000,
+        refetchInterval: (q) => ((q.state.error as AppError | null)?.status === 404 ? false : 5 * 60_000),
         retry: false,
     });
 }

--- a/web/src/lib/api/hooks/auth/useInstanceVersion.ts
+++ b/web/src/lib/api/hooks/auth/useInstanceVersion.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import getInstanceVersion from "../../client/auth/getInstanceVersion";
+
+// Feeds the version pill in the header. The backend re-checks releases on its
+// own interval, so a five minute poll here is enough for the pill to turn
+// amber while the tab is open. A backend without the endpoint (an older
+// self-host) fails once and the pill stays hidden.
+export default function useInstanceVersion() {
+    return useQuery({
+        queryKey: ["auth", "instance"],
+        queryFn: getInstanceVersion,
+        staleTime: 5 * 60_000,
+        refetchInterval: 5 * 60_000,
+        retry: false,
+    });
+}

--- a/web/src/lib/api/models/auth/InstanceUpdate.ts
+++ b/web/src/lib/api/models/auth/InstanceUpdate.ts
@@ -1,7 +1,8 @@
 /**
  * The platform admin's view of updates, served by GET /admin/instance/update.
  * Mirrors internal/app/updates.State. Only a platform admin can read it; the
- * member-facing summary is InstanceVersion.
+ * member-facing summary is InstanceVersion. Timestamps are Date objects:
+ * Request revives ISO strings on every response.
  */
 export interface InstanceCheckout {
     branch: string;
@@ -11,7 +12,7 @@ export interface InstanceCheckout {
     remote_commit: string;
     behind: number;
     dirty: boolean;
-    fetched_at: string;
+    fetched_at: Date;
     fetch_error?: string;
 }
 
@@ -22,8 +23,8 @@ export interface UpdateJob {
     status: UpdateJobStatus;
     target: string;
     step: string;
-    started_at: string;
-    finished_at?: string;
+    started_at: Date;
+    finished_at?: Date;
     error?: string;
     from_commit: string;
     to_commit?: string;
@@ -43,11 +44,11 @@ export interface InstanceUpdater {
 }
 
 export default interface InstanceUpdate {
-    running: { version: string; commit?: string; built_at?: string };
-    latest?: { tag: string; name?: string; html_url?: string; published_at?: string; channel: string };
+    running: { version: string; commit?: string; built_at?: Date };
+    latest?: { tag: string; name?: string; html_url?: string; published_at?: Date; channel: string };
     update_available: boolean;
     reason?: "release" | "commits";
-    checked_at?: string;
+    checked_at?: Date;
     check_error?: string;
     enabled: boolean;
     interval: string;

--- a/web/src/lib/api/models/auth/InstanceUpdate.ts
+++ b/web/src/lib/api/models/auth/InstanceUpdate.ts
@@ -1,0 +1,57 @@
+/**
+ * The platform admin's view of updates, served by GET /admin/instance/update.
+ * Mirrors internal/app/updates.State. Only a platform admin can read it; the
+ * member-facing summary is InstanceVersion.
+ */
+export interface InstanceCheckout {
+    branch: string;
+    detached: boolean;
+    commit: string;
+    describe: string;
+    remote_commit: string;
+    behind: number;
+    dirty: boolean;
+    fetched_at: string;
+    fetch_error?: string;
+}
+
+export type UpdateJobStatus = "running" | "succeeded" | "failed";
+
+export interface UpdateJob {
+    id: string;
+    status: UpdateJobStatus;
+    target: string;
+    step: string;
+    started_at: string;
+    finished_at?: string;
+    error?: string;
+    from_commit: string;
+    to_commit?: string;
+    // Absent unless fetched with log=1.
+    log?: string[] | null;
+}
+
+export interface InstanceUpdater {
+    configured: boolean;
+    status: "off" | "ok" | "unreachable";
+    error?: string;
+    mode?: "compose" | "command";
+    repo_dir?: string;
+    checkout?: InstanceCheckout;
+    job?: UpdateJob;
+    last_job?: UpdateJob;
+}
+
+export default interface InstanceUpdate {
+    running: { version: string; commit?: string; built_at?: string };
+    latest?: { tag: string; name?: string; html_url?: string; published_at?: string; channel: string };
+    update_available: boolean;
+    reason?: "release" | "commits";
+    checked_at?: string;
+    check_error?: string;
+    enabled: boolean;
+    interval: string;
+    channel: string;
+    repo: string;
+    updater: InstanceUpdater;
+}

--- a/web/src/lib/api/models/auth/InstanceVersion.ts
+++ b/web/src/lib/api/models/auth/InstanceVersion.ts
@@ -2,6 +2,7 @@
  * The running Warmbly on a self-hosted instance and whether a newer one
  * exists, served by GET /auth/instance. A hosted deployment answers
  * `self_hosted: false` and nothing else, so the dashboard shows no pill there.
+ * Timestamps are Date objects: Request revives ISO strings on every response.
  */
 export default interface InstanceVersion {
     self_hosted: boolean;
@@ -11,7 +12,7 @@ export default interface InstanceVersion {
     latest?: {
         tag: string;
         html_url?: string;
-        published_at?: string;
+        published_at?: Date;
     };
-    checked_at?: string;
+    checked_at?: Date;
 }

--- a/web/src/lib/api/models/auth/InstanceVersion.ts
+++ b/web/src/lib/api/models/auth/InstanceVersion.ts
@@ -1,0 +1,17 @@
+/**
+ * The running Warmbly on a self-hosted instance and whether a newer one
+ * exists, served by GET /auth/instance. A hosted deployment answers
+ * `self_hosted: false` and nothing else, so the dashboard shows no pill there.
+ */
+export default interface InstanceVersion {
+    self_hosted: boolean;
+    version?: string;
+    commit?: string;
+    update_available: boolean;
+    latest?: {
+        tag: string;
+        html_url?: string;
+        published_at?: string;
+    };
+    checked_at?: string;
+}

--- a/web/src/lib/api/models/auth/User.ts
+++ b/web/src/lib/api/models/auth/User.ts
@@ -17,6 +17,11 @@ export default interface User {
     // it briefly, so readers treat 0/undefined as the default 30.
     undo_send_seconds?: number;
 
+    // Platform admin access. is_admin is true for anyone holding any admin
+    // permission; the dashboard only uses it to link to the admin panel.
+    is_admin?: boolean;
+    admin_permissions?: number;
+
     tags: Tag[];
     categories: Category[];
     folders: Folder[];

--- a/web/src/lib/updateSession.ts
+++ b/web/src/lib/updateSession.ts
@@ -1,0 +1,42 @@
+// Remembers that this browser started an instance update, across the backend
+// restart and a reload, so the header can report the outcome once the backend
+// answers again instead of going quiet.
+
+const KEY = "warmbly.update.started";
+
+export interface StartedUpdate {
+    fromVersion: string;
+    fromCommit: string;
+    startedAt: number;
+}
+
+export function markUpdateStarted(fromVersion: string, fromCommit: string) {
+    try {
+        sessionStorage.setItem(KEY, JSON.stringify({ fromVersion, fromCommit, startedAt: Date.now() }));
+    } catch {
+        /* no storage: the open dialog still tracks the job */
+    }
+}
+
+export function readUpdateStarted(): StartedUpdate | null {
+    try {
+        const raw = sessionStorage.getItem(KEY);
+        if (!raw) return null;
+        const v = JSON.parse(raw) as StartedUpdate;
+        if (Date.now() - v.startedAt > 60 * 60_000) {
+            sessionStorage.removeItem(KEY);
+            return null;
+        }
+        return v;
+    } catch {
+        return null;
+    }
+}
+
+export function clearUpdateStarted() {
+    try {
+        sessionStorage.removeItem(KEY);
+    } catch {
+        /* ignore */
+    }
+}


### PR DESCRIPTION
## What

Self-hosted instances now know when a newer Warmbly exists and can update themselves from the UI.

- **Version stamping.** Every Go binary carries its tag, commit and build time (`internal/version`) via ldflags from the Dockerfiles, `make up` and CI. `warmblyctl status` prints it.
- **Continuous check.** The backend polls GitHub Releases (`UPDATE_CHECK_INTERVAL`, 30m default, `UPDATE_CHANNEL` stable/dev) and asks the updater for the checkout's commit distance behind its branch. Either signal marks an update as available.
- **Updater daemon** (`cmd/updater`, `internal/updater`). Host-side agent behind the update button: fetch, fast-forward (or check out the newest tag on a pinned checkout), rebuild images, recreate only the containers that changed, prune, wait for the backend, then recreate itself last. Refuses a dirty checkout, restores file ownership after running as root, persists the last job across its own restart. Compose ships it under the `updater` profile (`make up` enables it); bare-metal installs get a systemd unit that runs the new `scripts/upgrade-bare-metal.sh` in command mode.
- **Admin panel.** Version pill in the top bar (grey, amber with a pulsing dot when an update exists, spinner while updating or reconnecting), an update dialog with confirmation, progress bar, step chips and live log, restart tracking and result, a version card on Setup and health, and two new findings: `update_available` and `updater_unreachable`.
- **Dashboard.** Every member of a self-hosted workspace sees the same pill in the header (read-only, tooltip says to ask a platform admin). Platform admins get the full flow in a dialog with directional pane slides: overview, confirmation of what happens, animated step progress with log toggle, reconnect state, and a result pane that reloads after a countdown. A reload mid-update picks the job back up; a closed dialog reports the outcome as a toast.
- **Endpoints.** `GET /admin/instance/update` (+`?log=1`), `POST /admin/instance/update/check`, `POST /admin/instance/update/apply` behind the existing admin permissions and audited; `GET /v1/auth/instance` for any signed-in member (version and availability only, `self_hosted: false` on cloud).
- **Docs.** New `development/updates` page; configuration, instance health, deployment guide, bare-metal and API reference updated; `.env.example` gains an Updates block.

## Security notes

The updater holds the docker socket under compose, so it is profile-gated, has no published port, answers only to a bearer token shared with the backend, and the button is gated on `manage_settings` and audited. `UPDATER_URL=none` keeps the indicator without the button.

## Verification

`make lint`, `pnpm typecheck` + `pnpm lint` in `web/`, `admin/` and `docs/`, semver comparison unit tests, and the updater daemon smoke-tested against a local checkout (status, auth, a full command-mode job through the dashboard dialog). A real compose update run on a live stack was not exercised here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-hosted version indicators and update availability messaging.
  * Added administrator controls to check for and apply updates, with confirmation, progress, logs, restart tracking, and outcome reporting.
  * Added Docker Compose and bare-metal update workflows with configurable release channels and updater settings.
  * Added instance health findings for available updates and unreachable updaters.
  * Added build version and commit details to status displays.
  * Added authenticated contact suppression management and signed unsubscribe/resubscribe links.

* **Bug Fixes**
  * Improved update tracking across restarts and page reloads.
  * Added safer bare-metal upgrades and bounded health checks.

* **Documentation**
  * Documented update configuration, deployment workflows, API endpoints, and security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->