### PR TITLE
fix: a joining node is told an image tag that does not exist

### DIFF
--- a/docs/content/docs/development/configuration.mdx
+++ b/docs/content/docs/development/configuration.mdx
@@ -353,7 +353,6 @@ The variable must be set on the backend in every environment. The file itself is
 | `WORKER_BIND_IP` | Source address to bind outbound connections to, and the seed for a derived `WORKER_ID` | unset | yes |
 | `WORKER_PUBLIC_IP` | The address the worker reports to the control plane | detected | yes |
 | `WARMBLY_NODE_REGION` | Free-form label for where this node egresses from, e.g. `eu-central`. Placement prefers a worker near where a mailbox's provider expects sign-ins; unset scores neutral. Written by the join script from `--region` | unset | yes |
-| `WORKER_IMAGE` | Image the remote installer pulls. The built-in default does not match what CI publishes, so set it | built-in | yes |
 | `ENCRYPTED_KEYS_BACKEND_URL` | Backend base the worker fetches organization keys from | unset | yes |
 | `ENCRYPTED_KEYS_WORKER_TOKEN` | The worker's copy of `INTERNAL_API_TOKEN` | unset | yes |
 | `MAIL_TLS_INSECURE` | Skips certificate verification on mailbox connections | `false` | yes |

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -814,7 +814,7 @@ One thing to know if you are running a fork: GHCR creates each package private a
 
 Every app service in `docker-compose.yml` carries both an `image:` and a `build:` key, so the same file serves both paths. `docker compose pull && docker compose up -d` runs the published images and compiles nothing; `docker compose up --build` still builds this checkout. Pin a release with `WARMBLY_TAG=v1.4.2` in `.env`, or point `WARMBLY_IMAGE_PREFIX` at your own registry.
 
-To move a worker fleet onto a new release, update `WORKER_IMAGE` and use "Pull latest and restart" on each worker. Control-plane migrations are forward-only, so prefer rolling forward over rolling back.
+To move a fleet onto a new release, set the target once with `warmblyctl fleet version vX.Y.Z`. Nothing is pushed: each node asks what it should be running on its next heartbeat and its own update timer pulls and restarts it. Control-plane migrations are forward-only, so prefer rolling forward over rolling back.
 
 ## Upgrading and backups
 

--- a/internal/api/handler/fleet_nodes.go
+++ b/internal/api/handler/fleet_nodes.go
@@ -131,10 +131,12 @@ func (h *Handler) FleetJoin(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, fleetJoinResponse{
-		NodeID:           nodeID,
-		Role:             string(role),
-		EnvB64:           base64.StdEncoding.EncodeToString([]byte(renderNodeEnv(nodeID, role, req.Region))),
-		DesiredVersion:   reply.DesiredVersion,
+		NodeID: nodeID,
+		Role:   string(role),
+		EnvB64: base64.StdEncoding.EncodeToString([]byte(renderNodeEnv(nodeID, role, req.Region))),
+		// Not reply.DesiredVersion: an empty answer is "no opinion" to a node
+		// that is already running something, but this one has nothing to run.
+		DesiredVersion:   h.FleetNodes.JoinVersion(ctx, nodeID),
 		HeartbeatSeconds: nodeHeartbeatSeconds(reply.LivenessSeconds),
 	})
 }

--- a/internal/api/handler/nodescript/join.sh
+++ b/internal/api/handler/nodescript/join.sh
@@ -170,7 +170,10 @@ enrol() {
 
   [ -n "$NODE_ID" ] || die "the control plane did not return a node id"
   [ -n "$NODE_ENV" ] || die "the control plane returned no configuration for this node"
-  [ -n "$DESIRED_VERSION" ] || DESIRED_VERSION="latest"
+  # The control plane names a tag, including when it has no release resolved.
+  # This only catches a backend too old to do that, and it names the tag the
+  # project publishes: there is no `latest`.
+  [ -n "$DESIRED_VERSION" ] || DESIRED_VERSION="prod"
   log "Enrolled as $WARMBLY_ROLE node $NODE_ID"
 }
 

--- a/internal/app/fleetnode/service.go
+++ b/internal/app/fleetnode/service.go
@@ -182,6 +182,26 @@ func (s *Service) desiredVersion(ctx context.Context, nodeID uuid.UUID) string {
 	return s.withVariant(state.DesiredVersion())
 }
 
+// DefaultJoinTag is what a machine joining an instance with no resolved
+// release is told to run. It has to be a tag this project actually publishes:
+// `latest` is not one, and a node sent there fails on the image pull before it
+// ever heartbeats. The floating release tag is `prod`.
+const DefaultJoinTag = "prod"
+
+// JoinVersion is what a machine joining right now should start on.
+//
+// It differs from the heartbeat's answer in exactly one way. To a node that is
+// already running something, an unresolved release means "no opinion" and must
+// stay empty, because the alternative is a control-plane hiccup rolling the
+// fleet. A joining node has nothing to keep running, so it has to be told a
+// tag, and the fallback is the published floating one.
+func (s *Service) JoinVersion(ctx context.Context, nodeID uuid.UUID) string {
+	if v := s.desiredVersion(ctx, nodeID); v != "" {
+		return v
+	}
+	return s.withVariant(DefaultJoinTag)
+}
+
 // List returns the fleet, with each node's resolved target attached so a
 // caller can see at a glance which machines are behind.
 func (s *Service) List(ctx context.Context, role models.NodeRole) ([]models.FleetNode, error) {

--- a/internal/app/fleetnode/service_test.go
+++ b/internal/app/fleetnode/service_test.go
@@ -123,6 +123,65 @@ func TestDesiredVersionAppliesVariantToPinsAndFleetTarget(t *testing.T) {
 	}
 }
 
+// A joining node has nothing installed, so "no opinion" is not an answer it
+// can act on. It used to fall through to join.sh's `latest`, which this
+// project has never published, so the machine died on the image pull.
+func TestJoinVersionFallsBackToAPublishedTag(t *testing.T) {
+	id := uuid.New()
+
+	unresolved := &Service{
+		nodes:    stubNodes{node: &models.FleetNode{ID: id}},
+		settings: stubSettings{release: ""},
+		variant:  "-kafka",
+	}
+	if got := unresolved.JoinVersion(context.Background(), id); got != "prod-kafka" {
+		t.Errorf("unresolved release: got %q, want prod-kafka", got)
+	}
+
+	plain := &Service{
+		nodes:    stubNodes{node: &models.FleetNode{ID: id}},
+		settings: stubSettings{release: ""},
+	}
+	if got := plain.JoinVersion(context.Background(), id); got != "prod" {
+		t.Errorf("unresolved release, no variant: got %q, want prod", got)
+	}
+
+	// A resolved release still wins; the fallback is only for having nothing.
+	resolved := &Service{
+		nodes:    stubNodes{node: &models.FleetNode{ID: id}},
+		settings: stubSettings{release: "v0.4.5"},
+		variant:  "-kafka",
+	}
+	if got := resolved.JoinVersion(context.Background(), id); got != "v0.4.5-kafka" {
+		t.Errorf("resolved release: got %q, want v0.4.5-kafka", got)
+	}
+
+	// And a pin still wins over both.
+	pinned := &Service{
+		nodes:    stubNodes{node: &models.FleetNode{ID: id, PinnedVersion: "v0.4.4"}},
+		settings: stubSettings{release: "v0.4.5"},
+		variant:  "-kafka",
+	}
+	if got := pinned.JoinVersion(context.Background(), id); got != "v0.4.4-kafka" {
+		t.Errorf("pinned node: got %q, want v0.4.4-kafka", got)
+	}
+}
+
+// The heartbeat must NOT gain the fallback: a node that is already running
+// something has to be left alone when the control plane cannot resolve a
+// release, or one hiccup rolls the whole fleet.
+func TestHeartbeatKeepsNoOpinionEmpty(t *testing.T) {
+	id := uuid.New()
+	s := &Service{
+		nodes:    stubNodes{node: &models.FleetNode{ID: id}},
+		settings: stubSettings{release: ""},
+		variant:  "-kafka",
+	}
+	if got := s.desiredVersion(context.Background(), id); got != "" {
+		t.Errorf("unresolved release must stay empty on the heartbeat, got %q", got)
+	}
+}
+
 // List and Get feed the admin panel's "is this machine behind" column. A node
 // reports the WARMBLY_VERSION the join script wrote, which already carries the
 // suffix, so the target it is compared against has to carry it too or every


### PR DESCRIPTION
No machine can join this fleet today. `join.sh` falls back to `latest` when the control plane returns no `desired_version`, and this project has never published a `latest` tag: the floating one is `prod`. The node dies on the image pull before it ever heartbeats, so it does not even appear in `fleet list` to explain itself.

It is the default path, not an edge case. `RELEASES_ENABLED` defaults to `false`, so a stock instance resolves no release and every join takes the fallback.

## Where the default belongs

In the control plane, not the script. It is the only side that knows which image variant this instance's event bus needs (#449), so a fallback chosen in the shell would send a Kafka instance's worker to a build with no librdkafka in it, swapping one boot failure for another.

`JoinVersion` is therefore separate from the heartbeat's answer, and the difference is deliberate:

- **heartbeat**: an unresolved release stays `""`. A node already running something must be left alone, or one control-plane hiccup rolls the fleet. That invariant is unchanged and now has a test pinning it
- **join**: a machine with nothing installed cannot act on "no opinion", so it is told `prod`, with the variant suffix applied like any other version

A resolved release still wins, and a pin still wins over that.

`join.sh`'s own fallback moves from `latest` to `prod` as well. It is now unreachable against a current backend, but it is what an older one would still hit, and it should name a real tag either way.

## Stale docs removed

Two leftovers from the push-based provisioning deleted in migration `000140`/`000142`:

- `WORKER_IMAGE` in `configuration.mdx`, read by no code at all, documented as something an operator must set
- "update `WORKER_IMAGE` and use 'Pull latest and restart' on each worker" in `deployment-guide.mdx`, describing a button that no longer exists. Replaced with the pull-based flow that does: `warmblyctl fleet version vX.Y.Z`, then each node converges on its own heartbeat

## Tests

`JoinVersion` covers the unresolved case with and without a variant, that a resolved release wins, and that a pin wins over that. A separate test pins the heartbeat's empty answer so the fallback cannot be copied there later.

`make lint` (including `make join-check`) and `go test ./internal/app/fleetnode/ ./internal/api/handler/` pass.