### PR TITLE
Match an inbound Message-ID with and without its angle brackets

### DIFF
--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -93,7 +93,14 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 	// campaign progress, gating replied_at so automated replies (auto_reply /
 	// out_of_office) never count as a human reply for stop_on_reply / branching.
 	if s.AdvancedService != nil {
-		_ = s.AdvancedService.ProcessIncomingReply(ctx, e.Message.EmailID, e.Message)
+		// Logged, not propagated: the ingest must survive it, but a silent
+		// failure here is indistinguishable from a reply that linked fine.
+		if xerr := s.AdvancedService.ProcessIncomingReply(ctx, e.Message.EmailID, e.Message); xerr != nil {
+			log.Warn().Err(xerr).
+				Str("email_account_id", e.Message.EmailID.String()).
+				Str("message_id", e.Message.MessageID).
+				Msg("Reply-intent automation failed; inbox ingest kept")
+		}
 	}
 
 	return nil

--- a/internal/repository/pg_task.go
+++ b/internal/repository/pg_task.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -293,19 +294,24 @@ func (r *taskRepository) GetTask(ctx context.Context, taskID uuid.UUID) (*Task, 
 	return task, err
 }
 
-// GetTaskByMessageID retrieves the latest task by RFC Message-ID.
+// GetTaskByMessageID retrieves the latest task by RFC Message-ID. Probes both
+// bracket forms: the stamp stores "<id@host>", an inbound In-Reply-To may not.
 func (r *taskRepository) GetTaskByMessageID(ctx context.Context, messageID string) (*Task, error) {
+	bare := strings.Trim(strings.TrimSpace(messageID), "<>")
+	if bare == "" {
+		return nil, nil
+	}
 	query := `
 		SELECT id, task_type, email_account_id, status, message_id,
 		       scheduled_at, completed_at, cloud_task_name, created_at, updated_at
 		FROM tasks
-		WHERE message_id = $1
+		WHERE message_id = $1 OR message_id = $2
 		ORDER BY created_at DESC
 		LIMIT 1
 	`
 
 	task := &Task{}
-	err := r.db.QueryRow(ctx, query, messageID).Scan(
+	err := r.db.QueryRow(ctx, query, bare, "<"+bare+">").Scan(
 		&task.ID,
 		&task.TaskType,
 		&task.EmailAccountID,

--- a/internal/repository/task_message_id_live_test.go
+++ b/internal/repository/task_message_id_live_test.go
@@ -1,0 +1,101 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// The stamp stores "<id@host>" but an inbound In-Reply-To arrives either way,
+// and cleanMessageID strips the brackets before the lookup. Under the old exact
+// compare the bare-form case found nothing, so replied_at was never stamped and
+// stop_on_reply kept mailing a contact who had already answered.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveTaskByMessageID -v
+func TestLiveTaskByMessageIDMatchesBracketedAndBareForms(t *testing.T) {
+	_, pool := liveContactDB(t)
+	ctx := context.Background()
+
+	org := uuid.New()
+	user := uuid.New()
+	account := uuid.New()
+	task := uuid.New()
+	bare := "regression-" + uuid.NewString() + "@example.test"
+	stored := "<" + bare + ">"
+
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("setup %q: %v", sql, err)
+		}
+	}
+
+	// The user exists first: organizations.owner_user_id points at it.
+	exec(`INSERT INTO users (id, first_name, last_name, email)
+	      VALUES ($1, 'MsgID', 'Regression', $2)`,
+		user, "msgid-"+uuid.NewString()+"@example.test")
+	exec(`INSERT INTO organizations (id, name, owner_user_id)
+	      VALUES ($1, 'msgid regression', $2)`, org, user)
+	exec(`INSERT INTO email_accounts
+	        (id, user_id, organization_id, email, name, signature_plain, signature_html, provider)
+	      VALUES ($1, $2, $3, $4, 'MsgID Regression', '', '', 'smtp_imap')`,
+		account, user, org, "box-"+uuid.NewString()+"@example.test")
+	exec(`INSERT INTO tasks (id, task_type, email_account_id, status, message_id)
+	      VALUES ($1, 'campaign', $2, 'completed', $3)`, task, account, stored)
+
+	t.Cleanup(func() {
+		// Unwound in dependency order: tasks cascade from the mailbox, the
+		// mailbox and the org do not cascade from each other, and the org
+		// owns the user by foreign key, so the user goes last.
+		for _, stmt := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM email_accounts WHERE id = $1`, account},
+			{`DELETE FROM organizations WHERE id = $1`, org},
+			{`DELETE FROM users WHERE id = $1`, user},
+		} {
+			if _, err := pool.Exec(context.Background(), stmt.sql, stmt.arg); err != nil {
+				t.Errorf("cleanup %q: %v", stmt.sql, err)
+			}
+		}
+	})
+
+	repo := NewTaskRepository(pool)
+
+	for _, tc := range []struct {
+		name   string
+		lookup string
+	}{
+		{"bare form, as cleanMessageID hands it over", bare},
+		{"bracketed form, as the header carried it", stored},
+		{"bracketed with surrounding space", "  " + stored + "  "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := repo.GetTaskByMessageID(ctx, tc.lookup)
+			if err != nil {
+				t.Fatalf("lookup %q: %v", tc.lookup, err)
+			}
+			if got == nil {
+				t.Fatalf("lookup %q found no task; the reply would never link to its campaign", tc.lookup)
+			}
+			if got.ID != task {
+				t.Fatalf("lookup %q returned task %s, want %s", tc.lookup, got.ID, task)
+			}
+		})
+	}
+
+	t.Run("empty message id is not a wildcard", func(t *testing.T) {
+		for _, empty := range []string{"", "   ", "<>"} {
+			got, err := repo.GetTaskByMessageID(ctx, empty)
+			if err != nil {
+				t.Fatalf("lookup %q: %v", empty, err)
+			}
+			if got != nil {
+				t.Fatalf("lookup %q returned task %s; an absent header must match nothing", empty, got.ID)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## The problem

The two sides of the reply-to-campaign link disagree on the form of a Message-ID.

`advanced.cleanMessageID` strips the angle brackets off an inbound `In-Reply-To` before the lookup:

```go
func cleanMessageID(mid string) string {
    return strings.TrimSpace(strings.Trim(mid, "<>"))
}
```

`GetTaskByMessageID` then compares that bare form against the column with `WHERE message_id = $1`, while the outbound stamp always stores the bracketed RFC 5322 form. The compare could not agree, so `replied_at` was never stamped: `stop_on_reply` stayed inert and a contact who had already answered kept receiving the rest of the sequence.

## Evidence from a live self-host

A campaign test with 6 sends and 4 real replies. The replies synced with `in_reply_to` populated, and every one missed:

```
campaign | matches raw = 0 | matches normalised = 4
email    | matches raw = 0 | matches normalised = 1
warmup   | matches raw = 16 | matches normalised = 35
```

Warmup matching partly raw is the tell. `tasks.message_id` is stored bracketed 100% of the time; the variation is on the other side, because the replying client decides. On this install the synced replies split **21 bracketed to 27 bare**, so a raw compare succeeded only when the client happened to keep the brackets.

`campaign_contact_progress.replied_at` and `reply_class` were NULL for all six contacts.

## A second bug the regression test surfaced

With an empty `messageID`, the old predicate became `WHERE message_id = ''`, which is not a miss but a match: this install carries **151 tasks with an empty `message_id`**. A reply arriving with no `In-Reply-To` header at all matched one of them and linked itself to an unrelated campaign.

That is worse than the bracket bug and independent of it: not a lost attribution but a wrong one. The empty guard closes it.

## The change

- normalise the input once, then probe **both exact forms** (`WHERE message_id = $1 OR message_id = $2`, bare and bracketed)
- return early on an empty id

Probing two exact values rather than normalising the column keeps the lookup on the `message_id` index; `TRIM()` in the predicate would scan every task row on each inbound reply.

All three callers (`inbound_bounce.go:23`, `:79`, `advanced/service.go:858`) already test `task == nil`, so the early return needs no caller change.

The second commit replaces the bare `_ =` on `ProcessIncomingReply` in `HandleNewEmail` with a logged warning. It stays best-effort and non-blocking, as the comment above the call intends; only the silence changes. A failure there is currently indistinguishable from a reply that linked correctly, which is what made the bug above take a database query to find rather than a log line.

## Tests

`internal/repository/task_message_id_live_test.go`, in the existing `liveContactDB` + `WARMBLY_TEST_DB` pattern. Verified both ways: passes with the change, **fails without it**, including the `empty message id is not a wildcard` case, which is what surfaced the second bug.

gofmt, `go build ./...`, `go vet` and golangci-lint (v1.64.8) clean on top of current main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email reply processing by recognizing Message-IDs with surrounding whitespace or angle brackets.
  - Prevented empty Message-IDs from incorrectly matching tasks.
  - Preserved selection of the newest matching task.
  - Added error logging for incoming reply processing issues while allowing inbox ingestion to continue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Verified in production

Deployed on the self-host the evidence above came from, then a real reply was sent to a live campaign email:

```
replies linked today                      4 of 4
reply_class                               negative / positive, confidence 0.7, source model
follow-ups still pending for a replier    0
reply-intent warnings in the consumer     none
```

Before the change the same campaign left `replied_at` NULL on all six contacts. After it the link is made, the classifier runs, and `stop_on_reply` fires: nothing is queued for anyone who answered.

The silent consumer log also settles a question the investigation had left open. There was a suspicion that the sender-address fallback after the In-Reply-To lookup was failing independently, since it should have rescued the link even with the bracket mismatch. With the error now logged rather than discarded, it stays quiet, so there was no second failure: the bracket mismatch accounted for all of it.