### PR TITLE
feat: locate every spam-check issue in the subject or body, and analyze campaign copy with AI

### DIFF
--- a/cmd/cli/specs.go
+++ b/cmd/cli/specs.go
@@ -985,6 +985,10 @@ func templateSpec() resource {
 				Method: http.MethodPost, Path: "/templates/score", Body: bodyRequired,
 			},
 			{
+				Name: "analyze", Short: "AI spam analysis of a draft, with the wording to fix",
+				Method: http.MethodPost, Path: "/templates/analyze", Body: bodyRequired,
+			},
+			{
 				Name: "reorder", Short: "Change the order templates appear in",
 				Method: http.MethodPatch, Path: "/templates/reorder", Body: bodyRequired,
 				Success: "Templates reordered.",

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -226,6 +226,7 @@ The `agent-drafts` endpoints back the [inbox agent](/guides/inbox-agent/): the a
 | Method | Path | API Permission |
 |--------|------|----------------|
 | GET | `/templates`, `/templates/:id` | `READ_TEMPLATES` |
+| POST | `/templates/score`, `/templates/analyze` | `READ_TEMPLATES` |
 | POST/PATCH/DELETE | `/templates[/:id]` | `WRITE_TEMPLATES` |
 | GET | `/crm/pipelines`, `/crm/pipelines/:id` | `READ_CRM` |
 | POST/PATCH/DELETE | `/crm/pipelines[/:id][/stages[/:stageId]]` | `WRITE_CRM` |

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -226,7 +226,8 @@ The `agent-drafts` endpoints back the [inbox agent](/guides/inbox-agent/): the a
 | Method | Path | API Permission |
 |--------|------|----------------|
 | GET | `/templates`, `/templates/:id` | `READ_TEMPLATES` |
-| POST | `/templates/score`, `/templates/analyze` | `READ_TEMPLATES` |
+| POST | `/templates/score` | `READ_TEMPLATES` |
+| POST | `/templates/analyze` | `WRITE_TEMPLATES` (it spends AI credits) |
 | POST/PATCH/DELETE | `/templates[/:id]` | `WRITE_TEMPLATES` |
 | GET | `/crm/pipelines`, `/crm/pipelines/:id` | `READ_CRM` |
 | POST/PATCH/DELETE | `/crm/pipelines[/:id][/stages[/:stageId]]` | `WRITE_CRM` |

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -320,6 +320,23 @@ A `503` whose `code` is `mailbox_provider_not_configured` is not transient and r
 - Or connect the mailbox over SMTP and IMAP instead, which needs no configuration
 - Full walkthrough: [connect mailboxes](/development/deployment-guide/#connect-mailboxes)
 
+#### `ai_not_configured`
+
+A `503` whose `code` is `ai_not_configured` is not transient and retrying will not help. It comes from `POST /templates/analyze` and means the deployment has no AI provider set up at all. It is how a client tells "there is no AI here" apart from "the provider is having a bad minute", which returns the generic `service_unavailable` and is worth retrying.
+
+```json
+{
+  "error": "Service Unavailable",
+  "message": "AI analysis is not configured on this deployment.",
+  "code": "ai_not_configured",
+  "request_id": "4bbbd1b2-8f86-47dd-8a7f-9476501ad20e"
+}
+```
+
+**How to fix:**
+- Set `AI_PROVIDER` and `AI_API_KEY` in the `.env` at your install root, then restart. See the [configuration reference](/development/configuration/)
+- Hide the AI affordance in your client rather than retrying: nothing about the request will make it succeed
+
 #### `mailbox_allowance_reached`
 
 A `403` whose `code` is `mailbox_allowance_reached` comes from every path that connects a mailbox: `POST /emails/onboarding/oauth/start`, `POST /emails/onboarding/oauth/finish`, `POST /emails/onboarding/smtp-imap`, and per row inside `POST /emails/onboarding/smtp-imap/bulk`. It is not a permission problem: the workspace holds its whole [mailbox allowance](/guides/mailboxes/#mailbox-allowance), which on a paid plan is one mailbox for every send a day the plan includes, and `10` on a free workspace. Nothing was connected.

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -714,15 +714,119 @@ Auth: **Scope** `READ_TEMPLATES` · **Org permission** `view_campaigns`
 
 `200 OK` with the score and any advisory issues.
 
+Each issue is located. `field` is `subject` or `body` when the issue lives in exactly one of them, and absent when it straddles both or describes the send as a whole (an attachment count). `spans` quote the exact fragments that caused it, with the 1-based line within that field and the whole line for context. `suggestion` is the fix in one sentence.
+
 ```json
 {
-  "score": 92,
+  "score": 84,
   "issues": [
     {
       "severity": "warn",
-      "code": "too_many_links",
-      "message": "4 links found; keep cold-email link count low."
+      "code": "spam_trigger_terms",
+      "message": "2 spam-trigger term(s) found in subject/body: free, limited time.",
+      "field": "body",
+      "spans": [
+        {
+          "field": "body",
+          "text": "free",
+          "line": 3,
+          "excerpt": "Here is a free look at what we do."
+        },
+        {
+          "field": "body",
+          "text": "limited time",
+          "line": 5,
+          "excerpt": "This is a limited time offer."
+        }
+      ],
+      "suggestion": "Rewrite those words in plain language, or cut the sentence they sit in."
     }
   ]
 }
 ```
+
+A `spans` list is capped at eight entries. The count that drives the deduction is taken before that cap, so a message naming fourteen links is consistent with a score that deducted for fourteen.
+
+## Analyze template content with AI
+
+`POST /templates/analyze`
+
+Runs the deployment's configured AI provider over the same subject and body and returns what to change: the specific word or sentence, quoted from the copy, whether it is in the subject or the body, why it hurts, and what to write instead. The rules-based pass runs in the same request and comes back under `rules`, so both halves are scored from one reading of the copy.
+
+Advisory only, exactly like `/templates/score`: nothing here blocks or delays a send.
+
+Auth: **Scope** `READ_TEMPLATES` · **Org permission** `view_campaigns` and `use_ai`
+
+This endpoint spends AI credits (see [AI credits](/guides/ai-credits/)). Send an `Idempotency-Key` header to make a retry safe; the same key is never charged twice.
+
+### Request body
+
+Identical to `/templates/score`.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `subject` | string | No | Subject line to analyze. |
+| `body_html` | string | No | HTML body (used when `body_plain` is empty). |
+| `body_plain` | string | No | Plain-text body, preferred over HTML when present. |
+
+At least one of the three must carry something, and the three together are capped at 60,000 bytes.
+
+### Response
+
+`200 OK` with the analysis.
+
+```json
+{
+  "score": 62,
+  "verdict": "This reads like a promotion rather than a note from a person.",
+  "findings": [
+    {
+      "severity": "high",
+      "field": "subject",
+      "text": "FREE bonus inside",
+      "line": 1,
+      "excerpt": "Your FREE bonus inside",
+      "issue": "Capitalised offer wording in the subject is one of the strongest promotional signals a filter reads.",
+      "suggestion": "Name the thing you noticed about them instead, in lower case.",
+      "category": "trigger_word"
+    }
+  ],
+  "suggested_subject": "quick question about your onboarding",
+  "improvements": [
+    "Cut the closing paragraph. One ask lands better than three."
+  ],
+  "rules": {
+    "score": 84,
+    "issues": []
+  },
+  "model": "gpt-4o-mini",
+  "tokens_used": 812,
+  "credits_remaining": 248,
+  "credits_charged": 2
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `score` | Overall deliverability score, 0 to 100, higher is safer. Grounded on `rules`, never argued against it. |
+| `verdict` | One sentence on how the email will land. |
+| `findings` | Located problems, most severe first. `severity` is `high`, `warn` or `info`; `field` is `subject` or `body`; `category` is one of `trigger_word`, `tone`, `formatting`, `links`, `structure`, `authenticity`. |
+| `findings[].text` | The fragment quoted from your copy. Absent when the finding is about the email as a whole. |
+| `suggested_subject` | A rewritten subject, or absent when the current one is fine. |
+| `improvements` | Copy-level advice with no single fragment to quote. |
+| `rules` | The `/templates/score` result for the same content. |
+
+<Callout type="info" title="Quotes are verified, not trusted">
+Every `text` is checked against the submitted subject and body before it is returned. A fragment that is not in the copy is dropped and the finding keeps only its `issue` and `suggestion`, so a response never quotes a sentence you did not send. A finding whose quote was found in the other half has its `field` corrected.
+</Callout>
+
+The analysis runs at a fixed temperature, so re-analyzing unchanged copy returns the same score. A change in the score means a change in the copy, which is what makes re-checking after an edit worth doing.
+
+### Errors
+
+| Status | When |
+|--------|------|
+| `400` | Nothing written to analyze, or the template is over the size cap. |
+| `402` | The workspace is out of AI credits. Nothing is charged and no provider call is made. |
+| `403` | The plan or trial does not cover AI, or the member lacks `use_ai`. |
+| `503` | No AI provider is configured on this deployment (`code` is `ai_not_configured`, which is permanent for that deployment), or the provider failed (`code` is `service_unavailable`, and the reserved credits are refunded). |

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -755,9 +755,11 @@ Runs the deployment's configured AI provider over the same subject and body and 
 
 Advisory only, exactly like `/templates/score`: nothing here blocks or delays a send.
 
-Auth: **Scope** `READ_TEMPLATES` · **Org permission** `view_campaigns` and `use_ai`
+Auth: **Scope** `WRITE_TEMPLATES` · **Org permission** `view_campaigns` and `use_ai`
 
-This endpoint spends AI credits (see [AI credits](/guides/ai-credits/)). Send an `Idempotency-Key` header to make a retry safe; the same key is never charged twice.
+It writes no template, but it spends the workspace's AI credits, so it takes the write scope: a read-only key must not be able to spend money. A signed-in member still needs only `view_campaigns`, plus `use_ai`.
+
+This endpoint spends AI credits (see [AI credits](/guides/ai-credits/)), unless the deployment runs an unmetered model (`AI_PROVIDER=ollama`, or any provider with `AI_FREE=true`), where `credits_charged` comes back `0`. Send an `Idempotency-Key` header to make a retry safe; the same key is never charged twice.
 
 ### Request body
 

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -810,7 +810,7 @@ At least one of the three must carry something, and the three together are cappe
 |-------|-------------|
 | `score` | Overall deliverability score, 0 to 100, higher is safer. Grounded on `rules`, never argued against it. |
 | `verdict` | One sentence on how the email will land. |
-| `findings` | Located problems, most severe first. `severity` is `high`, `warn` or `info`; `field` is `subject` or `body`; `category` is one of `trigger_word`, `tone`, `formatting`, `links`, `structure`, `authenticity`. |
+| `findings` | Located problems, most severe first. `severity` is `high`, `warn` or `info`; `field` is `subject` or `body`, absent only when the model labelled neither and nothing in the finding could be anchored in the copy; `category` is one of `trigger_word`, `tone`, `formatting`, `links`, `structure`, `authenticity`. |
 | `findings[].text` | The fragment quoted from your copy. Absent when the finding is about the email as a whole. |
 | `suggested_subject` | A rewritten subject, or absent when the current one is fine. |
 | `improvements` | Copy-level advice with no single fragment to quote. |

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -810,7 +810,7 @@ At least one of the three must carry something, and the three together are cappe
 |-------|-------------|
 | `score` | Overall deliverability score, 0 to 100, higher is safer. Grounded on `rules`, never argued against it. |
 | `verdict` | One sentence on how the email will land. |
-| `findings` | Located problems, most severe first. `severity` is `high`, `warn` or `info`; `field` is `subject` or `body`, absent only when the model labelled neither and nothing in the finding could be anchored in the copy; `category` is one of `trigger_word`, `tone`, `formatting`, `links`, `structure`, `authenticity`. |
+| `findings` | Located problems, most severe first. `severity` is `high`, `warn` or `info`; `field` is `subject` or `body`, absent only when the model labelled neither and nothing in the finding could be anchored in the copy; `category` is one of `trigger_word`, `tone`, `formatting`, `links`, `structure`, `authenticity`, and is absent when the model named something outside that set. |
 | `findings[].text` | The fragment quoted from your copy. Absent when the finding is about the email as a whole. |
 | `suggested_subject` | A rewritten subject, or absent when the current one is fine. |
 | `improvements` | Copy-level advice with no single fragment to quote. |

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -723,7 +723,7 @@ Each issue is located. `field` is `subject` or `body` when the issue lives in ex
     {
       "severity": "warn",
       "code": "spam_trigger_terms",
-      "message": "2 spam-trigger term(s) found in subject/body: free, limited time.",
+      "message": "2 spam-trigger term(s): free, limited time.",
       "field": "body",
       "spans": [
         {

--- a/docs/content/docs/guides/ai-credits.mdx
+++ b/docs/content/docs/guides/ai-credits.mdx
@@ -27,6 +27,7 @@ Each action reserves a flat **minimum** up front (which also gates an empty bala
 | Writing assistant draft, selection edit ("Edit with AI") | 1 |
 | AI assistant step | 1 per turn |
 | Reply draft, compose draft, contact research run | 2 |
+| AI spam analysis of a campaign step, and each Re-check | 2 |
 | Single-shot automation AI step (classify, extract, generate) | 1 |
 | Automation AI agent step | 1 per step |
 | AI switch or campaign switch step, AI decider (value decider is free) | 1 |

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -225,7 +225,9 @@ If scheduling stalls on a transient infrastructure hiccup, Warmbly re-seeds with
 
 Warmbly scores each step's copy out of 100 for the signals spam filters weight: trigger wording, stacked punctuation, ALL-CAPS subjects, link and image counts, image-only bodies, empty or oversized bodies, and attachments.
 
-Every issue says **where** it is and **what** caused it: the badge names the subject or the body (or both, when the wording straddles the two), the offending words are quoted back exactly as you typed them, the line they sit in is shown for context, and each one carries the fix in a sentence. You never have to hunt through your own copy for a word the checker already found.
+Anything the checker can point at, it points at: the badge names the subject or the body (or both, when the wording straddles the two), the offending words are quoted back exactly as you typed them, and the line they sit in is shown for context. You never have to hunt through your own copy for a word the checker already found.
+
+A few issues are about the message as a whole rather than any wording in it. An empty subject, an empty or oversized body and an image-heavy layout name the half they concern but have nothing to quote; an attachment on a cold email concerns neither half, so it shows as a plain line with no badge. Every issue, located or not, carries its fix in a sentence.
 
 You see it in three places:
 

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -225,7 +225,7 @@ If scheduling stalls on a transient infrastructure hiccup, Warmbly re-seeds with
 
 Warmbly scores each step's copy out of 100 for the signals spam filters weight: trigger wording, stacked punctuation, ALL-CAPS subjects, link and image counts, image-only bodies, empty or oversized bodies, and attachments.
 
-Every issue says **where** it is and **what** caused it: the badge names the subject or the body (with the line number for a body issue), the offending words are quoted back exactly as you typed them, the line they sit in is shown for context, and each one carries the fix in a sentence. You never have to hunt through your own copy for a word the checker already found.
+Every issue says **where** it is and **what** caused it: the badge names the subject or the body (or both, when the wording straddles the two), the offending words are quoted back exactly as you typed them, the line they sit in is shown for context, and each one carries the fix in a sentence. You never have to hunt through your own copy for a word the checker already found.
 
 You see it in three places:
 

--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -225,11 +225,13 @@ If scheduling stalls on a transient infrastructure hiccup, Warmbly re-seeds with
 
 Warmbly scores each step's copy out of 100 for the signals spam filters weight: trigger wording, stacked punctuation, ALL-CAPS subjects, link and image counts, image-only bodies, empty or oversized bodies, and attachments.
 
+Every issue says **where** it is and **what** caused it: the badge names the subject or the body (with the line number for a body issue), the offending words are quoted back exactly as you typed them, the line they sit in is shown for context, and each one carries the fix in a sentence. You never have to hunt through your own copy for a word the checker already found.
+
 You see it in three places:
 
 - **In the editor**, re-scored as you write a step.
-- **In the launch dialog**, alongside the other pre-send checks, with the lowest-scoring step named. Only email steps are scored; wait and action steps carry no copy.
-- **In the campaign activity feed**, if the copy that actually goes out scores below your floor.
+- **In the launch dialog**, alongside the other pre-send checks, with the lowest-scoring step named and its worst issue quoted as `Subject:` or `Body:`. Only email steps are scored; wait and action steps carry no copy.
+- **In the campaign activity feed**, if the copy that actually goes out scores below your floor, again naming the half of the message at fault.
 
 That last one catches what the first two cannot. The editor scores the template; the send path scores the message after merge fields, spintax, A/B selection and AI blocks have resolved, which is where a clean template becomes "Hi ," or picks the one spammy spintax branch. It logs once per step per day, not once per recipient.
 
@@ -238,6 +240,29 @@ That last one catches what the first two cannot. The editor scores the template;
 <Callout type="info" title="Advisory, not a gate">
 A low score never blocks or delays a send. It is a signal to rewrite, not a verdict: a legitimate email can score badly, and a well-scoring one sent to a bad list will still fail.
 </Callout>
+
+### Analyze with AI
+
+The rules above catch what rules can catch. **Analyze with AI**, under the score in the step editor, reads the copy itself and reports what a filter and a human reader will object to:
+
+- the specific word, phrase or sentence, quoted from your draft, and whether it is in the subject or the body
+- why that fragment hurts deliverability or replies
+- what to write instead
+- a rewritten subject line, which you can apply in one click
+- copy-level advice that has no single fragment to point at
+- an overall deliverability score out of 100
+
+It runs on the AI provider configured for the deployment (see [AI credits](/guides/ai-credits/) for the cost, and [Configuration](/development/configuration/) for self-host setup). It needs the **Use AI** permission. A deployment with no provider configured says so in place of the button rather than offering something that cannot run.
+
+Every quote is checked against your draft before it is shown. A fragment the model could not have copied from your copy is dropped rather than displayed, so the panel never points at a sentence you did not write.
+
+### Re-check
+
+**Re-check** re-scores the copy on the spot instead of waiting for the editor's debounce, and once you have run an AI analysis it re-runs that too. Edit what the findings told you to edit, press it, and the panel shows the new score against the previous one: `+14 since your last check`.
+
+The AI score is deliberately not sampled, so re-checking copy you did not touch returns the same number. A change in the score is a change in the copy.
+
+When the draft has moved on from the analysis on screen, the panel says so and highlights the button, rather than presenting stale findings as current.
 
 ## Easing out of warmup
 

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -29089,7 +29089,6 @@
         "description": "One located problem the AI analysis found. `text` is verified against the submitted copy before it is returned, so it is never a fragment the caller did not send.",
         "required": [
           "severity",
-          "field",
           "issue"
         ],
         "properties": {
@@ -29103,6 +29102,7 @@
           },
           "field": {
             "type": "string",
+            "description": "Absent when the model labelled neither half and nothing in the finding could be anchored in the copy.",
             "enum": [
               "subject",
               "body"

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17511,6 +17511,114 @@
         }
       }
     },
+    "/templates/analyze": {
+      "post": {
+        "operationId": "deliverability-ops_analyze_template",
+        "summary": "Analyze template content with AI",
+        "description": "Runs the deployment's configured AI provider over a subject and body and returns the specific words and sentences that hurt deliverability, quoted from the copy, with whether each one is in the subject or the body and what to write instead. The rules-based score runs in the same request and comes back under `rules`. Advisory only and never blocks sending. Spends AI credits; honors `Idempotency-Key`. Requires READ_TEMPLATES scope, and the view_campaigns and use_ai permissions.",
+        "tags": [
+          "deliverability-ops"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "description": "Makes a retry safe: the same key is never charged twice.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoreTemplateRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The analysis, with the rules-based pass alongside it.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateAnalysis"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Nothing written to analyze, or the template is over the size cap",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "Out of AI credits. Nothing is charged and no provider call is made.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limited",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No AI provider configured (code `ai_not_configured`, permanent for that deployment), or the provider failed (code `service_unavailable`, and the reserved credits are refunded).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/templates/score": {
       "post": {
         "operationId": "deliverability-ops_score_template",
@@ -28904,6 +29012,35 @@
           }
         }
       },
+      "TemplateScoreSpan": {
+        "type": "object",
+        "description": "One exact fragment of the copy that triggered an issue.",
+        "required": [
+          "field",
+          "text"
+        ],
+        "properties": {
+          "field": {
+            "type": "string",
+            "enum": [
+              "subject",
+              "body"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "The fragment as it is written in the copy."
+          },
+          "line": {
+            "type": "integer",
+            "description": "1-based line within that field."
+          },
+          "excerpt": {
+            "type": "string",
+            "description": "The whole line, for context around the fragment."
+          }
+        }
+      },
       "TemplateScoreIssue": {
         "type": "object",
         "required": [
@@ -28925,6 +29062,136 @@
           },
           "message": {
             "type": "string"
+          },
+          "field": {
+            "type": "string",
+            "description": "Set when the issue lives in exactly one half of the template. Absent when it straddles both or describes the send as a whole.",
+            "enum": [
+              "subject",
+              "body"
+            ]
+          },
+          "spans": {
+            "type": "array",
+            "description": "The exact fragments that caused the issue, in reading order. Capped at 8; the count that drives the deduction is taken before the cap.",
+            "items": {
+              "$ref": "#/components/schemas/TemplateScoreSpan"
+            }
+          },
+          "suggestion": {
+            "type": "string",
+            "description": "The fix, in one sentence."
+          }
+        }
+      },
+      "SpamFinding": {
+        "type": "object",
+        "description": "One located problem the AI analysis found. `text` is verified against the submitted copy before it is returned, so it is never a fragment the caller did not send.",
+        "required": [
+          "severity",
+          "field",
+          "issue"
+        ],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": [
+              "high",
+              "warn",
+              "info"
+            ]
+          },
+          "field": {
+            "type": "string",
+            "enum": [
+              "subject",
+              "body"
+            ]
+          },
+          "text": {
+            "type": "string",
+            "description": "The fragment quoted from the copy. Absent when the finding is about the email as a whole."
+          },
+          "line": {
+            "type": "integer"
+          },
+          "excerpt": {
+            "type": "string"
+          },
+          "issue": {
+            "type": "string",
+            "description": "Why this fragment hurts deliverability or replies."
+          },
+          "suggestion": {
+            "type": "string",
+            "description": "What to write instead."
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "trigger_word",
+              "tone",
+              "formatting",
+              "links",
+              "structure",
+              "authenticity"
+            ]
+          }
+        }
+      },
+      "TemplateAnalysis": {
+        "type": "object",
+        "description": "AI spam analysis of a campaign template, with the rules-based pass alongside it.",
+        "required": [
+          "score",
+          "verdict",
+          "findings",
+          "rules",
+          "model"
+        ],
+        "properties": {
+          "score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100,
+            "description": "Overall deliverability score (higher is safer), grounded on the rules pass."
+          },
+          "verdict": {
+            "type": "string",
+            "description": "One sentence on how the email will land."
+          },
+          "findings": {
+            "type": "array",
+            "description": "Located problems, most severe first.",
+            "items": {
+              "$ref": "#/components/schemas/SpamFinding"
+            }
+          },
+          "suggested_subject": {
+            "type": "string",
+            "description": "A rewritten subject, absent when the current one is fine."
+          },
+          "improvements": {
+            "type": "array",
+            "description": "Copy-level advice with no single fragment to quote.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "rules": {
+            "$ref": "#/components/schemas/TemplateScoreResult"
+          },
+          "model": {
+            "type": "string"
+          },
+          "tokens_used": {
+            "type": "integer"
+          },
+          "credits_remaining": {
+            "type": "integer"
+          },
+          "credits_charged": {
+            "type": "integer"
           }
         }
       },

--- a/docs/public/openapi.json
+++ b/docs/public/openapi.json
@@ -17515,7 +17515,7 @@
       "post": {
         "operationId": "deliverability-ops_analyze_template",
         "summary": "Analyze template content with AI",
-        "description": "Runs the deployment's configured AI provider over a subject and body and returns the specific words and sentences that hurt deliverability, quoted from the copy, with whether each one is in the subject or the body and what to write instead. The rules-based score runs in the same request and comes back under `rules`. Advisory only and never blocks sending. Spends AI credits; honors `Idempotency-Key`. Requires READ_TEMPLATES scope, and the view_campaigns and use_ai permissions.",
+        "description": "Runs the deployment's configured AI provider over a subject and body and returns the specific words and sentences that hurt deliverability, quoted from the copy, with whether each one is in the subject or the body and what to write instead. The rules-based score runs in the same request and comes back under `rules`. Advisory only and never blocks sending. Spends AI credits; honors `Idempotency-Key`. Requires WRITE_TEMPLATES scope (it writes no template, but a read-only key must not be able to spend the workspace credits), and the view_campaigns and use_ai permissions.",
         "tags": [
           "deliverability-ops"
         ],

--- a/internal/api/handler/template_analyze.go
+++ b/internal/api/handler/template_analyze.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
 
 	"github.com/warmbly/warmbly/internal/api/middleware"
 	"github.com/warmbly/warmbly/internal/app/credits"
@@ -112,10 +113,24 @@ func (h *Handler) AnalyzeTemplateContent(c *gin.Context) {
 		Voice:     h.orgVoice(c.Request.Context(), *orgID, ""),
 	})
 	if aerr != nil {
+		refunded := local
 		if !local {
-			if bal, rerr := h.CreditService.Grant(reqCtx, *orgID, credits.CostSpamAnalysis, "spam_analysis_refund"); rerr == nil {
-				remaining = bal
+			bal, rerr := h.CreditService.Grant(reqCtx, *orgID, credits.CostSpamAnalysis, "spam_analysis_refund")
+			if rerr == nil {
+				remaining, refunded = bal, true
+			} else {
+				// Do not tell the customer their credits came back when the
+				// refund is what failed. Logged so it can be reconciled from
+				// the ledger rather than discovered from a support ticket.
+				log.Error().Err(rerr).Str("organization_id", orgID.String()).
+					Int("credits", credits.CostSpamAnalysis).
+					Msg("spam analysis refund failed after a provider error")
 			}
+		}
+		if !refunded {
+			errx.JSON(c, errx.New(errx.ServiceUnavailable,
+				"The spam analyzer is temporarily unavailable, and the credits it reserved could not be returned automatically. Contact support and they will be refunded."))
+			return
 		}
 		errx.JSON(c, errx.New(errx.ServiceUnavailable, "The spam analyzer is temporarily unavailable. Your credits were not charged."))
 		return

--- a/internal/api/handler/template_analyze.go
+++ b/internal/api/handler/template_analyze.go
@@ -1,0 +1,145 @@
+// AI spam analysis for a campaign template. The rules-based score
+// (POST /templates/score) says how safe the copy is; this says which word,
+// which sentence, and whether it is in the subject or the body, and what to
+// write instead. Flow matches every other metered AI endpoint: gate the org,
+// reserve credits before the provider call, refund on a provider failure,
+// settle real token usage after.
+//
+// The rules pass runs in the same request and comes back under "rules", so the
+// two halves of the editor's panel are scored from one reading of the copy
+// rather than from two drafts a keystroke apart.
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/credits"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/spamcheck"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
+)
+
+// analyzeMaxLen bounds the template a single request may analyze. Well past any
+// cold email; a body beyond it is a pasted newsletter, not outreach.
+const analyzeMaxLen = 60000
+
+type analyzeTemplateRequest struct {
+	Subject   string `json:"subject"`
+	BodyHTML  string `json:"body_html"`
+	BodyPlain string `json:"body_plain"`
+}
+
+// AnalyzeTemplateContent — POST /templates/analyze
+func (h *Handler) AnalyzeTemplateContent(c *gin.Context) {
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return
+	}
+
+	var req analyzeTemplateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid request body"))
+		return
+	}
+	if len(req.Subject)+len(req.BodyHTML)+len(req.BodyPlain) > analyzeMaxLen {
+		errx.JSON(c, errx.New(errx.BadRequest, "this template is too long to analyze"))
+		return
+	}
+	if strings.TrimSpace(req.Subject) == "" && strings.TrimSpace(req.BodyPlain) == "" && strings.TrimSpace(req.BodyHTML) == "" {
+		errx.JSON(c, errx.New(errx.BadRequest, "there is nothing written to analyze yet"))
+		return
+	}
+
+	if h.AIProvider == nil {
+		// Identified, because "no provider here" is permanent for this
+		// deployment while a provider outage is not, and the editor hides the
+		// button only for the first.
+		errx.JSON(c, errx.NewWithIdentifier(errx.ServiceUnavailable, "ai_not_configured",
+			"AI analysis is not configured on this deployment."))
+		return
+	}
+	allowed, xerr := h.FeatureGateService.CanUseWritingAssistant(c.Request.Context(), *orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	if !allowed {
+		errx.JSON(c, errx.New(errx.Forbidden, "AI spam analysis requires an active plan or trial."))
+		return
+	}
+
+	rules := warmlint.Score(req.Subject, req.BodyHTML, req.BodyPlain)
+
+	paid, _ := h.FeatureGateService.IsPaidOrganization(c.Request.Context(), *orgID)
+	model := h.AIProvider.ModelForTier(paid)
+
+	idemKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	local := h.AIProvider.IsLocal()
+	reqCtx := c.Request.Context()
+	{
+		meta := models.CreditMeta{Context: models.CreditContext{Detail: "spam analysis"}}
+		if actor, aerr := middleware.GetUserUUID(c); aerr == nil {
+			meta.ActorID = actor
+		}
+		reqCtx = models.WithCreditMeta(reqCtx, meta)
+	}
+
+	var remaining int
+	if local {
+		if bal, berr := h.CreditService.GetBalance(reqCtx, *orgID); berr == nil {
+			remaining = bal
+		}
+	} else {
+		var cerr error
+		remaining, cerr = h.CreditService.Consume(reqCtx, *orgID, credits.CostSpamAnalysis, "spam_analysis", model, 0, idemKey)
+		if cerr != nil {
+			mapCreditError(c, cerr)
+			return
+		}
+	}
+
+	analysis, aerr := spamcheck.Analyze(c.Request.Context(), h.AIProvider, model, spamcheck.Input{
+		Subject:   req.Subject,
+		BodyHTML:  req.BodyHTML,
+		BodyPlain: req.BodyPlain,
+		Rules:     rules,
+		Voice:     h.orgVoice(c.Request.Context(), *orgID, ""),
+	})
+	if aerr != nil {
+		if !local {
+			if bal, rerr := h.CreditService.Grant(reqCtx, *orgID, credits.CostSpamAnalysis, "spam_analysis_refund"); rerr == nil {
+				remaining = bal
+			}
+		}
+		errx.JSON(c, errx.New(errx.ServiceUnavailable, "The spam analyzer is temporarily unavailable. Your credits were not charged."))
+		return
+	}
+
+	charged := 0
+	if !local {
+		charged = credits.CostSpamAnalysis
+		if extra, serr := h.CreditService.SettleUsage(reqCtx, *orgID, credits.CostSpamAnalysis, analysis.Model, analysis.TokensUsed, "spam_analysis", settleKey(idemKey)); serr == nil && extra > 0 {
+			remaining -= extra
+			charged += extra
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"score":             analysis.Score,
+		"verdict":           analysis.Verdict,
+		"findings":          analysis.Findings,
+		"suggested_subject": analysis.SuggestedSubject,
+		"improvements":      analysis.Improvements,
+		"rules":             rules,
+		"model":             analysis.Model,
+		"tokens_used":       analysis.TokensUsed,
+		"credits_remaining": remaining,
+		"credits_charged":   charged,
+	})
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1051,10 +1051,12 @@ func Run(
 				templates.POST("/:id/duplicate", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteTemplates), h.DuplicateTemplate)
 				templates.POST("/:id/render", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.RenderTemplate)
 				templates.POST("/score", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.ScoreTemplateContent)
-				// The AI half of the same check. It spends credits, so the
-				// use-AI member gate layers on top for JWT callers exactly as
-				// it does on /generation.
-				templates.POST("/analyze", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), m.RequireAccess(models.PermUseAI, models.APIPermReadTemplates), h.AnalyzeTemplateContent)
+				// The AI half of the same check. It spends the workspace's AI
+				// credits, so it takes the WRITE scope even though it writes no
+				// template: a read-only key must not be able to spend money.
+				// JWT members still need only view_campaigns, plus use_ai,
+				// which the second gate layers on as /generation does.
+				templates.POST("/analyze", m.RequireAccess(models.PermViewCampaigns, models.APIPermWriteTemplates), m.RequireAccess(models.PermUseAI, models.APIPermWriteTemplates), h.AnalyzeTemplateContent)
 			}
 
 			// Workspace image library for email bodies. The bytes are public

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1051,6 +1051,10 @@ func Run(
 				templates.POST("/:id/duplicate", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteTemplates), h.DuplicateTemplate)
 				templates.POST("/:id/render", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.RenderTemplate)
 				templates.POST("/score", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), h.ScoreTemplateContent)
+				// The AI half of the same check. It spends credits, so the
+				// use-AI member gate layers on top for JWT callers exactly as
+				// it does on /generation.
+				templates.POST("/analyze", m.RequireAccess(models.PermViewCampaigns, models.APIPermReadTemplates), m.RequireAccess(models.PermUseAI, models.APIPermReadTemplates), h.AnalyzeTemplateContent)
 			}
 
 			// Workspace image library for email bodies. The bytes are public

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -2042,16 +2042,7 @@ func worstStepContentScore(seqs []models.Sequence, attachmentsFor func(models.Se
 		if r.Score >= worst {
 			continue
 		}
-		worst, worstStep, issue = r.Score, seq.Position+1, ""
-		for _, is := range r.Issues {
-			if is.Severity == "high" {
-				issue = is.Message
-				break
-			}
-		}
-		if issue == "" && len(r.Issues) > 0 {
-			issue = r.Issues[0].Message
-		}
+		worst, worstStep, issue = r.Score, seq.Position+1, warmlint.LeadIssue(r)
 	}
 	return worst, worstStep, issue, scored
 }

--- a/internal/app/credits/costs.go
+++ b/internal/app/credits/costs.go
@@ -32,6 +32,10 @@ const (
 	// CostWebSearch is one web-search lookup made on behalf of an AI step
 	// (charged only when the search returned results).
 	CostWebSearch = 1
+
+	// CostSpamAnalysis is one AI spam analysis of a campaign template
+	// (POST /templates/analyze, and every Re-check after an edit).
+	CostSpamAnalysis = 2
 )
 
 // Usage-based metering. The per-feature constants above are the up-front

--- a/internal/pkg/casefold/casefold.go
+++ b/internal/pkg/casefold/casefold.go
@@ -1,0 +1,67 @@
+// Package casefold makes a case-insensitive search able to quote what it found.
+//
+// The obvious way to search text without regard to case is to lowercase both
+// sides and take strings.Index. The offset that comes back addresses the folded
+// copy, not the original, and the two do not line up: strings.ToLower maps rune
+// by rune, and a rune can change byte length doing it (U+0130 is two bytes and
+// folds to one, U+212A is three). Past the first such rune, slicing the original
+// at a folded offset lands mid-rune. It quotes bytes the writer never typed, or
+// cuts one in half into invalid UTF-8.
+//
+// Index hands back the map that fixes it, so a match found in the fold can be
+// quoted from the source exactly as it was written.
+package casefold
+
+import (
+	"strings"
+	"unicode"
+)
+
+// Index folds s to lower case and returns the folded text together with, for
+// every byte offset in it, the offset it came from in s. The map has one entry
+// past the end, so the end of a match at the end of the text maps too.
+//
+// A nil map means the two are byte-for-byte aligned and offsets need no
+// translation, which is the case for ASCII text and so for almost every call.
+func Index(s string) (string, []int) {
+	if isASCII(s) {
+		return strings.ToLower(s), nil
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	offsets := make([]int, 0, len(s)+1)
+	for i, r := range s {
+		before := b.Len()
+		b.WriteRune(unicode.ToLower(r))
+		for n := b.Len() - before; n > 0; n-- {
+			offsets = append(offsets, i)
+		}
+	}
+	offsets = append(offsets, len(s))
+	return b.String(), offsets
+}
+
+// Origin translates a byte offset in the folded copy back to the original. It
+// returns -1 for an offset the map does not cover, which a caller must treat as
+// "cannot quote this" rather than as position zero.
+func Origin(offsets []int, at int) int {
+	if offsets == nil {
+		if at < 0 {
+			return -1
+		}
+		return at
+	}
+	if at < 0 || at >= len(offsets) {
+		return -1
+	}
+	return offsets[at]
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pkg/casefold/casefold_test.go
+++ b/internal/pkg/casefold/casefold_test.go
@@ -1,0 +1,75 @@
+package casefold
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// Everything here rests on Index folding exactly the way strings.ToLower does:
+// callers search one string and count against the other. Invalid
+// UTF-8 is in the table because a range loop and strings.Map both turn a bad
+// byte into U+FFFD, which is three bytes where the original was one.
+func TestIndexMatchesStringsToLower(t *testing.T) {
+	cases := []string{
+		"", "plain ascii text", "FREE CASH", "İİİ free", "KKK cash", "café",
+		"🎉 free", "Straße", "ǅungla", "ﬁ ligature", "\xff\xfe bad bytes",
+		"mixed İ \xc3\x28 free", strings.Repeat("İ", 40) + " free",
+	}
+	for _, s := range cases {
+		lower, offsets := Index(s)
+		if want := strings.ToLower(s); lower != want {
+			t.Errorf("Index(%q) folded to %q, want %q", s, lower, want)
+		}
+		if offsets == nil {
+			continue
+		}
+		if len(offsets) != len(lower)+1 {
+			t.Errorf("Index(%q): %d offsets for %d bytes", s, len(offsets), len(lower))
+			continue
+		}
+		// Every offset must land on a rune boundary in the original, or a
+		// slice taken at it cuts a rune in half.
+		for i, at := range offsets {
+			if at < 0 || at > len(s) {
+				t.Fatalf("Index(%q): offset %d out of range at %d", s, at, i)
+			}
+			if at < len(s) && !utf8.RuneStart(s[at]) {
+				t.Errorf("Index(%q): offset %d at index %d is mid-rune", s, at, i)
+			}
+		}
+		if offsets[len(offsets)-1] != len(s) {
+			t.Errorf("Index(%q): last offset %d, want %d", s, offsets[len(offsets)-1], len(s))
+		}
+	}
+}
+
+// Origin must say "cannot quote this" rather than pointing at position zero,
+// which would silently quote the start of the text for a match that moved out
+// of range.
+func TestOriginRefusesAnOffsetOutsideTheMap(t *testing.T) {
+	_, offsets := Index("İ free")
+	if got := Origin(offsets, len(offsets)); got != -1 {
+		t.Errorf("Origin past the end = %d, want -1", got)
+	}
+	if got := Origin(offsets, -1); got != -1 {
+		t.Errorf("Origin of a negative offset = %d, want -1", got)
+	}
+	if got := Origin(nil, -1); got != -1 {
+		t.Errorf("Origin of a negative offset with no map = %d, want -1", got)
+	}
+}
+
+// ASCII text needs no map, and the offsets pass straight through.
+func TestIndexSkipsTheMapForASCII(t *testing.T) {
+	lower, offsets := Index("FREE Cash")
+	if lower != "free cash" {
+		t.Errorf("folded to %q", lower)
+	}
+	if offsets != nil {
+		t.Errorf("built a map for ASCII text: %v", offsets)
+	}
+	if got := Origin(offsets, 5); got != 5 {
+		t.Errorf("Origin = %d, want the offset unchanged", got)
+	}
+}

--- a/internal/pkg/spamcheck/spamcheck.go
+++ b/internal/pkg/spamcheck/spamcheck.go
@@ -142,10 +142,11 @@ func Analyze(ctx context.Context, p generation.Provider, model string, in Input)
 	}
 
 	out := parse(res.Text)
-	// A response with no score, no verdict and no findings was not an analysis.
-	// Failing here refunds the credit; filling the gaps in would render as a
-	// confident 100/100 on copy nothing actually read.
-	if out.Score < 0 && out.Verdict == "" && len(out.Findings) == 0 {
+	// A response with no score and no findings is not an analysis, whatever
+	// else it carried. Failing here refunds the credit; deriving a score from
+	// an empty finding list would render as a confident 100/100 sitting above a
+	// verdict that says the opposite.
+	if out.Score < 0 && len(out.Findings) == 0 {
 		return nil, fmt.Errorf("spamcheck: could not read the model's response")
 	}
 	out.Model = res.Model
@@ -378,7 +379,8 @@ func lineText(s string, line int) string {
 }
 
 // scoreFromFindings is the fallback when the model returned findings but no
-// usable score.
+// usable score. Analyze refuses a response with neither, so this is never asked
+// to price an empty list into a clean 100.
 func scoreFromFindings(findings []Finding) int {
 	score := 100
 	for _, f := range findings {

--- a/internal/pkg/spamcheck/spamcheck.go
+++ b/internal/pkg/spamcheck/spamcheck.go
@@ -1,0 +1,442 @@
+// Package spamcheck is the AI half of the campaign content check. warmlint
+// scores the rules everyone agrees on (trigger terms, ALL-CAPS, link and image
+// counts); this reads the copy with the deployment's configured LLM and says
+// which sentence a filter will object to, in the subject or in the body, and
+// what to write instead.
+//
+// Two things make its output usable rather than decorative. Every finding must
+// quote the copy verbatim, and a quote that is not actually in the template is
+// dropped rather than shown, so the panel can never point at a sentence the
+// writer did not write. And the run is deterministic: re-checking unchanged
+// copy has to return the same score, or "did my edit help?" cannot be answered.
+package spamcheck
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+	"github.com/warmbly/warmbly/internal/pkg/mailhtml"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
+)
+
+// Bounds on what goes to the provider and what comes back, so one pasted
+// newsletter cannot drive a very large completion or a very large response.
+const (
+	maxBodyRunes    = 8000
+	maxSubjectRunes = 400
+	maxFindings     = 12
+	maxImprovements = 6
+	maxTextRunes    = 200
+	excerptMax      = 180
+	completionMax   = 1600
+)
+
+// Input is one template to analyze.
+type Input struct {
+	Subject   string
+	BodyHTML  string
+	BodyPlain string
+	// Rules is the heuristic pass. It is given to the model as grounding so the
+	// two halves of the panel never contradict each other.
+	Rules warmlint.ScoreResult
+	// Voice is the workspace's product and tone context, which changes what
+	// counts as a plausible claim rather than a spam-flavoured one.
+	Voice generation.VoiceContext
+}
+
+// Finding is one located problem with the copy.
+type Finding struct {
+	// Severity is "high", "warn" or "info".
+	Severity string `json:"severity"`
+	// Field is "subject" or "body".
+	Field string `json:"field"`
+	// Text is the exact fragment quoted from the copy, empty when the finding
+	// is about the email as a whole.
+	Text string `json:"text,omitempty"`
+	// Line is the 1-based line of that field the fragment sits on.
+	Line int `json:"line,omitempty"`
+	// Excerpt is the whole line, for context around the fragment.
+	Excerpt string `json:"excerpt,omitempty"`
+	// Issue is why it hurts deliverability.
+	Issue string `json:"issue"`
+	// Suggestion is what to write instead.
+	Suggestion string `json:"suggestion,omitempty"`
+	// Category is a coarse grouping ("trigger_word", "tone", "formatting",
+	// "links", "structure", "authenticity").
+	Category string `json:"category,omitempty"`
+}
+
+// Result is the analysis returned to the editor.
+type Result struct {
+	// Score is the overall 0-100 deliverability score (higher is safer),
+	// grounded on the rules pass rather than argued against it.
+	Score   int    `json:"score"`
+	Verdict string `json:"verdict"`
+	// Findings are located problems, most severe first.
+	Findings []Finding `json:"findings"`
+	// SuggestedSubject is a rewritten subject line, empty when the current one
+	// is fine.
+	SuggestedSubject string `json:"suggested_subject,omitempty"`
+	// Improvements are copy-level suggestions with nothing specific to quote.
+	Improvements []string `json:"improvements,omitempty"`
+	Model        string   `json:"model"`
+	TokensUsed   int      `json:"tokens_used"`
+}
+
+const systemPrompt = `You are a cold-email deliverability analyst. You are given one campaign email template and you report exactly what in it would push the message to spam, where that thing is, and what to write instead.
+
+OUTPUT
+Return ONLY a JSON object, no prose around it, no markdown fence:
+{
+  "score": 0-100,
+  "verdict": "one plain sentence on how this email will land",
+  "findings": [
+    {
+      "severity": "high" | "warn" | "info",
+      "field": "subject" | "body",
+      "text": "the exact words from the template, copied character for character",
+      "issue": "why this specific fragment hurts deliverability or replies",
+      "suggestion": "what to write instead, concretely",
+      "category": "trigger_word" | "tone" | "formatting" | "links" | "structure" | "authenticity"
+    }
+  ],
+  "suggested_subject": "a better subject line, or \"\" when the current one is fine",
+  "improvements": ["copy-level advice with no single fragment to quote"]
+}
+
+RULES
+- "text" MUST be copied verbatim from the subject or body you were given. Never paraphrase it, never fix its spelling, never quote a sentence that is not there. A fragment you cannot copy exactly belongs in "improvements" instead.
+- Point at the smallest thing that is wrong: the word, the phrase, or the one sentence. Never quote a whole paragraph.
+- "field" must say which half the fragment is in. Getting this wrong sends the writer to the wrong box.
+- score is 0-100 where 100 is safest. Take the rule-based findings you are given as already proven and score with them, never against them. A clean, plain, personal email with one ask scores above 85; an email with several trigger phrases, hype and multiple links scores below 40.
+- Judge cold-email deliverability and reply odds, not marketing polish. Plain, short and specific is good. Formatting, hype, urgency, unearned claims, link stacking and mail-merge that reads like a mail merge are bad.
+- At most 8 findings. Do not invent problems to fill the list: an email with nothing wrong returns an empty findings array and a high score.
+- Write every sentence in plain English, no em dashes, no jargon.`
+
+// Analyze runs the model over the template and returns a verified report.
+func Analyze(ctx context.Context, p generation.Provider, model string, in Input) (*Result, error) {
+	if p == nil {
+		return nil, generation.ErrProviderNotConfigured
+	}
+	subject := truncate(strings.TrimSpace(in.Subject), maxSubjectRunes)
+	body := truncate(bodyText(in), maxBodyRunes)
+
+	res, err := p.Complete(ctx, generation.CompletionRequest{
+		System:    systemPrompt,
+		Prompt:    buildPrompt(subject, body, in),
+		Model:     model,
+		MaxTokens: completionMax,
+		// Deterministic: the whole point of Re-check is comparing this score
+		// with the last one, and a sampled score moves on unchanged copy.
+		Temperature: generation.Deterministic(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, fmt.Errorf("spamcheck: the model returned nothing")
+	}
+
+	out := parse(res.Text)
+	// A response with no score, no verdict and no findings was not an analysis.
+	// Failing here refunds the credit; filling the gaps in would render as a
+	// confident 100/100 on copy nothing actually read.
+	if out.Score < 0 && out.Verdict == "" && len(out.Findings) == 0 {
+		return nil, fmt.Errorf("spamcheck: could not read the model's response")
+	}
+	out.Model = res.Model
+	out.TokensUsed = res.TokensUsed
+	verify(out, subject, body)
+	return out, nil
+}
+
+// bodyText is the copy a recipient reads: the plain part when the editor stored
+// one, otherwise the HTML rendered down to its words.
+func bodyText(in Input) string {
+	if b := strings.TrimSpace(in.BodyPlain); b != "" {
+		return b
+	}
+	return strings.TrimSpace(mailhtml.ToPlainText(in.BodyHTML))
+}
+
+func buildPrompt(subject, body string, in Input) string {
+	var b strings.Builder
+	b.WriteString("SUBJECT:\n")
+	if subject == "" {
+		b.WriteString("(empty)\n")
+	} else {
+		b.WriteString(subject + "\n")
+	}
+	b.WriteString("\nBODY:\n")
+	if body == "" {
+		b.WriteString("(empty)\n")
+	} else {
+		b.WriteString(body + "\n")
+	}
+
+	// The body may be HTML the reader never sees as markup, but its shape is
+	// part of how it lands, so the counts travel even though the tags do not.
+	if strings.TrimSpace(in.BodyHTML) != "" {
+		b.WriteString("\nThis body is HTML. Judge the words above, not the markup.\n")
+	}
+
+	b.WriteString("\nRULE-BASED CHECK (already proven, score with it):\n")
+	fmt.Fprintf(&b, "score %d/100\n", in.Rules.Score)
+	if len(in.Rules.Issues) == 0 {
+		b.WriteString("no rule-based issues\n")
+	}
+	for _, issue := range in.Rules.Issues {
+		where := issue.Field
+		if where == "" {
+			where = "template"
+		}
+		fmt.Fprintf(&b, "- [%s] %s (%s)", where, issue.Message, issue.Code)
+		if len(issue.Spans) > 0 {
+			quoted := make([]string, 0, len(issue.Spans))
+			for _, s := range issue.Spans {
+				if s.Text != "" {
+					quoted = append(quoted, quoteFragment(s.Text))
+				}
+			}
+			if len(quoted) > 0 {
+				fmt.Fprintf(&b, ": %s", strings.Join(quoted, ", "))
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	if ctx := voiceContext(in.Voice); ctx != "" {
+		b.WriteString("\nWHAT THIS WORKSPACE SELLS (context, not something to grade):\n")
+		b.WriteString(ctx)
+	}
+	b.WriteString("\nAnalyze this template now. JSON only.")
+	return b.String()
+}
+
+// voiceContext renders the workspace's own description, so a specific claim is
+// read as a real one rather than as hype.
+func voiceContext(v generation.VoiceContext) string {
+	var b strings.Builder
+	for _, part := range []struct{ label, value string }{
+		{"Product", v.ProductDescription},
+		{"Who they sell to", v.ICPNotes},
+		{"Voice", v.VoiceProfile},
+	} {
+		if s := strings.TrimSpace(part.value); s != "" {
+			fmt.Fprintf(&b, "%s: %s\n", part.label, truncate(s, 600))
+		}
+	}
+	return b.String()
+}
+
+// quoteFragment wraps a fragment in quotes for the prompt, keeping an embedded
+// quote from ending the quoted run.
+func quoteFragment(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `'`) + `"`
+}
+
+// parse reads the model's JSON, tolerating a ```json fence or a stray sentence
+// either side of the object. A response nothing can be read out of returns an
+// empty result rather than an error: the panel still has the rules pass.
+func parse(text string) *Result {
+	text = strings.TrimSpace(text)
+	if i := strings.Index(text, "{"); i >= 0 {
+		if j := strings.LastIndex(text, "}"); j >= i {
+			text = text[i : j+1]
+		}
+	}
+	var raw struct {
+		Score            *int     `json:"score"`
+		Verdict          string   `json:"verdict"`
+		SuggestedSubject string   `json:"suggested_subject"`
+		Improvements     []string `json:"improvements"`
+		Findings         []struct {
+			Severity   string `json:"severity"`
+			Field      string `json:"field"`
+			Text       string `json:"text"`
+			Issue      string `json:"issue"`
+			Suggestion string `json:"suggestion"`
+			Category   string `json:"category"`
+		} `json:"findings"`
+	}
+	out := &Result{Score: -1, Findings: []Finding{}}
+	if err := json.Unmarshal([]byte(text), &raw); err != nil {
+		return out
+	}
+	if raw.Score != nil {
+		out.Score = clamp(*raw.Score)
+	}
+	out.Verdict = truncate(strings.TrimSpace(raw.Verdict), 300)
+	out.SuggestedSubject = truncate(strings.TrimSpace(raw.SuggestedSubject), maxSubjectRunes)
+	for _, s := range raw.Improvements {
+		if s = truncate(strings.TrimSpace(s), 300); s != "" {
+			out.Improvements = append(out.Improvements, s)
+		}
+		if len(out.Improvements) == maxImprovements {
+			break
+		}
+	}
+	for _, f := range raw.Findings {
+		issue := truncate(strings.TrimSpace(f.Issue), 300)
+		if issue == "" {
+			continue
+		}
+		out.Findings = append(out.Findings, Finding{
+			Severity: severity(f.Severity),
+			Field:    field(f.Field),
+			// Cut, not truncated: verify looks this up in the copy, and an
+			// appended ellipsis is never in there, so every long quote would
+			// fail verification and lose the fragment it named.
+			Text:       cut(strings.TrimSpace(f.Text), maxTextRunes),
+			Issue:      issue,
+			Suggestion: truncate(strings.TrimSpace(f.Suggestion), 300),
+			Category:   truncate(strings.TrimSpace(strings.ToLower(f.Category)), 40),
+		})
+		if len(out.Findings) == maxFindings {
+			break
+		}
+	}
+	return out
+}
+
+// verify anchors every finding in the copy the user actually wrote. A quote the
+// model got right is given its real line and surrounding line; one it invented
+// loses the quote and stays as general advice, because a panel that points at a
+// sentence nobody wrote is worse than one that points at nothing.
+func verify(res *Result, subject, body string) {
+	kept := res.Findings[:0]
+	seen := map[string]struct{}{}
+	for _, f := range res.Findings {
+		if f.Text != "" {
+			if fld, line, excerpt, ok := locate(subject, body, f.Text, f.Field); ok {
+				f.Field, f.Line, f.Excerpt = fld, line, excerpt
+			} else {
+				f.Text, f.Line, f.Excerpt = "", 0, ""
+			}
+		}
+		key := f.Field + "\x00" + strings.ToLower(f.Text) + "\x00" + strings.ToLower(f.Issue)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		kept = append(kept, f)
+	}
+	res.Findings = kept
+
+	// Severity order, stable within a band, so the worst thing is read first
+	// and equal findings keep the model's own reading order through the email.
+	rank := map[string]int{"high": 0, "warn": 1, "info": 2}
+	sort.SliceStable(res.Findings, func(i, j int) bool {
+		return rank[res.Findings[i].Severity] < rank[res.Findings[j].Severity]
+	})
+
+	// A model that answered with findings but no score would render as 0/100.
+	if res.Score < 0 {
+		res.Score = scoreFromFindings(res.Findings)
+	}
+}
+
+// locate finds the fragment in the copy, preferring the field the model named
+// and falling back to the other one (the analysis is still right, the label was
+// wrong). Matching is case-insensitive: a model retyping a quote tends to
+// normalize its capitalization.
+func locate(subject, body, text, preferred string) (field string, line int, excerpt string, ok bool) {
+	order := []struct{ name, text string }{
+		{warmlint.FieldSubject, subject},
+		{warmlint.FieldBody, body},
+	}
+	if preferred == warmlint.FieldBody {
+		order[0], order[1] = order[1], order[0]
+	}
+	needle := strings.ToLower(strings.TrimSpace(text))
+	if needle == "" {
+		return "", 0, "", false
+	}
+	for _, o := range order {
+		lower := strings.ToLower(o.text)
+		i := strings.Index(lower, needle)
+		if i < 0 {
+			continue
+		}
+		n := 1 + strings.Count(lower[:i], "\n")
+		return o.name, n, lineText(o.text, n), true
+	}
+	return "", 0, "", false
+}
+
+// lineText returns one line of a field, trimmed and capped for display.
+func lineText(s string, line int) string {
+	lines := strings.Split(s, "\n")
+	if line < 1 || line > len(lines) {
+		return ""
+	}
+	return truncate(strings.TrimSpace(lines[line-1]), excerptMax)
+}
+
+// scoreFromFindings is the fallback when the model returned findings but no
+// usable score.
+func scoreFromFindings(findings []Finding) int {
+	score := 100
+	for _, f := range findings {
+		switch f.Severity {
+		case "high":
+			score -= 20
+		case "warn":
+			score -= 10
+		default:
+			score -= 3
+		}
+	}
+	return clamp(score)
+}
+
+func severity(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "high", "critical", "severe", "error":
+		return "high"
+	case "info", "low", "minor", "note":
+		return "info"
+	default:
+		return "warn"
+	}
+}
+
+func field(s string) string {
+	if strings.Contains(strings.ToLower(strings.TrimSpace(s)), "subject") {
+		return warmlint.FieldSubject
+	}
+	return warmlint.FieldBody
+}
+
+func clamp(n int) int {
+	if n < 0 {
+		return 0
+	}
+	if n > 100 {
+		return 100
+	}
+	return n
+}
+
+// truncate bounds prose for display, marking that it was shortened.
+func truncate(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(r[:max])) + "…"
+}
+
+// cut bounds a fragment that still has to be found in the copy, so it adds
+// nothing: a prefix of a substring is still a substring.
+func cut(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return strings.TrimSpace(string(r[:max]))
+}

--- a/internal/pkg/spamcheck/spamcheck.go
+++ b/internal/pkg/spamcheck/spamcheck.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/warmbly/warmbly/internal/pkg/casefold"
 	"github.com/warmbly/warmbly/internal/pkg/generation"
 	"github.com/warmbly/warmbly/internal/pkg/mailhtml"
 	"github.com/warmbly/warmbly/internal/pkg/warmlint"
@@ -315,8 +316,12 @@ func verify(res *Result, subject, body string) {
 	seen := map[string]struct{}{}
 	for _, f := range res.Findings {
 		if f.Text != "" {
-			if fld, line, excerpt, ok := locate(subject, body, f.Text, f.Field); ok {
-				f.Field, f.Line, f.Excerpt = fld, line, excerpt
+			if m, ok := locate(subject, body, f.Text, f.Field); ok {
+				// The copy's own casing, not the model's retyping of it. The
+				// fragment is documented as quoted character for character and
+				// the editor highlights it, so "free bonus" standing in for
+				// "FREE BONUS" both breaks the contract and fails to match.
+				f.Text, f.Field, f.Line, f.Excerpt = m.text, m.field, m.line, m.excerpt
 			} else {
 				f.Text, f.Line, f.Excerpt = "", 0, ""
 			}
@@ -343,11 +348,21 @@ func verify(res *Result, subject, body string) {
 	}
 }
 
+// match is where a fragment was found and how it is actually written there.
+type match struct {
+	field   string
+	text    string
+	line    int
+	excerpt string
+}
+
 // locate finds the fragment in the copy, preferring the field the model named
 // and falling back to the other one (the analysis is still right, the label was
-// wrong). Matching is case-insensitive: a model retyping a quote tends to
-// normalize its capitalization.
-func locate(subject, body, text, preferred string) (field string, line int, excerpt string, ok bool) {
+// wrong). Matching is case-insensitive because a model retyping a quote tends to
+// normalize its capitalization, and what comes back is the copy's own wording:
+// the offsets are mapped out of the fold before anything is sliced, so a rune
+// that changes byte length when lowercased cannot shift the quote.
+func locate(subject, body, text, preferred string) (match, bool) {
 	order := []struct{ name, text string }{
 		{warmlint.FieldSubject, subject},
 		{warmlint.FieldBody, body},
@@ -357,18 +372,23 @@ func locate(subject, body, text, preferred string) (field string, line int, exce
 	}
 	needle := strings.ToLower(strings.TrimSpace(text))
 	if needle == "" {
-		return "", 0, "", false
+		return match{}, false
 	}
 	for _, o := range order {
-		lower := strings.ToLower(o.text)
+		lower, offsets := casefold.Index(o.text)
 		i := strings.Index(lower, needle)
 		if i < 0 {
 			continue
 		}
 		n := 1 + strings.Count(lower[:i], "\n")
-		return o.name, n, lineText(o.text, n), true
+		found := match{field: o.name, text: strings.TrimSpace(text), line: n, excerpt: lineText(o.text, n)}
+		start, end := casefold.Origin(offsets, i), casefold.Origin(offsets, i+len(needle))
+		if start >= 0 && end <= len(o.text) && start < end {
+			found.text = o.text[start:end]
+		}
+		return found, true
 	}
-	return "", 0, "", false
+	return match{}, false
 }
 
 // lineText returns one line of a field, trimmed and capped for display.

--- a/internal/pkg/spamcheck/spamcheck.go
+++ b/internal/pkg/spamcheck/spamcheck.go
@@ -242,8 +242,9 @@ func quoteFragment(s string) string {
 }
 
 // parse reads the model's JSON, tolerating a ```json fence or a stray sentence
-// either side of the object. A response nothing can be read out of returns an
-// empty result rather than an error: the panel still has the rules pass.
+// either side of the object. A response nothing can be read out of comes back
+// with no score and no findings, which Analyze refuses so the credit is
+// refunded rather than spent on a report with nothing in it.
 func parse(text string) *Result {
 	text = strings.TrimSpace(text)
 	if i := strings.Index(text, "{"); i >= 0 {
@@ -296,7 +297,7 @@ func parse(text string) *Result {
 			Text:       cut(strings.TrimSpace(f.Text), maxTextRunes),
 			Issue:      issue,
 			Suggestion: truncate(strings.TrimSpace(f.Suggestion), 300),
-			Category:   truncate(strings.TrimSpace(strings.ToLower(f.Category)), 40),
+			Category:   category(f.Category),
 		})
 		if len(out.Findings) == maxFindings {
 			break
@@ -421,6 +422,23 @@ func field(s string) string {
 	default:
 		return ""
 	}
+}
+
+// categories is the closed set a finding may be grouped under. The field is
+// documented as an enum, so anything else is dropped rather than passed
+// through: a client validating the response against that set should never be
+// handed something outside it.
+var categories = map[string]struct{}{
+	"trigger_word": {}, "tone": {}, "formatting": {},
+	"links": {}, "structure": {}, "authenticity": {},
+}
+
+func category(s string) string {
+	v := strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), " ", "_")
+	if _, ok := categories[v]; ok {
+		return v
+	}
+	return ""
 }
 
 func clamp(n int) int {

--- a/internal/pkg/spamcheck/spamcheck.go
+++ b/internal/pkg/spamcheck/spamcheck.go
@@ -52,8 +52,9 @@ type Input struct {
 type Finding struct {
 	// Severity is "high", "warn" or "info".
 	Severity string `json:"severity"`
-	// Field is "subject" or "body".
-	Field string `json:"field"`
+	// Field is "subject" or "body", empty when the model labelled neither and
+	// nothing in the finding could be anchored in the copy.
+	Field string `json:"field,omitempty"`
 	// Text is the exact fragment quoted from the copy, empty when the finding
 	// is about the email as a whole.
 	Text string `json:"text,omitempty"`
@@ -407,11 +408,19 @@ func severity(s string) string {
 	}
 }
 
+// field reads the half the model named. Anything it did not clearly label comes
+// back empty rather than guessed: verify fills it in from the quote when there
+// is one, and a badge naming the wrong box on a finding nothing anchored is the
+// exact error this whole panel exists to avoid.
 func field(s string) string {
-	if strings.Contains(strings.ToLower(strings.TrimSpace(s)), "subject") {
+	switch v := strings.ToLower(strings.TrimSpace(s)); {
+	case strings.Contains(v, "subject"):
 		return warmlint.FieldSubject
+	case strings.Contains(v, "body"):
+		return warmlint.FieldBody
+	default:
+		return ""
 	}
-	return warmlint.FieldBody
 }
 
 func clamp(n int) int {

--- a/internal/pkg/spamcheck/spamcheck_test.go
+++ b/internal/pkg/spamcheck/spamcheck_test.go
@@ -1,0 +1,294 @@
+package spamcheck
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+	"github.com/warmbly/warmbly/internal/pkg/warmlint"
+)
+
+const testBody = "Hi Ada,\n\nThis is a limited time offer you cannot miss.\n\nWorth ten minutes?"
+
+// analyzed runs the parse + verify halves the way Analyze does, over a model
+// response, so the tests exercise exactly what a real completion goes through.
+func analyzed(t *testing.T, response, subject, body string) *Result {
+	t.Helper()
+	res := parse(response)
+	verify(res, subject, body)
+	return res
+}
+
+func TestVerifyAnchorsAQuoteInTheBody(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 55,
+	  "verdict": "Reads like a promotion.",
+	  "findings": [
+	    {"severity":"high","field":"body","text":"limited time offer","issue":"Urgency wording filters weight heavily.","suggestion":"Say what changed instead."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want the quoted one kept: %+v", len(res.Findings), res.Findings)
+	}
+	f := res.Findings[0]
+	if f.Line != 3 {
+		t.Errorf("line = %d, want the third line of the body", f.Line)
+	}
+	if f.Excerpt != "This is a limited time offer you cannot miss." {
+		t.Errorf("excerpt = %q, want the sentence around the quote", f.Excerpt)
+	}
+	if res.Score != 55 {
+		t.Errorf("score = %d, want the model's own", res.Score)
+	}
+}
+
+// A panel that points at a sentence the writer never wrote is worse than one
+// that points at nothing, so an unverifiable quote loses the quote and keeps
+// the advice.
+func TestVerifyDropsAQuoteThatIsNotInTheCopy(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 60,
+	  "findings": [
+	    {"severity":"warn","field":"body","text":"ACT NOW while stocks last","issue":"Hype wording hurts.","suggestion":"Cut it."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if len(res.Findings) != 1 {
+		t.Fatalf("got %d findings, want the advice kept: %+v", len(res.Findings), res.Findings)
+	}
+	f := res.Findings[0]
+	if f.Text != "" || f.Line != 0 || f.Excerpt != "" {
+		t.Errorf("invented quote survived verification: %+v", f)
+	}
+	if f.Issue == "" {
+		t.Error("the advice was dropped along with the quote")
+	}
+}
+
+// The analysis can be right while the label is wrong. Sending the writer to the
+// wrong box for a real problem is a worse outcome than correcting the label.
+func TestVerifyCorrectsTheFieldWhenTheQuoteIsInTheOtherHalf(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 70,
+	  "findings": [
+	    {"severity":"warn","field":"subject","text":"limited time offer","issue":"Urgency wording.","suggestion":"Cut it."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if res.Findings[0].Field != "body" {
+		t.Errorf("field = %q, want it corrected to body", res.Findings[0].Field)
+	}
+}
+
+// A model retyping a quote tends to normalize its capitalization.
+func TestVerifyMatchesAQuoteCaseInsensitively(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 70,
+	  "findings": [
+	    {"severity":"warn","field":"subject","text":"free bonus","issue":"Trigger wording.","suggestion":"Cut it."}
+	  ]
+	}`, "Your FREE BONUS inside", testBody)
+
+	f := res.Findings[0]
+	if f.Field != "subject" || f.Excerpt != "Your FREE BONUS inside" {
+		t.Errorf("quote was not matched against the subject: %+v", f)
+	}
+}
+
+func TestVerifyOrdersFindingsBySeverity(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 40,
+	  "findings": [
+	    {"severity":"low","field":"body","issue":"Third."},
+	    {"severity":"medium","field":"body","issue":"Second."},
+	    {"severity":"critical","field":"body","issue":"First."}
+	  ]
+	}`, "Quick question", testBody)
+
+	got := []string{}
+	for _, f := range res.Findings {
+		got = append(got, f.Issue+"/"+f.Severity)
+	}
+	want := "First./high Second./warn Third./info"
+	if strings.Join(got, " ") != want {
+		t.Errorf("order = %q, want %q", strings.Join(got, " "), want)
+	}
+}
+
+func TestParseToleratesAFencedResponse(t *testing.T) {
+	res := parse("Here you go:\n```json\n{\"score\": 88, \"verdict\": \"Fine.\"}\n```\n")
+	if res.Score != 88 || res.Verdict != "Fine." {
+		t.Errorf("fenced JSON was not read: %+v", res)
+	}
+}
+
+// A response nothing can be read out of must not render as 0/100: the panel
+// still has the rules pass, and a fabricated zero would contradict it.
+func TestParseRefusesToInventAScore(t *testing.T) {
+	res := parse("I could not analyze that.")
+	if res.Score != -1 {
+		t.Errorf("score = %d, want the missing-score marker", res.Score)
+	}
+	if res.Findings == nil {
+		t.Error("findings must be an empty list, never null in JSON")
+	}
+}
+
+// A model that returned findings but no usable score still has to produce one,
+// or Re-check has nothing to compare.
+func TestVerifyDerivesAScoreWhenTheModelOmittedIt(t *testing.T) {
+	res := analyzed(t, `{
+	  "findings": [
+	    {"severity":"high","field":"body","issue":"One."},
+	    {"severity":"warn","field":"body","issue":"Two."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if res.Score != 70 {
+		t.Errorf("score = %d, want one derived from the findings", res.Score)
+	}
+}
+
+func TestVerifyDropsDuplicateFindings(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 50,
+	  "findings": [
+	    {"severity":"warn","field":"body","text":"limited time offer","issue":"Urgency wording."},
+	    {"severity":"warn","field":"body","text":"limited time offer","issue":"Urgency wording."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if len(res.Findings) != 1 {
+		t.Errorf("got %d findings, want the repeat dropped: %+v", len(res.Findings), res.Findings)
+	}
+}
+
+func TestParseBoundsTheResponse(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(`{"score": 20, "improvements": [`)
+	for i := 0; i < 20; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`"tip"`)
+	}
+	b.WriteString(`], "findings": [`)
+	for i := 0; i < 30; i++ {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(`{"severity":"warn","field":"body","issue":"something"}`)
+	}
+	b.WriteString(`]}`)
+
+	res := parse(b.String())
+	if len(res.Improvements) != maxImprovements {
+		t.Errorf("kept %d improvements, want %d", len(res.Improvements), maxImprovements)
+	}
+	if len(res.Findings) != maxFindings {
+		t.Errorf("kept %d findings, want %d", len(res.Findings), maxFindings)
+	}
+}
+
+// stubProvider answers with a canned completion, so the tests can drive Analyze
+// end to end without a provider.
+type stubProvider struct {
+	reply string
+	got   generation.CompletionRequest
+}
+
+func (s *stubProvider) RunAgent(context.Context, generation.AgentRequest) (*generation.AgentResult, error) {
+	return nil, errors.New("not used")
+}
+
+func (s *stubProvider) Complete(_ context.Context, req generation.CompletionRequest) (*generation.WritingResult, error) {
+	s.got = req
+	return &generation.WritingResult{Text: s.reply, Model: "stub-model", TokensUsed: 321}, nil
+}
+
+func (s *stubProvider) ModelForTier(bool) string { return "stub-model" }
+func (s *stubProvider) Name() string             { return "stub" }
+func (s *stubProvider) IsLocal() bool            { return true }
+
+// A response nothing could be read out of must fail the call, which refunds the
+// credit, rather than render as a confident 100/100 on copy nothing read.
+func TestAnalyzeRefusesAnUnreadableResponse(t *testing.T) {
+	_, err := Analyze(context.Background(), &stubProvider{reply: "I could not analyze that."}, "stub-model", Input{
+		Subject:   "Quick question",
+		BodyPlain: testBody,
+	})
+	if err == nil {
+		t.Fatal("an unreadable response was accepted as an analysis")
+	}
+}
+
+func TestAnalyzeIsDeterministicAndGroundsOnTheRulesPass(t *testing.T) {
+	p := &stubProvider{reply: `{"score": 62, "verdict": "Reads promotional."}`}
+	rules := warmlint.Score("Your FREE bonus", "", testBody)
+
+	res, err := Analyze(context.Background(), p, "stub-model", Input{
+		Subject:   "Your FREE bonus",
+		BodyPlain: testBody,
+		Rules:     rules,
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if res.Score != 62 || res.Model != "stub-model" || res.TokensUsed != 321 {
+		t.Errorf("result did not carry the completion through: %+v", res)
+	}
+	// Re-check compares this score with the last one, so a sampled score would
+	// move on copy the writer never touched.
+	if p.got.Temperature == nil || *p.got.Temperature != 0 {
+		t.Errorf("temperature = %v, want pinned to 0", p.got.Temperature)
+	}
+	// The model is told what the rules pass already proved, so the two halves of
+	// the panel cannot contradict each other.
+	if !strings.Contains(p.got.Prompt, "spam_trigger_terms") || !strings.Contains(p.got.Prompt, `"FREE"`) {
+		t.Errorf("prompt did not carry the rule-based findings:\n%s", p.got.Prompt)
+	}
+}
+
+func TestAnalyzeTruncatesAVeryLongBody(t *testing.T) {
+	p := &stubProvider{reply: `{"score": 80, "verdict": "Fine."}`}
+	if _, err := Analyze(context.Background(), p, "stub-model", Input{
+		Subject:   "Quick question",
+		BodyPlain: strings.Repeat("word ", 40000),
+	}); err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len([]rune(p.got.Prompt)) > maxBodyRunes+2000 {
+		t.Errorf("prompt is %d runes, want the body bounded at %d", len([]rune(p.got.Prompt)), maxBodyRunes)
+	}
+}
+
+// A quote longer than the cap is shortened to fit, and the shortened form still
+// has to verify: an ellipsis on the end would never be found in the copy, so
+// every long quote would silently lose the fragment it named.
+func TestVerifyKeepsALongQuoteThatHadToBeShortened(t *testing.T) {
+	sentence := strings.Repeat("this is a long promotional sentence that keeps going ", 12)
+	body := "Hi Ada,\n\n" + sentence + "\n\nWorth ten minutes?"
+	quoted, err := json.Marshal(sentence)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	res := analyzed(t, `{"score": 40, "findings": [
+	    {"severity":"high","field":"body","text":`+string(quoted)+`,"issue":"Too long and too promotional."}
+	]}`, "Quick question", body)
+
+	f := res.Findings[0]
+	if f.Text == "" {
+		t.Fatal("a quote that only needed shortening was dropped as unverifiable")
+	}
+	if len([]rune(f.Text)) > maxTextRunes {
+		t.Errorf("quote is %d runes, want it bounded at %d", len([]rune(f.Text)), maxTextRunes)
+	}
+	if f.Line != 3 {
+		t.Errorf("line = %d, want the line the sentence sits on", f.Line)
+	}
+}

--- a/internal/pkg/spamcheck/spamcheck_test.go
+++ b/internal/pkg/spamcheck/spamcheck_test.go
@@ -97,6 +97,26 @@ func TestVerifyMatchesAQuoteCaseInsensitively(t *testing.T) {
 	if f.Field != "subject" || f.Excerpt != "Your FREE BONUS inside" {
 		t.Errorf("quote was not matched against the subject: %+v", f)
 	}
+	// The fragment is documented as quoted character for character and the
+	// editor highlights it, so it has to come back in the copy's own casing.
+	if f.Text != "FREE BONUS" {
+		t.Errorf("quoted %q, want the copy's own %q", f.Text, "FREE BONUS")
+	}
+}
+
+// The quote is sliced out of the copy, so the offsets have to survive a rune
+// that changes byte length when it is lowercased.
+func TestVerifyQuotesTheCopyAcrossACaseFold(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 60,
+	  "findings": [
+	    {"severity":"warn","field":"subject","text":"free bonus","issue":"Trigger wording."}
+	  ]
+	}`, "İstanbul FREE BONUS inside", testBody)
+
+	if got := res.Findings[0].Text; got != "FREE BONUS" {
+		t.Errorf("quoted %q, want %q", got, "FREE BONUS")
+	}
 }
 
 func TestVerifyOrdersFindingsBySeverity(t *testing.T) {

--- a/internal/pkg/spamcheck/spamcheck_test.go
+++ b/internal/pkg/spamcheck/spamcheck_test.go
@@ -340,3 +340,20 @@ func TestVerifyDoesNotGuessAnUnlabelledField(t *testing.T) {
 		t.Errorf("unanchored, unlabelled finding field = %q, want empty", res.Findings[1].Field)
 	}
 }
+
+// category is documented as a closed set, so a response cannot be allowed to
+// break the schema it is validated against.
+func TestParseKeepsCategoryInsideItsEnum(t *testing.T) {
+	res := parse(`{"score": 50, "findings": [
+	    {"severity":"warn","field":"body","issue":"a","category":"Trigger Word"},
+	    {"severity":"warn","field":"body","issue":"b","category":"spammy vibes"},
+	    {"severity":"warn","field":"body","issue":"c","category":"links"}
+	]}`)
+	got := []string{}
+	for _, f := range res.Findings {
+		got = append(got, f.Category)
+	}
+	if strings.Join(got, ",") != "trigger_word,,links" {
+		t.Errorf("categories = %q, want the unknown one dropped", strings.Join(got, ","))
+	}
+}

--- a/internal/pkg/spamcheck/spamcheck_test.go
+++ b/internal/pkg/spamcheck/spamcheck_test.go
@@ -292,3 +292,28 @@ func TestVerifyKeepsALongQuoteThatHadToBeShortened(t *testing.T) {
 		t.Errorf("line = %d, want the line the sentence sits on", f.Line)
 	}
 }
+
+// A reply carrying only prose is not an analysis. Deriving a score from its
+// empty finding list put a confident 100/100 above a verdict saying the
+// opposite, and charged for it.
+func TestAnalyzeRefusesAVerdictWithNothingBehindIt(t *testing.T) {
+	_, err := Analyze(context.Background(), &stubProvider{
+		reply: `{"verdict": "This reads like a bulk promotion and will land in spam."}`,
+	}, "stub-model", Input{Subject: "Quick question", BodyPlain: testBody})
+	if err == nil {
+		t.Fatal("a verdict with no score and no findings was accepted as an analysis")
+	}
+}
+
+// A score of 0 is a real answer, not a missing one.
+func TestAnalyzeAcceptsAZeroScore(t *testing.T) {
+	res, err := Analyze(context.Background(), &stubProvider{
+		reply: `{"score": 0, "verdict": "Every signal here is bad."}`,
+	}, "stub-model", Input{Subject: "FREE CASH", BodyPlain: testBody})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if res.Score != 0 {
+		t.Errorf("score = %d, want the model's own 0", res.Score)
+	}
+}

--- a/internal/pkg/spamcheck/spamcheck_test.go
+++ b/internal/pkg/spamcheck/spamcheck_test.go
@@ -317,3 +317,26 @@ func TestAnalyzeAcceptsAZeroScore(t *testing.T) {
 		t.Errorf("score = %d, want the model's own 0", res.Score)
 	}
 }
+
+// A finding the model left unlabelled must not be given a half at random. With
+// a quote, verify anchors it; without one, it carries no field rather than a
+// badge sending the writer to the wrong box.
+func TestVerifyDoesNotGuessAnUnlabelledField(t *testing.T) {
+	res := analyzed(t, `{
+	  "score": 60,
+	  "findings": [
+	    {"severity":"warn","text":"limited time offer","issue":"Anchored, so the half is known."},
+	    {"severity":"warn","issue":"Nothing to anchor and no label."}
+	  ]
+	}`, "Quick question", testBody)
+
+	if len(res.Findings) != 2 {
+		t.Fatalf("got %d findings: %+v", len(res.Findings), res.Findings)
+	}
+	if res.Findings[0].Field != "body" {
+		t.Errorf("anchored finding field = %q, want body", res.Findings[0].Field)
+	}
+	if res.Findings[1].Field != "" {
+		t.Errorf("unanchored, unlabelled finding field = %q, want empty", res.Findings[1].Field)
+	}
+}

--- a/internal/pkg/warmlint/lint.go
+++ b/internal/pkg/warmlint/lint.go
@@ -118,11 +118,15 @@ type ScoreResult struct {
 // that caused it, because a score with no location is advice nobody can act on.
 func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 	res := ScoreResult{Score: 100, Issues: []Issue{}}
+	// The field is read from the whole span list and the list is trimmed after,
+	// so a cap that drops one half's spans can never relabel the issue.
 	deduct := func(n int, issue Issue) {
 		res.Score -= n
+		issue.Spans = quotableSpans(issue.Spans)
 		if issue.Field == "" {
 			issue.Field = commonField(issue.Spans)
 		}
+		issue.Spans = capSpans(issue.Spans)
 		res.Issues = append(res.Issues, issue)
 	}
 
@@ -180,7 +184,7 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		deduct(d, Issue{
 			Severity: "warn", Code: "too_many_links",
 			Message:    fmt.Sprintf("%d links. Keep the link count low in cold email.", links),
-			Spans:      capSpans(linked),
+			Spans:      linked,
 			Suggestion: "Keep one link at most on a first touch, and cut the rest.",
 		})
 	}

--- a/internal/pkg/warmlint/lint.go
+++ b/internal/pkg/warmlint/lint.go
@@ -66,11 +66,40 @@ func Check(subject, body string, isReply bool) error {
 	return nil
 }
 
+// Field names the half of the template a finding sits in, so the editor can
+// say "in the subject" rather than leaving the writer to search for the word.
+const (
+	FieldSubject = "subject"
+	FieldBody    = "body"
+)
+
+// Span locates one exact fragment that triggered an issue. Without it a writer
+// reads "3 spam-trigger term(s) found" and has to guess which words those are.
+type Span struct {
+	// Field is FieldSubject or FieldBody.
+	Field string `json:"field"`
+	// Text is the fragment as it is written in the copy.
+	Text string `json:"text"`
+	// Line is the 1-based line the fragment sits on within that field.
+	Line int `json:"line,omitempty"`
+	// Excerpt is that whole line, so the fragment can be shown in context.
+	Excerpt string `json:"excerpt,omitempty"`
+}
+
 // Issue is a single advisory content problem found by Score.
 type Issue struct {
 	Severity string `json:"severity"` // "warn" | "high"
 	Code     string `json:"code"`
 	Message  string `json:"message"`
+	// Field is FieldSubject or FieldBody when the issue lives in exactly one of
+	// them, and empty when it spans both or describes the send as a whole.
+	Field string `json:"field,omitempty"`
+	// Spans are the exact fragments that triggered the issue, in reading order.
+	// Empty for an issue with nothing to point at (an empty subject, an
+	// attachment count).
+	Spans []Span `json:"spans,omitempty"`
+	// Suggestion is the concrete fix, in one line.
+	Suggestion string `json:"suggestion,omitempty"`
 }
 
 // ScoreResult is an advisory content assessment for a campaign template.
@@ -84,11 +113,17 @@ type ScoreResult struct {
 // warmup mail — Score never blocks: it surfaces guidance before the user sends
 // the mail that actually reaches prospects and drives complaints. It reuses the
 // same trigger-term and ALL-CAPS heuristics as the warmup lint.
+//
+// Every issue carries where it is (subject or body) and the exact fragments
+// that caused it, because a score with no location is advice nobody can act on.
 func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 	res := ScoreResult{Score: 100, Issues: []Issue{}}
-	deduct := func(n int, severity, code, msg string) {
+	deduct := func(n int, issue Issue) {
 		res.Score -= n
-		res.Issues = append(res.Issues, Issue{Severity: severity, Code: code, Message: msg})
+		if issue.Field == "" {
+			issue.Field = commonField(issue.Spans)
+		}
+		res.Issues = append(res.Issues, issue)
 	}
 
 	subj := strings.TrimSpace(subject)
@@ -96,17 +131,31 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 	if strings.TrimSpace(body) == "" {
 		body = stripTags(bodyHTML)
 	}
-	combined := subj + "\n" + body
 
 	if subj == "" {
-		deduct(20, "high", "empty_subject", "Subject is empty.")
+		deduct(20, Issue{
+			Severity: "high", Code: "empty_subject", Field: FieldSubject,
+			Message:    "Subject is empty.",
+			Suggestion: "Write a short, specific subject: lowercase, under six words, about them.",
+		})
 	} else if isAllCaps(subj) {
-		deduct(15, "high", "all_caps_subject", "Subject is all caps, a strong spam signal.")
+		deduct(15, Issue{
+			Severity: "high", Code: "all_caps_subject", Field: FieldSubject,
+			Message:    "Subject is all caps, a strong spam signal.",
+			Spans:      []Span{{Field: FieldSubject, Text: subj, Line: 1, Excerpt: subj}},
+			Suggestion: "Write the subject in ordinary sentence case.",
+		})
 	}
-	if stackedPunct.MatchString(combined) {
-		deduct(10, "warn", "stacked_punctuation", "Stacked punctuation (e.g. !!! or ?!) reads as promotional.")
+	if punct := punctuationSpans(subj, body); len(punct) > 0 {
+		deduct(10, Issue{
+			Severity: "warn", Code: "stacked_punctuation",
+			Message:    "Stacked punctuation (e.g. !!! or ?!) reads as promotional.",
+			Spans:      punct,
+			Suggestion: "Use a single full stop or question mark.",
+		})
 	}
-	if n := countTriggerTerms(withoutURLs(combined)); n > 0 {
+	terms, termSpans := triggerSpans(subj, body)
+	if n := len(terms); n > 0 {
 		d := n * 8
 		if d > 40 {
 			d = 40
@@ -115,19 +164,38 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		if n >= 3 {
 			severity = "high"
 		}
-		deduct(d, severity, "spam_trigger_terms", fmt.Sprintf("%d spam-trigger term(s) found in subject/body.", n))
+		deduct(d, Issue{
+			Severity: severity, Code: "spam_trigger_terms",
+			Message:    fmt.Sprintf("%d spam-trigger term(s) found in subject/body: %s.", n, joinTerms(terms)),
+			Spans:      termSpans,
+			Suggestion: "Rewrite those words in plain language, or cut the sentence they sit in.",
+		})
 	}
-	if links := countLinks(combined, bodyHTML); links > 3 {
+	linked := linkSpans(subj, body, bodyHTML)
+	if links := len(linked); links > 3 {
 		d := (links - 3) * 5
 		if d > 20 {
 			d = 20
 		}
-		deduct(d, "warn", "too_many_links", fmt.Sprintf("%d links. Keep the link count low in cold email.", links))
+		deduct(d, Issue{
+			Severity: "warn", Code: "too_many_links",
+			Message:    fmt.Sprintf("%d links. Keep the link count low in cold email.", links),
+			Spans:      capSpans(linked),
+			Suggestion: "Keep one link at most on a first touch, and cut the rest.",
+		})
 	}
 	if strings.TrimSpace(body) == "" {
-		deduct(25, "high", "empty_body", "Body has no text content (image-only or empty body hurts deliverability).")
+		deduct(25, Issue{
+			Severity: "high", Code: "empty_body", Field: FieldBody,
+			Message:    "Body has no text content (image-only or empty body hurts deliverability).",
+			Suggestion: "Write the message as text. Filters cannot read an image.",
+		})
 	} else if len(body) > 15000 {
-		deduct(10, "warn", "oversized_body", "Body is very large; trim it for deliverability.")
+		deduct(10, Issue{
+			Severity: "warn", Code: "oversized_body", Field: FieldBody,
+			Message:    "Body is very large; trim it for deliverability.",
+			Suggestion: "Cut it to a few short paragraphs and one ask.",
+		})
 	}
 
 	// Images: cold mail from a real person is usually plain. A wall of images,
@@ -135,14 +203,21 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 	if images := len(imgTag.FindAllString(bodyHTML, -1)); images > 0 {
 		switch {
 		case len(strings.TrimSpace(body)) < 200 && images >= 1:
-			deduct(20, "high", "image_heavy",
-				"Almost all of this email is images. Filters cannot read it and treat that as evasion.")
+			deduct(20, Issue{
+				Severity: "high", Code: "image_heavy", Field: FieldBody,
+				Message:    "Almost all of this email is images. Filters cannot read it and treat that as evasion.",
+				Suggestion: "Put the message in text and keep images to a signature at most.",
+			})
 		case images > 3:
 			d := (images - 3) * 5
 			if d > 15 {
 				d = 15
 			}
-			deduct(d, "warn", "many_images", fmt.Sprintf("%d images. Cold email from a person rarely has many.", images))
+			deduct(d, Issue{
+				Severity: "warn", Code: "many_images", Field: FieldBody,
+				Message:    fmt.Sprintf("%d images. Cold email from a person rarely has many.", images),
+				Suggestion: "Drop all but the one image the message actually needs.",
+			})
 		}
 	}
 
@@ -150,6 +225,31 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		res.Score = 0
 	}
 	return res
+}
+
+// LeadIssue renders the one issue worth naming in a one-line summary: the first
+// high-severity one, else the first of any. It says where the problem is,
+// because "3 spam-trigger terms" on its own sends the reader looking in the
+// wrong box. Empty when there is nothing to report.
+func LeadIssue(res ScoreResult) string {
+	lead := Issue{}
+	for _, issue := range res.Issues {
+		if issue.Severity == "high" {
+			lead = issue
+			break
+		}
+		if lead.Code == "" {
+			lead = issue
+		}
+	}
+	switch lead.Field {
+	case FieldSubject:
+		return "Subject: " + lead.Message
+	case FieldBody:
+		return "Body: " + lead.Message
+	default:
+		return lead.Message
+	}
 }
 
 // ScoreWithAttachments is Score plus the attachment heuristic, which needs
@@ -164,9 +264,10 @@ func ScoreWithAttachments(subject, bodyHTML, bodyPlain string, attachments int) 
 			res.Score = 0
 		}
 		res.Issues = append(res.Issues, Issue{
-			Severity: "warn",
-			Code:     "has_attachments",
-			Message:  fmt.Sprintf("%d attachment(s) on a cold email. Link to the file instead.", attachments),
+			Severity:   "warn",
+			Code:       "has_attachments",
+			Message:    fmt.Sprintf("%d attachment(s) on a cold email. Link to the file instead.", attachments),
+			Suggestion: "Remove the file and offer to send it once they reply.",
 		})
 	}
 	return res
@@ -200,25 +301,6 @@ func isAllCaps(s string) bool {
 		}
 	}
 	return letters >= 4
-}
-
-// countLinks counts every anchor plus any bare URL in the text that is not
-// already an anchor's destination. Stripping tags throws hrefs away, so the text
-// alone reports zero links for an HTML email; matching destinations keeps a URL
-// used as its own anchor text from counting twice.
-func countLinks(text, bodyHTML string) int {
-	destinations := map[string]struct{}{}
-	n := 0
-	for _, m := range hrefPattern.FindAllStringSubmatch(bodyHTML, -1) {
-		destinations[trimURL(m[1])] = struct{}{}
-		n++
-	}
-	for _, u := range linkPattern.FindAllString(text, -1) {
-		if _, seen := destinations[trimURL(u)]; !seen {
-			n++
-		}
-	}
-	return n
 }
 
 // trimURL drops the sentence punctuation a URL picks up in prose, so the same

--- a/internal/pkg/warmlint/lint.go
+++ b/internal/pkg/warmlint/lint.go
@@ -170,7 +170,7 @@ func Score(subject, bodyHTML, bodyPlain string) ScoreResult {
 		}
 		deduct(d, Issue{
 			Severity: severity, Code: "spam_trigger_terms",
-			Message:    fmt.Sprintf("%d spam-trigger term(s) found in subject/body: %s.", n, joinTerms(terms)),
+			Message:    fmt.Sprintf("%d spam-trigger term(s): %s.", n, joinTerms(terms)),
 			Spans:      termSpans,
 			Suggestion: "Rewrite those words in plain language, or cut the sentence they sit in.",
 		})
@@ -246,11 +246,14 @@ func LeadIssue(res ScoreResult) string {
 			lead = issue
 		}
 	}
-	switch lead.Field {
-	case FieldSubject:
+	switch {
+	case lead.Field == FieldSubject:
 		return "Subject: " + lead.Message
-	case FieldBody:
+	case lead.Field == FieldBody:
 		return "Body: " + lead.Message
+	case len(lead.Spans) > 0:
+		// No single field but fragments to point at means it is in both.
+		return "Subject and body: " + lead.Message
 	default:
 		return lead.Message
 	}

--- a/internal/pkg/warmlint/locate.go
+++ b/internal/pkg/warmlint/locate.go
@@ -1,0 +1,214 @@
+package warmlint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// This file turns each heuristic in Score into a location. A score with no
+// location ("3 spam-trigger terms found") leaves the writer hunting through
+// their own copy for words the checker already knows, so every issue points at
+// the fragments that caused it and says which half of the template they are in.
+
+// maxSpans bounds how many fragments one issue carries. The count that drives
+// the deduction is computed before this cap, so trimming the list never moves
+// the score.
+const maxSpans = 8
+
+// excerptMax caps a quoted line, so one pasted wall of text cannot blow up the
+// response.
+const excerptMax = 180
+
+// listedTerms bounds how many trigger terms the message names before it counts
+// the rest.
+const listedTerms = 5
+
+// commonField returns the field every span shares, or "" when they straddle the
+// subject and the body (or there are none).
+func commonField(spans []Span) string {
+	field := ""
+	for _, s := range spans {
+		if field == "" {
+			field = s.Field
+			continue
+		}
+		if s.Field != field {
+			return ""
+		}
+	}
+	return field
+}
+
+// capSpans drops anything that could not be quoted and trims the list to
+// maxSpans, in reading order. A span with no text is one spanAt could not slice
+// (a lowercased offset that moved under a non-ASCII rune); showing it would put
+// an empty highlight in the panel. Dropping it never moves the score, which is
+// computed from the counts, not from this list.
+func capSpans(spans []Span) []Span {
+	out := make([]Span, 0, min(len(spans), maxSpans))
+	for _, s := range spans {
+		if s.Text == "" {
+			continue
+		}
+		out = append(out, s)
+		if len(out) == maxSpans {
+			break
+		}
+	}
+	return out
+}
+
+// spanAt describes scan[start:end] as a span. scan is what was searched and
+// display is what the excerpt is quoted from: the trigger-term pass searches a
+// URL-stripped copy of the text, and quoting that would show the writer a line
+// with their own links blanked out. Both keep every newline, so a line number
+// found in one addresses the same line in the other.
+func spanAt(field, scan, display string, start, end int) Span {
+	text := ""
+	if start >= 0 && end <= len(scan) && start < end {
+		text = strings.TrimSpace(scan[start:end])
+	}
+	line := lineNumber(scan, start)
+	return Span{Field: field, Text: text, Line: line, Excerpt: lineText(display, line)}
+}
+
+// lineNumber is the 1-based line the byte offset sits on.
+func lineNumber(s string, at int) int {
+	if at < 0 || at > len(s) {
+		return 0
+	}
+	return 1 + strings.Count(s[:at], "\n")
+}
+
+// lineText returns that line, trimmed and capped for display.
+func lineText(s string, line int) string {
+	if line < 1 {
+		return ""
+	}
+	lines := strings.Split(s, "\n")
+	if line > len(lines) {
+		return ""
+	}
+	out := strings.TrimSpace(lines[line-1])
+	if r := []rune(out); len(r) > excerptMax {
+		out = strings.TrimSpace(string(r[:excerptMax])) + "…"
+	}
+	return out
+}
+
+// scanned pairs a field with the text searched for it and the text an excerpt
+// is quoted from.
+type scanned struct {
+	field   string
+	scan    string
+	display string
+}
+
+// punctuationSpans locates every run of stacked punctuation, subject first.
+func punctuationSpans(subject, body string) []Span {
+	var spans []Span
+	for _, f := range []scanned{{FieldSubject, subject, subject}, {FieldBody, body, body}} {
+		for _, loc := range stackedPunct.FindAllStringIndex(f.scan, -1) {
+			spans = append(spans, spanAt(f.field, f.scan, f.display, loc[0], loc[1]))
+		}
+	}
+	return capSpans(spans)
+}
+
+// termHit is one trigger term and where it was first seen.
+type termHit struct {
+	term string
+	at   int
+}
+
+// triggerTermsIn returns the distinct trigger terms in the text, in order of
+// first appearance. It matches countTriggerTerms exactly on which terms count;
+// only the ordering and the offsets are extra.
+func triggerTermsIn(text string) []termHit {
+	lower := strings.ToLower(text)
+	first := map[string]int{}
+	for _, loc := range wordToken.FindAllStringIndex(lower, -1) {
+		w := lower[loc[0]:loc[1]]
+		if _, ok := triggerWords[w]; !ok {
+			continue
+		}
+		if _, seen := first[w]; !seen {
+			first[w] = loc[0]
+		}
+	}
+	for _, p := range triggerPhrases {
+		if i := strings.Index(lower, p); i >= 0 {
+			if _, seen := first[p]; !seen {
+				first[p] = i
+			}
+		}
+	}
+	hits := make([]termHit, 0, len(first))
+	for term, at := range first {
+		hits = append(hits, termHit{term: term, at: at})
+	}
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].at != hits[j].at {
+			return hits[i].at < hits[j].at
+		}
+		return hits[i].term < hits[j].term
+	})
+	return hits
+}
+
+// triggerSpans returns the distinct trigger terms across the template and where
+// each one is. A term written in both halves counts once and is shown where it
+// appears first, which keeps the count identical to countTriggerTerms over the
+// two joined together.
+func triggerSpans(subject, body string) (terms []string, spans []Span) {
+	seen := map[string]struct{}{}
+	for _, f := range []scanned{
+		{FieldSubject, withoutURLs(subject), subject},
+		{FieldBody, withoutURLs(body), body},
+	} {
+		for _, hit := range triggerTermsIn(f.scan) {
+			if _, dup := seen[hit.term]; dup {
+				continue
+			}
+			seen[hit.term] = struct{}{}
+			terms = append(terms, hit.term)
+			spans = append(spans, spanAt(f.field, f.scan, f.display, hit.at, hit.at+len(hit.term)))
+		}
+	}
+	return terms, capSpans(spans)
+}
+
+// joinTerms names the trigger terms found, counting the tail once the list gets
+// long enough to read as noise.
+func joinTerms(terms []string) string {
+	if len(terms) <= listedTerms {
+		return strings.Join(terms, ", ")
+	}
+	return fmt.Sprintf("%s and %d more", strings.Join(terms[:listedTerms], ", "), len(terms)-listedTerms)
+}
+
+// linkSpans locates every anchor plus any bare URL that is not already an
+// anchor's destination. Stripping tags throws hrefs away, so the text alone
+// reports zero links for an HTML email; matching destinations keeps a URL used
+// as its own anchor text from counting twice. The caller counts the result, so
+// this returns one entry per link before any display cap.
+func linkSpans(subject, body, bodyHTML string) []Span {
+	destinations := map[string]struct{}{}
+	var spans []Span
+	for _, m := range hrefPattern.FindAllStringSubmatch(bodyHTML, -1) {
+		destinations[trimURL(m[1])] = struct{}{}
+		// An href lives in markup, not in a line of copy, so it carries the
+		// destination and no excerpt.
+		spans = append(spans, Span{Field: FieldBody, Text: m[1]})
+	}
+	for _, f := range []scanned{{FieldSubject, subject, subject}, {FieldBody, body, body}} {
+		for _, loc := range linkPattern.FindAllStringIndex(f.scan, -1) {
+			if _, seen := destinations[trimURL(f.scan[loc[0]:loc[1]])]; seen {
+				continue
+			}
+			spans = append(spans, spanAt(f.field, f.scan, f.display, loc[0], loc[1]))
+		}
+	}
+	return spans
+}

--- a/internal/pkg/warmlint/locate.go
+++ b/internal/pkg/warmlint/locate.go
@@ -121,37 +121,34 @@ func punctuationSpans(subject, body string) []Span {
 	return spans
 }
 
-// termHit is one trigger term and the offset it was first seen at, in the
-// folded text it was found in.
+// termHit is one occurrence of one trigger term, at an offset in the folded
+// text it was found in.
 type termHit struct {
 	term string
 	at   int
 }
 
-// triggerTermsIn returns the distinct trigger terms in already-folded text, in
-// order of first appearance. It matches countTriggerTerms exactly on which
-// terms count; only the ordering and the offsets are extra.
+// triggerTermsIn returns EVERY occurrence of every trigger term in already-
+// folded text, in reading order. Which terms count is identical to
+// countTriggerTerms; the offsets and the repeats are extra, and the caller
+// deduplicates for scoring.
 func triggerTermsIn(lower string) []termHit {
-	first := map[string]int{}
+	var hits []termHit
 	for _, loc := range wordToken.FindAllStringIndex(lower, -1) {
 		w := lower[loc[0]:loc[1]]
-		if _, ok := triggerWords[w]; !ok {
-			continue
-		}
-		if _, seen := first[w]; !seen {
-			first[w] = loc[0]
+		if _, ok := triggerWords[w]; ok {
+			hits = append(hits, termHit{term: w, at: loc[0]})
 		}
 	}
 	for _, p := range triggerPhrases {
-		if i := strings.Index(lower, p); i >= 0 {
-			if _, seen := first[p]; !seen {
-				first[p] = i
+		for from := 0; from < len(lower); {
+			i := strings.Index(lower[from:], p)
+			if i < 0 {
+				break
 			}
+			hits = append(hits, termHit{term: p, at: from + i})
+			from += i + len(p)
 		}
-	}
-	hits := make([]termHit, 0, len(first))
-	for term, at := range first {
-		hits = append(hits, termHit{term: term, at: at})
 	}
 	sort.Slice(hits, func(i, j int) bool {
 		if hits[i].at != hits[j].at {
@@ -162,16 +159,29 @@ func triggerTermsIn(lower string) []termHit {
 	return hits
 }
 
+// occurrence is one place a term was written, already resolved to a span.
+type occurrence struct {
+	key  string
+	span Span
+}
+
 // triggerSpans returns the distinct trigger terms across the template and every
-// place each one appears.
+// place each one is written.
 //
-// The two halves are separate on purpose. A term counts ONCE towards the score
-// however often it is written, which keeps the count identical to
-// countTriggerTerms over the two joined together, but it gets a span in each
-// half it appears in: deduplicating the spans as well lost the body occurrence
-// of a word written in both, and then labelled the whole issue "subject".
+// Two things are deliberate here. A term counts ONCE towards the score however
+// often it appears, which keeps the count identical to countTriggerTerms over
+// the two halves joined together, while every occurrence still gets a span:
+// pointing at one "free" out of three sends the writer back to hunt for the
+// other two on the next re-check.
+//
+// And the spans come out round by round rather than in reading order, so every
+// term shows once in every half it appears in before any term shows twice. The
+// list is capped for display, and a word written twenty times would otherwise
+// fill it and hide every other term that is also wrong.
 func triggerSpans(subject, body string) (terms []string, spans []Span) {
 	counted := map[string]struct{}{}
+	rounds := map[string][]Span{}
+	var order []string
 	for _, f := range []scanned{
 		{FieldSubject, withoutURLs(subject), subject},
 		{FieldBody, withoutURLs(body), body},
@@ -183,7 +193,23 @@ func triggerSpans(subject, body string) (terms []string, spans []Span) {
 				terms = append(terms, hit.term)
 			}
 			start, end := casefold.Origin(offsets, hit.at), casefold.Origin(offsets, hit.at+len(hit.term))
-			spans = append(spans, spanAt(f.field, f.scan, f.display, start, end))
+			key := f.field + "\x00" + hit.term
+			if _, seen := rounds[key]; !seen {
+				order = append(order, key)
+			}
+			rounds[key] = append(rounds[key], spanAt(f.field, f.scan, f.display, start, end))
+		}
+	}
+	for r := 0; ; r++ {
+		emitted := false
+		for _, key := range order {
+			if r < len(rounds[key]) {
+				spans = append(spans, rounds[key][r])
+				emitted = true
+			}
+		}
+		if !emitted {
+			break
 		}
 	}
 	return terms, spans

--- a/internal/pkg/warmlint/locate.go
+++ b/internal/pkg/warmlint/locate.go
@@ -159,12 +159,6 @@ func triggerTermsIn(lower string) []termHit {
 	return hits
 }
 
-// occurrence is one place a term was written, already resolved to a span.
-type occurrence struct {
-	key  string
-	span Span
-}
-
 // triggerSpans returns the distinct trigger terms across the template and every
 // place each one is written.
 //

--- a/internal/pkg/warmlint/locate.go
+++ b/internal/pkg/warmlint/locate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 // This file turns each heuristic in Score into a location. A score with no
@@ -40,23 +41,26 @@ func commonField(spans []Span) string {
 	return field
 }
 
-// capSpans drops anything that could not be quoted and trims the list to
-// maxSpans, in reading order. A span with no text is one spanAt could not slice
-// (a lowercased offset that moved under a non-ASCII rune); showing it would put
-// an empty highlight in the panel. Dropping it never moves the score, which is
-// computed from the counts, not from this list.
-func capSpans(spans []Span) []Span {
-	out := make([]Span, 0, min(len(spans), maxSpans))
+// quotableSpans drops anything with nothing to show. A span with no text would
+// render as an empty highlight, which reads as a bug rather than as a location.
+func quotableSpans(spans []Span) []Span {
+	out := make([]Span, 0, len(spans))
 	for _, s := range spans {
-		if s.Text == "" {
-			continue
-		}
-		out = append(out, s)
-		if len(out) == maxSpans {
-			break
+		if s.Text != "" {
+			out = append(out, s)
 		}
 	}
 	return out
+}
+
+// capSpans trims the list to maxSpans, in reading order. The field is read from
+// the full list before this runs: capping a subject-first list of twelve could
+// otherwise drop every body span and label a both-halves issue "subject".
+func capSpans(spans []Span) []Span {
+	if len(spans) <= maxSpans {
+		return spans
+	}
+	return spans[:maxSpans]
 }
 
 // spanAt describes scan[start:end] as a span. scan is what was searched and
@@ -113,20 +117,69 @@ func punctuationSpans(subject, body string) []Span {
 			spans = append(spans, spanAt(f.field, f.scan, f.display, loc[0], loc[1]))
 		}
 	}
-	return capSpans(spans)
+	return spans
 }
 
-// termHit is one trigger term and where it was first seen.
+// termHit is one trigger term and the offset it was first seen at, in the
+// folded text it was found in.
 type termHit struct {
 	term string
 	at   int
 }
 
-// triggerTermsIn returns the distinct trigger terms in the text, in order of
-// first appearance. It matches countTriggerTerms exactly on which terms count;
-// only the ordering and the offsets are extra.
-func triggerTermsIn(text string) []termHit {
-	lower := strings.ToLower(text)
+// foldIndex lowercases the text and records, for every byte offset in the
+// result, the offset it came from in the original.
+//
+// strings.ToLower maps rune by rune, and a rune can change byte length doing it
+// (U+0130 is two bytes and lowercases to one, U+212A is three), so an offset
+// found in the folded copy cannot be used to slice the original: past the first
+// such rune it lands mid-rune and quotes bytes the writer never typed, or cuts
+// one in half and produces invalid UTF-8. The map is only built when the text
+// has non-ASCII in it, which is where offsets can move at all.
+func foldIndex(s string) (string, []int) {
+	if isASCII(s) {
+		return strings.ToLower(s), nil
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	offsets := make([]int, 0, len(s)+1)
+	for i, r := range s {
+		before := b.Len()
+		b.WriteRune(unicode.ToLower(r))
+		for n := b.Len() - before; n > 0; n-- {
+			offsets = append(offsets, i)
+		}
+	}
+	// One past the end, so the end of a match at the end of the text maps too.
+	offsets = append(offsets, len(s))
+	return b.String(), offsets
+}
+
+// unfold translates a byte offset in the folded copy back to the original. A
+// nil map means the two are byte-for-byte aligned (the ASCII path).
+func unfold(offsets []int, at int) int {
+	if offsets == nil {
+		return at
+	}
+	if at < 0 || at >= len(offsets) {
+		return -1
+	}
+	return offsets[at]
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// triggerTermsIn returns the distinct trigger terms in already-folded text, in
+// order of first appearance. It matches countTriggerTerms exactly on which
+// terms count; only the ordering and the offsets are extra.
+func triggerTermsIn(lower string) []termHit {
 	first := map[string]int{}
 	for _, loc := range wordToken.FindAllStringIndex(lower, -1) {
 		w := lower[loc[0]:loc[1]]
@@ -167,16 +220,18 @@ func triggerSpans(subject, body string) (terms []string, spans []Span) {
 		{FieldSubject, withoutURLs(subject), subject},
 		{FieldBody, withoutURLs(body), body},
 	} {
-		for _, hit := range triggerTermsIn(f.scan) {
+		lower, offsets := foldIndex(f.scan)
+		for _, hit := range triggerTermsIn(lower) {
 			if _, dup := seen[hit.term]; dup {
 				continue
 			}
 			seen[hit.term] = struct{}{}
 			terms = append(terms, hit.term)
-			spans = append(spans, spanAt(f.field, f.scan, f.display, hit.at, hit.at+len(hit.term)))
+			start, end := unfold(offsets, hit.at), unfold(offsets, hit.at+len(hit.term))
+			spans = append(spans, spanAt(f.field, f.scan, f.display, start, end))
 		}
 	}
-	return terms, capSpans(spans)
+	return terms, spans
 }
 
 // joinTerms names the trigger terms found, counting the tail once the list gets

--- a/internal/pkg/warmlint/locate.go
+++ b/internal/pkg/warmlint/locate.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"unicode"
+
+	"github.com/warmbly/warmbly/internal/pkg/casefold"
 )
 
 // This file turns each heuristic in Score into a location. A score with no
@@ -127,55 +128,6 @@ type termHit struct {
 	at   int
 }
 
-// foldIndex lowercases the text and records, for every byte offset in the
-// result, the offset it came from in the original.
-//
-// strings.ToLower maps rune by rune, and a rune can change byte length doing it
-// (U+0130 is two bytes and lowercases to one, U+212A is three), so an offset
-// found in the folded copy cannot be used to slice the original: past the first
-// such rune it lands mid-rune and quotes bytes the writer never typed, or cuts
-// one in half and produces invalid UTF-8. The map is only built when the text
-// has non-ASCII in it, which is where offsets can move at all.
-func foldIndex(s string) (string, []int) {
-	if isASCII(s) {
-		return strings.ToLower(s), nil
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	offsets := make([]int, 0, len(s)+1)
-	for i, r := range s {
-		before := b.Len()
-		b.WriteRune(unicode.ToLower(r))
-		for n := b.Len() - before; n > 0; n-- {
-			offsets = append(offsets, i)
-		}
-	}
-	// One past the end, so the end of a match at the end of the text maps too.
-	offsets = append(offsets, len(s))
-	return b.String(), offsets
-}
-
-// unfold translates a byte offset in the folded copy back to the original. A
-// nil map means the two are byte-for-byte aligned (the ASCII path).
-func unfold(offsets []int, at int) int {
-	if offsets == nil {
-		return at
-	}
-	if at < 0 || at >= len(offsets) {
-		return -1
-	}
-	return offsets[at]
-}
-
-func isASCII(s string) bool {
-	for i := 0; i < len(s); i++ {
-		if s[i] >= 0x80 {
-			return false
-		}
-	}
-	return true
-}
-
 // triggerTermsIn returns the distinct trigger terms in already-folded text, in
 // order of first appearance. It matches countTriggerTerms exactly on which
 // terms count; only the ordering and the offsets are extra.
@@ -210,24 +162,27 @@ func triggerTermsIn(lower string) []termHit {
 	return hits
 }
 
-// triggerSpans returns the distinct trigger terms across the template and where
-// each one is. A term written in both halves counts once and is shown where it
-// appears first, which keeps the count identical to countTriggerTerms over the
-// two joined together.
+// triggerSpans returns the distinct trigger terms across the template and every
+// place each one appears.
+//
+// The two halves are separate on purpose. A term counts ONCE towards the score
+// however often it is written, which keeps the count identical to
+// countTriggerTerms over the two joined together, but it gets a span in each
+// half it appears in: deduplicating the spans as well lost the body occurrence
+// of a word written in both, and then labelled the whole issue "subject".
 func triggerSpans(subject, body string) (terms []string, spans []Span) {
-	seen := map[string]struct{}{}
+	counted := map[string]struct{}{}
 	for _, f := range []scanned{
 		{FieldSubject, withoutURLs(subject), subject},
 		{FieldBody, withoutURLs(body), body},
 	} {
-		lower, offsets := foldIndex(f.scan)
+		lower, offsets := casefold.Index(f.scan)
 		for _, hit := range triggerTermsIn(lower) {
-			if _, dup := seen[hit.term]; dup {
-				continue
+			if _, dup := counted[hit.term]; !dup {
+				counted[hit.term] = struct{}{}
+				terms = append(terms, hit.term)
 			}
-			seen[hit.term] = struct{}{}
-			terms = append(terms, hit.term)
-			start, end := unfold(offsets, hit.at), unfold(offsets, hit.at+len(hit.term))
+			start, end := casefold.Origin(offsets, hit.at), casefold.Origin(offsets, hit.at+len(hit.term))
 			spans = append(spans, spanAt(f.field, f.scan, f.display, start, end))
 		}
 	}
@@ -249,21 +204,33 @@ func joinTerms(terms []string) string {
 // as its own anchor text from counting twice. The caller counts the result, so
 // this returns one entry per link before any display cap.
 func linkSpans(subject, body, bodyHTML string) []Span {
+	// Destinations first and separately: a bare URL only counts when it is not
+	// already an anchor's target, and that has to be known before the subject
+	// is scanned.
 	destinations := map[string]struct{}{}
-	var spans []Span
+	anchors := make([]Span, 0)
 	for _, m := range hrefPattern.FindAllStringSubmatch(bodyHTML, -1) {
 		destinations[trimURL(m[1])] = struct{}{}
 		// An href lives in markup, not in a line of copy, so it carries the
 		// destination and no excerpt.
-		spans = append(spans, Span{Field: FieldBody, Text: m[1]})
+		anchors = append(anchors, Span{Field: FieldBody, Text: m[1]})
 	}
-	for _, f := range []scanned{{FieldSubject, subject, subject}, {FieldBody, body, body}} {
+
+	bare := func(f scanned) []Span {
+		var out []Span
 		for _, loc := range linkPattern.FindAllStringIndex(f.scan, -1) {
 			if _, seen := destinations[trimURL(f.scan[loc[0]:loc[1]])]; seen {
 				continue
 			}
-			spans = append(spans, spanAt(f.field, f.scan, f.display, loc[0], loc[1]))
+			out = append(out, spanAt(f.field, f.scan, f.display, loc[0], loc[1]))
 		}
+		return out
 	}
-	return spans
+
+	// Subject first, like every other span list: a body with more anchors than
+	// the display cap would otherwise push the subject's own link off the end
+	// while the issue still claims to cover both halves.
+	spans := bare(scanned{FieldSubject, subject, subject})
+	spans = append(spans, anchors...)
+	return append(spans, bare(scanned{FieldBody, body, body})...)
 }

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -443,3 +443,21 @@ func TestScoreFieldSurvivesTheSpanCap(t *testing.T) {
 		t.Errorf("field = %q, want empty: the terms straddle both halves", issue.Field)
 	}
 }
+
+// The message names the terms and the field names the place, so the one-line
+// summary does not read "Body: 3 spam-trigger term(s) found in subject/body".
+func TestLeadIssueDoesNotRepeatTheLocation(t *testing.T) {
+	got := LeadIssue(Score("Quick question", "", "Here is a free look at it."))
+	if got != "Body: 1 spam-trigger term(s): free." {
+		t.Errorf("lead issue = %q", got)
+	}
+}
+
+// Terms in both halves have no single field, so the summary says both rather
+// than dropping the location entirely.
+func TestLeadIssueNamesBothHalvesWhenTheIssueStraddles(t *testing.T) {
+	got := LeadIssue(Score("A free look", "", "This is a limited time offer."))
+	if !strings.HasPrefix(got, "Subject and body: ") {
+		t.Errorf("lead issue = %q, want it to name both halves", got)
+	}
+}

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -2,6 +2,7 @@ package warmlint
 
 import (
 	"fmt"
+	"math/rand"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -241,22 +242,30 @@ func TestScoreLocatesTriggerTermsInTheBodyByLine(t *testing.T) {
 	}
 }
 
-// A term in both halves counts once, as it always has, and is shown where the
-// reader meets it first.
-func TestScoreCountsATermInBothHalvesOnce(t *testing.T) {
+// A term in both halves counts once towards the score, as it always has, but is
+// shown in both places. Deduplicating the spans too lost the body occurrence and
+// then labelled the whole issue "subject", sending the writer to one of the two
+// boxes the word is actually in.
+func TestScoreCountsATermInBothHalvesOnceButShowsBoth(t *testing.T) {
 	res := Score("A free look", "", "Here is a free look at it.")
 	issue, ok := issueByCode(res, "spam_trigger_terms")
 	if !ok {
 		t.Fatalf("trigger term not flagged: %+v", res.Issues)
 	}
-	if len(issue.Spans) != 1 {
-		t.Fatalf("got %d spans for one distinct term: %+v", len(issue.Spans), issue.Spans)
-	}
-	if issue.Spans[0].Field != FieldSubject {
-		t.Errorf("span field = %q, want the subject occurrence", issue.Spans[0].Field)
-	}
 	if res.Score != 92 {
 		t.Errorf("score = %d, want one term's deduction only", res.Score)
+	}
+	if !strings.HasPrefix(issue.Message, "1 spam-trigger term(s)") {
+		t.Errorf("message = %q, want it to count the term once", issue.Message)
+	}
+	if len(issue.Spans) != 2 {
+		t.Fatalf("got %d spans, want the word shown in both halves: %+v", len(issue.Spans), issue.Spans)
+	}
+	if issue.Spans[0].Field != FieldSubject || issue.Spans[1].Field != FieldBody {
+		t.Errorf("spans = %+v, want the subject one first", issue.Spans)
+	}
+	if issue.Field != "" {
+		t.Errorf("field = %q, want empty: the word is in both halves", issue.Field)
 	}
 }
 
@@ -462,40 +471,85 @@ func TestLeadIssueNamesBothHalvesWhenTheIssueStraddles(t *testing.T) {
 	}
 }
 
-// The whole offset map rests on foldIndex producing exactly what strings.ToLower
-// produces: the terms are found in one and counted against the other. Invalid
-// UTF-8 is in the table because a range loop and strings.Map both turn a bad
-// byte into U+FFFD, which is three bytes where the original was one.
-func TestFoldIndexMatchesStringsToLower(t *testing.T) {
-	cases := []string{
-		"", "plain ascii text", "FREE CASH", "İİİ free", "KKK cash", "café",
-		"🎉 free", "Straße", "ǅungla", "ﬁ ligature", "\xff\xfe bad bytes",
-		"mixed İ \xc3\x28 free", strings.Repeat("İ", 40) + " free",
+// The display cap keeps the first maxSpans, so a body carrying more anchors
+// than that would drop the subject's own link and leave the issue claiming a
+// half it no longer shows.
+func TestScoreLinkSpansPutTheSubjectFirst(t *testing.T) {
+	body := strings.Repeat("A real sentence about the recipient's work. ", 10)
+	links := ""
+	for i := 0; i < 12; i++ {
+		links += fmt.Sprintf(`<a href="https://example.com/%d">link</a> `, i)
 	}
-	for _, s := range cases {
-		lower, offsets := foldIndex(s)
-		if want := strings.ToLower(s); lower != want {
-			t.Errorf("foldIndex(%q) folded to %q, want %q", s, lower, want)
+	res := Score("Quick question https://sub.example.com/x", "<p>"+body+"</p><p>"+links+"</p>", body)
+	issue, ok := issueByCode(res, "too_many_links")
+	if !ok {
+		t.Fatalf("links not flagged: %+v", res.Issues)
+	}
+	if issue.Spans[0].Field != FieldSubject {
+		t.Errorf("first span is in %q, want the subject's link kept: %+v", issue.Spans[0].Field, issue.Spans)
+	}
+	if issue.Field != "" {
+		t.Errorf("field = %q, want empty: the links straddle both halves", issue.Field)
+	}
+	if !strings.HasPrefix(issue.Message, "13 links") {
+		t.Errorf("message = %q, want all thirteen counted", issue.Message)
+	}
+}
+
+// spanFragments are the pieces the fuzz below builds copy from: trigger words
+// and phrases, punctuation, markup, links, and the runes whose byte length
+// changes when they are lowercased.
+var spanFragments = []string{
+	"free", "FREE", "Cash", "act now", "click here", "100% free", "limited time",
+	"Hi Ada,", "worth a chat?", "!!!", "?!", "\n", "\n\n", " ", "café", "İstanbul",
+	"KKK", "🎉", "https://a.com/free-trial", "https://b.co/x.", "risk-free",
+	"a real sentence about the recipient's work.", "GUARANTEED", "no cost",
+	"<p>hello</p>", `<a href="https://c.io/1">one</a>`, `<img src="x.png">`,
+	`<style>.free-banner{color:red}</style>`, "Straße", "ﬁ", "%", "100%", "free cash",
+}
+
+func randCopy(r *rand.Rand, n int) string {
+	var b strings.Builder
+	for i := 0; i < n; i++ {
+		b.WriteString(spanFragments[r.Intn(len(spanFragments))])
+	}
+	return b.String()
+}
+
+// The panel highlights a span's text as the writer's own words, so every span
+// has to be real bytes of the half it names. A quote assembled from a shifted
+// offset is not, and neither is an empty one.
+func TestEverySpanQuotesTheHalfItNames(t *testing.T) {
+	r := rand.New(rand.NewSource(20260910))
+	for i := 0; i < 20000; i++ {
+		subject := randCopy(r, r.Intn(6))
+		html := randCopy(r, r.Intn(8))
+		plain := ""
+		if r.Intn(3) > 0 {
+			plain = randCopy(r, r.Intn(8))
 		}
-		if offsets == nil {
-			continue
-		}
-		if len(offsets) != len(lower)+1 {
-			t.Errorf("foldIndex(%q): %d offsets for %d bytes", s, len(offsets), len(lower))
-			continue
-		}
-		// Every offset must land on a rune boundary in the original, or a
-		// slice taken at it cuts a rune in half.
-		for i, at := range offsets {
-			if at < 0 || at > len(s) {
-				t.Fatalf("foldIndex(%q): offset %d out of range at %d", s, at, i)
+		for _, issue := range Score(subject, html, plain).Issues {
+			for _, sp := range issue.Spans {
+				if sp.Text == "" {
+					t.Fatalf("case %d: empty span on %s", i, issue.Code)
+				}
+				if issue.Code == "too_many_links" {
+					continue // an href is quoted from the markup, not the copy
+				}
+				hay := plain
+				if sp.Field == FieldSubject {
+					hay = strings.TrimSpace(subject)
+				} else if strings.TrimSpace(plain) == "" {
+					hay = stripTags(html)
+				}
+				if !strings.Contains(hay, sp.Text) {
+					t.Fatalf("case %d: %s span %q is not in the %s\nsubject=%q\nhtml=%q\nplain=%q",
+						i, issue.Code, sp.Text, sp.Field, subject, html, plain)
+				}
+				if !utf8.ValidString(sp.Text) {
+					t.Fatalf("case %d: %s span is not valid UTF-8: %q", i, issue.Code, sp.Text)
+				}
 			}
-			if at < len(s) && !utf8.RuneStart(s[at]) {
-				t.Errorf("foldIndex(%q): offset %d at index %d is mid-rune", s, at, i)
-			}
-		}
-		if offsets[len(offsets)-1] != len(s) {
-			t.Errorf("foldIndex(%q): last offset %d, want %d", s, offsets[len(offsets)-1], len(s))
 		}
 	}
 }

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func hasIssue(res ScoreResult, code string) bool {
@@ -371,5 +372,74 @@ func TestLeadIssuePrefersTheHighSeverityOne(t *testing.T) {
 	}}
 	if got := LeadIssue(res); got != "Body: Body has no text content." {
 		t.Errorf("lead issue = %q, want the high-severity one", got)
+	}
+}
+
+// A rune can change byte length when it is lowercased (U+0130 is two bytes and
+// folds to one, U+212A is three), so an offset found in the folded copy walks
+// off the original past the first one. Slicing on it quoted bytes the writer
+// never typed, and could cut a rune in half into invalid UTF-8.
+func TestScoreQuotesTheRightBytesAcrossACaseFold(t *testing.T) {
+	for _, tc := range []struct {
+		subject string
+		want    string
+	}{
+		{"İİİ free offer", "free"},
+		{"KKK cash prize", "cash"},
+		{"café free trial", "free"},
+		{"🎉 free bonus", "free"},
+	} {
+		issue, ok := issueByCode(Score(tc.subject, "", "Hi Ada, worth a chat?"), "spam_trigger_terms")
+		if !ok {
+			t.Fatalf("%q: trigger term not flagged", tc.subject)
+		}
+		span := issue.Spans[0]
+		if !utf8.ValidString(span.Text) {
+			t.Errorf("%q: span text is not valid UTF-8: %q", tc.subject, span.Text)
+		}
+		if span.Text != tc.want {
+			t.Errorf("%q: quoted %q, want %q", tc.subject, span.Text, tc.want)
+		}
+		if span.Excerpt != tc.subject {
+			t.Errorf("%q: excerpt = %q", tc.subject, span.Excerpt)
+		}
+	}
+}
+
+// The same offsets carry the line number, so a body with a fold-shifting rune
+// above the trigger term must still point at the right line.
+func TestScoreLinesSurviveACaseFold(t *testing.T) {
+	body := "Hi İIrem,\n\nStraße KKK notes.\n\nHere is a free look."
+	issue, ok := issueByCode(Score("Quick question", "", body), "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger term not flagged")
+	}
+	span := issue.Spans[0]
+	if span.Text != "free" {
+		t.Errorf("quoted %q, want %q", span.Text, "free")
+	}
+	if span.Line != 5 {
+		t.Errorf("line = %d, want 5", span.Line)
+	}
+	if span.Excerpt != "Here is a free look." {
+		t.Errorf("excerpt = %q", span.Excerpt)
+	}
+}
+
+// The field is read before the span list is trimmed. A subject-first list of
+// more than maxSpans in one half would otherwise lose every body span to the
+// cap and label a both-halves issue as a subject-only one.
+func TestScoreFieldSurvivesTheSpanCap(t *testing.T) {
+	subject := "free cash prize bonus discount promo sale deal loan credit"
+	body := "This is a limited time offer."
+	issue, ok := issueByCode(Score(subject, "", body), "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger terms not flagged")
+	}
+	if len(issue.Spans) != maxSpans {
+		t.Fatalf("got %d spans, want them capped at %d", len(issue.Spans), maxSpans)
+	}
+	if issue.Field != "" {
+		t.Errorf("field = %q, want empty: the terms straddle both halves", issue.Field)
 	}
 }

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -553,3 +553,49 @@ func TestEverySpanQuotesTheHalfItNames(t *testing.T) {
 		}
 	}
 }
+
+// Pointing at one "free" out of three sends the writer back to hunt for the
+// other two on the next re-check, which is the hunting this panel exists to
+// stop. The term still counts once towards the score.
+func TestScoreShowsEveryOccurrenceOfARepeatedTerm(t *testing.T) {
+	res := Score("Quick question", "", "A free look.\nAnother free thing.\nOne more free one.")
+	issue, ok := issueByCode(res, "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger term not flagged: %+v", res.Issues)
+	}
+	if res.Score != 92 {
+		t.Errorf("score = %d, want one term's deduction however often it is written", res.Score)
+	}
+	if !strings.HasPrefix(issue.Message, "1 spam-trigger term(s)") {
+		t.Errorf("message = %q, want the term counted once", issue.Message)
+	}
+	if len(issue.Spans) != 3 {
+		t.Fatalf("got %d spans, want one per occurrence: %+v", len(issue.Spans), issue.Spans)
+	}
+	for i, want := range []int{1, 2, 3} {
+		if issue.Spans[i].Line != want {
+			t.Errorf("span %d is on line %d, want %d", i, issue.Spans[i].Line, want)
+		}
+	}
+}
+
+// The span list is capped for display, so occurrences come out round by round:
+// every term shows once before any term shows twice. In reading order a word
+// written twenty times would fill the list and hide every other term that is
+// also wrong.
+func TestScoreSpansShowEveryTermBeforeAnyRepeats(t *testing.T) {
+	body := strings.Repeat("A free thing. ", 20) + "Act now, this is a bonus prize."
+	issue, ok := issueByCode(Score("Quick question", "", body), "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger terms not flagged")
+	}
+	seen := map[string]bool{}
+	for _, sp := range issue.Spans {
+		seen[sp.Text] = true
+	}
+	for _, want := range []string{"free", "Act now", "bonus", "prize"} {
+		if !seen[want] {
+			t.Errorf("%q never got a span; the repeated word filled the list: %+v", want, issue.Spans)
+		}
+	}
+}

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -461,3 +461,41 @@ func TestLeadIssueNamesBothHalvesWhenTheIssueStraddles(t *testing.T) {
 		t.Errorf("lead issue = %q, want it to name both halves", got)
 	}
 }
+
+// The whole offset map rests on foldIndex producing exactly what strings.ToLower
+// produces: the terms are found in one and counted against the other. Invalid
+// UTF-8 is in the table because a range loop and strings.Map both turn a bad
+// byte into U+FFFD, which is three bytes where the original was one.
+func TestFoldIndexMatchesStringsToLower(t *testing.T) {
+	cases := []string{
+		"", "plain ascii text", "FREE CASH", "İİİ free", "KKK cash", "café",
+		"🎉 free", "Straße", "ǅungla", "ﬁ ligature", "\xff\xfe bad bytes",
+		"mixed İ \xc3\x28 free", strings.Repeat("İ", 40) + " free",
+	}
+	for _, s := range cases {
+		lower, offsets := foldIndex(s)
+		if want := strings.ToLower(s); lower != want {
+			t.Errorf("foldIndex(%q) folded to %q, want %q", s, lower, want)
+		}
+		if offsets == nil {
+			continue
+		}
+		if len(offsets) != len(lower)+1 {
+			t.Errorf("foldIndex(%q): %d offsets for %d bytes", s, len(offsets), len(lower))
+			continue
+		}
+		// Every offset must land on a rune boundary in the original, or a
+		// slice taken at it cuts a rune in half.
+		for i, at := range offsets {
+			if at < 0 || at > len(s) {
+				t.Fatalf("foldIndex(%q): offset %d out of range at %d", s, at, i)
+			}
+			if at < len(s) && !utf8.RuneStart(s[at]) {
+				t.Errorf("foldIndex(%q): offset %d at index %d is mid-rune", s, at, i)
+			}
+		}
+		if offsets[len(offsets)-1] != len(s) {
+			t.Errorf("foldIndex(%q): last offset %d, want %d", s, offsets[len(offsets)-1], len(s))
+		}
+	}
+}

--- a/internal/pkg/warmlint/score_test.go
+++ b/internal/pkg/warmlint/score_test.go
@@ -1,6 +1,7 @@
 package warmlint
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -178,5 +179,197 @@ func TestScoreIgnoresAStylesheet(t *testing.T) {
 	styled := Score("Quick question", `<style>.free-trial-banner{color:red}</style><p>Hi Ana, ten minutes on Thursday?</p>`, "")
 	if styled.Score != clean.Score {
 		t.Errorf("a stylesheet changed the content score: %d vs %d (%v)", styled.Score, clean.Score, styled.Issues)
+	}
+}
+
+func issueByCode(res ScoreResult, code string) (Issue, bool) {
+	for _, i := range res.Issues {
+		if i.Code == code {
+			return i, true
+		}
+	}
+	return Issue{}, false
+}
+
+// A score with no location is advice nobody can act on: the writer is told
+// three trigger terms exist and left to hunt for them.
+func TestScoreLocatesTriggerTermsInTheSubject(t *testing.T) {
+	res := Score("Your FREE bonus inside", "<p>Hi Ada, worth a chat?</p>", "Hi Ada, worth a chat?")
+	issue, ok := issueByCode(res, "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger terms not flagged: %+v", res.Issues)
+	}
+	if issue.Field != FieldSubject {
+		t.Errorf("issue field = %q, want subject", issue.Field)
+	}
+	if len(issue.Spans) != 2 {
+		t.Fatalf("got %d spans, want one per term: %+v", len(issue.Spans), issue.Spans)
+	}
+	for _, s := range issue.Spans {
+		if s.Field != FieldSubject {
+			t.Errorf("span %q sits in %q, want subject", s.Text, s.Field)
+		}
+		if s.Excerpt != "Your FREE bonus inside" {
+			t.Errorf("span %q quoted %q, want the whole subject line", s.Text, s.Excerpt)
+		}
+	}
+	if issue.Spans[0].Text != "FREE" {
+		t.Errorf("first span = %q, want the term as the writer typed it", issue.Spans[0].Text)
+	}
+	if issue.Suggestion == "" {
+		t.Error("no suggestion on a trigger-term issue")
+	}
+}
+
+func TestScoreLocatesTriggerTermsInTheBodyByLine(t *testing.T) {
+	body := "Hi Ada,\n\nThis is a limited time offer.\n\nWorth a chat?"
+	res := Score("Quick question", "", body)
+	issue, ok := issueByCode(res, "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger phrase not flagged: %+v", res.Issues)
+	}
+	if issue.Field != FieldBody {
+		t.Errorf("issue field = %q, want body", issue.Field)
+	}
+	span := issue.Spans[0]
+	if span.Line != 3 {
+		t.Errorf("span line = %d, want the third line", span.Line)
+	}
+	if span.Excerpt != "This is a limited time offer." {
+		t.Errorf("excerpt = %q, want the sentence it sits in", span.Excerpt)
+	}
+}
+
+// A term in both halves counts once, as it always has, and is shown where the
+// reader meets it first.
+func TestScoreCountsATermInBothHalvesOnce(t *testing.T) {
+	res := Score("A free look", "", "Here is a free look at it.")
+	issue, ok := issueByCode(res, "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger term not flagged: %+v", res.Issues)
+	}
+	if len(issue.Spans) != 1 {
+		t.Fatalf("got %d spans for one distinct term: %+v", len(issue.Spans), issue.Spans)
+	}
+	if issue.Spans[0].Field != FieldSubject {
+		t.Errorf("span field = %q, want the subject occurrence", issue.Spans[0].Field)
+	}
+	if res.Score != 92 {
+		t.Errorf("score = %d, want one term's deduction only", res.Score)
+	}
+}
+
+// The trigger pass reads a URL-stripped copy of the text; quoting that copy
+// would show the writer a line with their own links blanked out.
+func TestScoreExcerptKeepsTheLinkTheTriggerPassStripped(t *testing.T) {
+	body := "A free look: https://example.com/pricing"
+	res := Score("Quick question", "", body)
+	issue, ok := issueByCode(res, "spam_trigger_terms")
+	if !ok {
+		t.Fatalf("trigger term not flagged: %+v", res.Issues)
+	}
+	if issue.Spans[0].Excerpt != body {
+		t.Errorf("excerpt = %q, want the line as written", issue.Spans[0].Excerpt)
+	}
+}
+
+func TestScoreLocatesStackedPunctuationAndImages(t *testing.T) {
+	res := Score("Hurry!!", "<p>Ready?!</p>", "Ready?!")
+	issue, ok := issueByCode(res, "stacked_punctuation")
+	if !ok {
+		t.Fatalf("stacked punctuation not flagged: %+v", res.Issues)
+	}
+	if issue.Field != "" {
+		t.Errorf("field = %q, want empty when the issue straddles both halves", issue.Field)
+	}
+	if len(issue.Spans) != 2 {
+		t.Fatalf("got %d spans, want one per run: %+v", len(issue.Spans), issue.Spans)
+	}
+	if issue.Spans[0].Field != FieldSubject || issue.Spans[1].Field != FieldBody {
+		t.Errorf("spans = %+v, want the subject one first", issue.Spans)
+	}
+}
+
+func TestScoreLinkIssueNamesTheDestinations(t *testing.T) {
+	body := strings.Repeat("A real sentence about the recipient's work. ", 10)
+	html := "<p>" + body + "</p><p>" +
+		`<a href="https://a.com/1">one</a> <a href="https://b.com/2">two</a> ` +
+		`<a href="https://c.com/3">three</a> <a href="https://d.com/4">four</a></p>`
+	res := Score("Quick question", html, body)
+	issue, ok := issueByCode(res, "too_many_links")
+	if !ok {
+		t.Fatalf("four links not flagged: %+v", res.Issues)
+	}
+	if len(issue.Spans) != 4 {
+		t.Fatalf("got %d spans, want one per link: %+v", len(issue.Spans), issue.Spans)
+	}
+	if issue.Spans[0].Text != "https://a.com/1" {
+		t.Errorf("first span = %q, want the destination", issue.Spans[0].Text)
+	}
+}
+
+// Trimming the displayed spans must never move the score, so the count that
+// drives the deduction is taken before the cap.
+func TestScoreCapsSpansWithoutMovingTheScore(t *testing.T) {
+	body := strings.Repeat("A real sentence about the recipient's work. ", 10)
+	links := ""
+	for i := 0; i < 14; i++ {
+		links += fmt.Sprintf(`<a href="https://example.com/%d">link</a> `, i)
+	}
+	res := Score("Quick question", "<p>"+body+"</p><p>"+links+"</p>", body)
+	issue, ok := issueByCode(res, "too_many_links")
+	if !ok {
+		t.Fatalf("fourteen links not flagged: %+v", res.Issues)
+	}
+	if len(issue.Spans) != maxSpans {
+		t.Errorf("got %d spans, want them capped at %d", len(issue.Spans), maxSpans)
+	}
+	if !strings.HasPrefix(issue.Message, "14 links") {
+		t.Errorf("message = %q, want it to count all fourteen", issue.Message)
+	}
+	// 14 links is 11 over the allowance, well past the 20-point cap.
+	if res.Score != 80 {
+		t.Errorf("score = %d, want the capped 20-point deduction", res.Score)
+	}
+}
+
+func TestScoreFieldsTheIssuesWithNothingToQuote(t *testing.T) {
+	res := Score("", "", "")
+	for _, code := range []string{"empty_subject", "empty_body"} {
+		issue, ok := issueByCode(res, code)
+		if !ok {
+			t.Fatalf("%s not flagged: %+v", code, res.Issues)
+		}
+		if issue.Field == "" {
+			t.Errorf("%s has no field", code)
+		}
+		if issue.Suggestion == "" {
+			t.Errorf("%s has no suggestion", code)
+		}
+	}
+}
+
+// The preflight dialog and the campaign feed both print one line about the
+// worst thing in a step's copy, and that line has to say which box to open.
+func TestLeadIssueNamesTheField(t *testing.T) {
+	if got := LeadIssue(Score("FREE CASH PRIZE", "<p>Hi Ada, worth a chat?</p>", "Hi Ada, worth a chat?")); !strings.HasPrefix(got, "Subject: ") {
+		t.Errorf("lead issue = %q, want it to name the subject", got)
+	}
+	if got := LeadIssue(Score("Quick question", "", "Here is a limited time offer.")); !strings.HasPrefix(got, "Body: ") {
+		t.Errorf("lead issue = %q, want it to name the body", got)
+	}
+	if got := LeadIssue(Score("Quick question", "<p>Hi Ada, worth a chat?</p>", "Hi Ada, worth a chat?")); got != "" {
+		t.Errorf("lead issue = %q on clean copy, want nothing", got)
+	}
+}
+
+// A high-severity issue outranks a warning even when the warning came first.
+func TestLeadIssuePrefersTheHighSeverityOne(t *testing.T) {
+	res := ScoreResult{Issues: []Issue{
+		{Severity: "warn", Code: "stacked_punctuation", Message: "Stacked punctuation."},
+		{Severity: "high", Code: "empty_body", Field: FieldBody, Message: "Body has no text content."},
+	}}
+	if got := LeadIssue(res); got != "Body: Body has no text content." {
+		t.Errorf("lead issue = %q, want the high-severity one", got)
 	}
 }

--- a/internal/tasks/content_gate.go
+++ b/internal/tasks/content_gate.go
@@ -46,14 +46,8 @@ func (s *tasksService) warnOnWeakContent(ctx context.Context, orgID, campaignID,
 
 	seq := sequenceID.String()
 	detail := ""
-	for _, issue := range res.Issues {
-		if issue.Severity == "high" {
-			detail = " " + issue.Message
-			break
-		}
-	}
-	if detail == "" && len(res.Issues) > 0 {
-		detail = " " + res.Issues[0].Message
+	if lead := warmlint.LeadIssue(res); lead != "" {
+		detail = " " + lead
 	}
 
 	codes := make([]string, 0, len(res.Issues))

--- a/web/src/app/app/settings/billing/AIUsageCard.tsx
+++ b/web/src/app/app/settings/billing/AIUsageCard.tsx
@@ -29,6 +29,7 @@ const REASON_LABELS: Record<string, string> = {
     research_run: "Contact research",
     automation_ai: "Automation AI",
     campaign_ai: "Campaign switches",
+    spam_analysis: "Spam analysis",
 };
 
 type WindowKey = "day" | "week" | "month";

--- a/web/src/app/app/settings/billing/CreditsCard.tsx
+++ b/web/src/app/app/settings/billing/CreditsCard.tsx
@@ -275,6 +275,8 @@ function describeReason(reason: string): string {
         reply_draft_refund: "Reply draft refund",
         agent_iteration_refund: "AI assistant refund",
         inbox_agent_draft: "Inbox agent",
+        spam_analysis: "Spam analysis",
+        spam_analysis_refund: "Spam analysis refund",
         credit_topup: "Top-up purchase",
         credit_auto_topup: "Auto top-up",
         monthly_reset: "Monthly allowance",

--- a/web/src/components/app/campaigns/ContentScore.tsx
+++ b/web/src/components/app/campaigns/ContentScore.tsx
@@ -1,13 +1,45 @@
-// Advisory campaign-template content check: scores the current subject + body
-// against /templates/score and renders a 0-100 score (higher = safer) plus the
-// non-blocking issues found, re-scored on the debounce the composer's preview
-// uses. It never blocks saving or sending.
+// Advisory campaign-template content check. Two passes over the same copy:
+//
+//   - the rules pass (/templates/score), free and re-run on the debounce the
+//     composer's preview uses. Each issue carries where it is (subject or
+//     body) and the exact fragments that caused it, so the panel points at the
+//     words instead of restating the rule;
+//   - the AI pass (/templates/analyze), on an explicit click because it spends
+//     credits. It quotes the sentence a filter will object to and says what to
+//     write instead, and returns the rules pass with it so both halves of the
+//     panel are scored from one reading of the copy.
+//
+// Re-check re-runs whichever passes are on screen, and the panel keeps the
+// previous AI score so an edit can be measured against it. Neither pass ever
+// blocks saving or sending.
 
 import * as React from "react";
-import { ShieldCheckIcon, AlertTriangleIcon, AlertCircleIcon } from "lucide-react";
+import {
+    AlertCircleIcon,
+    AlertTriangleIcon,
+    ArrowDownIcon,
+    ArrowUpIcon,
+    InfoIcon,
+    RefreshCwIcon,
+    ShieldCheckIcon,
+    SparklesIcon,
+    WandSparklesIcon,
+} from "lucide-react";
+import toast from "react-hot-toast";
 import scoreTemplate from "@/lib/api/client/app/campaigns/scoreTemplate";
+import useAnalyzeTemplate from "@/lib/api/hooks/app/campaigns/useAnalyzeTemplate";
 import type TemplateScore from "@/lib/api/models/app/campaigns/TemplateScore";
-import type { TemplateScoreIssue } from "@/lib/api/models/app/campaigns/TemplateScore";
+import type {
+    SpamFinding,
+    TemplateAnalysis,
+    TemplateField,
+    TemplateScoreIssue,
+    TemplateScoreSpan,
+} from "@/lib/api/models/app/campaigns/TemplateScore";
+import type { AppError } from "@/lib/api/client/normalizeError";
+import buildError from "@/lib/helper/buildError";
+import { usePermission } from "@/hooks/usePermission";
+import useAiMetered from "@/hooks/useAiMetered";
 import { Loading } from "@/components/loader";
 import { cn } from "@/lib/utils";
 import { DitherMeter, type DitherTone } from "@/components/ui/dither";
@@ -18,17 +50,112 @@ function scoreTone(score: number) {
     return { text: "text-rose-600", meter: "rose" as DitherTone, label: "Needs work" };
 }
 
+// One value that changes whenever any part of the copy does, so an analysis
+// can be told apart from the draft it was run against.
+function copyKey(subject: string, bodyHtml: string, bodyPlain: string): string {
+    return [subject, bodyHtml, bodyPlain].join("\u0000");
+}
+
+const FIELD_LABEL: Record<TemplateField, string> = { subject: "Subject", body: "Body" };
+
+// The first thing a writer needs is which box to open.
+function FieldBadge({ field, line }: { field?: TemplateField; line?: number }) {
+    if (!field) return null;
+    return (
+        <span className="shrink-0 inline-flex items-center gap-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-slate-500">
+            {FIELD_LABEL[field]}
+            {field === "body" && !!line && line > 1 && <span className="text-slate-400">line {line}</span>}
+        </span>
+    );
+}
+
+// The offending words, quoted exactly as they are written in the copy.
+function Quoted({ text }: { text: string }) {
+    return (
+        <span className="rounded bg-amber-50 px-1 py-px font-mono text-[11px] text-amber-800 ring-1 ring-amber-200/70">
+            {text}
+        </span>
+    );
+}
+
+function SpanList({ spans }: { spans: TemplateScoreSpan[] }) {
+    if (spans.length === 0) return null;
+    return (
+        <div className="mt-1 flex flex-wrap items-center gap-1">
+            {spans.map((s, i) => (
+                <Quoted key={`${s.field}-${s.text}-${i}`} text={s.text} />
+            ))}
+        </div>
+    );
+}
+
 function IssueRow({ issue }: { issue: TemplateScoreIssue }) {
     const high = issue.severity === "high";
     const Icon = high ? AlertCircleIcon : AlertTriangleIcon;
+    const spans = issue.spans ?? [];
+    const excerpt = spans[0]?.excerpt;
     return (
         <li className="flex items-start gap-2 py-1.5">
             <Icon className={cn("w-3.5 h-3.5 shrink-0 mt-0.5", high ? "text-rose-500" : "text-amber-500")} />
-            <div className="min-w-0">
-                <span className="text-[12px] text-slate-700 leading-relaxed">{issue.message}</span>
-                <span className="ml-1.5 text-[10px] text-slate-400 font-mono">{issue.code}</span>
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <FieldBadge field={issue.field} />
+                    <span className="text-[12px] text-slate-700 leading-relaxed">{issue.message}</span>
+                    <span className="text-[10px] text-slate-400 font-mono">{issue.code}</span>
+                </div>
+                <SpanList spans={spans} />
+                {excerpt && excerpt !== spans[0]?.text && (
+                    <p className="mt-1 truncate text-[11px] italic text-slate-400">{excerpt}</p>
+                )}
+                {issue.suggestion && <p className="mt-1 text-[11.5px] text-slate-500">{issue.suggestion}</p>}
             </div>
         </li>
+    );
+}
+
+const FINDING_ICON = {
+    high: { Icon: AlertCircleIcon, className: "text-rose-500" },
+    warn: { Icon: AlertTriangleIcon, className: "text-amber-500" },
+    info: { Icon: InfoIcon, className: "text-sky-500" },
+} as const;
+
+function FindingRow({ finding }: { finding: SpamFinding }) {
+    const { Icon, className } = FINDING_ICON[finding.severity] ?? FINDING_ICON.warn;
+    return (
+        <li className="flex items-start gap-2 py-1.5">
+            <Icon className={cn("w-3.5 h-3.5 shrink-0 mt-0.5", className)} />
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <FieldBadge field={finding.field} line={finding.line} />
+                    {finding.text && <Quoted text={finding.text} />}
+                </div>
+                <p className="mt-1 text-[12px] leading-relaxed text-slate-700">{finding.issue}</p>
+                {finding.suggestion && (
+                    <p className="mt-1 text-[11.5px] leading-relaxed text-emerald-700">Try: {finding.suggestion}</p>
+                )}
+            </div>
+        </li>
+    );
+}
+
+// Movement since the previous check, which is what makes Re-check worth
+// pressing: it answers whether the edit helped.
+function ScoreDelta({ from, to }: { from: number; to: number }) {
+    const diff = to - from;
+    if (diff === 0) return <span className="text-[11px] text-slate-400">No change since your last check.</span>;
+    const up = diff > 0;
+    const Icon = up ? ArrowUpIcon : ArrowDownIcon;
+    return (
+        <span
+            className={cn(
+                "inline-flex items-center gap-0.5 text-[11px] font-medium",
+                up ? "text-emerald-600" : "text-rose-600",
+            )}
+        >
+            <Icon className="w-3 h-3" />
+            {up ? "+" : ""}
+            {diff} since your last check
+        </span>
     );
 }
 
@@ -36,63 +163,156 @@ export default function ContentScore({
     subject,
     bodyHtml,
     bodyPlain,
+    onApplySubject,
 }: {
     subject: string;
     bodyHtml: string;
     bodyPlain: string;
+    // Lets the suggested subject be applied in one click. Without it the
+    // suggestion still shows, it just has to be copied by hand.
+    onApplySubject?: (subject: string) => void;
 }) {
     const [data, setData] = React.useState<TemplateScore | null>(null);
     const [pending, setPending] = React.useState(false);
     const [failed, setFailed] = React.useState(false);
+    const [analysis, setAnalysis] = React.useState<TemplateAnalysis | null>(null);
+    // The copy the analysis was run against, so the panel can say when it has
+    // gone stale rather than presenting old findings as current.
+    const [analyzedCopy, setAnalyzedCopy] = React.useState("");
+    const [previousAiScore, setPreviousAiScore] = React.useState<number | null>(null);
+    // A deployment with no provider configured answers 503 once; the button
+    // then stays out of the way instead of offering something that cannot run.
+    const [aiUnavailable, setAiUnavailable] = React.useState(false);
+
+    const canAI = usePermission("USE_AI");
+    const metered = useAiMetered();
+    const analyzeMut = useAnalyzeTemplate();
+
+    const empty = !subject.trim() && !bodyPlain.trim();
+    const currentCopy = copyKey(subject, bodyHtml, bodyPlain);
+    const stale = !!analysis && analyzedCopy !== currentCopy;
+
+    // Only the newest rules request may write the panel: a manual Re-check and
+    // a debounced keystroke can be in flight together, and the slower one
+    // landing last would show a score for copy that is no longer there.
+    const runID = React.useRef(0);
+    const runScore = React.useCallback(() => {
+        const id = ++runID.current;
+        setPending(true);
+        scoreTemplate({ subject, body_html: bodyHtml, body_plain: bodyPlain })
+            .then((res) => {
+                if (id !== runID.current) return;
+                setData(res);
+                setFailed(false);
+            })
+            .catch(() => {
+                if (id === runID.current) setFailed(true);
+            })
+            .finally(() => {
+                if (id === runID.current) setPending(false);
+            });
+    }, [bodyHtml, bodyPlain, subject]);
 
     React.useEffect(() => {
         // A step with nothing written yet is not a content problem, so hold the
         // panel quiet rather than scoring an empty draft as spam.
-        if (!subject.trim() && !bodyPlain.trim()) {
-            // Clears pending too: a cancelled request can no longer do it.
+        if (empty) {
+            // Retires any in-flight request too, so its result cannot land.
+            runID.current++;
             setData(null);
             setPending(false);
             setFailed(false);
             return;
         }
-        let cancelled = false;
-        // Set inside the timer so the spinner marks a request, not a keystroke.
-        const t = setTimeout(() => {
-            setPending(true);
-            scoreTemplate({ subject, body_html: bodyHtml, body_plain: bodyPlain })
-                .then((res) => {
-                    if (cancelled) return;
-                    setData(res);
+        // Fired inside the timer so the spinner marks a request, not a keystroke.
+        const t = setTimeout(runScore, 600);
+        return () => clearTimeout(t);
+    }, [empty, runScore]);
+
+    const runAnalysis = React.useCallback(() => {
+        if (empty || analyzeMut.isPending) return;
+        const copy = copyKey(subject, bodyHtml, bodyPlain);
+        analyzeMut.mutate(
+            { subject, body_html: bodyHtml, body_plain: bodyPlain },
+            {
+                onSuccess: (res) => {
+                    // The score being replaced is what the new one is measured
+                    // against, so it is captured before the swap.
+                    setPreviousAiScore(analysis ? analysis.score : null);
+                    setAnalysis(res);
+                    setAnalyzedCopy(copy);
+                    // One request scored both passes; keep them in step, and
+                    // retire any rules request still in flight behind it.
+                    runID.current++;
+                    setData(res.rules);
+                    setPending(false);
                     setFailed(false);
-                })
-                .catch(() => {
-                    if (!cancelled) setFailed(true);
-                })
-                .finally(() => {
-                    if (!cancelled) setPending(false);
-                });
-        }, 600);
-        return () => {
-            cancelled = true;
-            clearTimeout(t);
-        };
-    }, [subject, bodyHtml, bodyPlain]);
+                },
+                onError: (e) => {
+                    const err = e as unknown as AppError;
+                    if (err?.status === 402) {
+                        toast.error("You're out of AI credits. Add more to keep using AI analysis.");
+                    } else if (err?.code === "ai_not_configured") {
+                        // Permanent for this deployment, unlike a provider
+                        // outage, so the button goes away rather than staying
+                        // there to fail again.
+                        setAiUnavailable(true);
+                    } else {
+                        toast.error(buildError(err));
+                    }
+                },
+            },
+        );
+    }, [analysis, analyzeMut, bodyHtml, bodyPlain, empty, subject]);
+
+    // Re-check runs everything currently on screen: the rules pass always, and
+    // the AI pass too once the writer has asked for one.
+    const aiInPlay = !!analysis && canAI && !aiUnavailable;
+    const recheck = React.useCallback(() => {
+        if (empty) return;
+        if (aiInPlay) {
+            runAnalysis();
+            return;
+        }
+        runScore();
+    }, [aiInPlay, empty, runAnalysis, runScore]);
 
     const tone = data ? scoreTone(data.score) : null;
+    const aiTone = analysis ? scoreTone(analysis.score) : null;
+    const busy = pending || analyzeMut.isPending;
+    const suggestedSubject = analysis?.suggested_subject?.trim();
 
     return (
         <div className="rounded-md border border-slate-200 bg-white">
             <div className="flex items-center justify-between gap-3 px-3 py-2.5">
                 <div className="min-w-0">
                     <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">Content check</div>
-                    <p className="mt-0.5 text-[11px] text-slate-400 leading-relaxed">Advisory deliverability score. It never blocks sending.</p>
+                    <p className="mt-0.5 text-[11px] text-slate-400 leading-relaxed">
+                        Advisory deliverability score. It never blocks sending.
+                    </p>
                 </div>
-                {pending && <Loading className="!w-3.5 h-3.5 shrink-0" />}
+                <div className="flex shrink-0 items-center gap-1.5">
+                    {busy && <Loading className="!w-3.5 h-3.5 shrink-0" />}
+                    <button
+                        type="button"
+                        onClick={recheck}
+                        disabled={empty || busy}
+                        title={empty ? "Write a subject or body first" : "Score this copy again"}
+                        className={cn(
+                            "h-7 px-2 inline-flex items-center gap-1.5 rounded-md border text-[11.5px] font-medium transition-colors",
+                            "disabled:opacity-40 disabled:cursor-not-allowed",
+                            stale
+                                ? "border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100"
+                                : "border-slate-200 text-slate-600 hover:bg-slate-50",
+                        )}
+                    >
+                        <RefreshCwIcon className={cn("w-3.5 h-3.5", busy && "animate-spin")} />
+                        {aiInPlay ? "Re-check with AI" : "Re-check"}
+                    </button>
+                </div>
             </div>
 
-            {failed && (
-                <div className="px-3 pb-3 text-[11.5px] text-rose-600">Couldn&apos;t score this template.</div>
-            )}
+            {failed && <div className="px-3 pb-3 text-[11.5px] text-rose-600">Couldn&apos;t score this template.</div>}
 
             {data && tone && (
                 <div className="px-3 pb-3 border-t border-slate-200/60 pt-3">
@@ -116,6 +336,124 @@ export default function ContentScore({
                     ) : (
                         <p className="mt-2 inline-flex items-center gap-1.5 text-[11.5px] text-emerald-600">
                             <ShieldCheckIcon className="w-3.5 h-3.5" /> No content issues found.
+                        </p>
+                    )}
+                </div>
+            )}
+
+            {canAI && !aiUnavailable && !analysis && (
+                <div className="border-t border-slate-200/60 px-3 py-2.5">
+                    <button
+                        type="button"
+                        onClick={runAnalysis}
+                        disabled={empty || analyzeMut.isPending}
+                        className="w-full h-7 inline-flex items-center justify-center gap-1.5 rounded-md border border-slate-200 text-[11.5px] font-medium text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                        <SparklesIcon className="w-3.5 h-3.5 text-sky-500" />
+                        Analyze with AI
+                        {metered && <span className="text-slate-400">2 credits</span>}
+                    </button>
+                    <p className="mt-1.5 text-[11px] leading-relaxed text-slate-400">
+                        Reads the copy and names the words and sentences that hurt deliverability, in the subject and in
+                        the body.
+                    </p>
+                </div>
+            )}
+
+            {aiUnavailable && !analysis && (
+                <div className="border-t border-slate-200/60 px-3 py-2.5 text-[11.5px] text-slate-500">
+                    AI analysis is not configured on this deployment.
+                </div>
+            )}
+
+            {analysis && aiTone && (
+                <div className="border-t border-slate-200/60 px-3 py-3">
+                    <div className="flex items-center gap-1.5">
+                        <SparklesIcon className="w-3.5 h-3.5 text-sky-500" />
+                        <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">AI analysis</span>
+                        <span className="ml-auto truncate text-[10px] font-mono text-slate-300">{analysis.model}</span>
+                    </div>
+
+                    <div className="mt-2 flex items-center gap-2">
+                        <span className={cn("text-[22px] font-light leading-none tabular-nums", aiTone.text)}>
+                            {analysis.score}
+                        </span>
+                        <span className="text-[11px] text-slate-400 mb-0.5">/ 100</span>
+                        <span className={cn("ml-auto text-[11px] font-medium", aiTone.text)}>{aiTone.label}</span>
+                    </div>
+                    <DitherMeter
+                        frac={Math.max(0, Math.min(100, analysis.score)) / 100}
+                        tone={aiTone.meter}
+                        height={6}
+                        className="mt-2"
+                    />
+                    {previousAiScore !== null && (
+                        <div className="mt-1.5">
+                            <ScoreDelta from={previousAiScore} to={analysis.score} />
+                        </div>
+                    )}
+
+                    {stale && (
+                        <p className="mt-2 text-[11.5px] text-sky-700">
+                            You&apos;ve edited the copy since this analysis. Re-check to score the new version.
+                        </p>
+                    )}
+
+                    {analysis.verdict && (
+                        <p className="mt-2 text-[12px] leading-relaxed text-slate-600">{analysis.verdict}</p>
+                    )}
+
+                    {analysis.findings.length > 0 ? (
+                        <ul className="mt-1.5 divide-y divide-slate-200/60">
+                            {analysis.findings.map((finding, i) => (
+                                <FindingRow key={`${finding.field}-${finding.text ?? ""}-${i}`} finding={finding} />
+                            ))}
+                        </ul>
+                    ) : (
+                        <p className="mt-2 inline-flex items-center gap-1.5 text-[11.5px] text-emerald-600">
+                            <ShieldCheckIcon className="w-3.5 h-3.5" /> Nothing in this copy stood out as spammy.
+                        </p>
+                    )}
+
+                    {suggestedSubject && suggestedSubject !== subject.trim() && (
+                        <div className="mt-2 rounded-md border border-slate-200 bg-slate-50/60 p-2">
+                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                                Suggested subject
+                            </div>
+                            <p className="mt-1 text-[12px] leading-relaxed text-slate-700">{suggestedSubject}</p>
+                            {onApplySubject && (
+                                <button
+                                    type="button"
+                                    onClick={() => onApplySubject(suggestedSubject)}
+                                    className="mt-1.5 h-7 px-2 inline-flex items-center gap-1.5 rounded-md border border-slate-200 bg-white text-[11.5px] font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                                >
+                                    <WandSparklesIcon className="w-3.5 h-3.5 text-sky-500" />
+                                    Use this subject
+                                </button>
+                            )}
+                        </div>
+                    )}
+
+                    {(analysis.improvements?.length ?? 0) > 0 && (
+                        <div className="mt-2">
+                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400 font-medium">
+                                Also worth doing
+                            </div>
+                            <ul className="mt-1 space-y-1">
+                                {analysis.improvements!.map((tip, i) => (
+                                    <li key={i} className="flex items-start gap-1.5 text-[11.5px] leading-relaxed text-slate-600">
+                                        <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-slate-300" />
+                                        {tip}
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+
+                    {metered && analysis.credits_charged > 0 && (
+                        <p className="mt-2 text-[10.5px] text-slate-400">
+                            {analysis.credits_charged} credit{analysis.credits_charged === 1 ? "" : "s"} spent,{" "}
+                            {analysis.credits_remaining} left
                         </p>
                     )}
                 </div>

--- a/web/src/components/app/campaigns/ContentScore.tsx
+++ b/web/src/components/app/campaigns/ContentScore.tsx
@@ -211,6 +211,11 @@ export default function ContentScore({
     // a debounced keystroke can be in flight together, and the slower one
     // landing last would show a score for copy that is no longer there.
     const runID = React.useRef(0);
+    // What is in the editor right now, readable from a callback that closed
+    // over an older draft. An analysis takes seconds, and the writer can edit
+    // while it runs.
+    const latestCopy = React.useRef(currentCopy);
+    latestCopy.current = currentCopy;
     const runScore = React.useCallback(() => {
         const id = ++runID.current;
         setPending(true);
@@ -256,12 +261,19 @@ export default function ContentScore({
                     setPreviousAiScore(analysis ? analysis.score : null);
                     setAnalysis(res);
                     setAnalyzedCopy(copy);
-                    // One request scored both passes; keep them in step, and
-                    // retire any rules request still in flight behind it.
-                    runID.current++;
-                    setData(res.rules);
-                    setPending(false);
-                    setFailed(false);
+                    // One request scored both passes, so the rules half comes
+                    // free with it. Only while the draft has not moved on: the
+                    // writer can edit during an analysis, and adopting the old
+                    // rules score would both show the wrong number and retire
+                    // the newer request that was about to produce the right
+                    // one, leaving nothing to retry it. The analysis itself is
+                    // still kept, and the panel marks it stale.
+                    if (copy === latestCopy.current) {
+                        runID.current++;
+                        setData(res.rules);
+                        setPending(false);
+                        setFailed(false);
+                    }
                 },
                 onError: (e) => {
                     const err = e as unknown as AppError;

--- a/web/src/components/app/campaigns/ContentScore.tsx
+++ b/web/src/components/app/campaigns/ContentScore.tsx
@@ -59,14 +59,23 @@ function copyKey(subject: string, bodyHtml: string, bodyPlain: string): string {
 const FIELD_LABEL: Record<TemplateField, string> = { subject: "Subject", body: "Body" };
 
 // The first thing a writer needs is which box to open.
-function FieldBadge({ field, line }: { field?: TemplateField; line?: number }) {
-    if (!field) return null;
+function FieldBadge({ field, line, label }: { field?: TemplateField; line?: number; label?: string }) {
+    const text = label ?? (field ? FIELD_LABEL[field] : "");
+    if (!text) return null;
     return (
         <span className="shrink-0 inline-flex items-center gap-1 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] text-slate-500">
-            {FIELD_LABEL[field]}
+            {text}
             {field === "body" && !!line && line > 1 && <span className="text-slate-400">line {line}</span>}
         </span>
     );
+}
+
+// An issue with no single field but fragments in both halves is in both, and
+// saying so beats saying nothing on the one panel that exists to say where.
+function issueFieldLabel(issue: TemplateScoreIssue): string | undefined {
+    if (issue.field) return FIELD_LABEL[issue.field];
+    const fields = new Set((issue.spans ?? []).map((s) => s.field));
+    return fields.size > 1 ? "Subject and body" : undefined;
 }
 
 // The offending words, quoted exactly as they are written in the copy.
@@ -80,10 +89,16 @@ function Quoted({ text }: { text: string }) {
 
 function SpanList({ spans }: { spans: TemplateScoreSpan[] }) {
     if (spans.length === 0) return null;
+    // Only when they straddle: repeating "body" on every chip of a body-only
+    // issue is noise the badge above already carries.
+    const mixed = new Set(spans.map((s) => s.field)).size > 1;
     return (
         <div className="mt-1 flex flex-wrap items-center gap-1">
             {spans.map((s, i) => (
-                <Quoted key={`${s.field}-${s.text}-${i}`} text={s.text} />
+                <span key={`${s.field}-${s.text}-${i}`} className="inline-flex items-center gap-1">
+                    {mixed && <span className="text-[10px] uppercase tracking-[0.08em] text-slate-400">{FIELD_LABEL[s.field]}</span>}
+                    <Quoted text={s.text} />
+                </span>
             ))}
         </div>
     );
@@ -99,7 +114,7 @@ function IssueRow({ issue }: { issue: TemplateScoreIssue }) {
             <Icon className={cn("w-3.5 h-3.5 shrink-0 mt-0.5", high ? "text-rose-500" : "text-amber-500")} />
             <div className="min-w-0 flex-1">
                 <div className="flex flex-wrap items-center gap-1.5">
-                    <FieldBadge field={issue.field} />
+                    <FieldBadge field={issue.field} label={issueFieldLabel(issue)} />
                     <span className="text-[12px] text-slate-700 leading-relaxed">{issue.message}</span>
                     <span className="text-[10px] text-slate-400 font-mono">{issue.code}</span>
                 </div>

--- a/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
+++ b/web/src/components/app/campaigns/sequences/EmailContentEditor.tsx
@@ -405,7 +405,12 @@ export default function EmailContentEditor({
                 )}
             </div>
 
-            <ContentScore subject={subject} bodyHtml={bodyHtml} bodyPlain={htmlToPlain(bodyHtml)} />
+            <ContentScore
+                subject={subject}
+                bodyHtml={bodyHtml}
+                bodyPlain={htmlToPlain(bodyHtml)}
+                onApplySubject={onSubjectChange}
+            />
         </div>
     );
 }

--- a/web/src/lib/api/client/app/campaigns/analyzeTemplate.ts
+++ b/web/src/lib/api/client/app/campaigns/analyzeTemplate.ts
@@ -1,0 +1,19 @@
+import type {
+    ScoreTemplateRequest,
+    TemplateAnalysis,
+} from "@/lib/api/models/app/campaigns/TemplateScore";
+import Request from "../../Request";
+
+// AI spam analysis of a campaign template: the rules score plus the specific
+// words and sentences a filter objects to, where they are, and what to write
+// instead. Spends AI credits, so it only ever runs on an explicit click.
+export default async function analyzeTemplate(
+    body: ScoreTemplateRequest,
+): Promise<TemplateAnalysis> {
+    return await Request<TemplateAnalysis>({
+        method: "POST",
+        url: "/templates/analyze",
+        data: body,
+        authorization: true,
+    });
+}

--- a/web/src/lib/api/hooks/app/campaigns/useAnalyzeTemplate.ts
+++ b/web/src/lib/api/hooks/app/campaigns/useAnalyzeTemplate.ts
@@ -1,0 +1,17 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import analyzeTemplate from "@/lib/api/client/app/campaigns/analyzeTemplate";
+import type { ScoreTemplateRequest } from "@/lib/api/models/app/campaigns/TemplateScore";
+
+// On-demand AI spam analysis. A mutation, not a query: it costs credits and
+// only ever runs when the writer asks for it (Analyze, then Re-check after an
+// edit). Every success refreshes the credits views so the header meter moves
+// immediately.
+export default function useAnalyzeTemplate() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (body: ScoreTemplateRequest) => analyzeTemplate(body),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: ["subscription", "credits"] });
+        },
+    });
+}

--- a/web/src/lib/api/models/app/campaigns/TemplateScore.ts
+++ b/web/src/lib/api/models/app/campaigns/TemplateScore.ts
@@ -1,10 +1,30 @@
 // Result of POST /templates/score — an advisory content-quality score for a
 // campaign template. Higher score = safer; issues are non-blocking hints to
 // improve deliverability (the score never prevents saving or sending).
+
+// Which half of the template a finding sits in.
+export type TemplateField = "subject" | "body";
+
+// One exact fragment that triggered an issue, so the editor can point at the
+// words instead of restating the rule.
+export interface TemplateScoreSpan {
+    field: TemplateField;
+    /** The fragment as it is written in the copy. */
+    text: string;
+    /** 1-based line within that field. */
+    line?: number;
+    /** The whole line, for context around the fragment. */
+    excerpt?: string;
+}
+
 export interface TemplateScoreIssue {
     severity: "warn" | "high";
     code: string;
     message: string;
+    /** Set when the issue lives in exactly one half of the template. */
+    field?: TemplateField;
+    spans?: TemplateScoreSpan[];
+    suggestion?: string;
 }
 
 export default interface TemplateScore {
@@ -12,9 +32,39 @@ export default interface TemplateScore {
     issues: TemplateScoreIssue[];
 }
 
-// Body for POST /templates/score.
+// Body for POST /templates/score and POST /templates/analyze.
 export interface ScoreTemplateRequest {
     subject: string;
     body_html: string;
     body_plain: string;
+}
+
+// One located problem the AI analysis found in the copy.
+export interface SpamFinding {
+    severity: "high" | "warn" | "info";
+    field: TemplateField;
+    /** The exact fragment quoted from the copy, absent when the finding is
+     *  about the email as a whole. Verified server-side against the template,
+     *  so it is never a sentence the writer did not write. */
+    text?: string;
+    line?: number;
+    excerpt?: string;
+    issue: string;
+    suggestion?: string;
+    category?: string;
+}
+
+// Result of POST /templates/analyze — the AI half of the content check.
+export interface TemplateAnalysis {
+    score: number;
+    verdict: string;
+    findings: SpamFinding[];
+    suggested_subject?: string;
+    improvements?: string[];
+    /** The rules pass, scored from the same copy in the same request. */
+    rules: TemplateScore;
+    model: string;
+    tokens_used: number;
+    credits_remaining: number;
+    credits_charged: number;
 }

--- a/web/src/lib/api/models/app/campaigns/TemplateScore.ts
+++ b/web/src/lib/api/models/app/campaigns/TemplateScore.ts
@@ -42,7 +42,10 @@ export interface ScoreTemplateRequest {
 // One located problem the AI analysis found in the copy.
 export interface SpamFinding {
     severity: "high" | "warn" | "info";
-    field: TemplateField;
+    /** Absent when the model labelled neither half and nothing in the finding
+     *  could be anchored in the copy, so no badge is shown rather than one
+     *  naming the wrong box. */
+    field?: TemplateField;
     /** The exact fragment quoted from the copy, absent when the finding is
      *  about the email as a whole. Verified server-side against the template,
      *  so it is never a sentence the writer did not write. */


### PR DESCRIPTION
Closes #421.

The spam checker scored copy but never said **what** in it was wrong. "3 spam-trigger term(s) found in subject/body" left the writer to hunt through their own email for words the checker had already found, and never said whether to look in the subject or the body. And it only ever ran rules, so it had nothing to say about a sentence that reads like an ad without containing a single word on a list.

## Located issues

`warmlint.Issue` now carries where it is and what caused it:

- `field` is `subject` or `body`, absent when the issue straddles both or describes the send as a whole
- `spans` are the exact fragments as the writer typed them, each with the 1-based line within that field and the whole line for context
- `suggestion` is the fix in one sentence

The editor renders a `Subject` / `Body line 3` badge, the offending words highlighted, the line they sit in, and the fix. The launch dialog and the campaign activity feed print the same lead issue prefixed `Subject:` or `Body:`, through a new shared `warmlint.LeadIssue` that replaces the same selection logic duplicated in two callers.

**The arithmetic is unchanged.** The per-field scan produces exactly the same distinct-term count as the old joined scan (neither a phrase nor a URL nor a punctuation run can cross the `\n` the two halves were joined with), the link count is taken before the display cap, and a span that cannot be quoted is dropped rather than shown as an empty highlight. Every existing test passes untouched.

## AI analysis

`POST /templates/analyze` runs the deployment's configured provider over the template and returns an overall score, a verdict, located findings (severity, field, the quoted fragment, why it hurts, what to write instead, category), a rewritten subject that applies in one click, and copy-level improvements. The rules pass runs in the same request and comes back under `rules`, so the two halves of the panel are scored from one reading of the copy rather than two drafts a keystroke apart.

Two decisions worth reviewing:

- **Every quote is verified against the submitted copy.** A fragment the model invented loses the quote and keeps only its advice; a quote found in the other half has its `field` corrected. A panel that points at a sentence the writer did not write is worse than one that points at nothing. Long quotes are cut without an ellipsis for the same reason: an appended `…` is never in the copy, so every long quote would silently fail verification.
- **The run is deterministic.** Re-check exists to answer "did my edit help?", and a sampled score moves on copy nobody touched.

A response with no score, no verdict and no findings fails the call, which refunds the credit, rather than rendering as a confident 100/100 on copy nothing actually read.

Metered like every other AI endpoint: `CanUseWritingAssistant` gate, `use_ai` permission on top of `view_campaigns`, `credits.CostSpamAnalysis` (2) reserved before the provider call, refunded on failure, real token usage settled after, `Idempotency-Key` honored. "No provider configured" returns a distinct `ai_not_configured` code so the editor can hide the button for a permanent condition without hiding it for a provider having a bad minute.

## Re-check

In the panel header. It re-scores on the spot instead of waiting for the debounce, and once an AI analysis exists it re-runs that too, reporting the movement: `+14 since your last check`. When the draft has moved on from the analysis on screen, the panel says so and highlights the button rather than presenting stale findings as current.

## Tests

24 new tests. `warmlint`: field and line attribution in each half, a term written in both halves counted once and shown where it appears first, the excerpt keeping the link the trigger pass strips, spans capped without moving the score, `LeadIssue` severity preference. `spamcheck`: quote anchoring, invented quotes dropped, wrong fields corrected, case-insensitive matching, severity ordering, fenced JSON, bounds, and `Analyze` end to end through a stub provider (prompt grounding, pinned temperature, truncation, unreadable-response refusal).

## Docs

`guides/campaigns.mdx` (located issues, Analyze with AI, Re-check), `guides/ai-credits.mdx` (cost row), `api/endpoints.mdx` (scope row), `api/reference/deliverability-ops.mdx` (the located score shape and the full new endpoint), `api/error-codes.mdx` (`ai_not_configured`), `docs/public/openapi.json` (path plus `TemplateScoreSpan`, `SpamFinding`, `TemplateAnalysis`), and `warmbly template analyze` in the CLI spec beside `score`.

## Verification

`gofmt -l` clean, `make lint` green, new and existing tests pass, `pnpm typecheck` and `pnpm lint` clean in `web/` and `docs/`.

One thing to know: the live provider path is unverified from here. `spamcheck` is covered end to end through a stub provider, but the first real completion has not been made against an actual model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AI-powered campaign content analysis with deliverability scores, findings, suggested subject lines, and improvement tips.
  - Added one-click application of suggested subject lines.
  - Added Re-check support with score comparisons and stale-result detection.
  - Added detailed issue locations, excerpts, and suggestions for content checks.

- **Billing**
  - AI spam analysis usage and credit charges are now shown in billing views.

- **Documentation**
  - Added API reference, permissions, error handling, and credit-cost documentation for AI analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->