### PR TITLE
fix: the tracking service panics on its first TLS connection

### DIFF
--- a/tracking/Cargo.lock
+++ b/tracking/Cargo.lock
@@ -3967,6 +3967,7 @@ dependencies = [
  "moka",
  "rdkafka",
  "reqwest 0.11.27",
+ "rustls 0.23.36",
  "schema_registry_converter",
  "sentry",
  "serde",

--- a/tracking/Cargo.toml
+++ b/tracking/Cargo.toml
@@ -18,6 +18,12 @@ aws-sdk-secretsmanager = "1.15"
 # NATS (default event bus): pure-Rust, no native librdkafka to compile.
 async-nats = "0.38"
 
+# rustls 0.23 refuses to pick a provider when both aws-lc-rs and ring are in
+# the tree, and both are: it panics on the first TLS connection rather than at
+# startup. Named here so main can install one explicitly. ring, because it
+# needs no C toolchain on the musl builder.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+
 # Kafka with Avro (optional; enabled with `--features kafka`). rdkafka is the
 # only native/librdkafka dependency, so the default build compiles far faster
 # and needs no libcurl/libsasl system headers.

--- a/tracking/src/main.rs
+++ b/tracking/src/main.rs
@@ -77,6 +77,13 @@ async fn connect_producer(config: &Config) -> Producer {
 
 #[tokio::main]
 async fn main() {
+    // Before any TLS connection. rustls 0.23 cannot choose between aws-lc-rs
+    // and ring when both are in the tree, and panics at the first handshake:
+    // a tls:// bus or a rediss:// cache takes the whole service down at
+    // startup, which plaintext local development never reveals.
+    // Ignored rather than unwrapped: a second install is not a failure.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Initialize tracing
     tracing_subscriber::registry()
         .with(


### PR DESCRIPTION
Deploying the tracking service against a `tls://` bus crashes it at startup:

```
thread 'main' panicked at rustls-0.23.36/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls
crate features. Call CryptoProvider::install_default() before this point to
select a provider manually, or make sure exactly one of the 'aws-lc-rs' and
'ring' features is enabled.
```

Both providers are in the tree — `Cargo.lock` carries `aws-lc-rs 1.17.0` and `ring 0.17.14`, pulled in by different dependencies — so rustls cannot pick one and panics at the first handshake rather than at startup.

The service therefore cannot open **any** TLS connection: not a `tls://` NATS bus, not a `rediss://` cache, not an HTTPS internal API call over a TLS-terminating proxy.

## Why nobody saw it

Local development and the shipped compose file both use plaintext `nats://`. The panic only fires when a TLS connection is actually attempted, so every test, every local run and every CI job passed while the service was unable to do TLS at all.

Found by deploying it, not by review.

## The fix

`rustls::crypto::ring::default_provider().install_default()` as the first statement in `main`, before tracing or config, so nothing can attempt a handshake first.

`ring` rather than `aws-lc-rs`: the builder is `rust:1.93-alpine`, and ring needs no C toolchain on musl.

The result is ignored rather than unwrapped — a second install is not a failure, and panicking on it would reintroduce the class of bug being fixed.

## Verification

`cargo check`, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all clean.

Worth being explicit about the limit: the compiler guards the *dependency*, since `main` now references `rustls::crypto::ring`, but nothing guards the `install_default()` call itself. Deleting that line still compiles and still passes every test, and the service would again only fail when it meets real TLS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS connection reliability when using secure bus or cache connections.
  * Prevented connection-handshake failures in environments with multiple cryptographic providers configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->