### PR TITLE
feat: give a hand-placed unsubscribe link a real anchor instead of the bare API URL

### DIFF
--- a/docs/content/docs/guides/unsubscribe.mdx
+++ b/docs/content/docs/guides/unsubscribe.mdx
@@ -21,7 +21,17 @@ The wording of the sentence and of the link text is yours to change.
 
 **Unsubscribe link** is the right choice when your list skews toward consumers, when your legal team asks for a link, or when your volume is high enough that provider bulk-sender rules apply. The link is unique to the recipient and campaign, signed so it cannot be guessed or altered, and valid for a year after the send. Clicking it opens a plain confirmation page with one button. Nothing happens until the button is pressed, because link scanners and preview fetchers follow every link in an email. The page then offers a way back for anyone who unsubscribed by mistake.
 
-You can also place the link inside your own copy instead of the footer: insert the **Unsubscribe link** variable from the variable menu, or type `{{.UnsubscribeLink}}`. Click tracking never rewrites it, so an opt-out is never counted as a click.
+You can also place the link inside your own copy instead of the footer: insert the **Unsubscribe link** variable from the variable menu, or type `{{.UnsubscribeLink}}`.
+
+Dropped into your copy on its own, the variable becomes a real link in the HTML message, labelled with the same **Link text** the footer uses ("Unsubscribe" by default). The recipient reads a word, not the signed address. To choose the wording yourself, select the text first and then pick **Unsubscribe link** from the variable menu, or press the link button and use the **Unsubscribe** shortcut next to the address field: the selected text becomes the link and Warmbly fills in the address at send time.
+
+Two things follow from that. The plain-text alternative of the message has nowhere to hide a URL, so it carries the address in full when you place the variable on its own, and only your wording when you wrap your own link around it. And click tracking never rewrites the link either way, so an opt-out is never counted as a click.
+
+### Plain-text campaigns
+
+A campaign with **Plain text only** switched on ships no HTML at all, so there is nothing for a link to hide inside: link mode and a hand-placed variable both print the full signed address in the copy, which is the one place a cold email least wants a long tracking-shaped URL. The composer warns while you are writing and the launch check warns again before you start.
+
+The answer there is the header. It is not visible copy, it works the same on a plain-text send, and it is what Gmail and Yahoo actually look for. Leave **Unsubscribe header** on, leave the opt-out line as the reply sentence, and the recipient gets a one-click control in their mail client plus a human sentence in the message.
 
 ## The List-Unsubscribe header
 

--- a/internal/app/advanced/plain_text_optout_test.go
+++ b/internal/app/advanced/plain_text_optout_test.go
@@ -13,18 +13,18 @@ func replyLineSettings() models.UnsubscribeSettings {
 }
 
 func TestPlainTextOptOutPassesWithTheReplyLine(t *testing.T) {
-	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
-	got := plainTextOptOutResult(c, replyLineSettings(), []models.Sequence{
-		emailStep(0, "Quick question", "Hi there, worth a chat?"),
-	})
-	if !got.Passed {
+	seqs := []models.Sequence{emailStep(0, "Quick question", "Hi there, worth a chat?")}
+	if got := plainTextOptOutResult(stepPlacingUnsubscribeLink(seqs)); !got.Passed {
 		t.Fatalf("reply-line opt-out should pass on a plain-text campaign: %+v", got)
 	}
 }
 
 func TestPlainTextOptOutWarnsOnLinkMode(t *testing.T) {
 	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "link"}
-	got := plainTextOptOutResult(c, replyLineSettings(), nil)
+	if replyLineSettings().Effective(c.UnsubscribeMode).Mode != models.UnsubscribeModeLink {
+		t.Fatal("campaign link mode should win over the workspace reply line")
+	}
+	got := plainTextOptOutResult("the opt-out line is set to Unsubscribe link")
 	if got.Passed || got.Severity != "warning" {
 		t.Fatalf("link mode on a plain-text campaign should warn: %+v", got)
 	}
@@ -33,45 +33,83 @@ func TestPlainTextOptOutWarnsOnLinkMode(t *testing.T) {
 	}
 }
 
-func TestPlainTextOptOutWarnsOnAHandPlacedVariable(t *testing.T) {
-	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
+func TestPlainTextOptOutCampaignModeOverridesTheWorkspaceLink(t *testing.T) {
+	// Workspace is on link mode, this campaign opted back to the reply line.
+	workspace := models.UnsubscribeSettings{Mode: models.UnsubscribeModeLink}
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "text"}
+	if workspace.Effective(c.UnsubscribeMode).Mode == models.UnsubscribeModeLink {
+		t.Fatal("campaign override to the reply line should not resolve to link mode")
+	}
+}
+
+func TestStepPlacingUnsubscribeLinkNamesTheStep(t *testing.T) {
 	seqs := []models.Sequence{
 		emailStep(0, "Quick question", "Hi there"),
 		{Kind: "wait", Position: 1},
 		emailStep(2, "Following up", "Not for you? "+models.UnsubscribeLinkToken),
 	}
-	got := plainTextOptOutResult(c, replyLineSettings(), seqs)
-	if got.Passed {
-		t.Fatalf("a hand-placed variable on a plain-text campaign should warn: %+v", got)
-	}
 	// Unnamed steps fall back to their place in builder order, not `position`,
 	// which is 0-based on some campaigns and 1-based on others.
-	if !strings.Contains(got.Message, "step 3 places the unsubscribe link variable") {
-		t.Fatalf("warning should name the step: %s", got.Message)
+	if got := stepPlacingUnsubscribeLink(seqs); !strings.Contains(got, "step 3 places the unsubscribe link variable") {
+		t.Fatalf("warning should name the step: %q", got)
 	}
 
 	named := []models.Sequence{{Kind: "email", Name: "Follow-up", BodyPlain: models.UnsubscribeLinkToken}}
-	if got := plainTextOptOutResult(c, replyLineSettings(), named); !strings.Contains(got.Message, `the step "Follow-up" places`) {
-		t.Fatalf("a named step should be named: %s", got.Message)
+	if got := stepPlacingUnsubscribeLink(named); !strings.Contains(got, `the step "Follow-up" places`) {
+		t.Fatalf("a named step should be named: %q", got)
 	}
 }
 
-func TestPlainTextOptOutIgnoresNonEmailStepsAndOtherCopy(t *testing.T) {
-	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
+func TestStepPlacingUnsubscribeLinkIgnoresNonEmailSteps(t *testing.T) {
 	seqs := []models.Sequence{
 		{Kind: "action", Position: 0, BodyPlain: models.UnsubscribeLinkToken},
 		emailStep(1, "Quick question", "Reply and I'll stop emailing."),
 	}
-	if got := plainTextOptOutResult(c, replyLineSettings(), seqs); !got.Passed {
-		t.Fatalf("a non-email node's config must not be read as copy: %+v", got)
+	if got := stepPlacingUnsubscribeLink(seqs); got != "" {
+		t.Fatalf("a non-email node's config must not be read as copy: %q", got)
 	}
 }
 
-func TestPlainTextOptOutCampaignModeOverridesTheWorkspaceLink(t *testing.T) {
-	// Workspace is on link mode, this campaign opted back to the reply line.
-	workspace := models.UnsubscribeSettings{Mode: models.UnsubscribeModeLink}
-	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "text"}
-	if got := plainTextOptOutResult(c, workspace, nil); !got.Passed {
-		t.Fatalf("campaign override to the reply line should pass: %+v", got)
+// A plain-text send ships body_plain, or the text of body_html when there is
+// none. A token that only ever sits in an HTML attribute never reaches the
+// recipient, so warning about it would be a false alarm.
+func TestStepPlacingUnsubscribeLinkIgnoresAnAttributeOnlyToken(t *testing.T) {
+	attrOnly := []models.Sequence{{
+		Kind:     "email",
+		Name:     "Intro",
+		Subject:  "Quick question",
+		BodyHTML: `<p>Or <a href="` + models.UnsubscribeLinkToken + `">no thanks</a>.</p>`,
+	}}
+	if got := stepPlacingUnsubscribeLink(attrOnly); got != "" {
+		t.Fatalf("a token only in an href never reaches a plain-text recipient: %q", got)
+	}
+
+	// The composer's own chip serializes as text inside a span, which the plain
+	// part does carry.
+	chip := []models.Sequence{{
+		Kind:     "email",
+		Name:     "Intro",
+		BodyHTML: `<p>Or <span data-var>` + models.UnsubscribeLinkToken + `</span>.</p>`,
+	}}
+	if got := stepPlacingUnsubscribeLink(chip); got == "" {
+		t.Fatal("a chip token does reach the plain part and should warn")
+	}
+
+	// An explicit plain body wins over the HTML, exactly as the send path does.
+	explicit := []models.Sequence{{
+		Kind:      "email",
+		Name:      "Intro",
+		BodyHTML:  `<p>Or <span data-var>` + models.UnsubscribeLinkToken + `</span>.</p>`,
+		BodyPlain: "Or reply and I'll stop.",
+	}}
+	if got := stepPlacingUnsubscribeLink(explicit); got != "" {
+		t.Fatalf("the plain body is what ships; the HTML must not be scanned: %q", got)
+	}
+}
+
+func TestStepPlacingUnsubscribeLinkCatchesTheSubject(t *testing.T) {
+	seqs := []models.Sequence{{Kind: "email", Name: "Intro", Subject: "Out? " + models.UnsubscribeLinkToken}}
+	if got := stepPlacingUnsubscribeLink(seqs); got == "" {
+		t.Fatal("a subject carries no HTML at all, so its token is always raw")
 	}
 }

--- a/internal/app/advanced/plain_text_optout_test.go
+++ b/internal/app/advanced/plain_text_optout_test.go
@@ -1,0 +1,77 @@
+package advanced
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// The workspace default: a reply line, no link anywhere.
+func replyLineSettings() models.UnsubscribeSettings {
+	return models.DefaultAdvancedOutreachSettings().Unsubscribe
+}
+
+func TestPlainTextOptOutPassesWithTheReplyLine(t *testing.T) {
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
+	got := plainTextOptOutResult(c, replyLineSettings(), []models.Sequence{
+		emailStep(0, "Quick question", "Hi there, worth a chat?"),
+	})
+	if !got.Passed {
+		t.Fatalf("reply-line opt-out should pass on a plain-text campaign: %+v", got)
+	}
+}
+
+func TestPlainTextOptOutWarnsOnLinkMode(t *testing.T) {
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "link"}
+	got := plainTextOptOutResult(c, replyLineSettings(), nil)
+	if got.Passed || got.Severity != "warning" {
+		t.Fatalf("link mode on a plain-text campaign should warn: %+v", got)
+	}
+	if !strings.Contains(got.Message, "opt-out line is set to Unsubscribe link") || got.Remediation == "" {
+		t.Fatalf("warning should name the cause and a way out: %+v", got)
+	}
+}
+
+func TestPlainTextOptOutWarnsOnAHandPlacedVariable(t *testing.T) {
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
+	seqs := []models.Sequence{
+		emailStep(0, "Quick question", "Hi there"),
+		{Kind: "wait", Position: 1},
+		emailStep(2, "Following up", "Not for you? "+models.UnsubscribeLinkToken),
+	}
+	got := plainTextOptOutResult(c, replyLineSettings(), seqs)
+	if got.Passed {
+		t.Fatalf("a hand-placed variable on a plain-text campaign should warn: %+v", got)
+	}
+	// Unnamed steps fall back to their place in builder order, not `position`,
+	// which is 0-based on some campaigns and 1-based on others.
+	if !strings.Contains(got.Message, "step 3 places the unsubscribe link variable") {
+		t.Fatalf("warning should name the step: %s", got.Message)
+	}
+
+	named := []models.Sequence{{Kind: "email", Name: "Follow-up", BodyPlain: models.UnsubscribeLinkToken}}
+	if got := plainTextOptOutResult(c, replyLineSettings(), named); !strings.Contains(got.Message, `the step "Follow-up" places`) {
+		t.Fatalf("a named step should be named: %s", got.Message)
+	}
+}
+
+func TestPlainTextOptOutIgnoresNonEmailStepsAndOtherCopy(t *testing.T) {
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "inherit"}
+	seqs := []models.Sequence{
+		{Kind: "action", Position: 0, BodyPlain: models.UnsubscribeLinkToken},
+		emailStep(1, "Quick question", "Reply and I'll stop emailing."),
+	}
+	if got := plainTextOptOutResult(c, replyLineSettings(), seqs); !got.Passed {
+		t.Fatalf("a non-email node's config must not be read as copy: %+v", got)
+	}
+}
+
+func TestPlainTextOptOutCampaignModeOverridesTheWorkspaceLink(t *testing.T) {
+	// Workspace is on link mode, this campaign opted back to the reply line.
+	workspace := models.UnsubscribeSettings{Mode: models.UnsubscribeModeLink}
+	c := &models.Campaign{TextOnly: true, UnsubscribeMode: "text"}
+	if got := plainTextOptOutResult(c, workspace, nil); !got.Passed {
+		t.Fatalf("campaign override to the reply line should pass: %+v", got)
+	}
+}

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -2055,62 +2055,83 @@ func worstStepContentScore(seqs []models.Sequence, attachmentsFor func(models.Se
 	return worst, worstStep, issue, scored
 }
 
-// plainTextOptOutCheck loads the campaign's steps and reports whether a
-// plain-text-only campaign is putting the opt-out link in the body. A step list
-// it could not read is scanned as empty: the mode alone is still worth warning
-// about, and a failed read must not invent a step that carries the variable.
+// plainTextOptOutCheck reports whether a plain-text-only campaign is putting the
+// opt-out link in the body. Link mode is decided by the settings alone; only a
+// hand-placed variable needs the steps, and a step list it could not read
+// reports as FAILED, not passed, like every other check that cannot run.
 func (s *service) plainTextOptOutCheck(ctx context.Context, campaign *models.Campaign, unsub models.UnsubscribeSettings, recommendations *[]string) models.PreflightCheckResult {
-	seqs, err := s.campaignRepo.GetSequencesByCampaignID(ctx, campaign.ID)
-	if err != nil {
-		seqs = nil
+	where := ""
+	if unsub.Effective(campaign.UnsubscribeMode).Mode == models.UnsubscribeModeLink {
+		where = "the opt-out line is set to Unsubscribe link"
+	} else {
+		seqs, err := s.campaignRepo.GetSequencesByCampaignID(ctx, campaign.ID)
+		if err != nil {
+			*recommendations = append(*recommendations, "Re-run preflight; the campaign's steps could not be read.")
+			return models.PreflightCheckResult{
+				Key:         "plain_text_opt_out",
+				Passed:      false,
+				Severity:    "warning",
+				Message:     "Could not read the campaign's steps to check what its opt-out puts in the copy.",
+				Remediation: "Re-run preflight.",
+			}
+		}
+		where = stepPlacingUnsubscribeLink(seqs)
 	}
-	check := plainTextOptOutResult(campaign, unsub, seqs)
+
+	check := plainTextOptOutResult(where)
 	if !check.Passed {
 		*recommendations = append(*recommendations, "On a plain-text campaign, let the unsubscribe header carry the opt-out instead of a link in the body.")
 	}
 	return check
 }
 
-// plainTextOptOutResult warns when a plain-text-only campaign puts the opt-out
-// link in the body: either through link mode or a step that places the
-// {{.UnsubscribeLink}} variable itself. Only called when campaign.TextOnly is
-// set, so it never fires on an HTML campaign, where the link renders as a word.
-func plainTextOptOutResult(campaign *models.Campaign, unsub models.UnsubscribeSettings, seqs []models.Sequence) models.PreflightCheckResult {
+// stepPlacingUnsubscribeLink names the first email step whose SHIPPED copy
+// carries the {{.UnsubscribeLink}} variable, or "" when none does. A plain-text
+// campaign sends body_plain, falling back to the text of body_html, so a token
+// that only ever appears in an HTML attribute (the author's own <a href>) never
+// reaches the recipient and is not worth warning about.
+func stepPlacingUnsubscribeLink(seqs []models.Sequence) string {
+	// Named, not numbered: `position` is 0-based on some campaigns and 1-based
+	// on others, so a number computed from it would point at the wrong step.
+	// The list arrives in builder order, so the index is the honest fallback
+	// when a step has no name.
+	for i, seq := range seqs {
+		if seq.Kind != "" && seq.Kind != "email" {
+			continue
+		}
+		body := seq.BodyPlain
+		if strings.TrimSpace(body) == "" {
+			body = htmlTagRE.ReplaceAllString(seq.BodyHTML, "")
+		}
+		if !strings.Contains(seq.Subject, models.UnsubscribeLinkToken) && !strings.Contains(body, models.UnsubscribeLinkToken) {
+			continue
+		}
+		if name := strings.TrimSpace(seq.Name); name != "" {
+			return fmt.Sprintf("the step %q places the unsubscribe link variable", name)
+		}
+		return fmt.Sprintf("step %d places the unsubscribe link variable", i+1)
+	}
+	return ""
+}
+
+// htmlTagRE strips tags to leave the text a plain-text send actually carries.
+// The send path derives its plain part the same way (tasks.ExtractPlainTextFromHTML),
+// which this package cannot call: tasks imports advanced.
+var htmlTagRE = regexp.MustCompile(`(?s)<[^>]*>`)
+
+// plainTextOptOutResult turns "what puts the link in the body", or "" for
+// nothing, into the check. Only called when campaign.TextOnly is set, so it
+// never fires on an HTML campaign, where the link renders as a word.
+func plainTextOptOutResult(where string) models.PreflightCheckResult {
 	check := models.PreflightCheckResult{
 		Key:      "plain_text_opt_out",
 		Passed:   true,
 		Severity: "warning",
 		Message:  "Plain text only: the opt-out puts no raw URL in the copy.",
 	}
-
-	where := ""
-	if unsub.Effective(campaign.UnsubscribeMode).Mode == models.UnsubscribeModeLink {
-		where = "the opt-out line is set to Unsubscribe link"
-	} else {
-		// Named, not numbered: `position` is 0-based on some campaigns and
-		// 1-based on others, so a number computed from it would point at the
-		// wrong step. The list arrives in builder order, so the index is the
-		// honest fallback when a step has no name.
-		for i, seq := range seqs {
-			if seq.Kind != "" && seq.Kind != "email" {
-				continue
-			}
-			if strings.Contains(seq.Subject, models.UnsubscribeLinkToken) ||
-				strings.Contains(seq.BodyHTML, models.UnsubscribeLinkToken) ||
-				strings.Contains(seq.BodyPlain, models.UnsubscribeLinkToken) {
-				if name := strings.TrimSpace(seq.Name); name != "" {
-					where = fmt.Sprintf("the step %q places the unsubscribe link variable", name)
-				} else {
-					where = fmt.Sprintf("step %d places the unsubscribe link variable", i+1)
-				}
-				break
-			}
-		}
-	}
 	if where == "" {
 		return check
 	}
-
 	check.Passed = false
 	check.Message = fmt.Sprintf("This campaign sends plain text only and %s, so recipients read the whole signed unsubscribe address instead of a word.", where)
 	check.Remediation = "Keep the List-Unsubscribe header on and switch the opt-out line to Reply to opt out, or turn plain text off so the link can render as a word."

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -1774,6 +1774,13 @@ func (s *service) RunPreflight(ctx context.Context, organizationID, campaignID u
 		checks = append(checks, check)
 	}
 
+	// A plain-text campaign has no HTML for an anchor to hide a URL in, so an
+	// in-body opt-out link prints its whole signed address in the copy. The
+	// List-Unsubscribe header does the same job and the reader never sees it.
+	if settings.Preflight.CheckUnsubscribeHeader && campaign.TextOnly {
+		checks = append(checks, s.plainTextOptOutCheck(ctx, campaign, settings.Unsubscribe, &recommendations))
+	}
+
 	if settings.Preflight.CheckTrackingDomain && (campaign.OpenTracking || campaign.LinkTracking) {
 		// The same pool the scheduler sends from (explicit senders, tags, or
 		// every active mailbox when neither is picked), so a campaign on the
@@ -2046,6 +2053,68 @@ func worstStepContentScore(seqs []models.Sequence, attachmentsFor func(models.Se
 		}
 	}
 	return worst, worstStep, issue, scored
+}
+
+// plainTextOptOutCheck loads the campaign's steps and reports whether a
+// plain-text-only campaign is putting the opt-out link in the body. A step list
+// it could not read is scanned as empty: the mode alone is still worth warning
+// about, and a failed read must not invent a step that carries the variable.
+func (s *service) plainTextOptOutCheck(ctx context.Context, campaign *models.Campaign, unsub models.UnsubscribeSettings, recommendations *[]string) models.PreflightCheckResult {
+	seqs, err := s.campaignRepo.GetSequencesByCampaignID(ctx, campaign.ID)
+	if err != nil {
+		seqs = nil
+	}
+	check := plainTextOptOutResult(campaign, unsub, seqs)
+	if !check.Passed {
+		*recommendations = append(*recommendations, "On a plain-text campaign, let the unsubscribe header carry the opt-out instead of a link in the body.")
+	}
+	return check
+}
+
+// plainTextOptOutResult warns when a plain-text-only campaign puts the opt-out
+// link in the body: either through link mode or a step that places the
+// {{.UnsubscribeLink}} variable itself. Only called when campaign.TextOnly is
+// set, so it never fires on an HTML campaign, where the link renders as a word.
+func plainTextOptOutResult(campaign *models.Campaign, unsub models.UnsubscribeSettings, seqs []models.Sequence) models.PreflightCheckResult {
+	check := models.PreflightCheckResult{
+		Key:      "plain_text_opt_out",
+		Passed:   true,
+		Severity: "warning",
+		Message:  "Plain text only: the opt-out puts no raw URL in the copy.",
+	}
+
+	where := ""
+	if unsub.Effective(campaign.UnsubscribeMode).Mode == models.UnsubscribeModeLink {
+		where = "the opt-out line is set to Unsubscribe link"
+	} else {
+		// Named, not numbered: `position` is 0-based on some campaigns and
+		// 1-based on others, so a number computed from it would point at the
+		// wrong step. The list arrives in builder order, so the index is the
+		// honest fallback when a step has no name.
+		for i, seq := range seqs {
+			if seq.Kind != "" && seq.Kind != "email" {
+				continue
+			}
+			if strings.Contains(seq.Subject, models.UnsubscribeLinkToken) ||
+				strings.Contains(seq.BodyHTML, models.UnsubscribeLinkToken) ||
+				strings.Contains(seq.BodyPlain, models.UnsubscribeLinkToken) {
+				if name := strings.TrimSpace(seq.Name); name != "" {
+					where = fmt.Sprintf("the step %q places the unsubscribe link variable", name)
+				} else {
+					where = fmt.Sprintf("step %d places the unsubscribe link variable", i+1)
+				}
+				break
+			}
+		}
+	}
+	if where == "" {
+		return check
+	}
+
+	check.Passed = false
+	check.Message = fmt.Sprintf("This campaign sends plain text only and %s, so recipients read the whole signed unsubscribe address instead of a word.", where)
+	check.Remediation = "Keep the List-Unsubscribe header on and switch the opt-out line to Reply to opt out, or turn plain text off so the link can render as a word."
+	return check
 }
 
 // contentScoreCheck scores every step's copy and reports the worst. A step list

--- a/internal/models/advanced_outreach.go
+++ b/internal/models/advanced_outreach.go
@@ -126,6 +126,12 @@ const (
 	UnsubscribeCopyMaxLen       = 300
 )
 
+// UnsubscribeLinkToken is the template token a step places by hand to put the
+// recipient's own opt-out link in its copy. The send path renders it as an
+// anchor in HTML, but plain text has nowhere to hide the address, so preflight
+// looks for it on a plain-text campaign.
+const UnsubscribeLinkToken = "{{.UnsubscribeLink}}"
+
 // UnsubscribeSettings is the workspace default for the in-body opt-out. The
 // List-Unsubscribe header is a per-campaign flag and is not part of this.
 type UnsubscribeSettings struct {

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -541,6 +541,12 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		bodyHTML = ""
 	}
 
+	// STEP 10.7: A hand-placed {{.UnsubscribeLink}} resolved to the bare signed
+	// URL; give it an anchor so the recipient reads "Unsubscribe" and not the
+	// API address (issue #341). After the plain part was derived, so plain text
+	// keeps the URL it needs, and before tracking, which leaves it alone.
+	bodyHTML = linkifyUnsubscribeURL(bodyHTML, unsubscribeURL, optOut.LinkText)
+
 	// STEP 10.75: Score the copy the recipient will actually receive, after
 	// merge fields, spintax, A/B and AI blocks have resolved. Advisory: it
 	// warns once per step and never blocks or delays the send.

--- a/internal/tasks/optout.go
+++ b/internal/tasks/optout.go
@@ -61,3 +61,72 @@ func appendOptOut(bodyHTML, bodyPlain string, settings models.UnsubscribeSetting
 	}
 	return bodyHTML, bodyPlain
 }
+
+// linkifyUnsubscribeURL turns a hand-placed {{.UnsubscribeLink}} into a real
+// link. The variable resolves to the recipient's signed URL, so a token
+// dropped into prose ships as the bare API address (issue #341); this wraps
+// every loose occurrence in an anchor labelled with the workspace's
+// unsubscribe link text instead. A URL the author already put in an
+// attribute (their own <a href>) is inside a tag and left untouched, and one
+// sitting as the text of an existing anchor becomes that anchor's label
+// rather than a nested link.
+func linkifyUnsubscribeURL(bodyHTML, linkURL, linkText string) string {
+	if bodyHTML == "" || linkURL == "" || !strings.Contains(bodyHTML, linkURL) {
+		return bodyHTML
+	}
+	label := html.EscapeString(strings.TrimSpace(linkText))
+	if label == "" {
+		label = models.DefaultUnsubscribeLinkText
+	}
+	anchor := `<a href="` + html.EscapeString(linkURL) + `">` + label + `</a>`
+
+	var b strings.Builder
+	b.Grow(len(bodyHTML) + len(anchor))
+	depth := 0 // open <a> elements around the current text node
+	for i := 0; i < len(bodyHTML); {
+		if bodyHTML[i] == '<' {
+			end := strings.IndexByte(bodyHTML[i:], '>')
+			if end < 0 {
+				b.WriteString(bodyHTML[i:]) // unterminated tag: copy the rest verbatim
+				break
+			}
+			tag := bodyHTML[i : i+end+1]
+			switch {
+			case isTagStart(tag, "a"):
+				depth++
+			case isTagStart(tag, "/a"):
+				if depth > 0 {
+					depth--
+				}
+			}
+			b.WriteString(tag)
+			i += end + 1
+			continue
+		}
+		stop := len(bodyHTML)
+		if next := strings.IndexByte(bodyHTML[i:], '<'); next >= 0 {
+			stop = i + next
+		}
+		with := anchor
+		if depth > 0 {
+			with = label
+		}
+		b.WriteString(strings.ReplaceAll(bodyHTML[i:stop], linkURL, with))
+		i = stop
+	}
+	return b.String()
+}
+
+// isTagStart reports whether tag (a full "<...>" slice) is the named tag,
+// case-insensitively: isTagStart(`<A HREF="x">`, "a") and
+// isTagStart("</A>", "/a") are both true.
+func isTagStart(tag, name string) bool {
+	if len(tag) < len(name)+2 || !strings.EqualFold(tag[1:1+len(name)], name) {
+		return false
+	}
+	switch c := tag[1+len(name)]; c {
+	case '>', '/', ' ', '\t', '\n', '\r', '\f':
+		return true
+	}
+	return false
+}

--- a/internal/tasks/optout.go
+++ b/internal/tasks/optout.go
@@ -85,7 +85,7 @@ func linkifyUnsubscribeURL(bodyHTML, linkURL, linkText string) string {
 	depth := 0 // open <a> elements around the current text node
 	for i := 0; i < len(bodyHTML); {
 		if bodyHTML[i] == '<' {
-			end := strings.IndexByte(bodyHTML[i:], '>')
+			end := tagEnd(bodyHTML[i:])
 			if end < 0 {
 				b.WriteString(bodyHTML[i:]) // unterminated tag: copy the rest verbatim
 				break
@@ -115,6 +115,28 @@ func linkifyUnsubscribeURL(bodyHTML, linkURL, linkText string) string {
 		i = stop
 	}
 	return b.String()
+}
+
+// tagEnd returns the index of the '>' that closes the tag starting at s[0], or
+// -1 when there is none. A '>' inside a quoted attribute value does not close
+// anything: reading one as the end split `<a title="x > y" href="URL">` into a
+// tag and a run of text, and the href in that "text" was then rewritten into a
+// dead link.
+func tagEnd(s string) int {
+	var quote byte
+	for i := 1; i < len(s); i++ {
+		switch c := s[i]; {
+		case quote != 0:
+			if c == quote {
+				quote = 0
+			}
+		case c == '"' || c == '\'':
+			quote = c
+		case c == '>':
+			return i
+		}
+	}
+	return -1
 }
 
 // isTagStart reports whether tag (a full "<...>" slice) is the named tag,

--- a/internal/tasks/optout_test.go
+++ b/internal/tasks/optout_test.go
@@ -88,6 +88,16 @@ func TestLinkifyUnsubscribeURL(t *testing.T) {
 		t.Fatalf("empty body changed: %q", got)
 	}
 
+	// A ">" inside a quoted attribute closes nothing. Reading one as the end of
+	// the tag turned the href that followed it into a dead link.
+	quoted := `<a title="x > y" href="` + url + `">read this</a>`
+	if got := linkifyUnsubscribeURL(quoted, url, "Unsubscribe"); got != quoted {
+		t.Fatalf("a quoted \">\" broke the tag scan: %s", got)
+	}
+	if got := linkifyUnsubscribeURL(`<p title="a > b">Bye. `+url+`</p>`, url, "Unsubscribe"); got != `<p title="a > b">Bye. <a href="`+url+`">Unsubscribe</a></p>` {
+		t.Fatalf("text after a quoted \">\" should still linkify: %s", got)
+	}
+
 	// A malformed body (unterminated tag) is copied through, never truncated.
 	if got := linkifyUnsubscribeURL("<p>hi<span "+url, url, "Unsubscribe"); got != "<p>hi<span "+url {
 		t.Fatalf("unterminated tag mangled: %s", got)

--- a/internal/tasks/optout_test.go
+++ b/internal/tasks/optout_test.go
@@ -41,3 +41,92 @@ func TestOptOutFooter(t *testing.T) {
 		t.Fatalf("off mode changed the body: %q / %q", h, p)
 	}
 }
+
+func TestLinkifyUnsubscribeURL(t *testing.T) {
+	const url = "https://api.example.com/unsubscribe/tok123"
+
+	// The variable chip the composer saves: a bare URL in a text node.
+	got := linkifyUnsubscribeURL(`<p>Not interested? <span data-var>`+url+`</span></p>`, url, "Unsubscribe")
+	want := `<p>Not interested? <span data-var><a href="` + url + `">Unsubscribe</a></span></p>`
+	if got != want {
+		t.Fatalf("bare token not linkified:\n got %s\nwant %s", got, want)
+	}
+
+	// The workspace's own link wording is what the anchor says.
+	if got := linkifyUnsubscribeURL("<p>"+url+"</p>", url, "Opt out"); !strings.Contains(got, `>Opt out</a>`) {
+		t.Fatalf("link text ignored: %s", got)
+	}
+	if got := linkifyUnsubscribeURL("<p>"+url+"</p>", url, "  "); !strings.Contains(got, ">Unsubscribe</a>") {
+		t.Fatalf("blank link text should fall back to the default: %s", got)
+	}
+	if got := linkifyUnsubscribeURL("<p>"+url+"</p>", url, `Bill & "Ted"`); !strings.Contains(got, `>Bill &amp; &#34;Ted&#34;</a>`) {
+		t.Fatalf("link text not escaped: %s", got)
+	}
+
+	// An author's own anchor is left exactly as written: no second link, no
+	// rewritten href.
+	own := `<p><a href="` + url + `" style="color:red">click here</a></p>`
+	if got := linkifyUnsubscribeURL(own, url, "Unsubscribe"); got != own {
+		t.Fatalf("author's anchor was rewritten: %s", got)
+	}
+
+	// The URL as the text of an existing anchor becomes its label rather than
+	// a nested link.
+	nested := `<a href="` + url + `">` + url + `</a>`
+	if got := linkifyUnsubscribeURL(nested, url, "Unsubscribe"); got != `<a href="`+url+`">Unsubscribe</a>` {
+		t.Fatalf("URL inside an anchor should become the label: %s", got)
+	}
+
+	// Nothing to do cases.
+	if got := linkifyUnsubscribeURL("<p>Hi</p>", url, "Unsubscribe"); got != "<p>Hi</p>" {
+		t.Fatalf("body without the link changed: %s", got)
+	}
+	if got := linkifyUnsubscribeURL("<p>"+url+"</p>", "", "Unsubscribe"); got != "<p>"+url+"</p>" {
+		t.Fatalf("no link to mint should be a no-op: %s", got)
+	}
+	if got := linkifyUnsubscribeURL("", url, "Unsubscribe"); got != "" {
+		t.Fatalf("empty body changed: %q", got)
+	}
+
+	// A malformed body (unterminated tag) is copied through, never truncated.
+	if got := linkifyUnsubscribeURL("<p>hi<span "+url, url, "Unsubscribe"); got != "<p>hi<span "+url {
+		t.Fatalf("unterminated tag mangled: %s", got)
+	}
+
+	// Case-insensitive anchor tracking: </A> closes <A>, so what follows is
+	// loose text again.
+	mixed := `<A HREF="` + url + `">x</A> or ` + url
+	if got := linkifyUnsubscribeURL(mixed, url, "Unsubscribe"); got != `<A HREF="`+url+`">x</A> or <a href="`+url+`">Unsubscribe</a>` {
+		t.Fatalf("mixed-case anchors mishandled: %s", got)
+	}
+}
+
+func TestLinkifiedUnsubscribeLinkSurvivesTracking(t *testing.T) {
+	const url = "https://api.example.com/unsubscribe/tok123"
+	body := linkifyUnsubscribeURL(`<p>Or `+url+` to stop. <a href="https://acme.com/pricing">pricing</a></p>`, url, "Unsubscribe")
+	out, links := WrapLinksForTracking(body, uuid.New(), uuid.New(), "t.example.com")
+	if len(links) != 1 || links[0].Destination != "https://acme.com/pricing" {
+		t.Fatalf("expected only the pricing link to be ticketed, got %+v", links)
+	}
+	if !strings.Contains(out, `href="`+url+`">Unsubscribe</a>`) {
+		t.Fatalf("unsubscribe anchor was rewritten: %s", out)
+	}
+}
+
+func TestFinishBodyLinkifiesHTMLAndKeepsThePlainURL(t *testing.T) {
+	const url = "https://api.example.com/unsubscribe/tok123"
+	off := models.UnsubscribeSettings{Mode: models.UnsubscribeModeOff, LinkText: "Unsubscribe"}
+	htmlOut, plainOut := finishBody(`<p>Bye. `+url+`</p>`, "", false, nil, &off, url)
+	if !strings.Contains(htmlOut, `<a href="`+url+`">Unsubscribe</a>`) {
+		t.Fatalf("html part not linkified: %s", htmlOut)
+	}
+	// Plain text cannot hide a URL, so it keeps the address itself.
+	if !strings.Contains(plainOut, url) {
+		t.Fatalf("plain part lost the link: %q", plainOut)
+	}
+	// No settings at all still linkifies, with the default wording.
+	htmlOut, _ = finishBody(`<p>`+url+`</p>`, "x", false, nil, nil, url)
+	if !strings.Contains(htmlOut, ">Unsubscribe</a>") {
+		t.Fatalf("nil settings should still linkify: %s", htmlOut)
+	}
+}

--- a/internal/tasks/preview.go
+++ b/internal/tasks/preview.go
@@ -85,9 +85,10 @@ func (s *tasksService) PreviewEmail(ctx context.Context, orgID uuid.UUID, in Ema
 }
 
 // finishBody applies what the send path adds after rendering, in its order:
-// derive the plain part, drop HTML for a plain-text campaign, add the mailbox
-// signature, then the opt-out footer (nil settings skip it). Shared by the
-// preview and the test send so both show what a recipient gets.
+// derive the plain part, drop HTML for a plain-text campaign, turn a
+// hand-placed unsubscribe link into an anchor, add the mailbox signature,
+// then the opt-out footer (nil settings skip it). Shared by the preview and
+// the test send so both show what a recipient gets.
 func finishBody(bodyHTML, bodyPlain string, textOnly bool, account *models.Email, optOut *models.UnsubscribeSettings, unsubURL string) (string, string) {
 	if bodyPlain == "" && bodyHTML != "" {
 		bodyPlain = ExtractPlainTextFromHTML(bodyHTML)
@@ -95,6 +96,12 @@ func finishBody(bodyHTML, bodyPlain string, textOnly bool, account *models.Email
 	if textOnly {
 		bodyHTML = ""
 	}
+	// After the plain part is derived, so plain text keeps the URL it needs.
+	linkText := ""
+	if optOut != nil {
+		linkText = optOut.LinkText
+	}
+	bodyHTML = linkifyUnsubscribeURL(bodyHTML, unsubURL, linkText)
 	if account != nil && account.SignatureSync {
 		if bodyHTML != "" {
 			bodyHTML = AddSignature(bodyHTML, account.SignatureHTML, true)

--- a/web/src/app/app/settings/sending/page.tsx
+++ b/web/src/app/app/settings/sending/page.tsx
@@ -230,7 +230,7 @@ function SendingSettings() {
 
             <Section
                 eyebrow="Unsubscribe"
-                description="The opt-out every campaign email carries, added after the signature. A reply that asks to stop, a click on the link, and the mail client's own unsubscribe button all put the recipient on the suppression list, and no campaign emails them again. A campaign can override this in its preferences."
+                description="The opt-out every campaign email carries, added after the signature. A reply that asks to stop, a click on the link, and the mail client's own unsubscribe button all put the recipient on the suppression list, and no campaign emails them again. For cold outreach the List-Unsubscribe header (per campaign, on by default) is what satisfies the bulk-sender rules, so this line can stay a plain sentence. A campaign can override this in its preferences."
             >
                 {isLoading || !draft ? (
                     <div className="h-7 w-40 rounded bg-slate-100 animate-pulse" />
@@ -311,7 +311,7 @@ function UnsubscribeRows({
                     mode === "text"
                         ? "A plain sentence inviting a reply. Reads like a personal email; the reply is detected and honoured automatically."
                         : mode === "link"
-                          ? "A sentence with a real unsubscribe link. One click on a confirmation page; the mail client may also show its own Unsubscribe button."
+                          ? "A sentence with a real unsubscribe link. One click on a confirmation page; the mail client may also show its own Unsubscribe button. Reads as bulk mail where a reply reads as a person, so keep it for lists that need a link. On a plain-text campaign it prints the full address in the copy."
                           : "No opt-out in the body. Keep the unsubscribe header on in each campaign, or you are relying on recipients replying."
                 }
             >

--- a/web/src/components/app/campaigns/preferences/CampaignAppearance.tsx
+++ b/web/src/components/app/campaigns/preferences/CampaignAppearance.tsx
@@ -9,6 +9,7 @@ import { Label, NumberInput, TextInput } from "@/components/ui/field";
 import SenderSelector from "./SenderSelector";
 import { SettingRow, Toggle } from "./components/CampaignPreferenceBoolBox";
 import { SelectMenu, type SelectOption } from "@/components/ui/select-menu";
+import { useOutreachSettings } from "@/lib/api/hooks/app/outreach/useOutreachSettings";
 
 const UNSUB_MODES: SelectOption[] = [
     { value: "inherit", label: "Workspace default" },
@@ -115,6 +116,14 @@ export function DeliverabilitySection({
     newCampaign: Campaign;
     setNewCampaign: SetCampaign;
 }) {
+    // The warning below is only true when the opt-out this campaign actually
+    // sends is a link, so "inherit" has to be resolved against the workspace
+    // default rather than assumed.
+    const { data: outreach } = useOutreachSettings();
+    const mode = newCampaign.unsubscribe_mode ?? "inherit";
+    const effectiveMode = mode === "inherit" || !mode ? (outreach?.unsubscribe?.mode ?? "text") : mode;
+    const plainTextLinkOptOut = newCampaign.text_only && effectiveMode === "link";
+
     return (
         <div className="space-y-5">
             <SettingRow
@@ -197,7 +206,7 @@ export function DeliverabilitySection({
                         as a personal email and is honoured automatically; a link is for lists that need one, and the
                         header above already covers the bulk-sender rules. The workspace default is set under Settings
                         &gt; Sending.
-                        {newCampaign.text_only && (
+                        {plainTextLinkOptOut && (
                             <span className="mt-1 block text-amber-700">
                                 This campaign sends plain text only, where a link has nowhere to hide its address: the
                                 recipient reads the full unsubscribe URL. Prefer the header and the reply line here.

--- a/web/src/components/app/campaigns/preferences/CampaignAppearance.tsx
+++ b/web/src/components/app/campaigns/preferences/CampaignAppearance.tsx
@@ -180,7 +180,7 @@ export function DeliverabilitySection({
             )}
             <SettingRow
                 title="Unsubscribe header"
-                description="Add a List-Unsubscribe header so mail clients can show their own one-click unsubscribe."
+                description="Add a List-Unsubscribe header so mail clients can show their own one-click unsubscribe. It is a header, not visible copy, so it changes nothing about how the email reads and works on plain-text sends too. This is the opt-out Gmail and Yahoo look for; leave it on."
                 control={
                     <Toggle
                         id="campaign-pref-unsub"
@@ -191,7 +191,20 @@ export function DeliverabilitySection({
             />
             <SettingRow
                 title="Opt-out line"
-                description="The opt-out appended after the signature of every email in this campaign. The workspace default is set under Settings > Sending."
+                description={
+                    <>
+                        The opt-out appended after the signature of every email in this campaign. Reply to opt out reads
+                        as a personal email and is honoured automatically; a link is for lists that need one, and the
+                        header above already covers the bulk-sender rules. The workspace default is set under Settings
+                        &gt; Sending.
+                        {newCampaign.text_only && (
+                            <span className="mt-1 block text-amber-700">
+                                This campaign sends plain text only, where a link has nowhere to hide its address: the
+                                recipient reads the full unsubscribe URL. Prefer the header and the reply line here.
+                            </span>
+                        )}
+                    </>
+                }
                 control={
                     <SelectMenu
                         value={newCampaign.unsubscribe_mode ?? "inherit"}

--- a/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
+++ b/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
@@ -38,8 +38,9 @@ import useCreateTemplate from "@/lib/api/hooks/app/templates/useCreateTemplate";
 import { useConfirm } from "@/hooks/context/confirm";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import buildError from "@/lib/helper/buildError";
-import { VARIABLES, htmlToPlain, promptToHtml, renderPreview, templateIssue } from "./emailPreview";
-import { LINK_VARIABLES } from "@/lib/templateVars";
+import { VARIABLES, htmlToPlain, linkifyUnsubscribe, promptToHtml, renderPreview, templateIssue } from "./emailPreview";
+import { LINK_VARIABLES, UNSUBSCRIBE_TOKEN } from "@/lib/templateVars";
+import useCampaign from "@/lib/api/hooks/app/campaigns/useCampaign";
 
 export default function EmailContentEditor({
     subject,
@@ -125,6 +126,13 @@ export default function EmailContentEditor({
     }, [tab, subject, bodyHtml, previewContact?.id, campaignId, previewMailbox?.id, stepId]);
 
     const tplIssue = templateIssue(subject) || templateIssue(bodyHtml) || templateIssue(htmlToPlain(bodyHtml));
+
+    // A plain-text campaign ships no HTML, so the send path cannot give the
+    // unsubscribe variable an anchor: the recipient reads the whole signed
+    // address. Preflight says the same at launch; say it here, while it is
+    // still one keystroke to fix.
+    const { data: previewCampaign } = useCampaign(campaignId ?? "");
+    const plainTextUnsubLink = !!previewCampaign?.text_only && bodyHtml.includes(UNSUBSCRIBE_TOKEN);
 
     // Toolbar: template library, save as template, write with AI.
     const { data: templates } = useTemplates("");
@@ -280,7 +288,7 @@ export default function EmailContentEditor({
                             className="tiptap-body min-h-[200px] px-3 py-2.5 text-[13px] leading-relaxed text-slate-800"
                             dangerouslySetInnerHTML={{
                                 __html:
-                                    (serverPreview?.body_html ?? renderPreview(bodyHtml)) ||
+                                    (serverPreview?.body_html ?? linkifyUnsubscribe(renderPreview(bodyHtml))) ||
                                     (serverPreview?.body_plain
                                         ? `<pre class="whitespace-pre-wrap font-sans">${escapeHtml(serverPreview.body_plain)}</pre>`
                                         : '<p class="text-slate-300">Nothing to preview yet.</p>'),
@@ -321,6 +329,16 @@ export default function EmailContentEditor({
                         {tplIssue} It&apos;ll fall back to plain text — fix it before sending.
                     </p>
                 ) : null}
+                {plainTextUnsubLink && (
+                    <p className="mt-1.5 flex items-start gap-1.5 text-[11px] text-amber-600">
+                        <AlertCircleIcon className="mt-px w-3.5 h-3.5 shrink-0" />
+                        <span>
+                            This campaign sends plain text only, so the unsubscribe link cannot render as a word and the
+                            recipient reads its whole address. Leave the unsubscribe header on and invite a reply
+                            instead, or turn plain text off in Preferences.
+                        </span>
+                    </p>
+                )}
                 {(serverPreview?.unresolved?.length ?? 0) > 0 && (
                     <p className="mt-1.5 flex items-start gap-1.5 text-[11px] text-amber-600">
                         <AlertCircleIcon className="mt-px w-3.5 h-3.5 shrink-0" />

--- a/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
+++ b/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
@@ -132,7 +132,8 @@ export default function EmailContentEditor({
     // address. Preflight says the same at launch; say it here, while it is
     // still one keystroke to fix.
     const { data: previewCampaign } = useCampaign(campaignId ?? "");
-    const plainTextUnsubLink = !!previewCampaign?.text_only && bodyHtml.includes(UNSUBSCRIBE_TOKEN);
+    const plainTextUnsubLink =
+        !!previewCampaign?.text_only && (bodyHtml.includes(UNSUBSCRIBE_TOKEN) || subject.includes(UNSUBSCRIBE_TOKEN));
 
     // Toolbar: template library, save as template, write with AI.
     const { data: templates } = useTemplates("");

--- a/web/src/components/app/campaigns/sequences/RichTextEditor.tsx
+++ b/web/src/components/app/campaigns/sequences/RichTextEditor.tsx
@@ -49,6 +49,7 @@ import { FormLinkNode } from "./nodes/FormLinkNode";
 import EditorSuggest from "./nodes/EditorSuggest";
 import {
     TOKEN_META,
+    UNSUBSCRIBE_TOKEN,
     cleanFieldName,
     parseToken,
     buildToken,
@@ -65,6 +66,17 @@ function insertToken(editor: Editor, token: string) {
     } else {
         editor.chain().focus().insertContent(token).run();
     }
+}
+
+// Picking the unsubscribe link with text selected links that text instead of
+// dropping a chip, so the copy keeps its own wording. With no selection the
+// chip is inserted and the send path gives it an anchor of its own.
+function insertLinkToken(editor: Editor, token: string) {
+    if (token !== UNSUBSCRIBE_TOKEN || editor.state.selection.empty) {
+        insertToken(editor, token);
+        return;
+    }
+    editor.chain().focus().setLink({ href: token }).run();
 }
 
 export default function RichTextEditor({
@@ -227,7 +239,11 @@ function Toolbar({ editor, variables, links = [] }: { editor: Editor; variables:
                 <Link2Icon className="w-3.5 h-3.5" />
             </Btn>
             <Divider />
-            <VariableMenu onPick={(v) => insertToken(editor, v)} variables={variables} links={links} />
+            <VariableMenu
+                onPick={(v) => (links.includes(v) ? insertLinkToken(editor, v) : insertToken(editor, v))}
+                variables={variables}
+                links={links}
+            />
             <button
                 type="button"
                 onMouseDown={(e) => e.preventDefault()}
@@ -276,6 +292,17 @@ function Toolbar({ editor, variables, links = [] }: { editor: Editor; variables:
                             placeholder="https://…"
                             className="h-7 w-56 rounded border border-slate-200 px-2 text-[12px] text-slate-800 outline-none focus:border-sky-400"
                         />
+                        {links.includes(UNSUBSCRIBE_TOKEN) && (
+                            <button
+                                type="button"
+                                onMouseDown={(e) => e.preventDefault()}
+                                onClick={() => setLinkUrl(UNSUBSCRIBE_TOKEN)}
+                                title="Point this link at the recipient's unsubscribe page"
+                                className="h-7 px-2 inline-flex items-center rounded text-[11.5px] font-medium text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+                            >
+                                Unsubscribe
+                            </button>
+                        )}
                         <button
                             type="button"
                             onClick={applyLink}

--- a/web/src/components/app/campaigns/sequences/emailPreview.ts
+++ b/web/src/components/app/campaigns/sequences/emailPreview.ts
@@ -139,6 +139,25 @@ export function renderPreview(s: string, ctx: PreviewCtx = SAMPLE): string {
     return out;
 }
 
+// linkifyUnsubscribe mirrors the send path (internal/tasks/optout.go): the
+// unsubscribe variable resolves to a signed URL a recipient should never have
+// to read, so a loose one in the body becomes an anchor. Only the local
+// fallback preview needs this; a server preview arrives already linkified. An
+// occurrence the author put in their own <a href> sits inside a tag and is
+// left alone, and one used as an anchor's text becomes that anchor's label.
+export function linkifyUnsubscribe(html: string, url: string = SAMPLE.UnsubscribeLink, text = "Unsubscribe"): string {
+    if (!url || !html.includes(url)) return html;
+    let depth = 0;
+    return html.replace(/<[^>]*>|[^<]+/g, (chunk) => {
+        if (chunk.startsWith("<")) {
+            if (/^<a[\s/>]/i.test(chunk)) depth++;
+            else if (/^<\/a[\s>]/i.test(chunk)) depth = Math.max(0, depth - 1);
+            return chunk;
+        }
+        return chunk.split(url).join(depth > 0 ? text : `<a href="${url}">${text}</a>`);
+    });
+}
+
 // templateIssue returns a friendly message when a template is obviously
 // malformed (an {{if}} without a matching {{end}}, or vice versa).
 export function templateIssue(s: string): string | null {

--- a/web/src/components/app/campaigns/sequences/emailPreview.ts
+++ b/web/src/components/app/campaigns/sequences/emailPreview.ts
@@ -6,7 +6,7 @@
 // The standard merge fields and their sample values live in one catalog
 // (@/lib/templateVars); imported for local use (renderPreview's default context)
 // and re-exported so existing imports keep working.
-import { VARIABLES, SAMPLE } from "@/lib/templateVars";
+import { VARIABLES, SAMPLE, HTML_CHUNK_RE } from "@/lib/templateVars";
 export { VARIABLES, SAMPLE };
 
 // Derive plain text from the editor HTML so both alternatives ship populated.
@@ -148,7 +148,7 @@ export function renderPreview(s: string, ctx: PreviewCtx = SAMPLE): string {
 export function linkifyUnsubscribe(html: string, url: string = SAMPLE.UnsubscribeLink, text = "Unsubscribe"): string {
     if (!url || !html.includes(url)) return html;
     let depth = 0;
-    return html.replace(/<[^>]*>|[^<]+/g, (chunk) => {
+    return html.replace(HTML_CHUNK_RE, (chunk) => {
         if (chunk.startsWith("<")) {
             if (/^<a[\s/>]/i.test(chunk)) depth++;
             else if (/^<\/a[\s>]/i.test(chunk)) depth = Math.max(0, depth - 1);

--- a/web/src/lib/templateVars.test.ts
+++ b/web/src/lib/templateVars.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { UNSUBSCRIBE_TOKEN, upgradeVariableTokens } from "./templateVars";
+import { linkifyUnsubscribe } from "@/components/app/campaigns/sequences/emailPreview";
+
+describe("upgradeVariableTokens", () => {
+    it("chips a token in text", () => {
+        expect(upgradeVariableTokens("<p>Hi {{.FirstName}}</p>")).toBe('<p>Hi <span data-var="">{{.FirstName}}</span></p>');
+    });
+
+    it("leaves a token that is an attribute value alone", () => {
+        // A link the author pointed at the unsubscribe variable: wrapping the
+        // token in a span here would break the tag.
+        const html = `<p><a href="${UNSUBSCRIBE_TOKEN}">no thanks</a></p>`;
+        expect(upgradeVariableTokens(html)).toBe(html);
+    });
+
+    it("is a no-op once the content already carries chips", () => {
+        const html = '<p><span data-var="">{{.FirstName}}</span> {{.Company}}</p>';
+        expect(upgradeVariableTokens(html)).toBe(html);
+    });
+});
+
+describe("linkifyUnsubscribe", () => {
+    const url = "https://example.com/unsubscribe/preview";
+
+    it("wraps a loose unsubscribe URL in an anchor", () => {
+        expect(linkifyUnsubscribe(`<p>Bye. ${url}</p>`)).toBe(`<p>Bye. <a href="${url}">Unsubscribe</a></p>`);
+    });
+
+    it("leaves an author's own anchor alone", () => {
+        const html = `<p><a href="${url}">no thanks</a></p>`;
+        expect(linkifyUnsubscribe(html)).toBe(html);
+    });
+
+    it("labels the URL when it is an anchor's own text", () => {
+        expect(linkifyUnsubscribe(`<a href="${url}">${url}</a>`)).toBe(`<a href="${url}">Unsubscribe</a>`);
+    });
+
+    it("does nothing when the body has no link", () => {
+        expect(linkifyUnsubscribe("<p>Hi</p>")).toBe("<p>Hi</p>");
+    });
+});

--- a/web/src/lib/templateVars.test.ts
+++ b/web/src/lib/templateVars.test.ts
@@ -14,6 +14,16 @@ describe("upgradeVariableTokens", () => {
         expect(upgradeVariableTokens(html)).toBe(html);
     });
 
+    it("keeps a tag whose attribute contains a >", () => {
+        // Reading the quoted ">" as the end of the tag split it, and the href
+        // that followed was then wrapped in a chip span.
+        const html = `<p><a title="x > y" href="${UNSUBSCRIBE_TOKEN}">no thanks</a></p>`;
+        expect(upgradeVariableTokens(html)).toBe(html);
+        expect(upgradeVariableTokens(`<p title="a > b">Hi {{.FirstName}}</p>`)).toBe(
+            '<p title="a > b">Hi <span data-var="">{{.FirstName}}</span></p>',
+        );
+    });
+
     it("is a no-op once the content already carries chips", () => {
         const html = '<p><span data-var="">{{.FirstName}}</span> {{.Company}}</p>';
         expect(upgradeVariableTokens(html)).toBe(html);
@@ -34,6 +44,11 @@ describe("linkifyUnsubscribe", () => {
 
     it("labels the URL when it is an anchor's own text", () => {
         expect(linkifyUnsubscribe(`<a href="${url}">${url}</a>`)).toBe(`<a href="${url}">Unsubscribe</a>`);
+    });
+
+    it("does not rewrite an href behind a quoted > in the same tag", () => {
+        const html = `<a title="x > y" href="${url}">read this</a>`;
+        expect(linkifyUnsubscribe(html)).toBe(html);
     });
 
     it("does nothing when the body has no link", () => {

--- a/web/src/lib/templateVars.ts
+++ b/web/src/lib/templateVars.ts
@@ -22,15 +22,20 @@ export const STANDARD_VARS: TemplateVar[] = [
     { token: "{{.Phone}}", key: "Phone", label: "Phone", desc: "The contact's phone number", sample: "+1 555-0100" },
 ];
 
+// The recipient's opt-out link. Named because the editor treats it specially:
+// applied to a text selection it becomes that text's href, so the copy can say
+// what it likes and the signed URL never shows.
+export const UNSUBSCRIBE_TOKEN = "{{.UnsubscribeLink}}";
+
 // Per-send values that are not contact fields. Only campaign email bodies
 // resolve these (template.go RenderTemplateWith); a deal name or automation
 // value has no recipient link to offer.
 export const LINK_VARS: TemplateVar[] = [
     {
-        token: "{{.UnsubscribeLink}}",
+        token: UNSUBSCRIBE_TOKEN,
         key: "UnsubscribeLink",
         label: "Unsubscribe link",
-        desc: "This recipient's own unsubscribe link. Use it to place the opt-out in your copy instead of the footer line",
+        desc: "This recipient's own unsubscribe link, rendered as a link labelled with your unsubscribe link text. Use it to place the opt-out in your copy instead of the footer line",
         sample: "https://example.com/unsubscribe/preview",
     },
 ];
@@ -140,10 +145,17 @@ export function upgradeVariableTokens(html: string): string {
         html.includes("data-form-link")
     )
         return html;
-    return html
-        .replace(FIELD_TOKEN_RE, (tok) => {
-            const esc = tok.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-            return `<span data-var="">${esc}</span>`;
-        })
-        .replace(FORM_LINK_RE, (tok, publicId: string) => `<span data-form-link="${publicId}">${tok}</span>`);
+    // Text nodes only. A token can legitimately live in an attribute (an
+    // <a href="{{.UnsubscribeLink}}"> the author wrote), and wrapping that one
+    // in a span would break the tag.
+    return html.replace(/<[^>]*>|[^<]+/g, (chunk) =>
+        chunk.startsWith("<")
+            ? chunk
+            : chunk
+                  .replace(FIELD_TOKEN_RE, (tok) => {
+                      const esc = tok.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+                      return `<span data-var="">${esc}</span>`;
+                  })
+                  .replace(FORM_LINK_RE, (tok, publicId: string) => `<span data-form-link="${publicId}">${tok}</span>`),
+    );
 }

--- a/web/src/lib/templateVars.ts
+++ b/web/src/lib/templateVars.ts
@@ -148,7 +148,7 @@ export function upgradeVariableTokens(html: string): string {
     // Text nodes only. A token can legitimately live in an attribute (an
     // <a href="{{.UnsubscribeLink}}"> the author wrote), and wrapping that one
     // in a span would break the tag.
-    return html.replace(/<[^>]*>|[^<]+/g, (chunk) =>
+    return html.replace(HTML_CHUNK_RE, (chunk) =>
         chunk.startsWith("<")
             ? chunk
             : chunk
@@ -159,3 +159,10 @@ export function upgradeVariableTokens(html: string): string {
                   .replace(FORM_LINK_RE, (tok, publicId: string) => `<span data-form-link="${publicId}">${tok}</span>`),
     );
 }
+
+// HTML_CHUNK_RE splits a body into alternating tags and text runs. A tag ends
+// at the first ">" OUTSIDE a quoted attribute value, so `<a title="x > y"
+// href="…">` stays one tag: reading the quoted ">" as the end split the tag and
+// let the href be treated as text. A stray "<" matches on its own and is left
+// alone rather than swallowing the rest of the body.
+export const HTML_CHUNK_RE = /<(?:"[^"]*"|'[^']*'|[^>"'])*>|[^<]+|</g;


### PR DESCRIPTION
Fixes #341.

## The bug

`{{.UnsubscribeLink}}` resolved to the recipient's signed URL as a bare string, so a token placed in the copy shipped as the raw API address. Only the footer in link mode ever built an anchor.

## The fix

`linkifyUnsubscribeURL` (`internal/tasks/optout.go`) walks the rendered HTML tag-aware and wraps every loose occurrence of the signed URL in `<a href="…">Unsubscribe</a>`, labelled with the workspace's configured **Link text**. A URL the author already put in their own `href` sits inside a tag and is untouched; one used as an existing anchor's text becomes that anchor's label instead of a nested link.

Wired into both send paths: `campaign_task.go` (step 10.7) and `finishBody` in `preview.go`, which the composer preview and test sends share. It runs after the plain-text part is derived, so plain text keeps the address it needs, and before tracking, which already skips `/unsubscribe/`.

## Editor

Picking **Unsubscribe link** with text selected now links that text rather than dropping a chip, and the link popover has an **Unsubscribe** shortcut that fills the address field, so the wording can be the author's. This matches how lemlist does it.

That exposed a latent bug: `upgradeVariableTokens` rewrote tokens inside attributes, which would have corrupted an `<a href="{{.UnsubscribeLink}}">` on reload. It now only touches text nodes.

## Plain text

A `text_only` campaign ships no HTML, so there is nothing for a link to hide inside and the recipient reads the whole signed address. New preflight check `plain_text_opt_out` (severity `warning`, never blocks a launch, only added for text-only campaigns) fires when link mode is effective or when a step places the variable itself, and the step composer says the same thing while you are writing. It names the step rather than numbering it, because `position` is 0-based on seeded campaigns and 1-based on ones created through `POST /campaigns`.

The recommendation in both places is the header: it is not visible copy, it works the same on a plain-text send, and it is what Gmail and Yahoo look for. Warmbly already defaults to header on plus a reply-to-opt-out sentence, which is stricter than Instantly (header opt-in) and matches the current operator consensus for cold email.

## Docs

`guides/unsubscribe.mdx` gains a **Plain-text campaigns** section and now states what the variable renders as, how to choose your own wording, and that the plain-text alternative carries the address only when the variable stands alone.

## Verification

Live smoke against a local backend with a real signer:

- bare token renders `<a href="…/unsubscribe/…">Unsubscribe</a>`, plain part keeps the URL; author's own anchor keeps its wording with the href resolved; the minted link returns 200 on the opt-out page
- text-only + link mode fires the preflight warning; switching to the reply line passes; placing the variable in a step fires naming `the step "Step 1"`; turning plain text off removes the check from the report entirely

Tests: 8 new Go cases in `internal/tasks/optout_test.go`, 5 in `internal/app/advanced/plain_text_optout_test.go`, 7 in `web/src/lib/templateVars.test.ts`. `make lint`, `go test`, web `tsc -b` / eslint / vitest and docs `types:check` / eslint all clean.

## Not in this PR

`ExtractPlainTextFromHTML` drops every link's href, so a plain part derived from HTML loses all URLs, not just this one. Fixing it would change the plain-text alternative of every email and belongs in its own change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Unsubscribe URLs in HTML emails are displayed as labeled links while remaining unchanged in plain-text messages.
  - Rich-text editing supports inserting unsubscribe links with selected text or a dedicated shortcut.
  - Email previews show unsubscribe formatting and plain-text campaign warnings.
  - Plain-text preflight checks identify unsubscribe links in campaign content and settings.

- **Bug Fixes**
  - Existing links, HTML attributes, and malformed markup are preserved during formatting.
  - Unsubscribe links are excluded from click tracking.

- **Documentation**
  - Expanded guidance covers unsubscribe headers, link placement, rendering, and plain-text limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->