### PR TITLE
fix: the tracking Kafka build has no OpenSSL, so SASL_SSL is refused at runtime

### DIFF
--- a/tracking/Cargo.lock
+++ b/tracking/Cargo.lock
@@ -2710,6 +2710,7 @@ dependencies = [
  "libc",
  "libz-sys",
  "num_enum",
+ "openssl-sys",
  "pkg-config",
 ]
 

--- a/tracking/Cargo.toml
+++ b/tracking/Cargo.toml
@@ -27,7 +27,11 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # Kafka with Avro (optional; enabled with `--features kafka`). rdkafka is the
 # only native/librdkafka dependency, so the default build compiles far faster
 # and needs no libcurl/libsasl system headers.
-rdkafka = { version = "0.36", features = ["cmake-build"], optional = true }
+# "ssl" is not optional in practice: every managed broker speaks SASL_SSL, and
+# without it librdkafka is built with -DWITH_SSL=0 and refuses
+# security.protocol=SASL_SSL at runtime with "OpenSSL not available at build
+# time". gssapi is deliberately left out; PLAIN and SCRAM need no cyrus-sasl.
+rdkafka = { version = "0.36", features = ["cmake-build", "ssl"], optional = true }
 apache-avro = { version = "0.21", features = ["derive"], optional = true }
 schema_registry_converter = { version = "4.0", features = ["avro", "blocking"], optional = true }
 

--- a/tracking/Dockerfile
+++ b/tracking/Dockerfile
@@ -29,6 +29,7 @@ RUN --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
     --mount=type=cache,id=cargo-target,target=/app/target \
     set -eux; \
     if [ -n "$CARGO_FEATURES" ]; then FEAT="--features $CARGO_FEATURES"; else FEAT=""; fi; \
+    export OPENSSL_STATIC=1; \
     cargo build --release $FEAT; \
     cp target/release/tracking /tracking
 


### PR DESCRIPTION
Pointing the tracking service at a managed broker crash-loops it:

```
Client config error: Unsupported value "SASL_SSL" for configuration property
"security.protocol": OpenSSL not available at build time
```

`rdkafka` was pulled in with `features = ["cmake-build"]` and nothing else. `ssl` is not in that list, so `rdkafka-sys` configures librdkafka with `-DWITH_SSL=0` and the resulting library rejects `security.protocol=SASL_SSL` outright. The producer never connects, the retry loop gives up after 8 attempts, and the process restarts, so the pixel and click endpoints stop serving too.

Nothing catches this before runtime. It compiles, it links, `cargo clippy --features kafka` is clean, and the image builds; the value is only rejected when a config is handed to librdkafka.

## The change

- `rdkafka` gains the `ssl` feature, which is `["openssl-sys"]`. `gssapi` is deliberately left out: it drags in cyrus-sasl, and PLAIN and SCRAM are built into librdkafka without it. Every managed broker speaks SASL_SSL with PLAIN or SCRAM, so `ssl` is what makes the Kafka build usable at all rather than an optional extra
- the Dockerfile exports `OPENSSL_STATIC=1` for the build, because the runtime stage is a bare alpine with only `ca-certificates` and `libgcc`. The builder already installs `openssl-dev` and `openssl-libs-static`; this makes the static halves actually get used, so the binary does not land in an image with no libssl to link against
- `Cargo.lock` picks up `openssl-sys`

## Verification

Compile-time checks provably cannot catch this, so it was verified by running the image against a real broker. The `linux/arm64` image was built from this branch and started against Confluent Cloud:

```
INFO tracking::kafka: Kafka producer connected to pkc-....confluent.cloud:9092
INFO tracking::kafka: Publishing tracking events as JSON
```

where the previous build refused the config outright. A request to `/t/o/:task_id` then returned 200 and the event was read back off the topic:

```json
{"event_type":"EMAIL_OPENED","task_id":"...","original_url":null,"link_id":null,
 "timestamp":"...","user_agent":"Mozilla/5.0 (probe)","ip_hash":"...",
 "client_ip":"192.168.215.0","scanner":null}
```

That is JSON with the field names `internal/events.TrackingEvent` decodes, so it also confirms the codec fix in #450 on the wire rather than only in a unit test.

`cargo clippy --all-targets -- -D warnings` clean with and without `--features kafka`, `cargo test` 29 passed, `cargo fmt --check` clean.
