### PR TITLE
fix(consumer): one mailbox error row per unresolved code, not one per sync pass

### DIFF
--- a/docs/content/docs/guides/mailboxes.mdx
+++ b/docs/content/docs/guides/mailboxes.mdx
@@ -40,6 +40,8 @@ If a mailbox fails to connect with a server-unreachable error and the host and p
 
 When a mail server goes down or stops answering, the mailbox is not deactivated. Warmbly says so once in the drawer, retries on a widening interval, and picks up where it left off when the server comes back. Nothing that arrived meanwhile is skipped, and the error clears itself on the first pass that reaches the server again.
 
+The same holds for a server that answers but refuses what Warmbly asked. The drawer shows one row carrying the server's own wording, not one row per retry, and it clears on the first pass that completes.
+
 With two-factor authentication on, generate an app password in your provider's security settings and use that.
 
 Warmbly signs in with whichever method your server offers, preferring CRAM-MD5, then LOGIN, then PLAIN. Servers that accept only one of these, which includes Microsoft 365 relays and most appliance relays, work without any setting to change.

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -51,7 +51,7 @@ func (s *JobsService) HandleEmailAuthError(ctx context.Context, event models.Ema
 			TaskID:         taskID,
 		}
 
-		if _, xerr := s.EmailAccountErrorRepository.Create(ctx, errorRecord); xerr != nil {
+		if _, xerr := s.EmailAccountErrorRepository.CreateOnce(ctx, errorRecord); xerr != nil {
 			log.Error().Str("error", xerr.Message).Msg("Failed to store email auth error")
 		}
 	}
@@ -116,7 +116,7 @@ func (s *JobsService) HandleEmailDisabled(ctx context.Context, event models.Emai
 			TaskID:         taskID,
 		}
 
-		if _, xerr := s.EmailAccountErrorRepository.Create(ctx, errorRecord); xerr != nil {
+		if _, xerr := s.EmailAccountErrorRepository.CreateOnce(ctx, errorRecord); xerr != nil {
 			log.Error().Str("error", xerr.Message).Msg("Failed to store email disabled error")
 		}
 	}
@@ -181,7 +181,7 @@ func (s *JobsService) HandleEmailRateLimited(ctx context.Context, event models.E
 			TaskID:         taskID,
 		}
 
-		if _, xerr := s.EmailAccountErrorRepository.Create(ctx, errorRecord); xerr != nil {
+		if _, xerr := s.EmailAccountErrorRepository.CreateOnce(ctx, errorRecord); xerr != nil {
 			log.Error().Str("error", xerr.Message).Msg("Failed to store rate limit error")
 		}
 	}

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -235,7 +235,13 @@ func (s *JobsService) HandleEmailServerError(ctx context.Context, event models.E
 		}
 	}
 
-	// Store error in database (as warning, not critical)
+	// Store error in database (as warning, not critical).
+	//
+	// CreateOnce, not Create: the sync loop retries a refused server about
+	// once a minute and relays what it got each time, so the same unresolved
+	// failure would otherwise fill the mailbox's error list with a row a
+	// minute for as long as the server keeps refusing (issue #405).
+	recorded := true
 	if s.EmailAccountErrorRepository != nil {
 		errorRecord := &repository.CreateEmailAccountError{
 			EmailAccountID: emailAccountID,
@@ -250,16 +256,19 @@ func (s *JobsService) HandleEmailServerError(ctx context.Context, event models.E
 			TaskID:         taskID,
 		}
 
-		if _, xerr := s.EmailAccountErrorRepository.Create(ctx, errorRecord); xerr != nil {
+		row, xerr := s.EmailAccountErrorRepository.CreateOnce(ctx, errorRecord)
+		if xerr != nil {
 			log.Error().Str("error", xerr.Message).Msg("Failed to store server error")
 		}
+		recorded = xerr == nil && row != nil
 	}
 
 	// Server errors are temporary - don't change account status
 	// The error will be auto-resolved when connectivity is restored
 
-	// Only send notification if error persists (based on user visibility flag)
-	if s.StreamingPublisher != nil && event.UserVisible {
+	// Only notify for an error we just recorded: a repeat of one already in
+	// the drawer must not toast the reader again every pass.
+	if s.StreamingPublisher != nil && event.UserVisible && recorded {
 		s.StreamingPublisher.PublishEmailWarning(
 			ctx,
 			event.UserID,

--- a/internal/app/consumer/event_email_error_test.go
+++ b/internal/app/consumer/event_email_error_test.go
@@ -13,14 +13,8 @@ import (
 // stubCreateRepo counts which of the two write paths the handler took.
 type stubCreateRepo struct {
 	repository.EmailAccountErrorRepository
-	created     int
 	createdOnce int
 	suppress    bool
-}
-
-func (s *stubCreateRepo) Create(context.Context, *repository.CreateEmailAccountError) (*repository.EmailAccountError, *errx.Error) {
-	s.created++
-	return &repository.EmailAccountError{}, nil
 }
 
 func (s *stubCreateRepo) CreateOnce(_ context.Context, in *repository.CreateEmailAccountError) (*repository.EmailAccountError, *errx.Error) {
@@ -53,9 +47,6 @@ func TestServerErrorRecordsOnePerUnresolvedCode(t *testing.T) {
 		}
 	}
 
-	if repo.created != 0 {
-		t.Errorf("took the unconditional Create path %d times; a repeating server error must not stack rows", repo.created)
-	}
 	if repo.createdOnce != 3 {
 		t.Errorf("CreateOnce called %d times, want one per relayed failure", repo.createdOnce)
 	}

--- a/internal/app/consumer/event_email_error_test.go
+++ b/internal/app/consumer/event_email_error_test.go
@@ -1,0 +1,80 @@
+package jobs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// stubCreateRepo counts which of the two write paths the handler took.
+type stubCreateRepo struct {
+	repository.EmailAccountErrorRepository
+	created     int
+	createdOnce int
+	suppress    bool
+}
+
+func (s *stubCreateRepo) Create(context.Context, *repository.CreateEmailAccountError) (*repository.EmailAccountError, *errx.Error) {
+	s.created++
+	return &repository.EmailAccountError{}, nil
+}
+
+func (s *stubCreateRepo) CreateOnce(_ context.Context, in *repository.CreateEmailAccountError) (*repository.EmailAccountError, *errx.Error) {
+	s.createdOnce++
+	if s.suppress {
+		return nil, nil
+	}
+	return &repository.EmailAccountError{ErrorCode: in.ErrorCode}, nil
+}
+
+// A mail server that refuses the same command on every pass is relayed on
+// every pass. Recording each one unconditionally filled a mailbox's error
+// list with an identical row a minute for as long as the refusal lasted
+// (issue #405), so the server-error path has to write conditionally.
+func TestServerErrorRecordsOnePerUnresolvedCode(t *testing.T) {
+	repo := &stubCreateRepo{}
+	s := &JobsService{EmailAccountErrorRepository: repo}
+
+	event := models.EmailErrorEvent{
+		EmailAccountID: uuid.NewString(),
+		UserID:         uuid.NewString(),
+		ErrorCode:      string(errx.MailErrorCodeImapUnknown),
+		Message:        "Something went wrong: NO System Error",
+		UserVisible:    true,
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := s.HandleEmailServerError(context.Background(), event); err != nil {
+			t.Fatalf("HandleEmailServerError: %v", err)
+		}
+	}
+
+	if repo.created != 0 {
+		t.Errorf("took the unconditional Create path %d times; a repeating server error must not stack rows", repo.created)
+	}
+	if repo.createdOnce != 3 {
+		t.Errorf("CreateOnce called %d times, want one per relayed failure", repo.createdOnce)
+	}
+}
+
+// A suppressed write is not an error: the row it wanted is already on screen.
+func TestServerErrorSurvivesASuppressedWrite(t *testing.T) {
+	repo := &stubCreateRepo{suppress: true}
+	s := &JobsService{EmailAccountErrorRepository: repo}
+
+	if err := s.HandleEmailServerError(context.Background(), models.EmailErrorEvent{
+		EmailAccountID: uuid.NewString(),
+		UserID:         uuid.NewString(),
+		ErrorCode:      string(errx.MailErrorCodeImapUnknown),
+		UserVisible:    true,
+	}); err != nil {
+		t.Fatalf("HandleEmailServerError: %v", err)
+	}
+	if repo.createdOnce != 1 {
+		t.Fatalf("CreateOnce called %d times, want 1", repo.createdOnce)
+	}
+}

--- a/internal/app/consumer/event_sync_state.go
+++ b/internal/app/consumer/event_sync_state.go
@@ -98,6 +98,10 @@ var transientMailErrorCodes = []string{
 	string(errx.MailErrorCodeServerUnreachable),
 	string(errx.MailErrorCodeConnectionLost),
 	string(errx.MailErrorCodeNotFound),
+	// A NO/BAD the client has no dedicated error for. It is relayed as a
+	// temporary server error and never deactivates the mailbox, so a pass
+	// that completed afterwards disproves it like any other outage.
+	string(errx.MailErrorCodeImapUnknown),
 }
 
 func (s *JobsService) resolveTransientMailErrors(ctx context.Context, emailID uuid.UUID, syncedAt *time.Time) {

--- a/internal/app/consumer/event_sync_state_test.go
+++ b/internal/app/consumer/event_sync_state_test.go
@@ -72,7 +72,7 @@ func TestSyncStateClearsTransientMailErrors(t *testing.T) {
 	if errRepo.calls != 1 {
 		t.Fatalf("resolved errors %d times, want once per relayed state", errRepo.calls)
 	}
-	want := map[string]bool{"SERVER_UNREACHABLE": true, "CONNECTION_LOST": true, "RESOURCE_NOT_FOUND": true}
+	want := map[string]bool{"SERVER_UNREACHABLE": true, "CONNECTION_LOST": true, "RESOURCE_NOT_FOUND": true, "IMAP_UNKNOWN": true}
 	for _, code := range errRepo.resolvedCodes {
 		if !want[code] {
 			t.Errorf("resolved %q, which a completed sync does not disprove", code)

--- a/internal/infrastructure/db/migrations/000145_one_unresolved_error_per_code.down.sql
+++ b/internal/infrastructure/db/migrations/000145_one_unresolved_error_per_code.down.sql
@@ -1,0 +1,17 @@
+-- Reverses 000145. The rows the up migration collapsed are recoverable
+-- because it stamped them with a resolved_by nothing else writes.
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_email_account_errors_code
+    ON email_account_errors (email_account_id, error_code)
+    WHERE resolved_at IS NULL;
+
+DROP INDEX IF EXISTS idx_email_account_errors_one_unresolved_per_code;
+
+UPDATE email_account_errors
+SET resolved_at = NULL,
+    resolved_by = NULL
+WHERE resolved_by = 'superseded';
+
+COMMIT;

--- a/internal/infrastructure/db/migrations/000145_one_unresolved_error_per_code.up.sql
+++ b/internal/infrastructure/db/migrations/000145_one_unresolved_error_per_code.up.sql
@@ -1,0 +1,40 @@
+-- One unresolved error row per mailbox per code.
+--
+-- The sync loop retries a refused mail server about once a minute and relays
+-- what it got every time, and the consumer recorded each one, so a mailbox
+-- whose server kept saying no collected an identical row a minute for as long
+-- as it lasted (issue #405). The insert is conditional now, but a conditional
+-- insert is not atomic on its own: two workers relaying the same failure at
+-- the same moment both see no row and both write one.
+--
+-- The unique index is what actually holds. It is partial on the unresolved
+-- rows, so the history of resolved errors is untouched and a problem that
+-- comes back after it was fixed is still recorded as news.
+
+BEGIN;
+
+-- Existing duplicates first, or the index cannot be built. The oldest of each
+-- group is kept because it says when the problem started; the rest are marked
+-- resolved rather than deleted, so the record of how long it went on survives.
+UPDATE email_account_errors AS e
+SET resolved_at = NOW(),
+    resolved_by = 'superseded'
+WHERE e.resolved_at IS NULL
+  AND EXISTS (
+      SELECT 1
+      FROM email_account_errors AS keep
+      WHERE keep.email_account_id = e.email_account_id
+        AND keep.error_code = e.error_code
+        AND keep.resolved_at IS NULL
+        AND (keep.created_at, keep.id) < (e.created_at, e.id)
+  );
+
+CREATE UNIQUE INDEX idx_email_account_errors_one_unresolved_per_code
+    ON email_account_errors (email_account_id, error_code)
+    WHERE resolved_at IS NULL;
+
+-- Same columns, same predicate, no longer unique: the index above serves every
+-- lookup this one did, and a redundant index is paid for on every write.
+DROP INDEX IF EXISTS idx_email_account_errors_code;
+
+COMMIT;

--- a/internal/repository/email_error_dedupe_live_test.go
+++ b/internal/repository/email_error_dedupe_live_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/google/uuid"
@@ -119,5 +120,96 @@ func TestLiveEmailErrorDedupeKeepsOneUnresolvedRowPerCode(t *testing.T) {
 	}
 	if rearmed == nil {
 		t.Error("an error recurring after it was resolved must be recorded again")
+	}
+}
+
+// CodeRabbit's catch on #406: a conditional insert is not atomic on its own.
+// Two workers relaying the same failure in the same instant both find no row
+// and both write one. Migration 000145 makes that impossible and ON CONFLICT
+// turns the loser into the ordinary "already on screen" answer instead of a
+// logged storage failure.
+func TestLiveEmailErrorDedupeSurvivesConcurrentRelays(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	repo := NewEmailAccountErrorRepository(handle)
+	ctx := context.Background()
+
+	account, user, org := uuid.New(), uuid.New(), uuid.New()
+	tag := "i405c-" + org.String()[:8]
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+	}
+	exec(`INSERT INTO users (id, first_name, last_name, email, password_hash)
+	      VALUES ($1, 'Ilse', 'Live', $2, 'x')`, user, tag+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id)
+	      VALUES ($1, 'Issue 405', $2, $3)`, org, tag, user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name, signature_plain, signature_html, provider)
+	      VALUES ($1, $2, $3, $4, 'Ilse', '', '', 'smtp_imap')`,
+		account, user, org, tag+"-mb@test.local")
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM email_account_errors WHERE email_account_id = $1`, account},
+			{`DELETE FROM email_accounts WHERE organization_id = $1`, org},
+			{`DELETE FROM organizations WHERE id = $1`, org},
+			{`DELETE FROM users WHERE id = $1`, user},
+		} {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup: %v", err)
+			}
+		}
+	})
+
+	const racers = 8
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		written int
+	)
+	start := make(chan struct{})
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			row, xerr := repo.CreateOnce(ctx, &CreateEmailAccountError{
+				EmailAccountID: account,
+				UserID:         user,
+				ErrorCode:      "IMAP_UNKNOWN",
+				Severity:       "WARNING",
+				ResolveMethod:  "RETRY",
+				Title:          "Email Error",
+				Message:        "Something went wrong: NO System Error",
+			})
+			mu.Lock()
+			defer mu.Unlock()
+			if xerr != nil {
+				t.Errorf("a losing racer must not surface a storage failure: %v", xerr.Message)
+				return
+			}
+			if row != nil {
+				written++
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if written != 1 {
+		t.Errorf("%d of %d racers believed they wrote the row, want exactly 1", written, racers)
+	}
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM email_account_errors
+		 WHERE email_account_id = $1 AND resolved_at IS NULL`, account).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("unresolved rows = %d after %d concurrent relays, want 1", n, racers)
 	}
 }

--- a/internal/repository/email_error_dedupe_live_test.go
+++ b/internal/repository/email_error_dedupe_live_test.go
@@ -1,0 +1,123 @@
+package repository
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// Issue #405: a self-hosted instance whose IMAP server refused the same
+// command every pass ended up with an error list holding one identical row per
+// minute. The insert is conditional in SQL, so this proves it against the real
+// table and the partial index it leans on.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/repository/ -run LiveEmailErrorDedupe -v
+
+func TestLiveEmailErrorDedupeKeepsOneUnresolvedRowPerCode(t *testing.T) {
+	handle, pool := liveContactDB(t)
+	repo := NewEmailAccountErrorRepository(handle)
+	ctx := context.Background()
+
+	account, user, org := uuid.New(), uuid.New(), uuid.New()
+	tag := "i405-" + org.String()[:8]
+	exec := func(sql string, args ...any) {
+		t.Helper()
+		if _, err := pool.Exec(ctx, sql, args...); err != nil {
+			t.Fatalf("fixture %q: %v", sql[:min(60, len(sql))], err)
+		}
+	}
+	exec(`INSERT INTO users (id, first_name, last_name, email, password_hash)
+	      VALUES ($1, 'Ilse', 'Live', $2, 'x')`, user, tag+"@test.local")
+	exec(`INSERT INTO organizations (id, name, slug, owner_user_id)
+	      VALUES ($1, 'Issue 405', $2, $3)`, org, tag, user)
+	exec(`INSERT INTO email_accounts (id, user_id, organization_id, email, name, signature_plain, signature_html, provider)
+	      VALUES ($1, $2, $3, $4, 'Ilse', '', '', 'smtp_imap')`,
+		account, user, org, tag+"-mb@test.local")
+
+	t.Cleanup(func() {
+		c := context.Background()
+		for _, step := range []struct {
+			sql string
+			arg any
+		}{
+			{`DELETE FROM email_account_errors WHERE email_account_id = $1`, account},
+			{`DELETE FROM email_accounts WHERE organization_id = $1`, org},
+			{`DELETE FROM organizations WHERE id = $1`, org},
+			{`DELETE FROM users WHERE id = $1`, user},
+		} {
+			if _, err := pool.Exec(c, step.sql, step.arg); err != nil {
+				t.Errorf("cleanup %q: %v", step.sql, err)
+			}
+		}
+	})
+
+	row := func(code string) *CreateEmailAccountError {
+		return &CreateEmailAccountError{
+			EmailAccountID: account,
+			UserID:         user,
+			ErrorCode:      code,
+			Severity:       "WARNING",
+			ResolveMethod:  "RETRY",
+			Title:          "Email Error",
+			Message:        "Something went wrong: NO System Error",
+		}
+	}
+
+	unresolved := func(code string) int {
+		t.Helper()
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM email_account_errors
+			 WHERE email_account_id = $1 AND error_code = $2 AND resolved_at IS NULL`,
+			account, code).Scan(&n); err != nil {
+			t.Fatalf("count: %v", err)
+		}
+		return n
+	}
+
+	first, xerr := repo.CreateOnce(ctx, row("IMAP_UNKNOWN"))
+	if xerr != nil {
+		t.Fatalf("CreateOnce: %v", xerr.Message)
+	}
+	if first == nil {
+		t.Fatal("the first occurrence of an error must be recorded")
+	}
+
+	// The sync loop relaying the same refusal for the next hour.
+	for i := 0; i < 5; i++ {
+		again, xerr := repo.CreateOnce(ctx, row("IMAP_UNKNOWN"))
+		if xerr != nil {
+			t.Fatalf("CreateOnce repeat: %v", xerr.Message)
+		}
+		if again != nil {
+			t.Fatalf("repeat %d wrote a second unresolved row for the same code", i+1)
+		}
+	}
+	if n := unresolved("IMAP_UNKNOWN"); n != 1 {
+		t.Errorf("unresolved IMAP_UNKNOWN rows = %d, want 1", n)
+	}
+
+	// A different failure is a different row: dedupe must not swallow it.
+	other, xerr := repo.CreateOnce(ctx, row("SERVER_UNREACHABLE"))
+	if xerr != nil {
+		t.Fatalf("CreateOnce other code: %v", xerr.Message)
+	}
+	if other == nil {
+		t.Fatal("a different error code must still be recorded")
+	}
+
+	// Once the mailbox recovers and the row is resolved, the next occurrence
+	// is news again, otherwise a mailbox that breaks twice reports once.
+	if xerr := repo.Resolve(ctx, first.ID, "test"); xerr != nil {
+		t.Fatalf("Resolve: %v", xerr.Message)
+	}
+	rearmed, xerr := repo.CreateOnce(ctx, row("IMAP_UNKNOWN"))
+	if xerr != nil {
+		t.Fatalf("CreateOnce after resolve: %v", xerr.Message)
+	}
+	if rearmed == nil {
+		t.Error("an error recurring after it was resolved must be recorded again")
+	}
+}

--- a/internal/repository/pg_email_error.go
+++ b/internal/repository/pg_email_error.go
@@ -46,6 +46,10 @@ type CreateEmailAccountError struct {
 // EmailAccountErrorRepository defines operations for email account errors
 type EmailAccountErrorRepository interface {
 	Create(ctx context.Context, err *CreateEmailAccountError) (*EmailAccountError, *errx.Error)
+	// CreateOnce is Create for an error that repeats until someone fixes it:
+	// it records nothing, and returns a nil record, while the account already
+	// has an unresolved error with the same code.
+	CreateOnce(ctx context.Context, err *CreateEmailAccountError) (*EmailAccountError, *errx.Error)
 	GetByAccountID(ctx context.Context, accountID uuid.UUID, unresolvedOnly bool) ([]EmailAccountError, *errx.Error)
 	GetByUserID(ctx context.Context, userID uuid.UUID, limit int) ([]EmailAccountError, *errx.Error)
 	Resolve(ctx context.Context, errorID uuid.UUID, resolvedBy string) *errx.Error
@@ -102,6 +106,66 @@ func (r *emailAccountErrorRepository) Create(ctx context.Context, data *CreateEm
 		&e.Title, &e.Message, &e.UserMessage, &e.ActionRequired, &e.TaskID,
 		&e.ResolvedAt, &e.ResolvedBy, &e.CreatedAt,
 	)
+	if err != nil {
+		db.CaptureError(err, query, params, "queryrow")
+		return nil, errx.InternalError()
+	}
+
+	return &e, nil
+}
+
+// CreateOnce records the error unless the account already has an unresolved
+// one carrying the same code, and returns (nil, nil) when it declined.
+//
+// A mail server that refuses the same command every pass is not a new problem
+// every pass. The sync loop retries about once a minute and reports what it
+// got, so one IMAP_UNKNOWN that nobody can fix wrote 1440 identical rows a day
+// into the mailbox's error list (issue #405). The insert is conditional in SQL
+// rather than a read followed by a write, because several workers can relay
+// the same failure at once.
+func (r *emailAccountErrorRepository) CreateOnce(ctx context.Context, data *CreateEmailAccountError) (*EmailAccountError, *errx.Error) {
+	query := `
+		INSERT INTO email_account_errors (
+			email_account_id, user_id, error_code, severity, resolve_method,
+			title, message, user_message, action_required, task_id
+		)
+		-- The casts are load-bearing: a SELECT source, unlike VALUES, gives
+		-- the planner no target columns to infer the parameter types from.
+		SELECT $1::uuid, $2::uuid, $3::varchar, $4::email_error_severity,
+		       $5::email_error_resolve_method, $6::varchar, $7::text, $8::text,
+		       $9::text, $10::uuid
+		WHERE NOT EXISTS (
+			SELECT 1 FROM email_account_errors
+			WHERE email_account_id = $1 AND error_code = $3 AND resolved_at IS NULL
+		)
+		RETURNING id, email_account_id, user_id, error_code, severity, resolve_method,
+		          title, message, user_message, action_required, task_id,
+		          resolved_at, resolved_by, created_at
+	`
+
+	params := []any{
+		data.EmailAccountID,
+		data.UserID,
+		data.ErrorCode,
+		data.Severity,
+		data.ResolveMethod,
+		data.Title,
+		data.Message,
+		data.UserMessage,
+		data.ActionRequired,
+		data.TaskID,
+	}
+
+	var e EmailAccountError
+	err := r.DB.QueryRow(ctx, query, params...).Scan(
+		&e.ID, &e.EmailAccountID, &e.UserID, &e.ErrorCode, &e.Severity, &e.ResolveMethod,
+		&e.Title, &e.Message, &e.UserMessage, &e.ActionRequired, &e.TaskID,
+		&e.ResolvedAt, &e.ResolvedBy, &e.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The row the caller wanted is already on screen, unresolved.
+		return nil, nil
+	}
 	if err != nil {
 		db.CaptureError(err, query, params, "queryrow")
 		return nil, errx.InternalError()
@@ -325,35 +389,4 @@ func MapSeverity(errType errx.MailErrorType) string {
 	default:
 		return "WARNING"
 	}
-}
-
-// GetUnresolvedByCode checks if there's already an unresolved error with the same code
-func (r *emailAccountErrorRepository) GetUnresolvedByCode(ctx context.Context, accountID uuid.UUID, errorCode string) (*EmailAccountError, *errx.Error) {
-	query := `
-		SELECT id, email_account_id, user_id, error_code, severity, resolve_method,
-		       title, message, user_message, action_required, task_id,
-		       resolved_at, resolved_by, created_at
-		FROM email_account_errors
-		WHERE email_account_id = $1
-		  AND error_code = $2
-		  AND resolved_at IS NULL
-		ORDER BY created_at DESC
-		LIMIT 1
-	`
-
-	var e EmailAccountError
-	err := r.DB.QueryRow(ctx, query, accountID, errorCode).Scan(
-		&e.ID, &e.EmailAccountID, &e.UserID, &e.ErrorCode, &e.Severity, &e.ResolveMethod,
-		&e.Title, &e.Message, &e.UserMessage, &e.ActionRequired, &e.TaskID,
-		&e.ResolvedAt, &e.ResolvedBy, &e.CreatedAt,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, nil // No existing error found
-		}
-		db.CaptureError(err, query, []any{accountID, errorCode}, "queryrow")
-		return nil, errx.InternalError()
-	}
-
-	return &e, nil
 }

--- a/internal/repository/pg_email_error.go
+++ b/internal/repository/pg_email_error.go
@@ -45,10 +45,11 @@ type CreateEmailAccountError struct {
 
 // EmailAccountErrorRepository defines operations for email account errors
 type EmailAccountErrorRepository interface {
-	Create(ctx context.Context, err *CreateEmailAccountError) (*EmailAccountError, *errx.Error)
-	// CreateOnce is Create for an error that repeats until someone fixes it:
-	// it records nothing, and returns a nil record, while the account already
-	// has an unresolved error with the same code.
+	// CreateOnce records an error unless the account already has an unresolved
+	// one with the same code, in which case it writes nothing and returns a
+	// nil record. It is the only write path: migration 000145 makes a second
+	// unresolved row for one code impossible, so an unconditional insert would
+	// only turn a repeat into a constraint violation.
 	CreateOnce(ctx context.Context, err *CreateEmailAccountError) (*EmailAccountError, *errx.Error)
 	GetByAccountID(ctx context.Context, accountID uuid.UUID, unresolvedOnly bool) ([]EmailAccountError, *errx.Error)
 	GetByUserID(ctx context.Context, userID uuid.UUID, limit int) ([]EmailAccountError, *errx.Error)
@@ -76,53 +77,20 @@ func NewEmailAccountErrorRepository(database *db.DB) EmailAccountErrorRepository
 }
 
 // Create stores a new email account error
-func (r *emailAccountErrorRepository) Create(ctx context.Context, data *CreateEmailAccountError) (*EmailAccountError, *errx.Error) {
-	query := `
-		INSERT INTO email_account_errors (
-			email_account_id, user_id, error_code, severity, resolve_method,
-			title, message, user_message, action_required, task_id
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-		RETURNING id, email_account_id, user_id, error_code, severity, resolve_method,
-		          title, message, user_message, action_required, task_id,
-		          resolved_at, resolved_by, created_at
-	`
-
-	params := []any{
-		data.EmailAccountID,
-		data.UserID,
-		data.ErrorCode,
-		data.Severity,
-		data.ResolveMethod,
-		data.Title,
-		data.Message,
-		data.UserMessage,
-		data.ActionRequired,
-		data.TaskID,
-	}
-
-	var e EmailAccountError
-	err := r.DB.QueryRow(ctx, query, params...).Scan(
-		&e.ID, &e.EmailAccountID, &e.UserID, &e.ErrorCode, &e.Severity, &e.ResolveMethod,
-		&e.Title, &e.Message, &e.UserMessage, &e.ActionRequired, &e.TaskID,
-		&e.ResolvedAt, &e.ResolvedBy, &e.CreatedAt,
-	)
-	if err != nil {
-		db.CaptureError(err, query, params, "queryrow")
-		return nil, errx.InternalError()
-	}
-
-	return &e, nil
-}
-
 // CreateOnce records the error unless the account already has an unresolved
 // one carrying the same code, and returns (nil, nil) when it declined.
 //
 // A mail server that refuses the same command every pass is not a new problem
 // every pass. The sync loop retries about once a minute and reports what it
 // got, so one IMAP_UNKNOWN that nobody can fix wrote 1440 identical rows a day
-// into the mailbox's error list (issue #405). The insert is conditional in SQL
-// rather than a read followed by a write, because several workers can relay
-// the same failure at once.
+// into the mailbox's error list (issue #405).
+//
+// Both guards are load-bearing. WHERE NOT EXISTS answers the ordinary repeat
+// without touching the index, and ON CONFLICT answers the race it cannot see:
+// two workers relaying the same failure in the same instant both find no row.
+// The unique index behind it is partial on the unresolved rows (migration
+// 000145), so resolved history is untouched and a problem that returns after
+// it was fixed is recorded again.
 func (r *emailAccountErrorRepository) CreateOnce(ctx context.Context, data *CreateEmailAccountError) (*EmailAccountError, *errx.Error) {
 	query := `
 		INSERT INTO email_account_errors (
@@ -138,6 +106,7 @@ func (r *emailAccountErrorRepository) CreateOnce(ctx context.Context, data *Crea
 			SELECT 1 FROM email_account_errors
 			WHERE email_account_id = $1 AND error_code = $3 AND resolved_at IS NULL
 		)
+		ON CONFLICT DO NOTHING
 		RETURNING id, email_account_id, user_id, error_code, severity, resolve_method,
 		          title, message, user_message, action_required, task_id,
 		          resolved_at, resolved_by, created_at


### PR DESCRIPTION
Follow-up to #405, which arrived with an `email_account_errors` table holding one identical `IMAP_UNKNOWN` row per sync pass.

The empty message itself is fixed in #402. This is the collateral: an IMAP server that refuses the same command every pass is not a new problem every pass, but every layer treated it as one.

## What was happening

`syncOnce` relays whatever the pass got (`internal/app/worker/wmail/start_sync.go:96`), the consumer records it, and the sync interval is about a minute. `IMAP_UNKNOWN` is not a transport error, so it misses the quiet-down that `syncOnce` applies to an unreachable server, and `HandleEmailServerError` inserted unconditionally. That is roughly 1440 rows a day per broken mailbox, plus a `PublishEmailWarning` per pass at the reader.

It never cleared either: `transientMailErrorCodes` is what a completed pass disproves, and `IMAP_UNKNOWN` was not in it, even though it is relayed as a temporary server error and never deactivates the mailbox.

## Changes

- **Migration 000145** makes "one unresolved row per mailbox per code" an actual constraint: a partial unique index on `(email_account_id, error_code) WHERE resolved_at IS NULL`. Existing duplicates would block it, so the migration collapses them first, keeping the oldest of each group because that is when the problem started and stamping the rest `resolved_by = 'superseded'` rather than deleting them. Nothing is lost, the resolved history is untouched, and the down migration is a real reversal. It also drops `idx_email_account_errors_code`, which had the same columns and predicate and is now redundant.
- **`CreateOnce`** on `EmailAccountErrorRepository` records the error unless an unresolved one with the same code exists, and returns `(nil, nil)` when it declines. Both guards are deliberate: `WHERE NOT EXISTS` answers the ordinary repeat without touching the index, `ON CONFLICT DO NOTHING` answers the race it cannot see, so a losing writer gets the ordinary "already on screen" answer instead of a logged storage failure.
- **`Create` is gone** and all four handlers use `CreateOnce`. With the constraint in place there is no case where an unconditional insert is right; leaving `Create` would only have turned a duplicate into an error on the auth, disabled and rate-limited paths. `HandleEmailServerError` additionally only notifies for a row it actually wrote.
- **`IMAP_UNKNOWN` joins `transientMailErrorCodes`**, so a pass that completes clears it like any other outage. Without this the dedupe would be worse than the disease: one row that never goes away.
- **Removed `GetUnresolvedByCode`**, written for exactly this guard, never added to the interface, never callable.
- **Docs**: `guides/mailboxes.mdx` already promised "says so once in the drawer" and "clears itself" for a server that stops answering. Extended to the server that answers and refuses, which is now also true.

## Verification

- `make lint` (golangci-lint + `check-migrations`), `gofmt -l` clean, `pnpm types:check` and `pnpm lint` in `docs/`
- `go test ./internal/app/consumer/ ./internal/repository/`
- **Migration, on an isolated database** (not the shared dev one, since this adds a migration): seeded 1440 identical unresolved rows plus a second error code and a pre-existing resolved row, applied it, and got one unresolved row per code with all 1441 rows preserved and the resolved history untouched. Down then up round-trips exactly, and a raw duplicate insert is rejected by the constraint afterwards.
- `TestLiveEmailErrorDedupeKeepsOneUnresolvedRowPerCode`: one unresolved row across six relays of the same code, a different code still recorded, the code re-armed once the row is resolved. Reverting the `WHERE NOT EXISTS` fails it on the first repeat.
- `TestLiveEmailErrorDedupeSurvivesConcurrentRelays`: eight simultaneous `CreateOnce` calls, one writer, no storage failures, one row. Removing `ON CONFLICT DO NOTHING` fails it.
