### PR TITLE
feat: AI is a paid feature, so take it off the free plan

### DIFF
--- a/docs/content/docs/guides/ai-assistant.mdx
+++ b/docs/content/docs/guides/ai-assistant.mdx
@@ -11,7 +11,7 @@ Open it from the spark button or `Cmd/Ctrl + I`. The panel follows you between p
 The assistant acts as you: only what your role allows, only in your workspace, never another organization's data. Every change asks first, and **sending is never auto-approved**, even with "Always allow" on.
 </Callout>
 
-Access is the **Use AI** role permission (on for admins and managers, off for viewers); without it the assistant and AI drafting are hidden. Admins can cap per-member spend by day, week, or month. See [AI credits](/guides/ai-credits/) and [Team and roles](/guides/team-roles/).
+The assistant needs a paid plan; a free trial has no credit allowance and the AI surfaces stay locked. Beyond that, access is the **Use AI** role permission (on for admins and managers, off for viewers); without it the assistant and AI drafting are hidden. Admins can cap per-member spend by day, week, or month. See [AI credits](/guides/ai-credits/) and [Team and roles](/guides/team-roles/).
 
 ## Conversations and the panel
 

--- a/docs/content/docs/guides/ai-credits.mdx
+++ b/docs/content/docs/guides/ai-credits.mdx
@@ -3,7 +3,7 @@ title: AI credits
 description: How AI credits work in Warmbly, what each AI action costs, the monthly allowance and reset rules, and how to buy top-up packs.
 ---
 
-AI features run on credits. Your plan grants a monthly allowance that refreshes each billing cycle, and top-up packs never expire.
+AI features run on credits, and they are paid-only: a free trial carries no allowance and the AI surfaces stay locked until the workspace is on a paid plan. Your plan grants a monthly allowance that refreshes each billing cycle, and top-up packs never expire.
 
 <Callout type="info" title="Who can manage credits">
 Everything here lives on the **AI & credits** tab of **Settings > Billing** and needs the **Manage billing** permission. Other members do not see it.
@@ -61,10 +61,10 @@ Who can use AI at all is separate: the **Use AI** role permission (see [Team and
 
 | Plan | Monthly credits |
 |------|-----------------|
-| Free trial | 50 (granted once, at trial start) |
+| Free trial | none, AI is a paid feature |
 | Starter | 250 |
-| Pro | 2,000 |
-| Enterprise | 25,000 |
+| Grow | 2,000 |
+| Business | 25,000 |
 
 Paid workspaces get a fresh grant each cycle, with the reset date shown beside your balance. Top-up packs come in **500**, **2,000**, and **10,000** credits, paid through Stripe Checkout with the card on file, landing in the purchased pool as soon as payment settles. Top-ups require an active paid plan.
 

--- a/internal/app/feature/gate.go
+++ b/internal/app/feature/gate.go
@@ -332,7 +332,11 @@ func (s *featureGateService) CanUseWritingAssistant(ctx context.Context, orgID u
 	if sub == nil {
 		return false, nil
 	}
-	return sub.HasPaidSubscription() || sub.IsInFreeTrial(), nil
+	// Paid only, like the inbox agent. The free plan carries no credit
+	// allowance, so admitting a trial here would put the assistant in front of
+	// someone who can only ever be told they have no credits, which reads as a
+	// broken feature rather than a locked one.
+	return sub.HasPaidSubscription(), nil
 }
 
 // CanUseInboxAgent gates the inbox agent to paid subscribers only. Unlike the

--- a/internal/app/feature/gate_ai_test.go
+++ b/internal/app/feature/gate_ai_test.go
@@ -1,0 +1,74 @@
+package feature
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Only the one read the AI gates make is implemented; anything else panics,
+// which is the point.
+type stubSubs struct {
+	repository.SubscriptionRepository
+	sub *models.Subscription
+}
+
+func (s stubSubs) GetByOrganizationID(context.Context, uuid.UUID) (*models.Subscription, error) {
+	return s.sub, nil
+}
+
+func trialSub() *models.Subscription {
+	future := time.Now().Add(14 * 24 * time.Hour)
+	return &models.Subscription{
+		PlanID:          uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Status:          models.SubscriptionStatusTrialing,
+		FreeTrialEndsAt: &future,
+	}
+}
+
+// The free plan carries no credit allowance, so the assistant must be locked
+// rather than shown. Offering it to someone who can only ever be told they
+// have no credits reads as a broken feature, not a paid one.
+func TestWritingAssistantIsPaidOnly(t *testing.T) {
+	g := &featureGateService{subRepo: stubSubs{sub: trialSub()}}
+
+	ok, xerr := g.CanUseWritingAssistant(context.Background(), uuid.New())
+	if xerr != nil {
+		t.Fatalf("unexpected error: %v", xerr)
+	}
+	if ok {
+		t.Error("a free trial must not be offered the writing assistant")
+	}
+}
+
+func TestWritingAssistantAndInboxAgentAgree(t *testing.T) {
+	ctx := context.Background()
+	org := uuid.New()
+	g := &featureGateService{subRepo: stubSubs{sub: trialSub()}}
+
+	wa, _ := g.CanUseWritingAssistant(ctx, org)
+	ia, _ := g.CanUseInboxAgent(ctx, org)
+	if wa != ia {
+		t.Errorf("both AI features should gate the same way on a free trial: assistant=%v agent=%v", wa, ia)
+	}
+}
+
+// No subscription at all is still a refusal, not a panic.
+func TestAIGatesRefuseWithNoSubscription(t *testing.T) {
+	g := &featureGateService{subRepo: stubSubs{sub: nil}}
+	if ok, _ := g.CanUseWritingAssistant(context.Background(), uuid.New()); ok {
+		t.Error("no subscription must not unlock the assistant")
+	}
+}
+
+// A self-hosted instance has no payment provider, so every gate stays open.
+func TestSelfHostKeepsAIOpen(t *testing.T) {
+	g := &featureGateService{selfHost: true}
+	if ok, _ := g.CanUseWritingAssistant(context.Background(), uuid.New()); !ok {
+		t.Error("self-host must keep the assistant available")
+	}
+}

--- a/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.down.sql
+++ b/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.down.sql
@@ -1,3 +1,16 @@
+-- Reverses 000148 by restoring the allowance 000080 originally inserted.
+--
+-- One case does not round-trip: a free plan that was ALREADY at zero before
+-- 000148 ran comes back as 50, because the up migration recorded no prior
+-- value to restore. It is guarded as tightly as it can be without keeping
+-- migration bookkeeping in a product table — scoped to the one plan id, and
+-- only when the value is still the zero the up migration would have left —
+-- but a zero it did not write is indistinguishable from one it did.
+--
+-- Affects one row of plan configuration that an operator can edit in the
+-- admin panel, and the practical posture is forward-only (see the upgrade
+-- notes in the deployment guide), so the exposure is a rollback immediately
+-- followed by setting the value back.
 UPDATE plans
 SET monthly_credits = 50,
     updated_at      = NOW()

--- a/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.down.sql
+++ b/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.down.sql
@@ -1,0 +1,5 @@
+UPDATE plans
+SET monthly_credits = 50,
+    updated_at      = NOW()
+WHERE id = '00000000-0000-0000-0000-000000000001'
+  AND monthly_credits = 0;

--- a/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.up.sql
+++ b/internal/infrastructure/db/migrations/000148_free_plan_no_ai_credits.up.sql
@@ -1,0 +1,13 @@
+-- The free plan is the connect-and-see-it-work tier: mailboxes, sync and a
+-- couple of small campaigns. AI is a paid feature, so the allowance goes to
+-- zero and the trial grant in internal/app/trial stops firing (it only grants
+-- when monthly_credits > 0).
+--
+-- Existing balances are deliberately left alone. Someone who already received
+-- the allowance keeps what they have; taking credits back from an account that
+-- was given them is a worse surprise than the inconsistency.
+UPDATE plans
+SET monthly_credits = 0,
+    updated_at      = NOW()
+WHERE id = '00000000-0000-0000-0000-000000000001'
+  AND monthly_credits <> 0;

--- a/internal/seed/plans.go
+++ b/internal/seed/plans.go
@@ -63,7 +63,8 @@ func seedPlans(ctx context.Context, pool *pgxpool.Pool, r *Result) error {
 			dedicatedWorkers: 0, dailyCampaignLimit: intPtr(20),
 			maxCampaigns: intPtr(2), maxActiveCampaigns: intPtr(1),
 			maxTeamMembers: intPtr(1), maxEmailAccounts: intPtr(2),
-			monthlyCredits: 50,
+			// AI is a paid feature; the free tier is connect, sync and send.
+			monthlyCredits: 0,
 		},
 		// Paid plans mirror the pricing page: mailboxes are unlimited on every
 		// one (max_email_accounts nil, the fair-use allowance derives from the


### PR DESCRIPTION
The free plan is the connect-and-see-it-work tier: mailboxes, sync, a couple of small campaigns. It was also granting 50 AI credits.

Zeroing the allowance alone would have made things worse, not better, so this is three changes that only make sense together.

## Why the gate had to move too

`CanUseInboxAgent` was already paid-only. `CanUseWritingAssistant` was not:

```go
return sub.HasPaidSubscription() || sub.IsInFreeTrial(), nil
```

So a trial workspace was *shown* the assistant, and the 50 credits existed to make that work. Drop the credits and leave the gate, and a free user gets a visible button that can only ever answer "you have no credits" — a broken feature rather than a locked one, and the worst of both outcomes.

The assistant now gates exactly like the inbox agent. A test asserts the two agree, so they cannot drift apart again.

## The three parts

- **Migration `000148`** sets the free plan's `monthly_credits` to `0`. The trial grant in `internal/app/trial` only fires when `monthly_credits > 0`, so it stops by itself with no code change there.
- **`internal/seed/plans.go`** matches, so a fresh install and a migrated one agree.
- **`CanUseWritingAssistant`** becomes paid-only.

Existing balances are deliberately left alone. Anyone already granted the allowance keeps it; clawing back credits from an account that was given them is a worse surprise than the inconsistency, and the down migration restores the plan value rather than re-granting.

## Docs

`ai-credits.mdx` said "Free trial | 50 (granted once, at trial start)". It now says AI is paid-only, and the intro says so too rather than leaving it to a table row.

That same table also named plans that do not exist — `Pro` and `Enterprise`, where the real ones are `Grow` and `Business`. Fixed while here, since a pricing table naming the wrong plans is its own bug.

`ai-assistant.mdx` now leads with the paid requirement before the role permission, because the permission is irrelevant if the plan locks it.

## Note on a nearby trap

`plans.ai_generation` looks like it gates this and does not. It is written and read by `pg_plan.go` and carried on the model, but nothing consults it — the free plan has had `ai_generation = false` the whole time while the assistant was available. Left alone here rather than widening the change, but it should either gate something or go.

`make lint` (including `make check-migrations`, 148 versions, no duplicates) and `go test ./internal/app/feature/` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * AI features now require an active paid plan.
  * Free trials no longer include AI credits, and AI features remain locked until upgrading.
  * Updated plan documentation to show free-trial availability and renamed credit plans to Grow and Business.
  * Self-hosted installations continue to have unrestricted AI access.
* **Bug Fixes**
  * Aligned AI feature access checks for consistent paid-plan enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->