### PR TITLE
fix: the realtime service logs its Redis password on every boot

### DIFF
--- a/realtime/lib/realtime/application.ex
+++ b/realtime/lib/realtime/application.ex
@@ -43,7 +43,10 @@ defmodule Realtime.Application do
     opts = [strategy: :one_for_one, name: Realtime.Supervisor]
 
     Logger.info("Starting Realtime application...")
-    Logger.info("Redis URL: #{Application.get_env(:realtime, :redis_url, "not configured")}")
+
+    Logger.info(
+      "Redis URL: #{redact_userinfo(Application.get_env(:realtime, :redis_url, "not configured"))}"
+    )
 
     Logger.info(
       "Connection limits: user=#{Application.get_env(:realtime, :max_connections_per_user, 10)}, ip=#{Application.get_env(:realtime, :max_connections_per_ip, 50)}, global=#{Application.get_env(:realtime, :max_connections_global, 100_000)}"
@@ -60,6 +63,20 @@ defmodule Realtime.Application do
   # transport (local dev and any non-GCP env). In Pub/Sub environments the
   # Broadway subscriber handles fan-out, so this stays off and events are never
   # delivered twice.
+  # The Redis URL carries its password in the userinfo, and this line put it in
+  # plain text in the boot log of every deployment. Logs are read, shipped and
+  # pasted far more casually than the variable itself, so the address stays
+  # (it is what makes this line useful) and the credential goes.
+  @doc false
+  def redact_userinfo(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{userinfo: nil} -> url
+      %URI{} = uri -> URI.to_string(%{uri | userinfo: "***"})
+    end
+  end
+
+  def redact_userinfo(other), do: other
+
   defp event_bridge_children do
     if Application.get_env(:realtime, :pubsub_enabled, false) do
       []

--- a/realtime/test/realtime/application_test.exs
+++ b/realtime/test/realtime/application_test.exs
@@ -1,0 +1,32 @@
+defmodule Realtime.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  describe "redact_userinfo/1" do
+    # This ran on every boot with the real password in it. The address has to
+    # survive, because naming which Redis the node attached to is the whole
+    # point of the line.
+    test "strips the credential but keeps the address" do
+      redacted =
+        Realtime.Application.redact_userinfo(
+          "rediss://default:supersecrettoken@optimal-poodle-166045.upstash.io:6379"
+        )
+
+      refute redacted =~ "supersecrettoken"
+      assert redacted == "rediss://***@optimal-poodle-166045.upstash.io:6379"
+    end
+
+    test "a url with no credential is untouched" do
+      assert Realtime.Application.redact_userinfo("redis://localhost:6379/0") ==
+               "redis://localhost:6379/0"
+    end
+
+    test "the not-configured fallback survives" do
+      assert Realtime.Application.redact_userinfo("not configured") == "not configured"
+    end
+
+    test "a username-only credential still goes" do
+      redacted = Realtime.Application.redact_userinfo("redis://someuser@redis.internal:6379")
+      refute redacted =~ "someuser"
+    end
+  end
+end


### PR DESCRIPTION
`Realtime.Application.start/2` logs the Redis URL verbatim, and that URL carries its password in the userinfo. Found in the live production log:

```
[info] Redis URL: rediss://default:gQAAAAAAAoid...@optimal-poodle-166045.upstash.io:6379
```

Every boot writes a working credential into the log stream, where it is retained by the platform's log viewer and gets shipped, tailed and pasted far more casually than the environment variable it came from. Anyone who can read logs can read Redis.

The line itself is worth keeping, since naming which instance a node attached to is exactly what it is for, so only the credential goes:

```
[info] Redis URL: rediss://***@optimal-poodle-166045.upstash.io:6379
```

`URI.parse/1` handles the non-URL fallback (`"not configured"`) without a special case: no userinfo, so it is returned untouched.

## Tests

`realtime/test/realtime/application_test.exs` is new: the password is gone while scheme, host and port survive, a credential-free URL is untouched, the `"not configured"` fallback survives, and a username-only credential is also removed (a URL with no password still names a valid principal).

`mix format --check-formatted`, `mix compile`, `mix test` (33 passed) clean.

## Note

The exposed Upstash token should be rotated regardless of this fix, since it has been in the logs of every deployment so far.