### PR TITLE
fix(imap): stop sending MODSEQ to servers without CONDSTORE, which failed every sync pass on IONOS

### DIFF
--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -473,8 +473,12 @@ func (c *Client) FetchEnvelopes(ctx context.Context, uids []imap.UID) ([]*Fetche
 		BodyStructure: &imap.FetchItemBodyStructure{
 			Extended: true,
 		},
-		Flags:        true,
-		ModSeq:       true,
+		Flags: true,
+		// MODSEQ is a CONDSTORE fetch item (RFC 7162). Asking a server that
+		// never advertised it for one is a malformed fetch-att, and a strict
+		// parser answers BAD and syncs nothing: issue #405, where IONOS said
+		// `BAD expected fetch-att instead of "MODSEQ BODY.P"` on every pass.
+		ModSeq:       c.condStore.Load(),
 		InternalDate: true,
 		RFC822Size:   true,
 		BodySection: []*imap.FetchItemBodySection{{

--- a/internal/client/smtpimap/imap/fetch_caps_test.go
+++ b/internal/client/smtpimap/imap/fetch_caps_test.go
@@ -1,0 +1,187 @@
+package imap
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// putMessage appends one message to INBOX and returns its UID.
+func putMessage(t *testing.T, c *Client) imap.UID {
+	t.Helper()
+	raw := "From: sender@test\r\n" +
+		"To: warmbly@test\r\n" +
+		"Subject: hello\r\n" +
+		"Message-ID: <fetch-caps@test>\r\n" +
+		"\r\n" +
+		"body\r\n"
+	cmd := c.client.Append("INBOX", int64(len(raw)), nil)
+	if _, err := cmd.Write([]byte(raw)); err != nil {
+		t.Fatalf("append write: %v", err)
+	}
+	if err := cmd.Close(); err != nil {
+		t.Fatalf("append close: %v", err)
+	}
+	data, err := cmd.Wait()
+	if err != nil {
+		t.Fatalf("append wait: %v", err)
+	}
+	return data.UID
+}
+
+// Issue #405. MODSEQ is a CONDSTORE fetch item (RFC 7162), and this package
+// asked for it on every FETCH regardless of what the server advertised. A
+// lenient server takes it anyway, which is why every test here passed; IONOS
+// answered `BAD expected fetch-att instead of "MODSEQ BODY.P"` and the
+// mailbox synced nothing, every pass, for as long as it was connected.
+//
+// go-imap emits the fetch items from a map, so MODSEQ lands in a different
+// position each time and the failure is not even reproducible in the same
+// shape twice. Assert on the command, not on this server's tolerance.
+func TestFetchEnvelopesOmitsModSeqWithoutCondStore(t *testing.T) {
+	c, wire := recordingServer(t, nil)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	if c.HasCondStore() {
+		t.Fatal("the test server must not advertise CONDSTORE")
+	}
+	uid := putMessage(t, c)
+	if _, err := c.SelectForSync("INBOX"); err != nil {
+		t.Fatalf("SelectForSync: %v", err)
+	}
+
+	got, xerr := c.FetchEnvelopes(context.Background(), []imap.UID{uid})
+	if xerr != nil {
+		t.Fatalf("FetchEnvelopes: %s", xerr.Message)
+	}
+	if len(got) != 1 {
+		t.Fatalf("fetched %d messages, want 1", len(got))
+	}
+
+	fetches := wire.commands("FETCH")
+	if len(fetches) == 0 {
+		t.Fatal("no FETCH reached the server")
+	}
+	for _, f := range fetches {
+		if strings.Contains(f, "MODSEQ") {
+			t.Errorf("asked a server without CONDSTORE for MODSEQ: %s", f)
+		}
+	}
+}
+
+// The other half: gating it must not quietly cost the CONDSTORE path its
+// mod-sequences, which are what the incremental sync keys on there. The
+// in-process server cannot advertise CONDSTORE (go-imap's server relays a
+// fixed allowlist that has no room for it), so the capability is set on the
+// client the way a real server's post-auth CAPABILITY would.
+func TestFetchEnvelopesAsksModSeqWithCondStore(t *testing.T) {
+	c, wire := recordingServer(t, nil)
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	uid := putMessage(t, c)
+	if _, err := c.SelectForSync("INBOX"); err != nil {
+		t.Fatalf("SelectForSync: %v", err)
+	}
+	c.condStore.Store(true)
+
+	// The result is deliberately ignored: this server refuses MODSEQ when
+	// CONDSTORE was not enabled, which is #405's failure reproduced in
+	// miniature. What is asserted is the command we chose to send.
+	_, _ = c.FetchEnvelopes(context.Background(), []imap.UID{uid})
+
+	var asked bool
+	for _, f := range wire.commands("FETCH") {
+		if strings.Contains(f, "MODSEQ") {
+			asked = true
+		}
+	}
+	if !asked {
+		t.Error("a CONDSTORE server was not asked for MODSEQ; the incremental sync loses its cursor")
+	}
+}
+
+// Same class as #405, one command over: LIST RETURN options are LIST-EXTENDED
+// grammar (RFC 5258), and SPECIAL-USE does not imply it. A server advertising
+// the folder attributes without the extended LIST would be sent a RETURN it
+// cannot parse, and a BAD there costs the account every folder.
+func TestListOptionsNeedListExtended(t *testing.T) {
+	status := &imap.StatusOptions{UIDValidity: true, UIDNext: true}
+
+	for _, tc := range []struct {
+		name        string
+		caps        imap.CapSet
+		wantStatus  bool
+		wantSpecial bool
+	}{
+		{
+			name: "plain RFC 3501 gets no RETURN at all",
+			caps: imap.CapSet{imap.CapIMAP4rev1: {}},
+		},
+		{
+			name: "SPECIAL-USE without LIST-EXTENDED is not enough",
+			caps: imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapSpecialUse: {}},
+		},
+		{
+			name: "LIST-STATUS without LIST-EXTENDED is not enough",
+			caps: imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapListStatus: {}},
+		},
+		{
+			name:        "LIST-EXTENDED unlocks what is also advertised",
+			caps:        imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapListExtended: {}, imap.CapSpecialUse: {}},
+			wantSpecial: true,
+		},
+		{
+			name:       "LIST-EXTENDED with LIST-STATUS folds STATUS in",
+			caps:       imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapListExtended: {}, imap.CapListStatus: {}},
+			wantStatus: true,
+		},
+		{
+			// IMAP4rev2 implies LIST-EXTENDED and LIST-STATUS.
+			name:        "IMAP4rev2 implies the extended LIST",
+			caps:        imap.CapSet{imap.CapIMAP4rev2: {}, imap.CapSpecialUse: {}},
+			wantStatus:  true,
+			wantSpecial: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts, listStatus := listOptionsFor(tc.caps, status)
+			if got := opts.ReturnStatus != nil; got != tc.wantStatus {
+				t.Errorf("ReturnStatus = %v, want %v", got, tc.wantStatus)
+			}
+			if listStatus != tc.wantStatus {
+				t.Errorf("listStatus = %v, want %v", listStatus, tc.wantStatus)
+			}
+			if opts.ReturnSpecialUse != tc.wantSpecial {
+				t.Errorf("ReturnSpecialUse = %v, want %v", opts.ReturnSpecialUse, tc.wantSpecial)
+			}
+		})
+	}
+}
+
+// End to end on the wire: a plain RFC 3501 server must be sent a bare LIST.
+func TestFoldersSendsBareListWithoutListExtended(t *testing.T) {
+	c, wire := recordingServer(t, nil, "Sent")
+	if err := c.Connect(); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+	boxes, err := c.Folders()
+	if err != nil {
+		t.Fatalf("Folders: %s", err.Message)
+	}
+	if len(boxes) != 2 {
+		t.Fatalf("listed %d folders, want 2", len(boxes))
+	}
+	lists := wire.commands("LIST")
+	if len(lists) == 0 {
+		t.Fatal("no LIST reached the server")
+	}
+	for _, l := range lists {
+		if strings.Contains(l, "RETURN") {
+			t.Errorf("sent LIST-EXTENDED grammar to a server that never advertised it: %s", l)
+		}
+	}
+}

--- a/internal/client/smtpimap/imap/folders.go
+++ b/internal/client/smtpimap/imap/folders.go
@@ -44,19 +44,7 @@ func (c *Client) foldersCapped(limit int) ([]models.Mailbox, *errx.MailError) {
 		// Asking a server without CONDSTORE for HIGHESTMODSEQ is a BAD.
 		HighestModSeq: caps.Has(imap.CapCondStore),
 	}
-	opts := &imap.ListOptions{}
-	// LIST-STATUS folds the STATUS of every folder into the one round trip;
-	// without it each kept folder is asked separately below.
-	listStatus := caps.Has(imap.CapListStatus)
-	if listStatus {
-		opts.ReturnStatus = status
-	}
-	// Gmail attaches \Sent, \Trash, \Junk, \All ... only when asked; on a
-	// plain LIST every folder is just \HasNoChildren and the canonical-folder
-	// mapping is left guessing from names ("Bin" filed as inbox).
-	if caps.Has(imap.CapSpecialUse) {
-		opts.ReturnSpecialUse = true
-	}
+	opts, listStatus := listOptionsFor(caps, status)
 
 	var all []models.Mailbox
 	statuses := map[string]*imap.StatusData{}
@@ -117,6 +105,34 @@ func (c *Client) foldersCapped(limit int) ([]models.Mailbox, *errx.MailError) {
 	}
 
 	return resp, nil
+}
+
+// listOptionsFor is the LIST options a server's capabilities allow, and
+// whether STATUS was folded into the same round trip.
+//
+// Every RETURN option is LIST-EXTENDED grammar (RFC 5258), which IMAP4rev2
+// implies and a plain RFC 3501 server does not. SPECIAL-USE does not bring it:
+// a server may advertise the folder attributes without the extended LIST that
+// requests them, and sending RETURN to one of those is a BAD that costs the
+// account its entire folder list, the same shape as the MODSEQ bug in #405.
+func listOptionsFor(caps imap.CapSet, status *imap.StatusOptions) (*imap.ListOptions, bool) {
+	opts := &imap.ListOptions{}
+	if !caps.Has(imap.CapListExtended) {
+		return opts, false
+	}
+	// LIST-STATUS folds the STATUS of every folder into the one round trip;
+	// without it each kept folder is asked separately.
+	listStatus := caps.Has(imap.CapListStatus)
+	if listStatus {
+		opts.ReturnStatus = status
+	}
+	// Gmail attaches \Sent, \Trash, \Junk, \All ... only when asked; on a
+	// plain LIST every folder is just \HasNoChildren and the canonical-folder
+	// mapping is left guessing from names ("Bin" filed as inbox).
+	if caps.Has(imap.CapSpecialUse) {
+		opts.ReturnSpecialUse = true
+	}
+	return opts, listStatus
 }
 
 // dedupeByName keeps one folder per name.

--- a/internal/client/smtpimap/imap/server_test.go
+++ b/internal/client/smtpimap/imap/server_test.go
@@ -1,9 +1,12 @@
 package imap
 
 import (
+	"bufio"
 	"context"
+	"io"
 	"net"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +22,12 @@ import (
 // against it, so "works on a plain RFC 3501 server" is a thing CI checks
 // rather than a thing we believe.
 func testServer(t *testing.T, caps imap.CapSet, folders ...string) *Client {
+	t.Helper()
+	return clientTo(t, startMemServer(t, caps, folders...))
+}
+
+// startMemServer runs the in-process server and returns its address.
+func startMemServer(t *testing.T, caps imap.CapSet, folders ...string) string {
 	t.Helper()
 	mem := imapmemserver.New()
 	user := imapmemserver.NewUser("warmbly@test", "hunter2")
@@ -49,7 +58,13 @@ func testServer(t *testing.T, caps imap.CapSet, folders ...string) *Client {
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })
 
-	host, port, _ := net.SplitHostPort(ln.Addr().String())
+	return ln.Addr().String()
+}
+
+// clientTo points a Client at an already-running server.
+func clientTo(t *testing.T, addr string) *Client {
+	t.Helper()
+	host, port, _ := net.SplitHostPort(addr)
 	c := &Client{
 		Email:    "warmbly@test",
 		AuthType: models.AuthPlain,
@@ -64,6 +79,86 @@ func testServer(t *testing.T, caps imap.CapSet, folders ...string) *Client {
 	}
 	t.Cleanup(func() { _ = c.Close() })
 	return c
+}
+
+// wireLog is every command the client sent.
+//
+// The in-process server is lenient: go-imap's own parser takes fetch items
+// the advertised capabilities do not cover, which is exactly how #405 shipped
+// past a package whose tests all run against a plain RFC 3501 server. A real
+// one answers BAD, so what has to be asserted is the command on the wire, not
+// whether this server happened to accept it.
+type wireLog struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (w *wireLog) add(line string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lines = append(w.lines, line)
+}
+
+// commands returns every recorded line whose command word matches, uppercased.
+func (w *wireLog) commands(name string) []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var out []string
+	for _, l := range w.lines {
+		// "<tag> <COMMAND> ..." and UID-prefixed forms.
+		fields := strings.Fields(strings.ToUpper(l))
+		if len(fields) >= 2 && (fields[1] == name || (fields[1] == "UID" && len(fields) >= 3 && fields[2] == name)) {
+			out = append(out, strings.ToUpper(l))
+		}
+	}
+	return out
+}
+
+// recordingServer is startMemServer behind a proxy that records the client's
+// half of the conversation.
+func recordingServer(t *testing.T, caps imap.CapSet, folders ...string) (*Client, *wireLog) {
+	t.Helper()
+	upstream := startMemServer(t, caps, folders...)
+	log := &wireLog{}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			down, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			up, err := net.Dial("tcp", upstream)
+			if err != nil {
+				_ = down.Close()
+				return
+			}
+			go func() { _, _ = io.Copy(down, up); _ = down.Close() }()
+			go func() {
+				defer func() { _ = up.Close() }()
+				r := bufio.NewReader(down)
+				for {
+					line, err := r.ReadString('\n')
+					if line != "" {
+						log.add(strings.TrimRight(line, "\r\n"))
+						if _, werr := up.Write([]byte(line)); werr != nil {
+							return
+						}
+					}
+					if err != nil {
+						return
+					}
+				}
+			}()
+		}
+	}()
+
+	return clientTo(t, ln.Addr().String()), log
 }
 
 func atoi(s string) int {


### PR DESCRIPTION
Closes #405.

The reporter ran v0.4.2, which made the worker print what the server actually said, and IONOS said:

```
BAD expected fetch-att instead of "MODSEQ BODY.P"
BAD expected fetch-att instead of "MODSEQ BODYST"
```

So it was ours all along. `FetchEnvelopes` asked for `ModSeq: true` unconditionally, and `MODSEQ` is a CONDSTORE fetch item (RFC 7162, and go-imap's own field comment says `// requires CONDSTORE`). IONOS advertises no CONDSTORE, so every FETCH we sent was a malformed `fetch-att` and every sync pass failed at the same point, forever, on any strict server without CONDSTORE.

The two different error strings are the same bug: go-imap emits the fetch items by ranging over a Go map, so `MODSEQ` lands in a different position each time and the server quotes whatever followed it, `BODY.P...` on one pass and `BODYST...` on the next.

## Changes

- **`MODSEQ` is gated on CONDSTORE.** The capability was already resolved post-auth into `c.condStore` and already gated `SELECT (CONDSTORE)`, `STATUS HIGHESTMODSEQ` and `SEARCH MODSEQ`. The fetch was the one place that skipped the check.
- **LIST `RETURN` options are gated on LIST-EXTENDED**, which is the same class of bug one command over. Every `RETURN` option is RFC 5258 grammar; IMAP4rev2 implies it, plain RFC 3501 does not, and SPECIAL-USE does not bring it. A server advertising the special-use folder attributes without the extended LIST would be sent a `RETURN` it cannot parse, and a BAD there costs the account its entire folder list. IONOS does advertise LIST-EXTENDED, so this is hardening rather than a second live failure. The decision moved into `listOptionsFor`, a pure function, so it can be tested across capability shapes.

## Why the existing tests missed it

This package's test server exists precisely to prove "works on a plain RFC 3501 server", and its own comment says so. But nothing had ever called `FetchEnvelopes` under it, so the one command that ignored the capability was the one command with no test.

Worse, asserting through that server is not enough on its own: it is lenient about some items a real server rejects. So the harness now records the client's half of the conversation through a proxy, and the tests assert on the command we sent rather than on whether this particular server tolerated it.

- `TestFetchEnvelopesOmitsModSeqWithoutCondStore` fetches a real message through the recorder and fails if `MODSEQ` appears on the wire. Reverting the gate fails it.
- `TestFetchEnvelopesAsksModSeqWithCondStore` covers the other direction, so gating cannot quietly cost the CONDSTORE path the cursor its incremental sync keys on.
- `TestListOptionsNeedListExtended` is a table over capability shapes, including the IMAP4rev2 implication and the two "advertised but not unlocked" cases. Removing the gate fails two of them.
- `TestFoldersSendsBareListWithoutListExtended` proves the bare LIST end to end on the wire.

## Verification

- `make lint` (golangci-lint + `check-migrations`), `gofmt -l` clean
- `go test ./internal/client/smtpimap/imap/ ./internal/app/worker/wmail/`
- Both gates mutation-tested: reverting either fails the tests that cover it

No migration, no API change, no docs change. `guides/mailboxes.mdx` already describes this behaviour correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IMAP compatibility with servers that do not advertise CONDSTORE, preventing message synchronization failures.
  - Fixed folder listing with standard RFC 3501 servers by avoiding unsupported extended LIST options.
  - Ensured optional message metadata is requested only when supported by the server.
- **Tests**
  - Added coverage for capability-dependent message fetching and folder listing behavior across different IMAP server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->