### PR TITLE
Campaigns send outside their sending window (and past their end date) when a follow-up is overdue

### DIFF
--- a/docs/content/docs/guides/campaigns.mdx
+++ b/docs/content/docs/guides/campaigns.mdx
@@ -166,6 +166,8 @@ A link that already carries one of these keeps the hand-written value; only the 
 
 Campaigns send only inside the **weekly sending windows** you define, in the campaign's timezone. Each day is independent, with different hours or several windows per day, set from presets like `Mon-Fri 9-5` or by dragging on the grid (which is Monday-first).
 
+A step whose turn comes while the window is shut waits for the next one; it is never sent late to catch up. That holds however overdue it is, so a follow-up whose wait elapsed at two in the afternoon does not go out at eleven at night because the campaign happened to look at it then. The step keeps its place in the queue and leaves in the next window that has mailbox capacity.
+
 Within a window Warmbly spreads the day's emails evenly, adds random jitter, and rounds to natural send times so nothing arrives in obvious bursts. A mailbox with its own timezone is also kept inside its local business hours (`8am` to `8pm`).
 
 The spread covers every mailbox on the campaign, not one at a time: the day's remaining capacity across the whole sending pool is paced across the hours left in the window. Adding a second healthy mailbox roughly doubles how fast a campaign works through its leads, while each mailbox still stays inside its own daily cap, hourly ceiling and minimum gap.
@@ -180,7 +182,7 @@ The delay counts from when that contact entered the campaign, not from when the 
 
 Follow-up spacing is separate and unaffected: that is each step's own wait, set on the connection into it (see [Sequences](/guides/sequences/#wait-and-spacing)). Every lead carries the moment it was enrolled, so turning a delay on does not re-delay people who joined weeks ago: their wait is already long past. Leads enrolled before this setting existed have no recorded moment and fall back to the campaign's creation date, which has the same effect. Changing the delay on a running campaign takes effect on save.
 
-Optional **campaign dates** bound when it may send. Leave both blank to run open-ended. Picking today as the start date means "start now", and clearing a start date on a running campaign removes the wait entirely. Schedule changes on an active campaign take effect immediately: the next send is recomputed on save, so a campaign waiting on a future start date starts sending as soon as you clear or shorten it.
+Optional **campaign dates** bound when it may send. Leave both blank to run open-ended. Picking today as the start date means "start now", and clearing a start date on a running campaign removes the wait entirely. Schedule changes on an active campaign take effect immediately: the next send is recomputed on save, so a campaign waiting on a future start date starts sending as soon as you clear or shorten it. Past the end date nothing goes out at all, including a follow-up that came due before it: the campaign finishes instead, and its activity log says it reached its end date.
 
 ## Start and stop
 

--- a/internal/scheduler/campaign_overdue_window_live_test.go
+++ b/internal/scheduler/campaign_overdue_window_live_test.go
@@ -1,0 +1,147 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// A campaign's sending window is a promise about when mail leaves, and an
+// OVERDUE follow-up used to break it.
+//
+// Every schedule gate in the placer is asked about the step's candidate time,
+// which for a follow-up starts at "when its wait elapsed". Once that moment is
+// in the past, two gates stop working: nextScheduleSlot deliberately returns an
+// instant that was ALREADY inside a window unchanged ("keep the exact
+// instant"), and the end-date comparison finds a candidate that predates the
+// end date. So the hard floor sat in the past, the not-due check read the step
+// as due, and the task sent it immediately — hours after the window closed, or
+// after the campaign was over.
+//
+// The chain reaches those hours routinely: a deferral is capped at
+// config.CampaignMaxDeferMinutes so a wake-up near closing time lands past it,
+// the reconciler re-seeds a dead chain a minute from now whatever the clock
+// says, and a dispatch failure is retried the same way.
+//
+//	WARMBLY_TEST_DB=postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable \
+//	  go test ./internal/scheduler/ -run LiveOverdue -v
+
+// overdueFollowUp gives the fixture's lead a step 1 sent at sentAt and a step 2
+// routed out of it with no wait, so step 2 has been due since sentAt.
+func overdueFollowUp(t *testing.T, pool *pgxpool.Pool, f *liveFixture, step1, contact uuid.UUID, sentAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	step2 := uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO sequences (id, campaign_id, organization_id, name, subject,
+	        body_plain, body_html, wait_after, position, kind)
+	    VALUES ($1, $2, $3, 'Step 2', 'Bump', 'Bump', '<p>Bump</p>', 0, 1, 'email')`,
+		step2, f.campaign, f.org); err != nil {
+		t.Fatalf("add step 2: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE sequences SET conditions = jsonb_build_object('branches',
+	        jsonb_build_array(jsonb_build_object('branch_id', 'else', 'target_step_id', $1::text)))
+	    WHERE id = $2`, step2.String(), step1); err != nil {
+		t.Fatalf("connect steps: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO campaign_contact_progress
+	    (campaign_id, contact_id, sequence_id, sent_at) VALUES ($1, $2, $3, $4)`,
+		f.campaign, contact, step1, sentAt); err != nil {
+		t.Fatalf("stamp step 1: %v", err)
+	}
+}
+
+// hhmm renders an instant as the campaigns table's time-of-day.
+func hhmm(t time.Time) string { return t.UTC().Format("15:04") }
+
+// An overdue follow-up must wait for the window to reopen, not go out the
+// moment the chain happens to wake up outside it.
+func TestLiveOverdueFollowUpWaitsForTheWindowToReopen(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	step1, contact := liveLead(t, pool, f.campaign)
+
+	// A window that closed an hour ago, and a step 1 that went out inside it.
+	now := time.Now().UTC()
+	opened, closed := now.Add(-3*time.Hour), now.Add(-1*time.Hour)
+	if _, err := pool.Exec(ctx,
+		`UPDATE campaigns SET start_time = $2, end_time = $3, days = 127 WHERE id = $1`,
+		f.campaign, hhmm(opened), hhmm(closed)); err != nil {
+		t.Fatalf("set the window: %v", err)
+	}
+	overdueFollowUp(t, pool, f, step1, contact, now.Add(-2*time.Hour))
+
+	at, pair, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(ctx, f.campaign)
+	if pair != nil && err == nil {
+		t.Fatalf("the scheduler authorised a send at %s, %s after the window closed at %s",
+			hhmm(now), time.Since(closed).Round(time.Minute), hhmm(closed))
+	}
+	if !errors.Is(err, ErrCampaignDeferred) {
+		t.Fatalf("want a deferral, got %v", err)
+	}
+	// The wake-up it parks is a future moment inside the window. Which DAY is
+	// deliberately not asserted: the distribution curve can push an early
+	// window's candidate past that day's close and cost it a day, which is its
+	// own thing and not what this test is about.
+	if !at.After(now) {
+		t.Fatalf("deferred to %s, which is not in the future", at.UTC().Format(time.RFC3339))
+	}
+	openMin := opened.Hour()*60 + opened.Minute()
+	closeMin := closed.Hour()*60 + closed.Minute()
+	if m := at.UTC().Hour()*60 + at.UTC().Minute(); m < openMin || m > closeMin {
+		t.Fatalf("deferred to %s, which is outside the %s-%s window it must wait for",
+			at.UTC().Format(time.RFC3339), hhmm(opened), hhmm(closed))
+	}
+}
+
+// The same step, with the window still open, must still go out promptly: the
+// fix is a floor on the candidate, not a new wait.
+func TestLiveOverdueFollowUpStillSendsInsideTheWindow(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	step1, contact := liveLead(t, pool, f.campaign)
+
+	// A window that opened two hours ago and is open for another two.
+	now := time.Now().UTC()
+	if _, err := pool.Exec(ctx,
+		`UPDATE campaigns SET start_time = $2, end_time = $3, days = 127 WHERE id = $1`,
+		f.campaign, hhmm(now.Add(-2*time.Hour)), hhmm(now.Add(2*time.Hour))); err != nil {
+		t.Fatalf("set the window: %v", err)
+	}
+	overdueFollowUp(t, pool, f, step1, contact, now.Add(-90*time.Minute))
+
+	_, pair, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(ctx, f.campaign)
+	if err != nil || pair == nil {
+		t.Fatalf("an overdue follow-up inside the window must send, got pair=%v err=%v", pair, err)
+	}
+}
+
+// The end date is the other gate a past candidate slipped under: the comparison
+// asked whether the moment the step came due was past the end date, not whether
+// now is.
+func TestLiveOverdueFollowUpRespectsTheEndDate(t *testing.T) {
+	handle, pool := liveDB(t)
+	f := newLiveFixture(t, pool, "UTC")
+	ctx := context.Background()
+	step1, contact := liveLead(t, pool, f.campaign)
+
+	now := time.Now().UTC()
+	if _, err := pool.Exec(ctx, `UPDATE campaigns SET end_date = $2 WHERE id = $1`,
+		f.campaign, now.Add(-time.Hour)); err != nil {
+		t.Fatalf("set the end date: %v", err)
+	}
+	overdueFollowUp(t, pool, f, step1, contact, now.Add(-2*time.Hour))
+
+	_, pair, _, err := liveScheduler(t, handle, pool).CalculateNextCampaignTime(ctx, f.campaign)
+	if pair != nil && err == nil {
+		t.Fatal("the scheduler authorised a send for a campaign that ended an hour ago")
+	}
+	if !errors.Is(err, ErrCampaignEnded) {
+		t.Fatalf("want the campaign reported as ended, got %v", err)
+	}
+}

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -311,6 +311,20 @@ func (s *schedulerService) placeCampaignSend(ctx context.Context, campaign *mode
 		baseTime = *nextPair.NotBefore
 	}
 
+	// An OVERDUE step's earliest possible send is now, never the moment it
+	// became due. Every schedule gate below is asked about `baseTime`, and for
+	// a follow-up whose wait elapsed hours ago that instant is in the past —
+	// where nextScheduleSlot deliberately keeps an instant that was already
+	// inside a sending window, and the end-date comparison finds a candidate
+	// that predates the end date. So a step that came due at 2pm passed both
+	// gates at 11pm: hardFloor sat in the past, STEP 14.5 read it as due, and
+	// the task sent it hours after the window closed, or days after the
+	// campaign ended. The window has to be asked about the send that is
+	// actually about to happen, which is this one, now.
+	if baseTime.Before(time.Now()) {
+		baseTime = time.Now()
+	}
+
 	// STEP 5: Apply campaign schedule constraints
 	// Fall back to UTC if campaign has no timezone set (account timezone checked later)
 	campaignTZName := campaign.Timezone


### PR DESCRIPTION
Found while reviewing #442. Pre-existing — reproduced on `main` at `b0050507`, the commit before that merge.

## What happens

A follow-up whose wait elapsed **while the window was shut** is sent the moment the chain next wakes up, whatever the clock says.

Proven against a real campaign: window `07:02–09:02` UTC, step 1 sent at `08:02` (inside), step 2 with no wait. At `10:02` — an hour after the window closed — `CalculateNextCampaignTime` hands back a **sendable pair**, and the task handler sends whatever pair it is given.

Same defect, second symptom: a campaign **past its end date** also sends an overdue follow-up instead of finishing.

## Why

Every schedule gate in the placer is asked about the step's candidate time, which for a follow-up starts at *when its wait elapsed*:

```go
baseTime = lastSentTime.Add(waitDuration)      // 08:02 — two hours ago
...
if campaign.EndDate != nil && candidateTime.After(*campaign.EndDate) { ... }
candidateTime = nextScheduleSlot(candidateTime, windows, campaignTZ)
hardFloor := candidateTime
```

Once that instant is in the past, two gates stop working:

- `nextScheduleSlot` deliberately returns an instant that was **already inside a window** unchanged — `return from // already inside a window — keep the exact instant`. `08:02` was inside `07:02–09:02`, so it comes back untouched.
- the end-date comparison asks whether the moment the step came due is past the end date, not whether *now* is.

So `hardFloor` sits in the past, STEP 14.5's `time.Until(hardFloor) > grace` is false, the pair is returned as sendable, and the handler sends it immediately.

The weekday mask survives by luck: a past instant on a non-sending day makes `nextScheduleSlot` walk forward, so that one already defers.

## How the chain reaches those hours

The wake-up is normally placed inside the window, but three ordinary paths put a tick outside it:

- a deferral is capped at `config.CampaignMaxDeferMinutes`, so a wake-up computed near closing time lands past the close
- the reconciler re-seeds a chain with no successor at `now + 1 minute`, whatever the clock says
- a dispatch failure is retried the same way

## The fix

One floor, before the gates:

```go
if baseTime.Before(time.Now()) {
	baseTime = time.Now()
}
```

An overdue step's earliest possible send is **now**, never the moment it became due. The window, the weekday mask and the end date are then all asked about the send that is actually about to happen. It is a floor, not a new wait: nothing that was already due stops being due, and an overdue step inside an open window still goes out on the same tick.

## How other tools behave

Every platform with published behaviour waits for the next window. None send late to catch up:

- **Outreach**, explicitly: *"If a step lands outside of an available time block, Outreach will wait until the next available window to initiate that step."* And on cascade: *"As that step moves forward, the rest of the schedule will move forward so the following steps do not play 'catch up.'"*
- **Apollo**: automatic emails wait for an allowed sending window after their wait time ends.
- **lemlist**: delays that push an email outside the schedule queue it for the next available window.
- **HubSpot sequences**: an enrollment landing outside the window reschedules into the next one. Sending outside it is treated as a bug by their users — there is a community thread titled exactly "sequences sending outside the email send window".
- **Woodpecker**: overdue follow-ups are *prioritised* over new leads once sending resumes, rather than sent outside hours.

Warmbly's own docs already promised this — the entry-delay section says a step "goes out in the first sending window that has mailbox capacity, exactly like any other step". The code just did not do it for an overdue one.

## Tests

`internal/scheduler/campaign_overdue_window_live_test.go`, all mutation-tested (the floor removed, the tests watched to fail — 40/40 runs):

- `TestLiveOverdueFollowUpWaitsForTheWindowToReopen` — refuses to send, and parks a future wake-up whose time of day is inside the window
- `TestLiveOverdueFollowUpStillSendsInsideTheWindow` — the same overdue step still sends promptly while the window is open, so the floor has not become a wait
- `TestLiveOverdueFollowUpRespectsTheEndDate` — reports the campaign ended instead of sending

The first assertion deliberately does not pin which *day* the wake-up lands on. `applyDistributionCurve` can push an early-morning window's candidate past that day's close (it nudges an hour before 9am toward 9am, which overshoots a window ending at 9:02), and `intersectWindows` then walks to the next day. That is a separate, self-correcting behaviour and pinning the day here made the test flake 2 runs in 6 for a reason that has nothing to do with this fix. Worth its own look — a narrow early window can lose a day — but not worth changing send-time shaping from inside this change.

## Verification

`make lint` passes, `gofmt -l` clean, `pnpm types:check` passes in `docs/`. The three live tests that fail on this database (`internal/app/warmup` ×2 and `TestLiveRepairedVerificationRestoresRouting`) reproduce identically on a fresh `origin/main` worktree.

## Docs

`guides/campaigns.mdx`: the Scheduling section now states that a step whose turn comes while the window is shut waits for the next one and is never sent late to catch up, and the campaign-dates paragraph says nothing goes out past the end date including an already-due follow-up.