### PR TITLE
Pass EMAIL_VERIFY_HELO_HOST and EMAIL_VERIFY_MAIL_FROM through to the services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -431,6 +431,24 @@ BILLING_PROVIDER=none
 # BOX_OUTLOOK_CLIENT_SECRET=
 
 
+# === Pre-send verification (optional) =========================================
+#
+# The built-in SMTP probe checks an address before a campaign sends to it. It
+# greets the recipient's server with EMAIL_VERIFY_HELO_HOST, which has to be a
+# public fully-qualified name for this instance. Unset, it falls back to the
+# host of APP_URL; when neither is a real public name the probe is skipped and
+# every address stays "unknown", which still sends.
+#
+# Backend only. Never a worker: a worker is a sending IP.
+# EMAIL_VERIFY_HELO_HOST=verify.example.com
+# EMAIL_VERIFY_MAIL_FROM=verify@example.com
+#
+# An instance-wide MillionVerifier key. Every workspace that has not connected
+# its own key is checked through this one, spending its credits, instead of the
+# built-in probe.
+# EMAIL_VERIFY_MILLIONVERIFIER_API_KEY=
+
+
 # === Worker (set in each worker's own environment) ============================
 #
 # Workers hold no database. They reach organization keys over the backend's

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,12 +202,12 @@ x-selfhost-env: &selfhost-env
   AI_MODEL_PAID: ${AI_MODEL_PAID:-}
   AI_BASE_URL: ${AI_BASE_URL:-}
   AI_FREE: ${AI_FREE:-}
-  # Pre-send email verification (in-house SMTP probe). The HELO name must be
-  # a public FQDN that resolves to this host's egress IP, or the prober
-  # declines to run rather than guess — a bad HELO makes Postfix reject at
-  # RCPT, which reads as "mailbox does not exist" and burns good leads.
+
+  # Pre-send verification. The HELO name must be a public FQDN for this host,
+  # or the probe is skipped and every address stays unknown.
   EMAIL_VERIFY_HELO_HOST: ${EMAIL_VERIFY_HELO_HOST:-}
   EMAIL_VERIFY_MAIL_FROM: ${EMAIL_VERIFY_MAIL_FROM:-}
+  EMAIL_VERIFY_MILLIONVERIFIER_API_KEY: ${EMAIL_VERIFY_MILLIONVERIFIER_API_KEY:-}
 
   SEARCH_PROVIDER: ${SEARCH_PROVIDER:-}
   SEARCH_API_URL: ${SEARCH_API_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -202,6 +202,13 @@ x-selfhost-env: &selfhost-env
   AI_MODEL_PAID: ${AI_MODEL_PAID:-}
   AI_BASE_URL: ${AI_BASE_URL:-}
   AI_FREE: ${AI_FREE:-}
+  # Pre-send email verification (in-house SMTP probe). The HELO name must be
+  # a public FQDN that resolves to this host's egress IP, or the prober
+  # declines to run rather than guess — a bad HELO makes Postfix reject at
+  # RCPT, which reads as "mailbox does not exist" and burns good leads.
+  EMAIL_VERIFY_HELO_HOST: ${EMAIL_VERIFY_HELO_HOST:-}
+  EMAIL_VERIFY_MAIL_FROM: ${EMAIL_VERIFY_MAIL_FROM:-}
+
   SEARCH_PROVIDER: ${SEARCH_PROVIDER:-}
   SEARCH_API_URL: ${SEARCH_API_URL:-}
   SEARCH_API_KEY: ${SEARCH_API_KEY:-}


### PR DESCRIPTION
The in-house SMTP verifier reads `EMAIL_VERIFY_HELO_HOST` and `EMAIL_VERIFY_MAIL_FROM`, but neither is in the compose environment block, so on a Docker self-host the values sit in `.env` and never reach the container.

The prober then declines to run rather than guess a HELO name, which is the right call (a bad HELO makes the remote Postfix reject at RCPT, and that reads as "mailbox does not exist", burning good leads). But the visible result is that every contact comes back `unknown` with a message asking for a public fully-qualified HELO hostname that the operator has already set.

This adds the two passthroughs next to the other verification settings in `x-selfhost-env`. Both default to empty, so an install that does not set them behaves exactly as before.

Found on a self-hosted install where the verifier returned `unknown` for every address until the values were injected by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that invalid HELO configuration skips SMTP probes, leaving email addresses with an unknown verification status.
  * Documented optional pre-send email verification, including SMTP probe settings, HELO hostname, sender configuration, fallback behavior, and backend-only scope.

* **Chores**
  * Added configuration options for external email verification through MillionVerifier, including an instance-wide API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->