### PR TITLE
Send only the attachments a step actually carries, and org-scope the attachment routes

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1332,6 +1332,11 @@ func main() {
 		if aware, ok := campaignService.(campaign.AttachmentAware); ok {
 			aware.WireAttachments(attachmentRepoForHandler, s3ForHandler)
 		}
+		// Deleting a step cascades its attachment rows away, so the sequence
+		// service needs the same store to drop the objects behind them.
+		if aware, ok := sequenceService.(sequence.AttachmentAware); ok {
+			aware.WireAttachments(attachmentRepoForHandler, s3ForHandler)
+		}
 		// Attaching a lead to a running campaign has to wake that campaign's
 		// parked send chain, or the lead sits queued until the chain's next
 		// tick. Wired here because contactService is built before the scheduler

--- a/docs/content/docs/api/reference/campaigns.mdx
+++ b/docs/content/docs/api/reference/campaigns.mdx
@@ -563,7 +563,7 @@ An `ABWinnerAnalysis` object.
 
 `GET /campaigns/:id/attachments`
 
-List the campaign's attachments. Each entry carries a short-lived presigned download `url`. **Scope** `READ_CAMPAIGNS` · **Org permission** `view_campaigns`.
+List every attachment of the campaign. Each entry carries a short-lived presigned download `url` and its `step_id`: a file scoped to a step is sent by that step alone, and a `null` `step_id` means every step of the campaign sends it. **Scope** `READ_CAMPAIGNS` · **Org permission** `view_campaigns`.
 
 | Parameter | In | Type | Description |
 | --- | --- | --- | --- |
@@ -594,13 +594,13 @@ A `data` array of attachment objects (no pagination wrapper).
 
 `POST /campaigns/:id/attachments`
 
-Upload a file to attach to the campaign (or one step). Sent as `multipart/form-data`, not JSON. **Scope** `WRITE_CAMPAIGNS` · **Org permission** `manage_campaigns`.
+Upload a file to attach to the campaign, or to one of its steps. Sent as `multipart/form-data`, not JSON. **Scope** `WRITE_CAMPAIGNS` · **Org permission** `manage_campaigns`.
 
 | Parameter | In | Type | Description |
 | --- | --- | --- | --- |
 | `id` | path | uuid | Campaign id. |
 | `file` | form (multipart) | file | Required. The file to upload (max 15 MB). Executable and script types are rejected. |
-| `step_id` | form (multipart) | uuid | Optional. Scope the attachment to one sequence step. |
+| `step_id` | form (multipart) | uuid | Optional. Scope the attachment to one sequence step of this campaign, which is then the only step that sends it. Omit it to attach the file to every step. A step of another campaign returns `404`. |
 
 ### Response
 
@@ -660,7 +660,7 @@ A `PreflightReport` object.
 
 `POST /campaigns/:id/test-email`
 
-Send a one-off test of a sequence step to a chosen recipient through a chosen mailbox. The message is assembled the way a real send is: merge fields and spintax resolve for the contact, the campaign's attachments are attached, the mailbox signature and the campaign's opt-out footer are appended, and a plain-text campaign ships without an HTML part. The subject is prefixed with `[TEST]`. Opens and clicks on a test are never tracked, and its opt-out link names no contact, so clicking it suppresses nobody. Defaults to the first step when `step_id` is omitted. **Scope** `SEND_CAMPAIGNS` · **Org permission** `send_campaigns`.
+Send a one-off test of a sequence step to a chosen recipient through a chosen mailbox. The message is assembled the way a real send is: merge fields and spintax resolve for the contact, the files that step sends are attached (the campaign's unscoped attachments plus that step's own), the mailbox signature and the campaign's opt-out footer are appended, and a plain-text campaign ships without an HTML part. The subject is prefixed with `[TEST]`. Opens and clicks on a test are never tracked, and its opt-out link names no contact, so clicking it suppresses nobody. Defaults to the first step when `step_id` is omitted. **Scope** `SEND_CAMPAIGNS` · **Org permission** `send_campaigns`.
 
 The mailbox may be any mailbox of the organization, not only one the caller connected, and it does not have to be in the campaign's sender pool. An API key with an `allowed_email_accounts` list can only test from those mailboxes. Passing `contact_id` additionally requires `READ_CONTACTS` (org permission `view_contacts`), since the rendered copy reads that contact's fields.
 
@@ -1069,6 +1069,7 @@ Render subject and body templates for a contact exactly as the send path would, 
 | `contact_id` | uuid | no | A contact of the organization to render for, with its custom fields. Omitted uses the built-in sample contact. |
 | `contact` | object | no | Override fields on the contact being rendered for (the sample or the one from `contact_id`): `first_name`, `last_name`, `email`, `company`, `phone`, and a `custom_fields` map of string to string. |
 | `campaign_id` | uuid | no | Campaign of the organization whose opt-out footer, plain-text setting and attachments apply. The opt-out link in the preview names no contact. |
+| `step_id` | uuid | no | The step being previewed, so `attachments` lists what that step sends. Without it only the campaign-wide files are listed. |
 | `account_id` | uuid | no | Mailbox of the organization whose signature is appended (when signature sync is on) and which is reported as `from`. |
 
 ```json
@@ -1083,7 +1084,7 @@ Render subject and body templates for a contact exactly as the send path would, 
 
 ### Response
 
-A `TemplatePreview` object. `errors` lists template parse errors that would block sending, `unresolved` lists literal tokens left after render. `from` is present when `account_id` was given, `attachments` when `campaign_id` was given and the campaign has files attached. All four are omitted when empty.
+A `TemplatePreview` object. `errors` lists template parse errors that would block sending, `unresolved` lists literal tokens left after render. `from` is present when `account_id` was given, `attachments` when `campaign_id` was given and there are files on the send (the campaign-wide ones plus `step_id`'s own). All four are omitted when empty.
 
 ```json
 {

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -20740,6 +20740,7 @@
         "required": [
           "id",
           "campaign_id",
+          "step_id",
           "filename",
           "created_at"
         ],

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -4286,7 +4286,7 @@
                   "step_id": {
                     "type": "string",
                     "format": "uuid",
-                    "description": "Scope the attachment to one sequence step."
+                    "description": "Scope the attachment to one sequence step of this campaign, which is then the only step that sends it. Omit to attach the file to every step. A step of another campaign is 404."
                   }
                 }
               }
@@ -20757,7 +20757,8 @@
               "string",
               "null"
             ],
-            "format": "uuid"
+            "format": "uuid",
+            "description": "The sequence step that sends this file. Null means every step of the campaign sends it."
           },
           "filename": {
             "type": "string"
@@ -21226,6 +21227,26 @@
           "body_plain": {
             "type": "string"
           },
+          "contact_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "A contact of the organization to render for. Omitted renders the built-in sample. Requires READ_CONTACTS."
+          },
+          "campaign_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Campaign whose opt-out footer, plain-text setting and attachments apply."
+          },
+          "account_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Mailbox whose signature applies and which is reported as the sender."
+          },
+          "step_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The step being previewed, so the attachment list is the one that step sends. Omitted lists the campaign-wide files only."
+          },
           "contact": {
             "type": "object",
             "description": "Override fields on the built-in sample contact.",
@@ -21281,6 +21302,42 @@
               "type": "string"
             },
             "description": "Literal {{...}} tokens left after render. Omitted when empty."
+          },
+          "from": {
+            "type": "object",
+            "description": "The sender as recipients see it. Present when account_id was given.",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string",
+                "format": "email"
+              }
+            }
+          },
+          "attachments": {
+            "type": "array",
+            "description": "The files this send carries: the campaign-wide attachments plus step_id's own. Present when campaign_id was given and there are any.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "filename": {
+                  "type": "string"
+                },
+                "size": {
+                  "type": "integer",
+                  "description": "Size in bytes."
+                },
+                "mime_type": {
+                  "type": "string"
+                }
+              }
+            }
           }
         }
       },

--- a/internal/api/handler/attachment.go
+++ b/internal/api/handler/attachment.go
@@ -88,6 +88,10 @@ func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
 		return
 	}
 
+	// Cap the body before anything reads it, so a huge upload can't pin a
+	// worker: the first form field read parses the whole multipart body.
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, attachmentMaxBytes+(1<<20))
+
 	// Optional step_id scopes the attachment to one step; without it the file
 	// rides every step of the campaign. A malformed or foreign step is refused
 	// rather than silently widened to the whole campaign.
@@ -110,8 +114,6 @@ func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
 		seqID = &id
 	}
 
-	// Cap the body before parsing so a huge upload can't pin a worker.
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, attachmentMaxBytes+(1<<20))
 	fh, err := c.FormFile("file")
 	if err != nil {
 		errx.JSON(c, errx.New(errx.BadRequest, "file is required"))

--- a/internal/api/handler/attachment.go
+++ b/internal/api/handler/attachment.go
@@ -52,16 +52,30 @@ func sanitizeFilename(name string) string {
 
 func mb(b int64) int64 { return b / (1024 * 1024) }
 
-// UploadCampaignAttachment — POST /campaigns/:id/attachments (multipart "file")
-func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
+// attachmentCampaign resolves the campaign these attachment routes address and
+// proves it belongs to the caller's organization. The route id is a raw path
+// parameter, so without this an attachment could be listed, uploaded or deleted
+// on another workspace's campaign.
+func (h *Handler) attachmentCampaign(c *gin.Context) (campaignID, orgID uuid.UUID, xerr *errx.Error) {
 	campaignID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
-		errx.JSON(c, errx.ErrUuid)
-		return
+		return uuid.Nil, uuid.Nil, errx.ErrUuid
 	}
-	orgID := middleware.GetOrganizationID(c)
-	if orgID == nil {
-		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+	org := middleware.GetOrganizationID(c)
+	if org == nil {
+		return uuid.Nil, uuid.Nil, errx.New(errx.BadRequest, "no organization selected")
+	}
+	if _, xerr := h.CampaignService.Get(c.Request.Context(), org.String(), campaignID.String()); xerr != nil {
+		return uuid.Nil, uuid.Nil, xerr
+	}
+	return campaignID, *org, nil
+}
+
+// UploadCampaignAttachment — POST /campaigns/:id/attachments (multipart "file")
+func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
+	campaignID, orgID, xerr := h.attachmentCampaign(c)
+	if xerr != nil {
+		errx.JSON(c, xerr)
 		return
 	}
 	userID, err := uuid.Parse(middleware.GetUserID(c))
@@ -74,12 +88,26 @@ func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
 		return
 	}
 
-	// Optional sequence_id form field scopes the attachment to one step.
+	// Optional step_id scopes the attachment to one step; without it the file
+	// rides every step of the campaign. A malformed or foreign step is refused
+	// rather than silently widened to the whole campaign.
 	var seqID *uuid.UUID
-	if s := strings.TrimSpace(c.PostForm("step_id")); s != "" {
-		if id, perr := uuid.Parse(s); perr == nil {
-			seqID = &id
+	if raw := strings.TrimSpace(c.PostForm("step_id")); raw != "" {
+		id, perr := uuid.Parse(raw)
+		if perr != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, "step_id must be a uuid"))
+			return
 		}
+		belongs, berr := h.AttachmentRepo.StepBelongsToCampaign(c.Request.Context(), campaignID, id)
+		if berr != nil {
+			errx.JSON(c, errx.InternalError())
+			return
+		}
+		if !belongs {
+			errx.JSON(c, errx.New(errx.NotFound, "step not found in this campaign"))
+			return
+		}
+		seqID = &id
 	}
 
 	// Cap the body before parsing so a huge upload can't pin a worker.
@@ -100,12 +128,12 @@ func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
 	}
 
 	// Plan-based overall storage quota (org-wide).
-	limit, xerr := h.FeatureGateService.GetStorageLimitBytes(c.Request.Context(), *orgID)
+	limit, xerr := h.FeatureGateService.GetStorageLimitBytes(c.Request.Context(), orgID)
 	if xerr != nil {
 		errx.JSON(c, xerr)
 		return
 	}
-	used, err := h.AttachmentRepo.SumStorageUsedByOrg(c.Request.Context(), *orgID)
+	used, err := h.AttachmentRepo.SumStorageUsedByOrg(c.Request.Context(), orgID)
 	if err != nil {
 		errx.JSON(c, errx.InternalError())
 		return
@@ -163,9 +191,9 @@ func (h *Handler) UploadCampaignAttachment(c *gin.Context) {
 
 // ListCampaignAttachments — GET /campaigns/:id/attachments
 func (h *Handler) ListCampaignAttachments(c *gin.Context) {
-	campaignID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		errx.JSON(c, errx.ErrUuid)
+	campaignID, _, xerr := h.attachmentCampaign(c)
+	if xerr != nil {
+		errx.JSON(c, xerr)
 		return
 	}
 	atts, err := h.AttachmentRepo.ListByCampaign(c.Request.Context(), campaignID)
@@ -182,9 +210,9 @@ func (h *Handler) ListCampaignAttachments(c *gin.Context) {
 
 // DeleteCampaignAttachment — DELETE /campaigns/:id/attachments/:attachmentId
 func (h *Handler) DeleteCampaignAttachment(c *gin.Context) {
-	campaignID, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		errx.JSON(c, errx.ErrUuid)
+	campaignID, _, xerr := h.attachmentCampaign(c)
+	if xerr != nil {
+		errx.JSON(c, xerr)
 		return
 	}
 	attID, err := uuid.Parse(c.Param("attachmentId"))

--- a/internal/api/handler/campaign.go
+++ b/internal/api/handler/campaign.go
@@ -35,6 +35,9 @@ type templatePreviewRequest struct {
 	ContactID  *uuid.UUID `json:"contact_id"`
 	CampaignID *uuid.UUID `json:"campaign_id"`
 	AccountID  *uuid.UUID `json:"account_id"`
+	// The step being previewed, so the attachment list is the one that step
+	// sends. Omitted lists the campaign-wide files only.
+	StepID *uuid.UUID `json:"step_id"`
 }
 
 // orgContact resolves a contact that must belong to orgID; any other id, or an
@@ -68,7 +71,7 @@ func sampleContact() models.Contact {
 // send path would, returning the output plus any parse errors and unresolved
 // tokens. With campaign_id and account_id it also applies the mailbox
 // signature, the opt-out footer and the plain-text rule, and lists the
-// attachments the send carries. No side effects — powers the composer's live
+// attachments the send carries (the campaign-wide files, plus step_id's own). No side effects — powers the composer's live
 // preview + inline validation.
 func (h *Handler) PreviewCampaignTemplate(c *gin.Context) {
 	orgID := middleware.GetOrganizationID(c)
@@ -90,6 +93,9 @@ func (h *Handler) PreviewCampaignTemplate(c *gin.Context) {
 			return
 		}
 		in.Campaign = campaign
+		if req.StepID != nil {
+			in.SequenceID = *req.StepID
+		}
 	}
 	if req.AccountID != nil {
 		if xerr := mailboxAllowed(c, *req.AccountID); xerr != nil {

--- a/internal/app/advanced/content_score_test.go
+++ b/internal/app/advanced/content_score_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -29,7 +31,7 @@ func TestWorstStepContentScoreSkipsNonEmailSteps(t *testing.T) {
 		emailStep(3, "Following up on my note", good),
 	}
 
-	worst, _, _, scored := worstStepContentScore(seqs, 0)
+	worst, _, _, scored := worstStepContentScore(seqs, nil)
 	if scored != 2 {
 		t.Errorf("scored %d steps, want the 2 email steps", scored)
 	}
@@ -44,7 +46,7 @@ func TestWorstStepContentScoreReportsNothingToScore(t *testing.T) {
 	_, _, _, scored := worstStepContentScore([]models.Sequence{
 		{Kind: "wait", Position: 0},
 		{Kind: "action", Position: 1},
-	}, 0)
+	}, nil)
 	if scored != 0 {
 		t.Errorf("scored %d steps, want 0", scored)
 	}
@@ -60,7 +62,7 @@ func TestWorstStepContentScoreReportsThePositionOfTheWorstStep(t *testing.T) {
 		emailStep(2, "FREE CASH PRIZE GUARANTEED!!!", "Act now, click here, 100% free, risk free."),
 	}
 
-	worst, step, issue, scored := worstStepContentScore(seqs, 0)
+	worst, step, issue, scored := worstStepContentScore(seqs, nil)
 	if scored != 2 {
 		t.Fatalf("scored %d steps, want 2", scored)
 	}
@@ -78,20 +80,46 @@ func TestWorstStepContentScoreReportsThePositionOfTheWorstStep(t *testing.T) {
 // An empty step list falls out with nothing scored: the caller reports that
 // rather than treating it as passing content.
 func TestWorstStepContentScoreOnEmptyCampaign(t *testing.T) {
-	if _, _, _, scored := worstStepContentScore(nil, 0); scored != 0 {
+	if _, _, _, scored := worstStepContentScore(nil, nil); scored != 0 {
 		t.Errorf("scored %d steps on an empty campaign, want 0", scored)
 	}
 }
 
-// Attachments are campaign-wide, so preflight weighs them the way the send path
-// does instead of reporting a score the activity feed later contradicts.
+// Preflight weighs attachments the way the send path does instead of reporting
+// a score the activity feed later contradicts.
 func TestWorstStepContentScoreCountsAttachments(t *testing.T) {
 	good := strings.Repeat("A real sentence about the recipient's work. ", 5)
 	seqs := []models.Sequence{emailStep(0, "Quick question about hiring", good)}
 
-	clean, _, _, _ := worstStepContentScore(seqs, 0)
-	withAtt, _, _, _ := worstStepContentScore(seqs, 2)
+	clean, _, _, _ := worstStepContentScore(seqs, nil)
+	withAtt, _, _, _ := worstStepContentScore(seqs, func(models.Sequence) int { return 2 })
 	if withAtt >= clean {
 		t.Errorf("attachment score %d not below the clean %d", withAtt, clean)
+	}
+}
+
+// A file scoped to one step is only carried by that step, so it may only drag
+// that step's score down: counting it against every step made preflight report
+// a step the send path would never warn about.
+func TestWorstStepContentScoreCountsAttachmentsPerStep(t *testing.T) {
+	good := strings.Repeat("A real sentence about the recipient's work. ", 5)
+	first := emailStep(0, "Quick question about hiring", good)
+	first.ID = uuid.New()
+	second := emailStep(1, "Following up on my note", good)
+	second.ID = uuid.New()
+
+	perStep := map[uuid.UUID]int{first.ID: 3}
+	worst, step, _, scored := worstStepContentScore([]models.Sequence{first, second}, func(seq models.Sequence) int {
+		return perStep[seq.ID]
+	})
+	if scored != 2 {
+		t.Fatalf("scored %d steps, want 2", scored)
+	}
+	if step != 1 {
+		t.Errorf("worst step reported as %d, want 1 (the step holding the files)", step)
+	}
+	clean, _, _, _ := worstStepContentScore([]models.Sequence{second}, nil)
+	if worst >= clean {
+		t.Errorf("step with attachments scored %d, want below the clean %d", worst, clean)
 	}
 }

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -1994,13 +1994,19 @@ func (s *service) ProcessRetryableDeadLetters(ctx context.Context) (int, *errx.E
 // worstStepContentScore returns the lowest-scoring email step's score, number,
 // leading issue, and how many steps were scored. Only email steps carry copy: a
 // wait or action node would otherwise score as the campaign's worst content.
-func worstStepContentScore(seqs []models.Sequence, attachments int) (worst, worstStep int, issue string, scored int) {
+// attachmentsFor gives the file count of one step's send, which differs per
+// step now that a file can be scoped to one.
+func worstStepContentScore(seqs []models.Sequence, attachmentsFor func(models.Sequence) int) (worst, worstStep int, issue string, scored int) {
 	worst = 101
 	for _, seq := range seqs {
 		if seq.Kind != "" && seq.Kind != "email" {
 			continue
 		}
 		scored++
+		attachments := 0
+		if attachmentsFor != nil {
+			attachments = attachmentsFor(seq)
+		}
 		r := warmlint.ScoreWithAttachments(seq.Subject, seq.BodyHTML, seq.BodyPlain, attachments)
 		if r.Score >= worst {
 			continue
@@ -2047,9 +2053,11 @@ func (s *service) contentScoreCheck(ctx context.Context, campaignID uuid.UUID, f
 		}
 	}
 
-	// Attachments are campaign-wide and the send path scores them, so preflight
-	// weighs them too rather than reporting a score the feed later contradicts.
-	attachments := 0
+	// The send path scores the files each step actually carries, so preflight
+	// counts them the same way (campaign-wide plus that step's own) rather than
+	// reporting a score the feed later contradicts.
+	campaignWide := 0
+	perStep := map[uuid.UUID]int{}
 	if s.attachmentRepo != nil {
 		atts, aerr := s.attachmentRepo.ListByCampaign(ctx, campaignID)
 		if aerr != nil {
@@ -2063,10 +2071,18 @@ func (s *service) contentScoreCheck(ctx context.Context, campaignID uuid.UUID, f
 				Remediation: "Re-run preflight.",
 			}
 		}
-		attachments = len(atts)
+		for _, a := range atts {
+			if a.SequenceID == nil {
+				campaignWide++
+				continue
+			}
+			perStep[*a.SequenceID]++
+		}
 	}
 
-	worst, worstStep, issue, scored := worstStepContentScore(seqs, attachments)
+	worst, worstStep, issue, scored := worstStepContentScore(seqs, func(seq models.Sequence) int {
+		return campaignWide + perStep[seq.ID]
+	})
 	if scored == 0 {
 		return models.PreflightCheckResult{
 			Key:      "content_score",

--- a/internal/app/sequence/handler.go
+++ b/internal/app/sequence/handler.go
@@ -2,6 +2,10 @@ package sequence
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
@@ -29,6 +33,51 @@ func (s *sequenceService) UpdateLayout(ctx context.Context, userID, campaignID s
 	return s.sequenceRepository.UpdateLayout(ctx, userID, campaignID, positions)
 }
 
+// Delete removes a step. Its attachment rows go with it through the cascade,
+// so the objects behind them are listed first and dropped once the delete has
+// committed — otherwise the bytes stay in storage against the org's quota with
+// no row left to reach them.
 func (s *sequenceService) Delete(ctx context.Context, userID, campaignID, sequenceID string) *errx.Error {
-	return s.sequenceRepository.Delete(ctx, userID, campaignID, sequenceID)
+	keys := s.stepObjectKeys(ctx, campaignID, sequenceID)
+
+	if xerr := s.sequenceRepository.Delete(ctx, userID, campaignID, sequenceID); xerr != nil {
+		return xerr
+	}
+
+	for _, key := range keys {
+		if err := s.storage.Delete(ctx, key); err != nil {
+			sentry.CaptureException(fmt.Errorf("sequence %s delete: object %s: %w", sequenceID, key, err))
+		}
+	}
+	return nil
+}
+
+// stepObjectKeys lists the storage keys of the files scoped to one step. Best
+// effort: a step still deletes when they cannot be read, it just leaves its
+// objects behind rather than refusing the edit.
+func (s *sequenceService) stepObjectKeys(ctx context.Context, campaignID, sequenceID string) []string {
+	if s.attachmentRepo == nil || s.storage == nil {
+		return nil
+	}
+	cID, err := uuid.Parse(campaignID)
+	if err != nil {
+		return nil
+	}
+	sID, err := uuid.Parse(sequenceID)
+	if err != nil {
+		return nil
+	}
+	atts, err := s.attachmentRepo.ListForStep(ctx, cID, sID)
+	if err != nil {
+		sentry.CaptureException(fmt.Errorf("sequence %s delete: list attachments: %w", sequenceID, err))
+		return nil
+	}
+	keys := make([]string, 0, len(atts))
+	for _, a := range atts {
+		// ListForStep also returns the campaign-wide files, which outlive the step.
+		if a.SequenceID != nil && *a.SequenceID == sID {
+			keys = append(keys, a.S3Key)
+		}
+	}
+	return keys
 }

--- a/internal/app/sequence/service.go
+++ b/internal/app/sequence/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/infrastructure/storage"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
 )
@@ -18,10 +19,24 @@ type SequenceService interface {
 
 type sequenceService struct {
 	sequenceRepository repository.SequenceRepository
+	attachmentRepo     repository.AttachmentRepository
+	storage            storage.Store
 }
 
 func NewService(sequenceRepository repository.SequenceRepository) SequenceService {
 	return &sequenceService{
 		sequenceRepository: sequenceRepository,
 	}
+}
+
+// AttachmentAware is implemented by the sequence service so main can hand it
+// the attachment repository and object store. Deleting a step cascades its
+// attachment rows away, so without these the files scoped to that step leave
+// their bytes in storage forever, still counted against the org's quota.
+type AttachmentAware interface {
+	WireAttachments(repo repository.AttachmentRepository, store storage.Store)
+}
+
+func (s *sequenceService) WireAttachments(repo repository.AttachmentRepository, store storage.Store) {
+	s.attachmentRepo, s.storage = repo, store
 }

--- a/internal/repository/attachment_step_scope_live_test.go
+++ b/internal/repository/attachment_step_scope_live_test.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// A campaign attachment carries an optional sequence_id, and the send path now
+// honours it: a step sends the campaign-wide files plus its own, and nothing
+// scoped to another step. Cover for the scoping query itself, plus the guard
+// that refuses a step_id belonging to another campaign (the FK only proves the
+// step exists).
+//
+// Run against the dev stack:
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveAttachmentStepScope -v
+func TestLiveAttachmentStepScope(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	f := newSharedOrgFixture(t, pool)
+	repo := NewAttachmentRepository(handle)
+	ctx := context.Background()
+
+	stepOne, stepTwo, otherCampaignStep := uuid.New(), uuid.New(), uuid.New()
+	for _, s := range []struct {
+		id       uuid.UUID
+		campaign uuid.UUID
+		position int
+	}{{stepOne, f.campaign, 0}, {stepTwo, f.campaign, 1}, {otherCampaignStep, f.other, 0}} {
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO sequences (id, campaign_id, organization_id, name, subject, body_html, body_plain, position)
+			 VALUES ($1, $2, $3, 'Step', 'Subject', '<p>Body</p>', 'Body', $4)`,
+			s.id, s.campaign, f.org, s.position); err != nil {
+			t.Fatalf("fixture sequence: %v", err)
+		}
+	}
+
+	insert := func(name string, step *uuid.UUID) {
+		t.Helper()
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO campaign_attachments (campaign_id, sequence_id, user_id, filename, size, mime_type, s3_key)
+			 VALUES ($1, $2, $3, $4, 10, 'application/pdf', $5)`,
+			f.campaign, step, f.owner, name, "live/"+name); err != nil {
+			t.Fatalf("fixture attachment %s: %v", name, err)
+		}
+	}
+	insert("everystep.pdf", nil)
+	insert("stepone.pdf", &stepOne)
+	insert("steptwo.pdf", &stepTwo)
+
+	names := func(step uuid.UUID) []string {
+		t.Helper()
+		atts, err := repo.ListForStep(ctx, f.campaign, step)
+		if err != nil {
+			t.Fatalf("ListForStep: %v", err)
+		}
+		out := make([]string, 0, len(atts))
+		for _, a := range atts {
+			out = append(out, a.Filename)
+		}
+		return out
+	}
+
+	same := func(got, want []string) bool {
+		if len(got) != len(want) {
+			return false
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	if got := names(stepOne); !same(got, []string{"everystep.pdf", "stepone.pdf"}) {
+		t.Errorf("step one sends %v, want the campaign-wide file and its own", got)
+	}
+	if got := names(stepTwo); !same(got, []string{"everystep.pdf", "steptwo.pdf"}) {
+		t.Errorf("step two sends %v, want the campaign-wide file and its own", got)
+	}
+	// A step of the campaign that owns no files still carries the campaign-wide
+	// ones, and uuid.Nil (no step in context) carries only those.
+	if got := names(uuid.Nil); !same(got, []string{"everystep.pdf"}) {
+		t.Errorf("unscoped list is %v, want the campaign-wide file alone", got)
+	}
+
+	// Every file of the campaign is still listed for the dashboard.
+	all, err := repo.ListByCampaign(ctx, f.campaign)
+	if err != nil {
+		t.Fatalf("ListByCampaign: %v", err)
+	}
+	if len(all) != 3 {
+		t.Errorf("ListByCampaign returned %d files, want all 3", len(all))
+	}
+
+	for _, tc := range []struct {
+		name string
+		step uuid.UUID
+		want bool
+	}{
+		{"own step", stepOne, true},
+		{"another campaign's step", otherCampaignStep, false},
+		{"unknown step", uuid.New(), false},
+	} {
+		got, err := repo.StepBelongsToCampaign(ctx, f.campaign, tc.step)
+		if err != nil {
+			t.Fatalf("StepBelongsToCampaign(%s): %v", tc.name, err)
+		}
+		if got != tc.want {
+			t.Errorf("StepBelongsToCampaign(%s) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/repository/pg_attachment.go
+++ b/internal/repository/pg_attachment.go
@@ -17,6 +17,14 @@ type AttachmentRepository interface {
 	Create(ctx context.Context, att *models.CampaignAttachment) error
 	GetByID(ctx context.Context, id uuid.UUID) (*models.CampaignAttachment, error)
 	ListByCampaign(ctx context.Context, campaignID uuid.UUID) ([]models.CampaignAttachment, error)
+	// ListForStep returns what one step's send carries: the campaign-wide files
+	// (no sequence_id) plus the ones scoped to that step. uuid.Nil asks for the
+	// campaign-wide set alone.
+	ListForStep(ctx context.Context, campaignID, sequenceID uuid.UUID) ([]models.CampaignAttachment, error)
+	// StepBelongsToCampaign guards the sequence_id an upload names: the FK only
+	// proves the step exists, not that it is a step of this campaign, and one
+	// pointed at another campaign's step would never be sent by either.
+	StepBelongsToCampaign(ctx context.Context, campaignID, sequenceID uuid.UUID) (bool, error)
 	Delete(ctx context.Context, id uuid.UUID) error
 	// SumStorageUsedByOrg totals the bytes of every attachment owned by the org
 	// (joined through campaigns) — the basis for the per-plan storage quota.
@@ -76,6 +84,34 @@ func (r *attachmentRepository) ListByCampaign(ctx context.Context, campaignID uu
 		out = append(out, a)
 	}
 	return out, rows.Err()
+}
+
+func (r *attachmentRepository) ListForStep(ctx context.Context, campaignID, sequenceID uuid.UUID) ([]models.CampaignAttachment, error) {
+	rows, err := r.DB.Query(ctx, `SELECT `+attachmentCols+`
+		FROM campaign_attachments
+		WHERE campaign_id = $1 AND (sequence_id IS NULL OR sequence_id = $2)
+		ORDER BY created_at ASC`, campaignID, sequenceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]models.CampaignAttachment, 0)
+	for rows.Next() {
+		var a models.CampaignAttachment
+		if err := scanAttachment(rows, &a); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+func (r *attachmentRepository) StepBelongsToCampaign(ctx context.Context, campaignID, sequenceID uuid.UUID) (bool, error) {
+	var ok bool
+	err := r.DB.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM sequences WHERE id = $1 AND campaign_id = $2)`,
+		sequenceID, campaignID).Scan(&ok)
+	return ok, err
 }
 
 func (r *attachmentRepository) Delete(ctx context.Context, id uuid.UUID) error {

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -417,9 +417,10 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		return nil
 	}
 
-	// Load campaign attachments (campaign-wide; metadata only — the worker
-	// fetches the bytes from object storage by S3 key at send time).
-	attachmentRefs := s.campaignAttachmentRefs(ctx, campaign.ID)
+	// Load this step's attachments (campaign-wide files plus the step's own;
+	// metadata only — the worker fetches the bytes from object storage by S3
+	// key at send time).
+	attachmentRefs := s.campaignAttachmentRefs(ctx, campaign.ID, sequence.ID)
 
 	// STEP 7.5: Update campaign task with contact_id and sequence_id for tracking
 	// This allows the tracking consumer to find the correct contact/sequence when

--- a/internal/tasks/preview.go
+++ b/internal/tasks/preview.go
@@ -21,6 +21,9 @@ type EmailPreviewInput struct {
 	Contact   models.Contact
 	Campaign  *models.Campaign
 	Account   *models.Email
+	// SequenceID names the step being previewed, so the attachment list is the
+	// one that step sends. Zero lists the campaign-wide files only.
+	SequenceID uuid.UUID
 }
 
 // EmailPreviewFrom is the sender as the recipient will see it.
@@ -70,7 +73,7 @@ func (s *tasksService) PreviewEmail(ctx context.Context, orgID uuid.UUID, in Ema
 		out.From = &EmailPreviewFrom{Name: strings.TrimSpace(in.Account.Name), Email: in.Account.Email}
 	}
 	if in.Campaign != nil && s.attachmentRepo != nil {
-		atts, err := s.attachmentRepo.ListByCampaign(ctx, in.Campaign.ID)
+		atts, err := s.attachmentRepo.ListForStep(ctx, in.Campaign.ID, in.SequenceID)
 		if err != nil {
 			log.Warn().Err(err).Str("campaign_id", in.Campaign.ID.String()).Msg("preview: load campaign attachments failed")
 		}
@@ -106,14 +109,15 @@ func finishBody(bodyHTML, bodyPlain string, textOnly bool, account *models.Email
 	return bodyHTML, bodyPlain
 }
 
-// campaignAttachmentRefs lists the files a campaign send carries, as the refs
-// the worker resolves from object storage. A load failure sends without them
-// rather than failing the send, and is logged.
-func (s *tasksService) campaignAttachmentRefs(ctx context.Context, campaignID uuid.UUID) []models.AttachmentRef {
+// campaignAttachmentRefs lists the files one step's send carries, as the refs
+// the worker resolves from object storage: the campaign-wide files plus the
+// ones scoped to that step (uuid.Nil = campaign-wide only). A load failure
+// sends without them rather than failing the send, and is logged.
+func (s *tasksService) campaignAttachmentRefs(ctx context.Context, campaignID, sequenceID uuid.UUID) []models.AttachmentRef {
 	if s.attachmentRepo == nil {
 		return nil
 	}
-	atts, err := s.attachmentRepo.ListByCampaign(ctx, campaignID)
+	atts, err := s.attachmentRepo.ListForStep(ctx, campaignID, sequenceID)
 	if err != nil {
 		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("Failed to load campaign attachments")
 		return nil

--- a/internal/tasks/step_attachments_test.go
+++ b/internal/tasks/step_attachments_test.go
@@ -1,0 +1,55 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// stubAttachmentRepo records the scope a send asked for and answers with the
+// rows a step-scoped query would return.
+type stubAttachmentRepo struct {
+	repository.AttachmentRepository
+	gotCampaign uuid.UUID
+	gotSequence uuid.UUID
+	rows        []models.CampaignAttachment
+}
+
+func (s *stubAttachmentRepo) ListForStep(_ context.Context, campaignID, sequenceID uuid.UUID) ([]models.CampaignAttachment, error) {
+	s.gotCampaign, s.gotSequence = campaignID, sequenceID
+	return s.rows, nil
+}
+
+// The files a send carries are the step's, not the campaign's: sequence_id was
+// stored on upload and honoured by the duplicate path, but the send path listed
+// every attachment of the campaign, so a file attached to step 1 rode step 2,
+// step 3 and every follow-up after them.
+func TestCampaignAttachmentRefsAsksForTheStepsFiles(t *testing.T) {
+	campaignID, sequenceID := uuid.New(), uuid.New()
+	repo := &stubAttachmentRepo{rows: []models.CampaignAttachment{
+		{S3Key: "k1", Filename: "brief.pdf", MimeType: "application/pdf"},
+	}}
+	s := &tasksService{attachmentRepo: repo}
+
+	refs := s.campaignAttachmentRefs(context.Background(), campaignID, sequenceID)
+
+	if repo.gotCampaign != campaignID || repo.gotSequence != sequenceID {
+		t.Fatalf("listed (%s, %s), want the campaign and step being sent (%s, %s)",
+			repo.gotCampaign, repo.gotSequence, campaignID, sequenceID)
+	}
+	if len(refs) != 1 || refs[0].S3Key != "k1" || refs[0].Filename != "brief.pdf" {
+		t.Fatalf("refs = %#v, want the step's one file", refs)
+	}
+}
+
+// Without an attachment store a send still goes out, carrying nothing.
+func TestCampaignAttachmentRefsWithoutAStore(t *testing.T) {
+	s := &tasksService{}
+	if refs := s.campaignAttachmentRefs(context.Background(), uuid.New(), uuid.New()); refs != nil {
+		t.Fatalf("refs = %#v, want none", refs)
+	}
+}

--- a/internal/tasks/test_email.go
+++ b/internal/tasks/test_email.go
@@ -73,7 +73,7 @@ func (s *tasksService) SendTestEmail(ctx context.Context, orgID uuid.UUID, accou
 		MessageID:      generateMessageID(account.Email),
 		IsWarmup:       false,
 		UnsubscribeURL: headerURL,
-		Attachments:    s.campaignAttachmentRefs(ctx, campaign.ID),
+		Attachments:    s.campaignAttachmentRefs(ctx, campaign.ID, sequence.ID),
 	}
 
 	taskID := uuid.New()

--- a/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
+++ b/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
@@ -49,7 +49,8 @@ export default function EmailContentEditor({
     subjectPlaceholder = "Quick question, {{.FirstName}}",
     bodyPlaceholder = "Hi {{.FirstName}}, …",
     campaignId,
-    testStepId,
+    stepId,
+    canSendTest = false,
     dirty = false,
 }: {
     subject: string;
@@ -61,8 +62,12 @@ export default function EmailContentEditor({
     // When set, the preview renders for a chosen lead and mailbox and shows the
     // campaign's opt-out footer, signature and attachments.
     campaignId?: string;
-    // When set, the preview offers "Send test" for this saved step.
-    testStepId?: string;
+    // The saved step this copy is sent by, so the preview lists the files that
+    // step attaches.
+    stepId?: string;
+    // Offer "Send test" for that step. Off for a variant arm: the test send
+    // mails the step's saved copy, which is not what this arm holds.
+    canSendTest?: boolean;
     // Unsaved edits: the test send mails the saved step, so it waits for a save.
     dirty?: boolean;
 }) {
@@ -103,6 +108,7 @@ export default function EmailContentEditor({
                 ...(campaignId && previewContact ? { contact_id: previewContact.id } : {}),
                 ...(campaignId ? { campaign_id: campaignId } : {}),
                 ...(campaignId && previewMailbox ? { account_id: previewMailbox.id } : {}),
+                ...(campaignId && stepId ? { step_id: stepId } : {}),
             })
                 .then((p) => {
                     if (active) setServerPreview(p);
@@ -116,7 +122,7 @@ export default function EmailContentEditor({
             clearTimeout(t);
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [tab, subject, bodyHtml, previewContact?.id, campaignId, previewMailbox?.id]);
+    }, [tab, subject, bodyHtml, previewContact?.id, campaignId, previewMailbox?.id, stepId]);
 
     const tplIssue = templateIssue(subject) || templateIssue(bodyHtml) || templateIssue(htmlToPlain(bodyHtml));
 
@@ -245,11 +251,11 @@ export default function EmailContentEditor({
                                 <span className="px-1 text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Preview as</span>
                                 <PreviewContactPicker campaignId={campaignId} value={previewContact} onChange={setPreviewContact} />
                                 <PreviewMailboxPicker inboxes={senders.inboxes} value={previewMailbox} onChange={setPreviewMailbox} />
-                                {testStepId && (
+                                {stepId && canSendTest && (
                                     <div className="ml-auto">
                                         <SendTestButton
                                             campaignId={campaignId}
-                                            stepId={testStepId}
+                                            stepId={stepId}
                                             contact={previewContact}
                                             mailbox={previewMailbox}
                                             dirty={dirty}

--- a/web/src/components/app/campaigns/sequences/SequenceView.tsx
+++ b/web/src/components/app/campaigns/sequences/SequenceView.tsx
@@ -124,7 +124,8 @@ export default function SequenceView({
                     bodyHtml={draft.body_html}
                     onBodyChange={(html, plain) => patch({ body_html: html, body_plain: plain })}
                     campaignId={campaignId}
-                    testStepId={sequence.id}
+                    stepId={sequence.id}
+                    canSendTest
                     dirty={savable}
                 />
 

--- a/web/src/components/app/campaigns/sequences/StepEmailArms.tsx
+++ b/web/src/components/app/campaigns/sequences/StepEmailArms.tsx
@@ -333,6 +333,7 @@ function VariantEditor({
                 subjectPlaceholder="Leave blank to reuse the step's subject"
                 bodyPlaceholder="Leave blank to reuse the step's body"
                 campaignId={campaignId}
+                stepId={variant.step_id ?? undefined}
             />
         </div>
     );

--- a/web/src/lib/api/client/app/campaigns/previewTemplate.ts
+++ b/web/src/lib/api/client/app/campaigns/previewTemplate.ts
@@ -20,7 +20,7 @@ export interface TemplatePreview {
     unresolved?: string[]; // literal {{…}} tokens left after render
     // Present when account_id was given: the sender as recipients see it.
     from?: TemplatePreviewFrom;
-    // Present when campaign_id was given and the campaign has files attached.
+    // Present when campaign_id was given and this step's send carries files.
     attachments?: TemplatePreviewAttachment[];
 }
 
@@ -32,6 +32,9 @@ export interface TemplatePreviewInput {
     contact_id?: string;
     // Applies the campaign's opt-out footer and plain-text rule and lists its attachments.
     campaign_id?: string;
+    // The step being previewed, so the attachments listed are the ones that step
+    // sends (campaign-wide files plus its own). Without it, campaign-wide only.
+    step_id?: string;
     // Applies that mailbox's signature and reports it as the sender.
     account_id?: string;
 }


### PR DESCRIPTION
Two defects behind the per-step attachment UI in #323, found while reviewing it.

## The send path ignored `sequence_id`

`campaign_attachments.sequence_id` has existed since migration 000017, the upload endpoint accepts `step_id`, the API reference documents it as "scope the attachment to one sequence step", and campaign duplicate already remaps it onto the copied steps. The send path was the one place that ignored it: `campaignAttachmentRefs` listed every attachment of the campaign, so a file attached to step 1 was mailed by step 2, step 3 and every follow-up after them. On cold outreach that is exactly the deliverability problem a per-step attachment is meant to avoid.

Now a send carries the campaign-wide files (no `step_id`) plus the step's own, through one `ListForStep` query used by the campaign send, the test send and the composer preview. The preview takes a `step_id` so it lists what that step sends, and the preflight content score counts each step's own files instead of applying the campaign-wide total to every step (a step-scoped PDF used to drag down the score of steps that never carried it).

Uploading with a `step_id` that is not a step of this campaign is now `404`, and a malformed one is `400`. The foreign key only proves the step exists, so before this a step id from another campaign was accepted and produced a row no step would ever send. A malformed id was silently dropped, quietly widening the file to every step.

## The attachment routes were not org-scoped

`ListCampaignAttachments`, `UploadCampaignAttachment` and `DeleteCampaignAttachment` took `:id` straight from the path to the repository. `RequireOrganization` only proves the caller has an organization, not that the campaign is in it, and unlike every other campaign sub-route these three never went through a service that scopes by org. With another workspace's campaign id you could list their attachments *including short-lived presigned download URLs*, upload a file their campaign would then send, or delete their rows and stored objects. All three now resolve the campaign through `CampaignService.Get(orgID, id)` first, so a campaign outside the caller's organization is a 404.

## Tests

- `internal/tasks/step_attachments_test.go` — the send asks for the step's files, not the campaign's
- `internal/repository/attachment_step_scope_live_test.go` (`WARMBLY_TEST_DB`) — `ListForStep` returns campaign-wide plus the step's own and nothing scoped to another step; `StepBelongsToCampaign` refuses another campaign's step. Run against the dev stack, passing
- `internal/app/advanced/content_score_test.go` — a file scoped to one step only scores against that step

`make lint` (gofmt + golangci-lint + check-migrations) clean, `pnpm typecheck` and `pnpm lint` clean in `web/` (no new warnings). Docs updated: attachment scoping and the new `step_id` preview parameter in the campaigns API reference, plus `openapi.json`. No migrations.

Ordering note: this should land before #323, which mounts the per-step attachments editor in the composer. Merged the other way round, that UI would present per-step attachments the send path does not honour.

## Two smaller things found in the same file

- the upload's `MaxBytesReader` was installed after `c.PostForm("step_id")`, and the first form-field read parses the whole multipart body, so the cap it was meant to impose never applied. It now goes in before anything touches the body.
- deleting a step cascades its attachment rows away (`sequence_id ... ON DELETE CASCADE`), which left the objects in storage forever, still counted against the organization's storage quota, with no row left to reach them. The sequence service now drops those objects after the delete commits, the way campaign delete already does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign attachments can now be assigned to specific sequence steps while retaining campaign-wide attachments.
  * Template previews and test emails support selecting a sequence step and display applicable attachments.
  * Render previews include sender details and rendered attachment metadata.
  * Campaign schedules now support per-day scheduling windows.
  * Deleting a sequence step also removes its associated stored attachments.

* **Bug Fixes**
  * Content scoring now applies attachment penalties to the relevant steps.
  * Improved validation and storage quota handling for attachment uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->