### PR TITLE
Mount StepAttachments in the step composer (#307 item 3)

### DIFF
--- a/docs/content/docs/guides/sequences.mdx
+++ b/docs/content/docs/guides/sequences.mdx
@@ -26,6 +26,8 @@ The Preview tab renders through the real send engine against a sample contact, s
 Apply a saved template to a step, or save a step as a reusable one from the composer. Templates carry their subject and body and live in your shared library.
 </Callout>
 
+Upload attachments for each step below its composer by dragging and dropping files or clicking the upload area. They are included with every email sent by that step and can be removed there. Campaign-level attachments without a `step_id`, which can only be added through the API, do not appear in the step composer.
+
 ### Action steps
 
 A step can perform an action instead of sending: add or remove a tag, label email, create a task, create a deal or move its stage, unsubscribe the contact, notify (fires your webhooks and integrations), run an automation, or switch. They connect like email steps and work best at the end of a reply branch, for example creating a deal and notifying your team on a positive reply.

--- a/web/src/components/app/campaigns/sequences/SequenceView.tsx
+++ b/web/src/components/app/campaigns/sequences/SequenceView.tsx
@@ -9,6 +9,7 @@ import { GitBranchIcon, Loader2Icon } from "lucide-react";
 import toast from "react-hot-toast";
 import type Sequence from "@/lib/api/models/app/campaigns/sequences/Sequence";
 import EmailContentEditor from "./EmailContentEditor";
+import StepAttachments from "./StepAttachments";
 import { Label, TextInput } from "@/components/ui/field";
 import useUpdateSequence from "@/lib/api/hooks/app/campaigns/sequences/useUpdateSequence";
 import type { AppError } from "@/lib/api/client/normalizeError";
@@ -133,6 +134,10 @@ export default function SequenceView({
                             starts a new thread instead of replying in the existing one.
                         </p>
                     </div>
+                )}
+
+                {sequence.kind === "email" && (
+                    <StepAttachments campaignId={campaignId} sequenceId={sequence.id} />
                 )}
             </div>
         </div>


### PR DESCRIPTION
Refs #307 (item 3).

`StepAttachments.tsx` (per-step upload, list and delete) existed but had no importer, so files attached to a step through the API were invisible in the dashboard and nobody could add or remove them from the UI, while the worker kept sending them.

- `SequenceView` now renders `StepAttachments` under the composer for email steps (the original arm, including the embedded arm inside the A/B editor); variants share the step's attachments, so the variant editor is untouched
- placed below the follow-up threading note, clear of the composer props that #315 changed, so it rebases cleanly on current main
- the sequences guide describes per-step attachments in the composer

Kept it below the composer for now, matching the component's own header note. If you would rather have it in the new preview toolbar, I am happy to move it in a follow-up.

`pnpm typecheck` and `pnpm lint` clean in `web/` (no new warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing attachments at the email-step level in sequences.
  * Email sequence steps now include an attachment section for uploading and removing files.
  * Email previews and test sends can display signatures, opt-out footers, and campaign attachments.
* **Documentation**
  * Documented attachment delivery behavior and clarified that campaign-level attachments are available only through the API.
  * Documented test sends using saved content without tracking or suppression effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->