### PR TITLE
fix: the realtime event bridge is a second Redis connection and needs the same TLS options

### DIFF
--- a/realtime/lib/realtime/redis/event_subscriber.ex
+++ b/realtime/lib/realtime/redis/event_subscriber.ex
@@ -24,7 +24,10 @@ defmodule Realtime.Redis.EventSubscriber do
   def init(_opts) do
     redis_url = Application.get_env(:realtime, :redis_url, "redis://localhost:6379/0")
 
-    case Redix.PubSub.start_link(redis_url) do
+    # Same TLS options as the command pool: a managed Redis presents a wildcard
+    # certificate that Erlang's default hostname check rejects, and this
+    # connection is the one that delivers every realtime event.
+    case Redix.PubSub.start_link(redis_url, Realtime.Redis.tls_opts(redis_url)) do
       {:ok, conn} ->
         {:ok, _ref} = Redix.PubSub.subscribe(conn, @channel, self())
         Logger.info("Realtime Redis event bridge subscribing to '#{@channel}'")


### PR DESCRIPTION
Follow-up to #452. That fixed `Realtime.Redis`, the command pool, but the `hostname_check_failed` alerts did not stop in production: `Realtime.Redis.EventSubscriber` opens its own connection through `Redix.PubSub.start_link/1` and got no socket options either.

It is the more consequential of the two. The pool backs rate limiting and fails open by design, so its failure degrades quietly. This connection is the bridge that carries every realtime event the Go backend and consumer publish, so while it cannot connect the dashboard receives nothing at all: no live inbox arrivals, no presence, no campaign updates.

It now passes `Realtime.Redis.tls_opts/1`, the same helper, so there is one definition of how this instance talks to Redis rather than two places to keep in step. `Redix.PubSub.start_link(uri, opts)` merges opts over the URI-derived options, so the credentials and database from `REDIS_URL` are untouched.

## Verified against the real instance

Run against the production Upstash URL, since a unit test cannot tell you whether a certificate actually verifies:

```
WITHOUT opts:       FAILED -> %Redix.ConnectionError{reason: :closed}
                    {:hostname_check_failed, {:requested, ~c"optimal-poodle-166045.upstash.io"}, ...}
WITH opts (pool):   PING -> "PONG"
WITH opts (pubsub): subscribed to realtime:events
```

The first line is what production has been doing on both connections.

`mix format --check-formatted`, `mix compile` and `mix test` (29 passed) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redis Pub/Sub connections now apply the configured TLS options, improving secure connectivity for realtime updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->