### PR TITLE
fix: sslmode=verify-full against RDS could never have worked

### DIFF
--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -53,6 +53,17 @@ RUN apk add --no-cache ca-certificates tzdata postgresql-client && \
 # with "mkdir /data/blobs/emails: permission denied".
 RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
 
+# Amazon RDS presents a chain rooted in an RDS CA that is in no public trust
+# store, so sslmode=verify-full cannot work against it from the system bundle
+# alone. Shipping AWS's truststore makes verification possible for operators who
+# opt in with sslrootcert=/etc/ssl/rds/global-bundle.pem; nothing here changes
+# the default, because pointing every install at an RDS-only store would break
+# a Postgres fronted by a public CA.
+RUN mkdir -p /etc/ssl/rds && \
+    wget -qO /etc/ssl/rds/global-bundle.pem \
+      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && \
+    chmod 0644 /etc/ssl/rds/global-bundle.pem
+
 COPY --from=builder /out/backend /app/backend
 COPY --from=builder /out/seed /app/seed
 COPY --from=builder /out/migrate /app/migrate

--- a/deploy/docker/consumer.Dockerfile
+++ b/deploy/docker/consumer.Dockerfile
@@ -38,6 +38,17 @@ RUN apk add --no-cache ca-certificates tzdata && \
 # with "mkdir /data/blobs/emails: permission denied".
 RUN mkdir -p /data/blobs && chown -R warmbly:warmbly /data
 
+# Amazon RDS presents a chain rooted in an RDS CA that is in no public trust
+# store, so sslmode=verify-full cannot work against it from the system bundle
+# alone. Shipping AWS's truststore makes verification possible for operators who
+# opt in with sslrootcert=/etc/ssl/rds/global-bundle.pem; nothing here changes
+# the default, because pointing every install at an RDS-only store would break
+# a Postgres fronted by a public CA.
+RUN mkdir -p /etc/ssl/rds && \
+    wget -qO /etc/ssl/rds/global-bundle.pem \
+      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && \
+    chmod 0644 /etc/ssl/rds/global-bundle.pem
+
 COPY --from=builder /out/consumer /app/consumer
 
 USER warmbly

--- a/deploy/split-cloud/control-plane.env.example
+++ b/deploy/split-cloud/control-plane.env.example
@@ -11,7 +11,9 @@ DEPLOYMENT_MODE=self_hosted
 
 # --- data -------------------------------------------------------------------
 # Reached across the internet, so TLS is verified rather than merely offered.
-PRIMARY_DB=postgres://warmbly:<password>@db.eu-central-1.rds.amazonaws.com:5432/warmbly?sslmode=verify-full
+# RDS chains to a root in no public trust store, so verification needs AWS's
+# bundle, which the backend and consumer images ship at the path below.
+PRIMARY_DB=postgres://warmbly:<password>@db.us-east-1.rds.amazonaws.com:5432/warmbly?sslmode=verify-full&sslrootcert=/etc/ssl/rds/global-bundle.pem
 REDIS=rediss://:<password>@bus.example.com:6380
 
 # --- event bus --------------------------------------------------------------

--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -293,6 +293,7 @@ On `filesystem`, a remote worker writes blobs to its own disk rather than a volu
 | Variable | What it does | Default | Restart needed |
 |---|---|---|---|
 | `PRIMARY_DB` | PostgreSQL connection string. Carries inline credentials, so it is never returned by any API | the compose postgres | yes |
+| `PGSSLROOTCERT` | Certificate bundle used to verify the database's TLS certificate, read by the Postgres driver. Amazon RDS chains to a root in no public trust store, so `sslmode=verify-full` against it needs AWS's bundle; the backend and consumer images ship it at `/etc/ssl/rds/global-bundle.pem`. Prefer `sslrootcert=` in the DSN so the setting travels with the connection it applies to | unset (system trust store) | yes |
 | `DATABASE_URL` | The realtime service's own name for the same database | the compose postgres | yes |
 | `DATABASE_POOL_SIZE` | Maximum pooled connections **for the realtime service only**. The Go services use the driver default and do not read it | `10` | yes |
 | `DATABASE_SSL` | Whether the realtime service connects to Postgres over TLS | `true`, and `false` under compose | yes |

--- a/docs/content/docs/development/split-deployment.mdx
+++ b/docs/content/docs/development/split-deployment.mdx
@@ -42,6 +42,12 @@ The backend reaches Postgres and Redis on every request, so the round trips betw
 
 ## Two things that are not optional
 
+<Callout title="RDS needs AWS's certificate bundle">
+Amazon RDS presents a chain rooted in an RDS CA that is in no public trust store, so `sslmode=verify-full` fails with `x509: certificate signed by unknown authority` against the system bundle alone. The backend and consumer images ship AWS's truststore at `/etc/ssl/rds/global-bundle.pem`; point `sslrootcert` at it, as above.
+
+`sslmode=require` is the fallback if you cannot. It still encrypts, and `rds.force_ssl=1` still forces TLS server side, but nothing verifies the server's identity, so a caller that reaches the wrong host will not notice.
+</Callout>
+
 <Callout type="warn" title="Redis has to be TLS here">
 The cache holds each organization's decrypted data key for the life of its entry. A plaintext connection across the internet publishes key material, and a password does not change that. On one machine the loopback bind was the protection; once the control plane is somewhere else, TLS is.
 </Callout>
@@ -125,7 +131,7 @@ The renewal hook is the part that matters after day one. Neither service re-read
 `deploy/split-cloud/control-plane.env.example` is every setting, annotated. The ones that decide whether a fleet can exist at all:
 
 ```bash
-PRIMARY_DB=postgres://warmbly:...@db.eu-central-1.rds.amazonaws.com:5432/warmbly?sslmode=verify-full
+PRIMARY_DB=postgres://warmbly:...@db.us-east-1.rds.amazonaws.com:5432/warmbly?sslmode=verify-full&sslrootcert=/etc/ssl/rds/global-bundle.pem
 REDIS=rediss://:<password>@bus.example.com:6380
 NATS_URL=tls://<token>@bus.example.com:4222
 ENCRYPTED_KEYS_BACKEND_URL=https://api.example.com


### PR DESCRIPTION
The split-deployment docs tell operators to connect to Amazon RDS with `sslmode=verify-full`. That fails every time:

```
failed to open database: tls: failed to verify certificate:
x509: certificate signed by unknown authority
```

Checked against a real instance rather than assumed:

```
subject= CN=<instance>.us-east-1.rds.amazonaws.com, OU=RDS, O=Amazon.com
issuer=  CN=Amazon RDS us-east-1 Subordinate CA RSA2048 G1, O=Amazon Web Services
Verify return code: 19 (self-signed certificate in certificate chain)
```

RDS chains to an Amazon RDS root that is **not** in any public trust store. The system bundle in the image cannot verify it, so the documented configuration crash-loops the backend on its first migration.

## The fix

The backend and consumer images now ship AWS's global truststore at `/etc/ssl/rds/global-bundle.pem`, and the docs point `sslrootcert` at it:

```
PRIMARY_DB=postgres://...?sslmode=verify-full&sslrootcert=/etc/ssl/rds/global-bundle.pem
```

**`PGSSLROOTCERT` is deliberately not set as an image default.** Doing so would replace the trust store for every deployment, and a self-hoster whose Postgres is fronted by a public CA would then fail to verify a certificate that was previously fine. Shipping the file and letting the DSN opt in keeps the change additive.

Only backend and consumer: workers reach relational data through the internal API and open no database connection.

## Docs

`split-deployment.mdx`, `configuration.mdx` and `control-plane.env.example` all carried the broken DSN. Each is corrected, with a callout explaining why RDS is different and what `sslmode=require` costs you if you fall back to it (it encrypts, but nothing verifies the server's identity).

## Verification

`make lint` green including `check-dockerfiles`; `pnpm types:check` clean in `docs/`.

The certificate chain above is from the live instance this was found on, not from documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Backend and consumer images now include the Amazon RDS global CA bundle, enabling optional full TLS certificate verification for RDS connections.

- **Documentation**
  - Added configuration guidance for `PGSSLROOTCERT` and RDS certificate verification.
  - Updated split-deployment guidance and example connection settings with the bundled certificate path, `sslmode=verify-full`, and fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->