### PR TITLE
Show the campaign's every-step attachments in the step composer

### DIFF
--- a/docs/content/docs/guides/sequences.mdx
+++ b/docs/content/docs/guides/sequences.mdx
@@ -28,7 +28,7 @@ The Preview tab renders through the real send engine, so merge fields, condition
 Apply a saved template to a step, or save a step as a reusable one from the composer. Templates carry their subject and body and live in your shared library.
 </Callout>
 
-Upload attachments for each step below its composer by dragging and dropping files or clicking the upload area. They are included with every email sent by that step and can be removed there. Campaign-level attachments without a `step_id`, which can only be added through the API, do not appear in the step composer.
+Upload attachments for a step below its composer by dragging and dropping files or clicking the upload area. A file uploaded there is sent with every email from that step and from no other step, and can be removed in the same place. Files attached to the campaign itself rather than to a step, which can only be added through the API, ride every step: they are listed under **Sent with every step** so each step shows everything it carries. Attachments count against your workspace storage limit, and removing a step deletes the files scoped to it.
 
 ### Action steps
 

--- a/web/src/components/app/campaigns/sequences/StepAttachments.tsx
+++ b/web/src/components/app/campaigns/sequences/StepAttachments.tsx
@@ -1,10 +1,11 @@
 // Per-step attachments editor (lives under the Step composer). Drag-and-drop or
 // click to upload files for this step; lists each file with its name + size and
-// a delete control, and shows the total size used across the step's files.
+// a delete control, and shows the total size the step's send carries.
 //
-// Attachments are scoped to the step via step_id on upload; the list is the
-// campaign-wide set filtered down to this step. Campaign-level attachments (no
-// step_id) are not shown here.
+// A file uploaded here is scoped to the step (step_id on upload) and is sent by
+// this step alone. Files attached to the campaign itself (no step_id, added
+// through the API) ride every step, so they are listed in their own group
+// rather than hidden: the send path carries them here too.
 
 import React from "react";
 import { PaperclipIcon, UploadCloudIcon, Loader2Icon, Trash2Icon, FileIcon } from "lucide-react";
@@ -36,7 +37,10 @@ export default function StepAttachments({
     const [dragging, setDragging] = React.useState(false);
 
     const attachments = (all ?? []).filter((a) => a.step_id === sequenceId);
-    const totalSize = attachments.reduce((sum, a) => sum + (a.size || 0), 0);
+    // No step_id: attached to the campaign, so every step sends it.
+    const everyStep = (all ?? []).filter((a) => !a.step_id);
+    const carried = [...everyStep, ...attachments];
+    const totalSize = carried.reduce((sum, a) => sum + (a.size || 0), 0);
 
     const uploadFiles = React.useCallback(
         (files: FileList | File[]) => {
@@ -61,12 +65,46 @@ export default function StepAttachments({
         if (e.dataTransfer?.files?.length) uploadFiles(e.dataTransfer.files);
     };
 
-    const remove = (a: Attachment) => {
-        confirm.show(`Remove "${a.filename}" from this step?`, async () => {
-            await del.mutateAsync(a.id);
-            toast.success("Attachment removed.");
-        });
+    const remove = (a: Attachment, everywhere: boolean) => {
+        confirm.show(
+            everywhere
+                ? `Remove "${a.filename}" from every step of this campaign?`
+                : `Remove "${a.filename}" from this step?`,
+            async () => {
+                await del.mutateAsync(a.id);
+                toast.success("Attachment removed.");
+            },
+        );
     };
+
+    const row = (a: Attachment, everywhere: boolean) => (
+        <div key={a.id} className="flex items-center gap-2.5 px-3 py-2">
+            <FileIcon className="w-3.5 h-3.5 shrink-0 text-slate-400" />
+            <div className="min-w-0 flex-1">
+                <a
+                    href={a.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="block truncate text-[12.5px] font-medium text-slate-800 hover:text-sky-700"
+                    title={a.filename}
+                >
+                    {a.filename}
+                </a>
+                <div className="truncate text-[10.5px] text-slate-400">
+                    {formatBytes(a.size)}
+                    {a.mime_type ? ` · ${a.mime_type}` : ""}
+                </div>
+            </div>
+            <button
+                type="button"
+                onClick={() => remove(a, everywhere)}
+                title={everywhere ? "Remove from every step" : "Remove attachment"}
+                className="size-7 shrink-0 inline-flex items-center justify-center rounded-md text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
+            >
+                <Trash2Icon className="w-3.5 h-3.5" />
+            </button>
+        </div>
+    );
 
     return (
         <div className="rounded-md border border-slate-200 bg-white">
@@ -78,9 +116,9 @@ export default function StepAttachments({
                             Attachments
                         </div>
                         <p className="truncate text-[11px] text-slate-400">
-                            {attachments.length === 0
+                            {carried.length === 0
                                 ? "Attach files to send with this step."
-                                : `${attachments.length} file${attachments.length === 1 ? "" : "s"} · ${formatBytes(totalSize)} used`}
+                                : `${carried.length} file${carried.length === 1 ? "" : "s"} on this step · ${formatBytes(totalSize)}`}
                         </p>
                     </div>
                 </div>
@@ -122,45 +160,38 @@ export default function StepAttachments({
                         {upload.isPending ? "Uploading…" : "Drag files here or click to upload"}
                     </span>
                     <span className="text-[10.5px] text-slate-400">
-                        Files are sent with every email from this step.
+                        Sent with every email from this step, and no other step.
                     </span>
                 </button>
 
                 {isLoading ? (
                     <div className="text-[11.5px] text-slate-400">Loading attachments…</div>
-                ) : attachments.length === 0 ? (
-                    <p className="text-[11.5px] text-slate-400">No attachments yet.</p>
                 ) : (
-                    <div className="divide-y divide-slate-200/60 rounded-md border border-slate-200">
-                        {attachments.map((a) => (
-                            <div key={a.id} className="flex items-center gap-2.5 px-3 py-2">
-                                <FileIcon className="w-3.5 h-3.5 shrink-0 text-slate-400" />
-                                <div className="min-w-0 flex-1">
-                                    <a
-                                        href={a.url}
-                                        target="_blank"
-                                        rel="noreferrer"
-                                        className="block truncate text-[12.5px] font-medium text-slate-800 hover:text-sky-700"
-                                        title={a.filename}
-                                    >
-                                        {a.filename}
-                                    </a>
-                                    <div className="truncate text-[10.5px] text-slate-400">
-                                        {formatBytes(a.size)}
-                                        {a.mime_type ? ` · ${a.mime_type}` : ""}
-                                    </div>
-                                </div>
-                                <button
-                                    type="button"
-                                    onClick={() => remove(a)}
-                                    title="Remove attachment"
-                                    className="size-7 shrink-0 inline-flex items-center justify-center rounded-md text-slate-400 hover:text-rose-600 hover:bg-rose-50 transition-colors"
-                                >
-                                    <Trash2Icon className="w-3.5 h-3.5" />
-                                </button>
+                    <>
+                        {attachments.length === 0 ? (
+                            <p className="text-[11.5px] text-slate-400">No attachments on this step yet.</p>
+                        ) : (
+                            <div className="divide-y divide-slate-200/60 rounded-md border border-slate-200">
+                                {attachments.map((a) => row(a, false))}
                             </div>
-                        ))}
-                    </div>
+                        )}
+
+                        {everyStep.length > 0 && (
+                            <div>
+                                <div className="mb-1.5 flex items-baseline gap-2">
+                                    <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                                        Sent with every step
+                                    </span>
+                                    <span className="text-[10.5px] text-slate-400">
+                                        Attached to the campaign, not to one step
+                                    </span>
+                                </div>
+                                <div className="divide-y divide-slate-200/60 rounded-md border border-slate-200 bg-slate-50/40">
+                                    {everyStep.map((a) => row(a, true))}
+                                </div>
+                            </div>
+                        )}
+                    </>
                 )}
             </div>
         </div>


### PR DESCRIPTION
Follow-up to #323 and #325.

#323 mounted the per-step attachments editor in the composer, and #325 made the send path honour `step_id`, so a file scoped to a step is now carried by that step alone. That leaves one gap: the panel filters the list by `step_id`, so a file attached to the campaign itself (no `step_id`, which is the only shape the API offered before per-step uploads existed) is invisible in the composer while every step still sends it. A user reading the panel sees "no attachments" on a step that mails a PDF.

The panel now shows both, in two groups:

- the step's own files, uploaded here, sent by this step and no other
- **Sent with every step**, the campaign's unscoped files, on a tinted card with the note "Attached to the campaign, not to one step"

The header count is what the step's send actually carries (both groups) rather than only the step-scoped files, and the upload hint says what a file uploaded here is scoped to. Removing an unscoped file asks "Remove … from every step of this campaign?" instead of "from this step?", because that is what the delete does.

The sequences guide is updated to match, including that attachments count against the workspace storage limit and that removing a step deletes the files scoped to it (#325).

`pnpm typecheck` and `pnpm lint` clean in `web/` (no new warnings), `pnpm types:check` and `pnpm lint` clean in `docs/`. No API or backend change.
