### PR TITLE
Stop the dashboard showing stale campaign counts and a permanent "Slow connection" (#316, #319)

### DIFF
--- a/docs/content/docs/guides/collaboration.mdx
+++ b/docs/content/docs/guides/collaboration.mdx
@@ -38,7 +38,7 @@ Indicators are workspace-scoped. Teammates see only your name, avatar, current p
 
 A dot in the header reports the live connection: green **Live** when it is healthy, amber **Slow connection** or red **Poor connection** when heartbeats are taking longer than they should, amber **Reconnecting...** while it retries, and red **Disconnected** when it is down. The reading comes from the measured round trip to the realtime service, so amber means your connection genuinely is slow rather than merely busy.
 
-Nothing is lost while it is down. Warmbly refreshes what it can on a slower cycle so counts and lists still move, and on reconnect it refetches everything that could have drifted, since live events are not replayed after the fact. On a self-hosted install a permanently disconnected dot usually means the realtime service is not running; see [troubleshooting](/development/troubleshooting/).
+Stored data still catches up while it is down. Warmbly refreshes counts and lists on a slower cycle, and on reconnect it refetches everything that could have drifted. The events themselves are never replayed, so live-only signals such as presence and cursors resume from wherever things stand rather than backfilling what you missed. On a self-hosted install a permanently disconnected dot usually means the realtime service is not running; see [troubleshooting](/development/troubleshooting/).
 
 ## Live cursors and chat
 

--- a/docs/content/docs/guides/collaboration.mdx
+++ b/docs/content/docs/guides/collaboration.mdx
@@ -34,6 +34,12 @@ Indicators are workspace-scoped. Teammates see only your name, avatar, current p
 
 **Events are permission-aware**: a member without inbox access never receives unibox events, and billing events reach only those who can manage billing. See [Team roles](/guides/team-roles/).
 
+## Connection status
+
+A dot in the header reports the live connection: green **Live** when it is healthy, amber **Slow connection** or red **Poor connection** when heartbeats are taking longer than they should, amber **Reconnecting...** while it retries, and red **Disconnected** when it is down. The reading comes from the measured round trip to the realtime service, so amber means your connection genuinely is slow rather than merely busy.
+
+Nothing is lost while it is down. Warmbly refreshes what it can on a slower cycle so counts and lists still move, and on reconnect it refetches everything that could have drifted, since live events are not replayed after the fact. On a self-hosted install a permanently disconnected dot usually means the realtime service is not running; see [troubleshooting](/development/troubleshooting/).
+
 ## Live cursors and chat
 
 On a shared page you see each other's cursors move, tagged with avatar and name, across the contacts table, deal board, unibox, settings, and everywhere else. On app-scrolling pages the cursor tracks content as either person scrolls.

--- a/web/src/hooks/RealtimeManager.tsx
+++ b/web/src/hooks/RealtimeManager.tsx
@@ -7,6 +7,12 @@ import { useRealtimeEvents } from './useRealtimeEvents'
 import { PresenceProvider } from './PresenceProvider'
 import useUnseenCount from '@/lib/api/hooks/app/unibox/useUnseenCount'
 
+// Heartbeat roundtrip bands behind the header's connection indicator. A healthy
+// socket answers in tens of milliseconds, and the provider's own watchdog gives
+// up at 8s and reconnects, so "poor" stays well under that.
+const DEGRADED_LATENCY_MS = 500
+const POOR_LATENCY_MS = 2000
+
 export function RealtimeManager({ children }: { children: React.ReactNode }) {
   const { isConnected, reconnectAttempt, joinChannel, leaveChannel } = useSocket()
   const { user } = useUserProfile()
@@ -17,10 +23,9 @@ export function RealtimeManager({ children }: { children: React.ReactNode }) {
   const addJoinedChannel = useAppStore((s) => s.addJoinedChannel)
   const removeJoinedChannel = useAppStore((s) => s.removeJoinedChannel)
   const setUnseenCount = useAppStore((s) => s.setUnseenCount)
+  const wsLatencyMs = useAppStore((s) => s.wsLatencyMs)
 
   const queryClient = useQueryClient()
-  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const lastHeartbeatRef = useRef<number>(Date.now())
   const hadConnectionRef = useRef(false)
 
   // Catch-up on reconnect: events are fire-and-forget, so anything emitted
@@ -101,30 +106,26 @@ export function RealtimeManager({ children }: { children: React.ReactNode }) {
     }
   }, [isConnected, currentOrg?.id, joinChannel, leaveChannel, addJoinedChannel, removeJoinedChannel])
 
-  // Connection quality monitoring
+  // Connection quality, from the heartbeat roundtrip the socket provider
+  // measures. The previous version compared its own 5s interval against
+  // itself, so ordinary timer drift read as "degraded" and the header claimed
+  // "Slow connection" on a perfectly healthy socket.
   useEffect(() => {
     if (!isConnected) return
-
-    lastHeartbeatRef.current = Date.now()
-
-    heartbeatRef.current = setInterval(() => {
-      const elapsed = Date.now() - lastHeartbeatRef.current
-      if (elapsed > 15000) {
-        setConnectionQuality('poor')
-      } else if (elapsed > 5000) {
-        setConnectionQuality('degraded')
-      } else {
-        setConnectionQuality('good')
-      }
-      lastHeartbeatRef.current = Date.now()
-    }, 5000)
-
-    return () => {
-      if (heartbeatRef.current) {
-        clearInterval(heartbeatRef.current)
-      }
+    // Null until the first heartbeat reply lands: a connected socket with
+    // nothing to report yet, not a slow one.
+    if (wsLatencyMs === null) {
+      setConnectionQuality('good')
+      return
     }
-  }, [isConnected, setConnectionQuality])
+    if (wsLatencyMs > POOR_LATENCY_MS) {
+      setConnectionQuality('poor')
+    } else if (wsLatencyMs > DEGRADED_LATENCY_MS) {
+      setConnectionQuality('degraded')
+    } else {
+      setConnectionQuality('good')
+    }
+  }, [isConnected, wsLatencyMs, setConnectionQuality])
 
   // Seed the unread inbox count from the server. The store value is otherwise
   // session-only (realtime increments it but it starts at 0), so seeding makes

--- a/web/src/hooks/useRealtimeFallback.ts
+++ b/web/src/hooks/useRealtimeFallback.ts
@@ -1,0 +1,16 @@
+import { useConnectionStatus } from "@/stores";
+
+// How often a realtime-backed list refetches while the socket is not
+// delivering. Slow on purpose: this is a safety net, not the primary path.
+export const REALTIME_FALLBACK_INTERVAL_MS = 60_000;
+
+// A react-query refetchInterval for a list kept current by realtime
+// invalidation. False while the socket is connected, so a healthy dashboard
+// polls nothing; a slow poll once it is not, so the list cannot sit on its
+// staleTime with no event coming to refresh it. Deliberately keyed on the
+// connection being down rather than on reported quality: a connected socket
+// still delivers, and the indicator's quality signal covers latency, not loss.
+export default function useRealtimeFallbackInterval(enabled = true): number | false {
+    const { status } = useConnectionStatus();
+    return enabled && status !== "connected" ? REALTIME_FALLBACK_INTERVAL_MS : false;
+}

--- a/web/src/lib/api/hooks/app/campaigns/useCampaigns.ts
+++ b/web/src/lib/api/hooks/app/campaigns/useCampaigns.ts
@@ -2,6 +2,7 @@ import { useInfiniteQuery, type InfiniteData } from "@tanstack/react-query";
 import getCampaigns from "@/lib/api/client/app/campaigns/getCampaigns";
 import { DEFAULT_PAGINATION_LIMIT } from "@/lib/information";
 import type GetCampaigns from "@/lib/api/models/app/campaigns/GetCampaigns";
+import useRealtimeFallbackInterval from "@/hooks/useRealtimeFallback";
 
 interface UseCampaignsProps {
     query: string;
@@ -11,6 +12,10 @@ interface UseCampaignsProps {
 }
 
 export default function useCampaigns({ query, folder, limit = DEFAULT_PAGINATION_LIMIT, enabled = true }: UseCampaignsProps) {
+    // Send counts on these cards move on realtime invalidation, so the long
+    // staleTime below is free while the socket is up and strands the list for
+    // five minutes when it is not. Poll only in that second case.
+    const refetchInterval = useRealtimeFallbackInterval(enabled);
     const queryResult = useInfiniteQuery<
         GetCampaigns,
         Error,
@@ -29,6 +34,7 @@ export default function useCampaigns({ query, folder, limit = DEFAULT_PAGINATION
         },
         staleTime: 5 * 60 * 1000,
         gcTime: 10 * 60 * 1000,
+        refetchInterval,
         enabled,
     });
 


### PR DESCRIPTION
Closes #316, closes #319. Both came out of item 7 of #307, the one the reporter and I agreed was not the hour-long analytics lag it looked like. Chasing why they nonetheless saw stale numbers turned up two real defects, one of which explains the misdiagnosis.

## The header has been lying about the connection (#319)

`RealtimeManager` set connection quality from a `5000`ms interval that compared each tick against its own previous tick. Timers fire late, never early, so the elapsed time was always a shade over `5000`ms, which is exactly the "degraded" threshold. The result: a healthy socket reports **Slow connection** on essentially every pass, and green **Live** is close to unreachable.

The honest signal was already there and unread. `SocketProvider` stamps each heartbeat by ref and publishes the true round trip on the matching reply, clearing it on close. Nothing consumed it, though the store comment says it exists precisely so quality can be real "instead of guessing". Quality now comes from that measurement, and the self-referential interval and its two refs are gone. A null latency on a connected socket means the first heartbeat has not landed yet, which reads as good rather than slow.

Bands sit well under the provider's own `8000`ms watchdog, which already force-reconnects a socket that stops answering.

This is why item 7 of #307 was filed as an analytics bug: the reporter saw "Slow connection", reasonably concluded that was why their numbers looked stale, and reported the symptom rather than the cause.

## The campaigns list had no fallback when the socket was down (#316)

Campaign analytics are live, computed per request, and the campaigns list is invalidated by realtime events. That makes its five-minute `staleTime` free while the socket is up, and a trap when it is not: with no events arriving and `refetchOnWindowFocus` off globally, the cached page is served for the full five minutes and returning to the tab does not rescue it.

`useRealtimeFallbackInterval` returns a refetch interval only while the socket is not connected, and `false` otherwise, so a healthy dashboard still polls nothing. The campaigns list uses it. The hook is deliberately keyed on the connection being down rather than on reported quality: a connected socket still delivers, and quality describes latency, not loss. It is written to be reusable by the other realtime-backed lists that carry the same long cache, but this change only wires the one the issue is about.

Worth noting the existing catch-up already handles the other half: on reconnect after a real outage, `RealtimeManager` invalidates everything. The gap was only the window while the socket was still down.

## Verification

`pnpm typecheck`, `pnpm lint` and the full `vitest` suite pass in `web/` (64 tests, including the existing realtime channel tests that exercise this provider). `pnpm types:check` and `pnpm lint` pass in `docs/`. No Go, backend or migration changes.

Docs: the collaboration guide now says what each state of the header dot means, that the reading is a measured round trip, and what still refreshes while the connection is down, pointing self-hosters at troubleshooting when the dot stays red.

## Not included

Whether the indicator should be more prominent when data may be stale is a product call, so I left it alone rather than deciding it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection quality indicators now reflect measured round-trip latency.
  * Data automatically refreshes every 60 seconds when realtime connectivity is unavailable.
  * Campaign data continues updating through periodic refreshes during realtime outages.

* **Documentation**
  * Clarified offline fallback behavior, including refreshed counts and lists after reconnection.
  * Documented that live-only events, such as presence and cursor updates, are not replayed after reconnecting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->