### PR TITLE
fix: the tracking service must not write Avro to a JSON consumer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,8 +348,15 @@ jobs:
       # kafka.rs. That file ships as the published tracking:*-kafka image, so a
       # break in it would otherwise surface at release time rather than here.
       # This is the Rust half of the `go build -tags kafka` step above.
+      # The Debian equivalents of what tracking/Dockerfile installs on alpine
+      # for this build. libcurl is needed even though rdkafka-sys configures
+      # with -DWITH_CURL=0: librdkafka's rdkafka_conf.c includes curl/curl.h
+      # unconditionally, so the build fails at the first object without it.
       - name: Install librdkafka build dependencies
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake libsasl2-dev libssl-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake pkg-config libssl-dev libcurl4-openssl-dev libsasl2-dev zlib1g-dev
 
       - name: Run Clippy (kafka feature)
         run: cargo clippy --features kafka --all-targets -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,17 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      # The Kafka publisher is behind a cargo feature, so none of the steps
+      # above compile it: `cargo clippy` on the default build never opens
+      # kafka.rs. That file ships as the published tracking:*-kafka image, so a
+      # break in it would otherwise surface at release time rather than here.
+      # This is the Rust half of the `go build -tags kafka` step above.
+      - name: Install librdkafka build dependencies
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends cmake libsasl2-dev libssl-dev
+
+      - name: Run Clippy (kafka feature)
+        run: cargo clippy --features kafka --all-targets -- -D warnings
+
   elixir-ci:
     name: Elixir CI
     needs: changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ Do not:
 
 ## Local Development
 
-Event codec: `CODEC_PROVIDER=json` is required wherever workers are exercised (the worker command/result envelopes carry untyped bodies Avro cannot serialize); the Makefile and docker-compose set it everywhere. `tracking-events` keeps its own Avro path regardless.
+Event codec: `CODEC_PROVIDER=json` is required wherever workers are exercised (the worker command/result envelopes carry untyped bodies Avro cannot serialize); the Makefile and docker-compose set it everywhere. `tracking-events` reads the same setting: the consumer decodes both of its topics with one codec, so the Rust publisher honours `CODEC_PROVIDER` on Kafka as well as on NATS. Avro there needs a Schema Registry and is refused at boot without one; JSON needs nothing.
 
 Infra runs in docker; the Go services and frontends run natively on the host for fast iteration — no docker image rebuilds when you change app code. Targets live in the `Makefile`.
 

--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -569,6 +569,7 @@ The Rust open and click service. It reads its own environment, so these have to 
 | `TRACKING_SCANNER_ASN_HEADER` | Header a trusted proxy sets with the source ASN, which is what makes `asn:` entries match. Read only from a proxy in `TRACKING_TRUSTED_PROXIES`. On Cloudflare, a transform rule writing `ip.src.asnum`. Empty disables ASN matching | empty |
 | `EVENTBUS_PROVIDER` | `nats` or `kafka`. Kafka needs the `tracking:*-kafka` image, or a build with `CARGO_FEATURES=kafka` | `nats` |
 | `NATS_URL`, `NATS_SUBJECT_PREFIX` | JetStream address and subject prefix. The publish subject is `<prefix>.<topic>` | `nats://localhost:4222`, `warmbly` |
+| `CODEC_PROVIDER` | `json` or `avro`, and it has to match the consumer's. `avro` is refused at boot without `SCHEMA_REGISTRY_URL` | `json` |
 | `KAFKA_TRACKING_TOPIC` | Event topic, read by the Rust publisher **and** the Go subscriber | `tracking-events` |
 | `KAFKA_BOOTSTRAP_SERVERS`, `KAFKA_SASL_USERNAME`, `KAFKA_SASL_PASSWORD` | Broker transport when `EVENTBUS_PROVIDER=kafka` | unset |
 | `SCHEMA_REGISTRY_URL`, `SCHEMA_REGISTRY_KEY`, `SCHEMA_REGISTRY_SECRET` | Registry for the Avro codec | unset |

--- a/docs/content/docs/development/events.mdx
+++ b/docs/content/docs/development/events.mdx
@@ -17,7 +17,11 @@ Message encoding is orthogonal to transport, selected by `CODEC_PROVIDER`:
 - `json`: plain JSON, no external dependencies. Required for the self-host stack (the worker command and result envelopes carry untyped bodies Avro cannot serialize).
 - `avro`: Avro with Confluent Schema Registry (`SCHEMA_REGISTRY_URL` plus optional key/secret), also behind the `kafka` build tag. The topic name is used as the Schema Registry subject.
 
-The Rust tracking service follows the same switch: it publishes JSON to JetStream by default, and only speaks Kafka plus Avro when compiled with its `kafka` cargo feature, which is what the `tracking:*-kafka` image is.
+The Rust tracking service follows both switches. It speaks Kafka only when compiled with its `kafka` cargo feature, which is what the `tracking:*-kafka` image is, and it encodes with `CODEC_PROVIDER` on either transport. So a Kafka deployment on `CODEC_PROVIDER=json` needs no Schema Registry at all, and `avro` there is refused at boot without `SCHEMA_REGISTRY_URL` rather than failing at the first published event.
+
+<Callout type="warn" title="One codec covers both topics">
+The consumer decodes `jobs.worker-events` and `tracking-events` with the same `CODEC_PROVIDER`, and worker envelopes cannot be Avro. That makes `json` the only value a working deployment uses, and it is why the tracking publisher has to read the setting rather than always writing Avro: a JSON consumer handed Avro drops every open and click with nothing but a deserialize warning.
+</Callout>
 
 ## Topics
 

--- a/tracking/src/config.rs
+++ b/tracking/src/config.rs
@@ -33,6 +33,12 @@ pub struct Config {
     /// The event topic/subject name (shared by both backends). Default
     /// "tracking-events".
     pub kafka_topic: String,
+    /// Wire format for published events: "json" (default) or "avro". It has to
+    /// match the consumer's CODEC_PROVIDER, which is one setting covering both
+    /// topics it reads, and worker envelopes cannot be Avro. So json is what a
+    /// working deployment uses; avro needs a Schema Registry.
+    #[cfg_attr(not(feature = "kafka"), allow(dead_code))]
+    pub codec_provider: String,
     /// Kafka transport settings (only read by the kafka-feature build).
     #[cfg_attr(not(feature = "kafka"), allow(dead_code))]
     pub kafka_brokers: String,
@@ -134,6 +140,11 @@ impl Config {
         let nats_subject_prefix =
             env::var("NATS_SUBJECT_PREFIX").unwrap_or_else(|_| "warmbly".to_string());
         info!("Event bus provider: {}", eventbus_provider);
+
+        let codec_provider = env::var("CODEC_PROVIDER")
+            .unwrap_or_else(|_| "json".to_string())
+            .to_lowercase();
+        info!("Event codec: {}", codec_provider);
 
         // Event topic/subject name (shared by both backends).
         let kafka_topic = Self::get_optional(
@@ -277,6 +288,7 @@ impl Config {
             host,
             port,
             eventbus_provider,
+            codec_provider,
             nats_url,
             nats_subject_prefix,
             kafka_topic,
@@ -362,6 +374,7 @@ impl Config {
             host,
             port,
             eventbus_provider: "kafka".to_string(),
+            codec_provider: "json".to_string(),
             nats_url: env::var("NATS_URL").unwrap_or_else(|_| "nats://localhost:4222".to_string()),
             nats_subject_prefix: env::var("NATS_SUBJECT_PREFIX")
                 .unwrap_or_else(|_| "warmbly".to_string()),

--- a/tracking/src/events.rs
+++ b/tracking/src/events.rs
@@ -24,3 +24,62 @@ pub struct TrackingEvent {
     /// field existed.
     pub scanner: Option<String>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::TrackingEvent;
+
+    /// The JSON these fields serialize to is the wire format on both buses now:
+    /// NATS has always carried it, and the Kafka path writes it too whenever
+    /// CODEC_PROVIDER is json. The Go consumer decodes it into
+    /// internal/events.TrackingEvent by these exact names, and a rename on
+    /// either side costs every open and click with nothing but a deserialize
+    /// warning, so the names are pinned here.
+    #[test]
+    fn json_field_names_match_the_go_consumer() {
+        let event = TrackingEvent {
+            event_type: "EMAIL_OPENED".to_string(),
+            task_id: "11111111-2222-3333-4444-555555555555".to_string(),
+            original_url: None,
+            link_id: None,
+            timestamp: "2026-09-12T07:00:00Z".to_string(),
+            user_agent: Some("Mozilla/5.0".to_string()),
+            ip_hash: Some("deadbeef".to_string()),
+            client_ip: Some("203.0.113.0".to_string()),
+            scanner: None,
+        };
+
+        let value: serde_json::Value = serde_json::from_slice(
+            &serde_json::to_vec(&event).expect("tracking events must serialize"),
+        )
+        .expect("and the result must be an object");
+
+        let mut got: Vec<&str> = value
+            .as_object()
+            .expect("a tracking event is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        got.sort_unstable();
+
+        let want = [
+            "client_ip",
+            "event_type",
+            "ip_hash",
+            "link_id",
+            "original_url",
+            "scanner",
+            "task_id",
+            "timestamp",
+            "user_agent",
+        ];
+        assert_eq!(
+            got, want,
+            "tracking event JSON keys drifted from the Go side"
+        );
+        assert_eq!(value["event_type"], "EMAIL_OPENED");
+        // Nullable fields travel as null rather than being omitted, which is
+        // what the Go pointer fields decode.
+        assert!(value["original_url"].is_null());
+    }
+}

--- a/tracking/src/kafka.rs
+++ b/tracking/src/kafka.rs
@@ -39,7 +39,11 @@ pub const TRACKING_EVENT_SCHEMA: &str = r#"
 pub struct KafkaProducer {
     producer: Arc<FutureProducer>,
     topic: String,
-    encoder: Arc<RwLock<AvroEncoder<'static>>>,
+    /// Some only under CODEC_PROVIDER=avro. JSON is the default because the Go
+    /// consumer decodes both of its topics with one codec and worker envelopes
+    /// cannot be Avro, so a JSON consumer handed Avro drops every open and
+    /// click with nothing but a deserialize warning.
+    encoder: Option<Arc<RwLock<AvroEncoder<'static>>>>,
 }
 
 /// Avro encoding for the shared TrackingEvent (Kafka path only). The struct
@@ -132,37 +136,45 @@ impl KafkaProducer {
         let producer: FutureProducer = client_config.create()?;
         info!("Kafka producer connected to {}", config.kafka_brokers);
 
-        // Configure Schema Registry
-        let sr_settings = if let Some((key, secret)) = config.schema_registry_auth() {
-            SrSettings::new_builder(config.schema_registry_url.clone())
-                .set_basic_authorization(&key, Some(&secret))
-                .build()?
+        // Schema Registry is only built for the Avro codec. Building it for JSON
+        // would demand a registry URL that a JSON deployment has no reason to
+        // have, and an empty one fails at the first publish rather than at boot.
+        let encoder = if config.codec_provider == "avro" {
+            if config.schema_registry_url.is_empty() {
+                return Err(
+                    "CODEC_PROVIDER=avro needs SCHEMA_REGISTRY_URL; set it, or use CODEC_PROVIDER=json"
+                        .into(),
+                );
+            }
+            let sr_settings = if let Some((key, secret)) = config.schema_registry_auth() {
+                SrSettings::new_builder(config.schema_registry_url.clone())
+                    .set_basic_authorization(&key, Some(&secret))
+                    .build()?
+            } else {
+                SrSettings::new(config.schema_registry_url.clone())
+            };
+            info!(
+                "Schema Registry connected to {}",
+                config.schema_registry_url
+            );
+            Some(Arc::new(RwLock::new(AvroEncoder::new(sr_settings))))
         } else {
-            SrSettings::new(config.schema_registry_url.clone())
+            info!("Publishing tracking events as JSON");
+            None
         };
-
-        let encoder = AvroEncoder::new(sr_settings);
-        info!(
-            "Schema Registry connected to {}",
-            config.schema_registry_url
-        );
 
         Ok(Self {
             producer: Arc::new(producer),
             topic: config.kafka_topic.clone(),
-            encoder: Arc::new(RwLock::new(encoder)),
+            encoder,
         })
     }
 
     pub async fn publish(&self, event: TrackingEvent) {
-        // Serialize event using Avro with Schema Registry
-        let payload = match self.serialize_avro(&event).await {
+        let payload = match self.serialize(&event).await {
             Ok(p) => p,
             Err(e) => {
-                observability::report_issue(
-                    "Failed to serialize tracking event with Avro",
-                    &e.to_string(),
-                );
+                observability::report_issue("Failed to serialize tracking event", &e.to_string());
                 return;
             }
         };
@@ -195,11 +207,16 @@ impl KafkaProducer {
         }
     }
 
-    async fn serialize_avro(
+    /// JSON unless an Avro encoder was built, which is the same bytes the NATS
+    /// path writes, so the Go consumer decodes Kafka and NATS identically.
+    async fn serialize(
         &self,
         event: &TrackingEvent,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
-        let encoder = self.encoder.read().await;
+        let Some(encoder) = &self.encoder else {
+            return Ok(serde_json::to_vec(event)?);
+        };
+        let encoder = encoder.read().await;
 
         // Use schema registry encoder to serialize with proper schema ID prefix
         let payload = encoder


### PR DESCRIPTION
Switching an instance to `EVENTBUS_PROVIDER=kafka` silently stops every open and click from being recorded. Nothing errors; the events just disappear.

Two independent reasons, both in the Kafka path only:

1. `KafkaProducer::new` builds an `AvroEncoder` unconditionally and `publish` always serializes through it. The Go consumer deserializes `tracking-events` with `consumerCodec`, the one `CODEC_PROVIDER` selects. With the required `CODEC_PROVIDER=json` it is handed Avro bytes, `receive` logs `failed to deserialize tracking event` and returns nil so the event is skipped, and the campaign never learns the mail was opened.
2. The encoder is built from `config.schema_registry_url`, which is optional and defaults to empty. With no registry configured every `serialize_avro` call fails at publish time, one `report_issue` per event, and the event is dropped before it reaches the broker at all.

The NATS path never had either problem because it writes `serde_json::to_vec` and the consumer reads JSON.

## What this changes

`CODEC_PROVIDER` is now read by the tracking service and honoured on Kafka, the same setting the Go side already reads:

- `json` (the default) serializes with `serde_json::to_vec`, byte for byte what the NATS path writes, so the consumer decodes Kafka and NATS identically and no Schema Registry is involved
- `avro` keeps the existing encoder, and is now refused at boot with a clear message when `SCHEMA_REGISTRY_URL` is empty, instead of starting happily and dropping events one at a time

`CODEC_PROVIDER=json` is not a preference here, it is the only value that works: the consumer decodes `jobs.worker-events` and `tracking-events` with one codec, and worker envelopes carry untyped bodies Avro cannot serialize. A tracking publisher that ignores the setting can therefore only ever be wrong. That is what this fixes.

## Tests

`json_field_names_match_the_go_consumer` in `events.rs` pins the serialized key set against `internal/events.TrackingEvent`'s json tags, and asserts nullable fields travel as `null` rather than being omitted, which is what the Go pointer fields decode. It guards the format on both transports, since they now share it.

`cargo test` 29 passed, `cargo clippy --all-targets -- -D warnings` clean with and without `--features kafka`, `cargo fmt --check` clean.

## Docs

`events.mdx`, `configuration.mdx` and `AGENTS.md` all said tracking keeps its own Avro path regardless of the codec. They now describe the switch, and say plainly why one codec covering both topics makes json the only working value.