### PR TITLE
fix: realtime cannot complete either of its TLS connections

### DIFF
--- a/deploy/docker/realtime.Dockerfile
+++ b/deploy/docker/realtime.Dockerfile
@@ -28,7 +28,7 @@ RUN mix release
 # the crypto NIF fails to load against an older libcrypto (missing symbols).
 FROM alpine:3.23
 
-RUN apk add --no-cache libstdc++ openssl ncurses-libs wget
+RUN apk add --no-cache libstdc++ openssl ncurses-libs
 RUN adduser -D -u 1000 warmbly
 
 # Amazon RDS presents a chain rooted in an RDS CA that is in no public trust

--- a/deploy/docker/realtime.Dockerfile
+++ b/deploy/docker/realtime.Dockerfile
@@ -28,8 +28,19 @@ RUN mix release
 # the crypto NIF fails to load against an older libcrypto (missing symbols).
 FROM alpine:3.23
 
-RUN apk add --no-cache libstdc++ openssl ncurses-libs
+RUN apk add --no-cache libstdc++ openssl ncurses-libs wget
 RUN adduser -D -u 1000 warmbly
+
+# Amazon RDS presents a chain rooted in an RDS CA that is in no public trust
+# store, and Postgrex verifies the peer against the system store by default.
+# Shipping AWS's truststore lets an operator opt in with
+# DATABASE_SSL_CA_FILE=/etc/ssl/rds/global-bundle.pem; nothing here changes the
+# default, because pointing every install at an RDS-only store would break a
+# Postgres fronted by a public CA.
+RUN mkdir -p /etc/ssl/rds && \
+    wget -qO /etc/ssl/rds/global-bundle.pem \
+      https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem && \
+    chmod 0644 /etc/ssl/rds/global-bundle.pem
 
 WORKDIR /app
 

--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -324,6 +324,7 @@ A worker's command topic is named after the node id issued when it joined, so th
 | `DATABASE_URL` | The realtime service's own name for the same database | the compose postgres | yes |
 | `DATABASE_POOL_SIZE` | Maximum pooled connections **for the realtime service only**. The Go services use the driver default and do not read it | `10` | yes |
 | `DATABASE_SSL` | Whether the realtime service connects to Postgres over TLS | `true`, and `false` under compose | yes |
+| `DATABASE_SSL_CA_FILE` | CA bundle the realtime service verifies Postgres against. Unset verifies against the system store, which has no Amazon RDS root in it, so an RDS database needs this set to `/etc/ssl/rds/global-bundle.pem` (shipped in the image) | unset | yes |
 
 Migrations are embedded in the backend binary and applied on boot. There is no separate migration step, and a standalone `/app/migrate` binary ships in the image for the cases where you want one.
 

--- a/docs/content/docs/development/split-deployment.mdx
+++ b/docs/content/docs/development/split-deployment.mdx
@@ -43,7 +43,7 @@ The backend reaches Postgres and Redis on every request, so the round trips betw
 ## Two things that are not optional
 
 <Callout title="RDS needs AWS's certificate bundle">
-Amazon RDS presents a chain rooted in an RDS CA that is in no public trust store, so `sslmode=verify-full` fails with `x509: certificate signed by unknown authority` against the system bundle alone. The backend and consumer images ship AWS's truststore at `/etc/ssl/rds/global-bundle.pem`; point `sslrootcert` at it, as above.
+Amazon RDS presents a chain rooted in an RDS CA that is in no public trust store, so `sslmode=verify-full` fails with `x509: certificate signed by unknown authority` against the system bundle alone. The backend, consumer and realtime images ship AWS's truststore at `/etc/ssl/rds/global-bundle.pem`; point `sslrootcert` at it, as above. Realtime is Elixir and reads no DSN parameters, so it takes the same bundle through `DATABASE_SSL_CA_FILE` instead.
 
 `sslmode=require` is the fallback if you cannot. It still encrypts, and `rds.force_ssl=1` still forces TLS server side, but nothing verifies the server's identity, so a caller that reaches the wrong host will not notice.
 </Callout>

--- a/realtime/config/runtime.exs
+++ b/realtime/config/runtime.exs
@@ -74,15 +74,32 @@ if config_env() == :prod do
   # /etc/ssl/rds/global-bundle.pem. It is opt-in rather than the default for
   # the same reason the backend makes sslrootcert opt-in: pointing every
   # install at an RDS-only store would break a Postgres fronted by a public CA.
+  #
+  # A name that is present but blank counts as unset, the same rule the error
+  # DSN below follows: compose passes every optional variable through as "", and
+  # `cacertfile: ~c""` with verify_peer is no CA source at all, so it fails the
+  # handshake instead of falling back to the system store.
+  database_ssl_ca_file =
+    case System.get_env("DATABASE_SSL_CA_FILE") do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+
   database_ssl =
     cond do
       System.get_env("DATABASE_SSL", "true") != "true" ->
         false
 
-      ca_file = System.get_env("DATABASE_SSL_CA_FILE") ->
+      database_ssl_ca_file ->
         [
           verify: :verify_peer,
-          cacertfile: to_charlist(ca_file),
+          cacertfile: to_charlist(database_ssl_ca_file),
           customize_hostname_check: [
             match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
           ]

--- a/realtime/config/runtime.exs
+++ b/realtime/config/runtime.exs
@@ -68,10 +68,34 @@ if config_env() == :prod do
     secret_key_base: secret_key_base,
     check_origin: System.get_env("CHECK_ORIGIN", "false") == "true"
 
+  # Postgrex verifies the server against the system CA store, which has no
+  # Amazon RDS root in it, so an RDS database needs DATABASE_SSL_CA_FILE
+  # pointing at a bundle. The image ships AWS's at
+  # /etc/ssl/rds/global-bundle.pem. It is opt-in rather than the default for
+  # the same reason the backend makes sslrootcert opt-in: pointing every
+  # install at an RDS-only store would break a Postgres fronted by a public CA.
+  database_ssl =
+    cond do
+      System.get_env("DATABASE_SSL", "true") != "true" ->
+        false
+
+      ca_file = System.get_env("DATABASE_SSL_CA_FILE") ->
+        [
+          verify: :verify_peer,
+          cacertfile: to_charlist(ca_file),
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]
+        ]
+
+      true ->
+        true
+    end
+
   # Ecto Repo configuration (for API key validation)
   config :realtime, Realtime.Repo,
     url: database_url,
-    ssl: System.get_env("DATABASE_SSL", "true") == "true",
+    ssl: database_ssl,
     pool_size: String.to_integer(System.get_env("DATABASE_POOL_SIZE") || "10"),
     show_sensitive_data_on_connection_error: true
 

--- a/realtime/lib/realtime/redis.ex
+++ b/realtime/lib/realtime/redis.ex
@@ -37,8 +37,8 @@ defmodule Realtime.Redis do
   # Erlang's default hostname check does not match a wildcard certificate, and
   # every managed Redis presents one (`*.upstash.io`, ElastiCache, Redis Cloud).
   # Without the https match fun the handshake fails with
-  # {:bad_cert, :hostname_check_failed} on all #{@pool_size} connections and the
-  # pool never comes up, which reads as "Redis unavailable" and fails open.
+  # {:bad_cert, :hostname_check_failed} on every connection in the pool, which
+  # reads as "Redis unavailable" and fails open rather than as an error.
   #
   # Redix drops only the keys given here from its own defaults, so verify_peer
   # and the system CA store still apply.

--- a/realtime/lib/realtime/redis.ex
+++ b/realtime/lib/realtime/redis.ex
@@ -20,16 +20,40 @@ defmodule Realtime.Redis do
   @impl true
   def init(_opts) do
     redis_url = Application.get_env(:realtime, :redis_url, "redis://localhost:6379/0")
+    opts = tls_opts(redis_url)
 
     children =
       for i <- 0..(@pool_size - 1) do
         Supervisor.child_spec(
-          {Redix, {redis_url, [name: :"redix_#{i}"]}},
+          {Redix, {redis_url, [name: :"redix_#{i}"] ++ opts}},
           id: {Redix, i}
         )
       end
 
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  @doc false
+  # Erlang's default hostname check does not match a wildcard certificate, and
+  # every managed Redis presents one (`*.upstash.io`, ElastiCache, Redis Cloud).
+  # Without the https match fun the handshake fails with
+  # {:bad_cert, :hostname_check_failed} on all #{@pool_size} connections and the
+  # pool never comes up, which reads as "Redis unavailable" and fails open.
+  #
+  # Redix drops only the keys given here from its own defaults, so verify_peer
+  # and the system CA store still apply.
+  def tls_opts(url) do
+    if String.starts_with?(url, "rediss://") do
+      [
+        socket_opts: [
+          customize_hostname_check: [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]
+        ]
+      ]
+    else
+      []
+    end
   end
 
   @doc """

--- a/realtime/test/realtime/redis_test.exs
+++ b/realtime/test/realtime/redis_test.exs
@@ -1,0 +1,32 @@
+defmodule Realtime.RedisTest do
+  use ExUnit.Case, async: true
+
+  alias Realtime.Redis
+
+  describe "tls_opts/1" do
+    test "plain redis:// gets no socket options" do
+      assert Redis.tls_opts("redis://localhost:6379/0") == []
+    end
+
+    # Every managed Redis presents a wildcard certificate (*.upstash.io and
+    # friends), and Erlang's default hostname check rejects one. Without this
+    # the whole pool fails to connect with {:bad_cert, :hostname_check_failed}.
+    test "rediss:// asks for the https wildcard match fun" do
+      opts = Redis.tls_opts("rediss://user:pass@optimal-poodle-166045.upstash.io:6379")
+
+      assert [socket_opts: socket_opts] = opts
+      assert [customize_hostname_check: [match_fun: match_fun]] = socket_opts
+      assert is_function(match_fun, 2)
+    end
+
+    # The returned match fun has to actually accept a wildcard, which is the
+    # behaviour this exists for; asserting only on shape would pass with the
+    # wrong :public_key helper.
+    test "the match fun accepts a wildcard certificate for the host" do
+      [socket_opts: [customize_hostname_check: [match_fun: match_fun]]] =
+        Redis.tls_opts("rediss://example.upstash.io:6379")
+
+      assert match_fun.({:dns_id, ~c"example.upstash.io"}, {:dNSName, ~c"*.upstash.io"})
+    end
+  end
+end


### PR DESCRIPTION
`warmblyctl status` against production reports the realtime service unreachable, and its log explains why: it never finishes connecting to anything. Two separate TLS problems, each of which alone keeps the service from working.

## Redis: a wildcard certificate is rejected

Ten `CLIENT ALERT: Fatal - Handshake Failure - {:bad_cert, :hostname_check_failed}` per attempt, one per pool connection.

Erlang's default hostname check does not match a wildcard certificate. Every managed Redis presents one: Upstash serves `CN=*.upstash.io`, and ElastiCache and Redis Cloud do the same. Redix's own docs call this out:

> Some Redis servers, notably Amazon ElastiCache, use wildcard certificates that require additional socket options for successful verification

`Realtime.Redis` passed no socket options, so the whole pool failed to connect. Because the module fails open by design, this surfaces as "Redis unavailable" rather than as an error anyone would chase: rate limiting silently returns defaults and presence state has nowhere to live.

The fix is the documented option, applied only for `rediss://`. Redix drops just the keys you supply from its own defaults, so `verify: :verify_peer` and the system CA store still apply; this does not weaken verification, it makes it able to succeed.

## Postgres: the RDS root is not publicly trusted

`Postgrex.Protocol failed to connect: tcp connect (...rds.amazonaws.com:5432): timeout`.

The timeout is a network problem outside this repo (the service had no static egress IP, so the database security group dropped it). But fixing the network only exposes the next failure: Postgrex defaults to `[cacerts: :public_key.cacerts_get(), verify: :verify_peer, ...]`, and Amazon RDS presents a chain rooted in an RDS CA that is in no public trust store. The same problem the Go services already solved by shipping AWS's bundle and pointing `sslrootcert` at it.

Realtime is Elixir and reads no DSN parameters, so it gets the equivalent knob:

- the image now ships `/etc/ssl/rds/global-bundle.pem`, as `backend.Dockerfile` and `consumer.Dockerfile` already do
- `DATABASE_SSL_CA_FILE` points Postgrex at a bundle, with `verify_peer` and the https match fun

It is opt-in rather than the default for exactly the reason the backend's `sslrootcert` is: defaulting every install to an RDS-only store would break a Postgres fronted by a public CA. `DATABASE_SSL=true` with no CA file keeps today's behaviour.

## Tests

`realtime/test/realtime/redis_test.exs` is new. It asserts `redis://` gets no socket options, `rediss://` asks for the match fun, and, importantly, that the returned fun actually accepts `*.upstash.io` for `example.upstash.io`. Asserting only on the shape would have passed with the wrong `:public_key` helper, which is the mistake this is guarding.

`mix format --check-formatted`, `mix compile` and `mix test` (29 passed) all clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional CA bundle support for verified PostgreSQL TLS connections, including Amazon RDS.
  - Added improved hostname verification for secure Redis connections using `rediss://`.

- **Documentation**
  - Documented the `DATABASE_SSL_CA_FILE` setting, its default behavior, and the configuration required for Amazon RDS.
  - Updated split-deployment guidance for PostgreSQL certificate verification and the bundled AWS truststore.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->