### PR TITLE
feat: plans an operator can grant, visible in the admin panel

### DIFF
--- a/admin/src/app/dashboard/OrganizationDetailPage.tsx
+++ b/admin/src/app/dashboard/OrganizationDetailPage.tsx
@@ -55,6 +55,7 @@ import type {
 } from "@/lib/api/models/admin";
 import { OrganizationOverridesDialog } from "./OrganizationOverridesDialog";
 import { OrganizationRiskCard, RiskBadge } from "./OrganizationRiskCard";
+import { OrganizationManagedPlanCard } from "./OrganizationManagedPlanCard";
 
 const TABS = [
     { id: "overview", label: "Overview", icon: LayoutDashboard },
@@ -192,6 +193,11 @@ export default function OrganizationDetailPage() {
                     )}
                 </SummaryCard>
             </div>
+
+            <section className="mt-6">
+                <h2 className="text-sm font-semibold mb-2">Plan</h2>
+                <OrganizationManagedPlanCard orgId={org.id} />
+            </section>
 
             <section className="mt-6">
                 <h2 className="text-sm font-semibold mb-2">Abuse posture</h2>

--- a/admin/src/app/dashboard/OrganizationManagedPlanCard.tsx
+++ b/admin/src/app/dashboard/OrganizationManagedPlanCard.tsx
@@ -24,6 +24,15 @@ import {
 } from "@/lib/api/client/admin/organizations";
 import type { ManagedPlan } from "@/lib/api/models/admin";
 
+/** A date input gives "YYYY-MM-DD" with no time. Reading that with `new Date`
+ *  yields UTC midnight, so a grant made for today is already expired for
+ *  anyone west of UTC, and the date displayed back can be the previous day.
+ *  The grant runs to the end of the chosen day in the operator's own zone. */
+function endOfLocalDay(day: string): string {
+    const [y, m, d] = day.split("-").map(Number);
+    return new Date(y, m - 1, d, 23, 59, 59, 999).toISOString();
+}
+
 function fmt(ts?: string | null) {
     if (!ts) return null;
     return new Date(ts).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
@@ -85,7 +94,7 @@ export function OrganizationManagedPlanCard({ orgId }: { orgId: string }) {
             grantOrganizationManagedPlan(orgId, {
                 plan_id: planId,
                 reason: reason.trim(),
-                until: until ? new Date(until).toISOString() : null,
+                until: until ? endOfLocalDay(until) : null,
             }),
         onSuccess: (m) => {
             applied("Plan granted")(m);

--- a/admin/src/app/dashboard/OrganizationManagedPlanCard.tsx
+++ b/admin/src/app/dashboard/OrganizationManagedPlanCard.tsx
@@ -1,0 +1,235 @@
+// A plan an operator granted rather than Stripe: internal workspaces, design
+// partners, support gestures. Before this the only way to make a workspace
+// paid was a Stripe subscription id, so the alternative was writing a fake one
+// into the database.
+//
+// Reading needs view_organizations; granting and revoking need
+// manage_organizations, so an admin without it sees the record rather than
+// buttons that can only answer 403.
+
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { BadgeCheck, CalendarClock, Gift, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAdminPerm } from "@/hooks/useAdminPerm";
+import { AdminPerm } from "@/lib/auth/permissions";
+import {
+    getOrganizationManagedPlan,
+    grantOrganizationManagedPlan,
+    listAdminPlans,
+    revokeOrganizationManagedPlan,
+} from "@/lib/api/client/admin/organizations";
+import type { ManagedPlan } from "@/lib/api/models/admin";
+
+function fmt(ts?: string | null) {
+    if (!ts) return null;
+    return new Date(ts).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+export function ManagedPlanBadge({ managed, expired }: { managed: boolean; expired: boolean }) {
+    if (managed) {
+        return (
+            <Badge variant="outline" className="text-[10px] border-sky-300 bg-sky-50 text-sky-700">
+                managed
+            </Badge>
+        );
+    }
+    if (expired) {
+        return (
+            <Badge variant="outline" className="text-[10px] border-amber-300 bg-amber-50 text-amber-700">
+                grant lapsed
+            </Badge>
+        );
+    }
+    return null;
+}
+
+export function OrganizationManagedPlanCard({ orgId }: { orgId: string }) {
+    const qc = useQueryClient();
+    const canManage = useAdminPerm(AdminPerm.ManageOrganizations);
+    const [granting, setGranting] = useState(false);
+    const [planId, setPlanId] = useState("");
+    const [reason, setReason] = useState("");
+    const [until, setUntil] = useState("");
+
+    const managedQuery = useQuery({
+        queryKey: ["admin", "organizations", orgId, "managed-plan"],
+        queryFn: () => getOrganizationManagedPlan(orgId),
+        enabled: !!orgId,
+    });
+
+    // Only loaded once the form is open: most visits to this card are to read
+    // the record, not to grant.
+    const plansQuery = useQuery({
+        queryKey: ["admin", "plans"],
+        queryFn: () => listAdminPlans(),
+        enabled: granting,
+    });
+
+    function applied(message: string) {
+        return (managed: ManagedPlan) => {
+            qc.setQueryData(["admin", "organizations", orgId, "managed-plan"], managed);
+            // The org detail shows the plan name, and the list inlines the
+            // badge, so both go stale on a grant.
+            qc.invalidateQueries({ queryKey: ["admin", "organizations", orgId] });
+            qc.invalidateQueries({ queryKey: ["admin", "organizations"] });
+            toast.success(message);
+        };
+    }
+
+    const grantMutation = useMutation({
+        mutationFn: () =>
+            grantOrganizationManagedPlan(orgId, {
+                plan_id: planId,
+                reason: reason.trim(),
+                until: until ? new Date(until).toISOString() : null,
+            }),
+        onSuccess: (m) => {
+            applied("Plan granted")(m);
+            setGranting(false);
+            setReason("");
+            setUntil("");
+        },
+        onError: (e: Error) => toast.error(e.message || "Failed to grant the plan"),
+    });
+
+    const revokeMutation = useMutation({
+        mutationFn: () => revokeOrganizationManagedPlan(orgId),
+        onSuccess: applied("Grant revoked; the workspace is back on what it pays for"),
+        onError: (e: Error) => toast.error(e.message || "Failed to revoke the grant"),
+    });
+
+    if (managedQuery.isLoading) return <Skeleton className="h-28 w-full" />;
+    if (managedQuery.error || !managedQuery.data) {
+        return (
+            <div className="text-sm text-red-600 border border-red-200 bg-red-50 rounded-md p-3">
+                Failed to load the plan grant.
+            </div>
+        );
+    }
+
+    const m = managedQuery.data;
+    const plans = plansQuery.data?.plans ?? [];
+
+    return (
+        <div className="border border-border rounded-lg bg-card">
+            <div className="flex items-start justify-between gap-3 p-3 border-b border-border">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <Gift className="size-4 text-muted-foreground" />
+                        <span className="text-sm font-medium">Managed plan</span>
+                        <ManagedPlanBadge managed={m.managed} expired={m.expired} />
+                    </div>
+                    <div className="text-xs text-muted-foreground mt-1">
+                        {m.managed
+                            ? "Paid because we granted it, not because Stripe says so."
+                            : m.expired
+                              ? "The grant has lapsed; the workspace is back on what it pays for."
+                              : "No grant. This workspace is entitled by Stripe alone."}
+                    </div>
+                </div>
+                {canManage && (
+                    <div className="flex items-center gap-2">
+                        {(m.managed || m.expired) && (
+                            <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => revokeMutation.mutate()}
+                                disabled={revokeMutation.isPending}
+                            >
+                                <X className="size-3.5 mr-1" /> Revoke
+                            </Button>
+                        )}
+                        <Button size="sm" variant="outline" onClick={() => setGranting((v) => !v)}>
+                            <BadgeCheck className="size-3.5 mr-1" />
+                            {m.managed ? "Change" : "Grant"}
+                        </Button>
+                    </div>
+                )}
+            </div>
+
+            {(m.managed || m.expired) && (
+                <dl className="p-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs border-b border-border">
+                    <div>
+                        <dt className="text-muted-foreground">Reason</dt>
+                        <dd className="mt-0.5">{m.reason || "—"}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-muted-foreground">Granted</dt>
+                        <dd className="mt-0.5">{fmt(m.granted_at) ?? "—"}</dd>
+                    </div>
+                    <div>
+                        <dt className="text-muted-foreground">Expires</dt>
+                        <dd className="mt-0.5 inline-flex items-center gap-1">
+                            {m.until ? (
+                                <>
+                                    <CalendarClock className="size-3" /> {fmt(m.until)}
+                                </>
+                            ) : (
+                                "open-ended"
+                            )}
+                        </dd>
+                    </div>
+                </dl>
+            )}
+
+            {granting && canManage && (
+                <div className="p-3 space-y-2">
+                    <label className="block text-xs text-muted-foreground">
+                        Plan
+                        <select
+                            className="mt-1 w-full h-8 rounded-md border border-border bg-background px-2 text-xs"
+                            value={planId}
+                            onChange={(e) => setPlanId(e.target.value)}
+                        >
+                            <option value="">Choose a plan…</option>
+                            {plans.map((p) => (
+                                <option key={p.id} value={p.id}>
+                                    {p.name}
+                                    {p.public === false ? " (private)" : ""}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="block text-xs text-muted-foreground">
+                        Reason
+                        <input
+                            className="mt-1 w-full h-8 rounded-md border border-border bg-background px-2 text-xs"
+                            placeholder="Why this workspace is paid without paying"
+                            value={reason}
+                            onChange={(e) => setReason(e.target.value)}
+                        />
+                    </label>
+                    <label className="block text-xs text-muted-foreground">
+                        Expires (optional)
+                        <input
+                            type="date"
+                            className="mt-1 w-full h-8 rounded-md border border-border bg-background px-2 text-xs"
+                            value={until}
+                            onChange={(e) => setUntil(e.target.value)}
+                        />
+                        <span className="block mt-1 text-[11px]">
+                            Leave empty for an open-ended grant. A date lapses on its own, so nobody has to
+                            remember to revoke it.
+                        </span>
+                    </label>
+                    <div className="flex items-center gap-2 pt-1">
+                        <Button
+                            size="sm"
+                            onClick={() => grantMutation.mutate()}
+                            disabled={!planId || !reason.trim() || grantMutation.isPending}
+                        >
+                            Grant
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => setGranting(false)}>
+                            Cancel
+                        </Button>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/admin/src/app/dashboard/OrganizationsPage.tsx
+++ b/admin/src/app/dashboard/OrganizationsPage.tsx
@@ -117,11 +117,34 @@ const columns: Column<AdminOrgListItem>[] = [
                             enterprise
                         </Badge>
                     )}
+                    {/* Paid because we said so. Worth seeing in the table: it is
+                        the difference between revenue and a grant. */}
+                    {o.managed_plan && (
+                        <Badge
+                            variant="outline"
+                            className="text-[10px] border-sky-300 bg-sky-50 text-sky-700"
+                            title={o.managed_plan_reason ?? "Granted by an operator"}
+                        >
+                            managed
+                        </Badge>
+                    )}
+                    {o.managed_plan_expired && (
+                        <Badge
+                            variant="outline"
+                            className="text-[10px] border-amber-300 bg-amber-50 text-amber-700"
+                            title={o.managed_plan_reason ?? "The grant has lapsed"}
+                        >
+                            grant lapsed
+                        </Badge>
+                    )}
                 </div>
             ) : (
                 <span className="text-xs text-muted-foreground">—</span>
             ),
-        csv: (o) => o.plan_name || "",
+        csv: (o) =>
+            [o.plan_name || "", o.managed_plan ? "managed" : "", o.managed_plan_expired ? "grant lapsed" : ""]
+                .filter(Boolean)
+                .join(" "),
     },
     {
         id: "channel",
@@ -218,6 +241,7 @@ export default function OrganizationsPage() {
     const [visibility, setVisibility] = useState<VisibilityFilter>("");
     const [subStatus, setSubStatus] = useState("");
     const [enterprise, setEnterprise] = useState(false);
+    const [managedPlan, setManagedPlan] = useState(false);
     const [hasOverrides, setHasOverrides] = useState(false);
     const [risk, setRisk] = useState<RiskFilter>("");
     const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
@@ -250,7 +274,7 @@ export default function OrganizationsPage() {
     const { reset } = pager;
 
     const filterKey = JSON.stringify({
-        query, status, visibility, subStatus, enterprise, hasOverrides, risk, cancelAtPeriodEnd,
+        query, status, visibility, subStatus, enterprise, managedPlan, hasOverrides, risk, cancelAtPeriodEnd,
         hasActiveSubscription, noSubscription, ownerBanned, hasActiveCampaigns, hasEmailAccounts,
         utmSource, utmMedium, hasAcquisition, noAcquisition,
         memMin, memMax, mbMin, mbMax, campMin, campMax, created, trialEnd, periodEnd, updated, sort,
@@ -269,6 +293,7 @@ export default function OrganizationsPage() {
                 plan_visibility: visibility || undefined,
                 subscription_status: subStatus || undefined,
                 enterprise: enterprise || undefined,
+                managed_plan: managedPlan || undefined,
                 has_overrides: hasOverrides || undefined,
                 risk_state: risk && risk !== "flagged" ? risk : undefined,
                 risk_flagged: risk === "flagged" || undefined,
@@ -308,7 +333,7 @@ export default function OrganizationsPage() {
 
     const rows = data?.data ?? [];
 
-    const bools = [enterprise, hasOverrides, cancelAtPeriodEnd, hasActiveSubscription, noSubscription, ownerBanned, hasActiveCampaigns, hasEmailAccounts, hasAcquisition, noAcquisition];
+    const bools = [enterprise, managedPlan, hasOverrides, cancelAtPeriodEnd, hasActiveSubscription, noSubscription, ownerBanned, hasActiveCampaigns, hasEmailAccounts, hasAcquisition, noAcquisition];
     const ranges = [[memMin, memMax], [mbMin, mbMax], [campMin, campMax]];
     const activeCount =
         (query ? 1 : 0) +
@@ -329,6 +354,7 @@ export default function OrganizationsPage() {
         setVisibility("");
         setSubStatus("");
         setEnterprise(false);
+        setManagedPlan(false);
         setHasOverrides(false);
         setCancelAtPeriodEnd(false);
         setHasActiveSubscription(false);
@@ -399,6 +425,7 @@ export default function OrganizationsPage() {
                             />
                             <div className="mt-2 flex flex-col gap-2">
                                 <ToggleFilter checked={enterprise} onChange={setEnterprise} label="Enterprise plan" />
+                                <ToggleFilter checked={managedPlan} onChange={setManagedPlan} label="Managed plan" />
                                 <ToggleFilter checked={hasActiveSubscription} onChange={setHasActiveSubscription} label="Active subscription" />
                                 <ToggleFilter checked={cancelAtPeriodEnd} onChange={setCancelAtPeriodEnd} label="Canceling at period end" />
                                 <ToggleFilter checked={noSubscription} onChange={setNoSubscription} label="No subscription" />

--- a/admin/src/lib/api/client/admin/organizations.ts
+++ b/admin/src/lib/api/client/admin/organizations.ts
@@ -11,6 +11,8 @@ import type {
     OrganizationLimitOverrides,
     OrgRisk,
     SetOrgRiskOverrideRequest,
+    AdminPlan,
+    ManagedPlan,
     UpdateOrgOverridesRequest,
 } from "@/lib/api/models/admin";
 
@@ -65,6 +67,45 @@ export function updateOrganizationOverrides(
         url: `/admin/organizations/${id}/overrides`,
         authorization: true,
         data: body,
+    });
+}
+
+/** Every plan, private ones included. The customer endpoint returns public
+ *  plans only, and a grant is usually onto a private one. */
+export function listAdminPlans(): Promise<{ plans: AdminPlan[] }> {
+    return Request({
+        method: "GET",
+        url: `/admin/plans`,
+        authorization: true,
+    });
+}
+
+/** A plan an operator granted rather than Stripe. */
+export function getOrganizationManagedPlan(id: string): Promise<ManagedPlan> {
+    return Request({
+        method: "GET",
+        url: `/admin/organizations/${id}/managed-plan`,
+        authorization: true,
+    });
+}
+
+export function grantOrganizationManagedPlan(
+    id: string,
+    body: { plan_id: string; reason: string; until?: string | null },
+): Promise<ManagedPlan> {
+    return Request({
+        method: "PUT",
+        url: `/admin/organizations/${id}/managed-plan`,
+        authorization: true,
+        data: body,
+    });
+}
+
+export function revokeOrganizationManagedPlan(id: string): Promise<ManagedPlan> {
+    return Request({
+        method: "DELETE",
+        url: `/admin/organizations/${id}/managed-plan`,
+        authorization: true,
     });
 }
 

--- a/admin/src/lib/api/models/admin.ts
+++ b/admin/src/lib/api/models/admin.ts
@@ -749,6 +749,13 @@ export interface AdminOrgListItem {
     plan_name?: string | null;
     plan_public?: boolean | null;
     is_enterprise: boolean;
+    /** Paid because an operator said so, not because Stripe says so. */
+    managed_plan: boolean;
+    /** A grant that lapsed. Distinct from never having had one: the workspace
+     *  is back on free and the reason is still on file. */
+    managed_plan_expired: boolean;
+    managed_plan_reason?: string | null;
+    managed_plan_until?: string | null;
 }
 
 /** The workspace's fused abuse posture. */
@@ -880,6 +887,8 @@ export interface AdminOrgSearch {
     created_within?: number; // days; omit for any
     has_overrides?: boolean;
     enterprise?: boolean;
+    /** Plans an operator granted rather than Stripe. */
+    managed_plan?: boolean;
     risk_state?: OrgRiskState | "";
     risk_flagged?: boolean;
     // Acquisition channel
@@ -917,4 +926,25 @@ export interface AdminOrgSearch {
     limit?: number;
     sort_by?: "created_at" | "name" | "owner_email" | "member_count" | "email_account_count" | "campaign_count";
     sort_desc?: boolean;
+}
+
+/** A plan an operator granted rather than Stripe, for internal workspaces,
+ *  design partners and support gestures. */
+export interface ManagedPlan {
+    managed: boolean;
+    expired: boolean;
+    plan_id: string;
+    granted_at?: string | null;
+    granted_by?: string | null;
+    reason?: string | null;
+    until?: string | null;
+}
+
+/** A plan row as the admin plans endpoint returns it. Only the fields the
+ *  grant picker needs. */
+export interface AdminPlan {
+    id: string;
+    name?: string | null;
+    public?: boolean | null;
+    price?: number | string | null;
 }

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -761,7 +761,7 @@ func main() {
 		if dailyThrottleService == nil {
 			dailyThrottleService = dailythrottle.NewService(cache)
 		}
-		organizationService = organization.NewService(organizationRepository, subscriptionRepository, userRepostory, dailyThrottleService)
+		organizationService = organization.NewService(organizationRepository, subscriptionRepository, userRepostory, planRepository, dailyThrottleService)
 
 		// Plan-based webhook/integration fan-out throttle. The cap scales with
 		// the org's effective mailbox allowance (see WebhookDispatchLimit) so a

--- a/cmd/warmblyctl/client.go
+++ b/cmd/warmblyctl/client.go
@@ -108,6 +108,7 @@ func (c *conn) orgService() organization.OrganizationService {
 		repository.NewOrganizationRepository(c.db.Pool),
 		repository.NewSubscriptionRepository(c.db.Pool),
 		c.users,
+		repository.NewPlanRepository(c.db.Pool),
 		nil,
 	)
 }

--- a/docs/content/docs/guides/billing.mdx
+++ b/docs/content/docs/guides/billing.mdx
@@ -57,7 +57,9 @@ A managed plan entitles exactly what the plan entitles. Nothing about the produc
 
 Operators grant one from the admin panel on the workspace, under **Plan**. The organization list marks granted workspaces with a `managed` badge and can filter to them, so "who is paid because we said so" is answerable without checking Stripe. A grant that has lapsed keeps its reason on file and is shown as `grant lapsed` rather than disappearing.
 
-Revoking a grant returns the workspace to whatever it actually pays for, which for most is the free plan.
+A grant is held beside the plan a workspace pays for, never on top of it, so a paying workspace that is granted a different plan goes back to the one it pays for when the grant ends. Revoking returns the workspace to whatever it actually pays for, which for most is the free plan.
+
+One thing a grant does not do: monthly AI credits are granted when an invoice is paid, and a granted plan raises no invoice, so a managed workspace does not receive a recurring credit allowance. Top up its balance directly if it needs credits.
 
 ## Self-hosted deployments
 

--- a/docs/content/docs/guides/billing.mdx
+++ b/docs/content/docs/guides/billing.mdx
@@ -49,6 +49,16 @@ Need a single limit raised without moving plan? Request an increase from **Setti
 
 **Payment** links out to the Stripe billing portal. Cards and the billing email are held by Stripe and never touch Warmbly, so they are read and changed there. Invoices and PDF receipts live in the portal too.
 
+## Plans granted by an operator
+
+A workspace can be put on a plan without paying for it. Warmbly calls this a **managed plan**, and it exists for internal workspaces, design partners and support gestures.
+
+A managed plan entitles exactly what the plan entitles. Nothing about the product behaves differently, and nothing is charged: no Stripe subscription is created, no invoice is raised, and the billing page still shows what the workspace would pay. The grant carries the reason it was made and who made it, and it can be open-ended or given an expiry date, in which case it lapses on its own.
+
+Operators grant one from the admin panel on the workspace, under **Plan**. The organization list marks granted workspaces with a `managed` badge and can filter to them, so "who is paid because we said so" is answerable without checking Stripe. A grant that has lapsed keeps its reason on file and is shown as `grant lapsed` rather than disappearing.
+
+Revoking a grant returns the workspace to whatever it actually pays for, which for most is the free plan.
+
 ## Self-hosted deployments
 
 A self-hosted instance running without a billing provider has every feature unlocked and no billing page. See [Warmbly Cloud](/guides/warmbly-cloud/) for how a self-hosted instance links to a hosted workspace.

--- a/internal/api/handler/admin_org_plan.go
+++ b/internal/api/handler/admin_org_plan.go
@@ -1,0 +1,137 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// adminManagedPlanRequest is a grant. A reason is required for the same reason
+// the risk override requires one: an unexplained paid workspace is the thing
+// this feature exists to avoid creating.
+type adminManagedPlanRequest struct {
+	PlanID string     `json:"plan_id"`
+	Reason string     `json:"reason"`
+	Until  *time.Time `json:"until,omitempty"`
+}
+
+// AdminListPlans returns every plan, private ones included. The customer
+// endpoint returns only public plans, and a grant is most often onto a private
+// one (an internal or partner plan), so the picker needs the full list.
+func (h *Handler) AdminListPlans(c *gin.Context) {
+	if h.SubscriptionService == nil {
+		errx.JSON(c, errx.New(errx.ServiceUnavailable, "plans are not available on this instance"))
+		return
+	}
+	plans, xerr := h.SubscriptionService.ListPlans(c.Request.Context(), false)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"plans": plans})
+}
+
+// AdminGetOrgManagedPlan reports whether a workspace is paid because an
+// operator said so, and why.
+func (h *Handler) AdminGetOrgManagedPlan(c *gin.Context) {
+	orgID, ok := adminOrgParam(c)
+	if !ok {
+		return
+	}
+	if h.OrganizationService == nil {
+		errx.JSON(c, errx.New(errx.ServiceUnavailable, "organizations are not available on this instance"))
+		return
+	}
+	managed, xerr := h.OrganizationService.GetManagedPlan(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, managed)
+}
+
+// AdminGrantOrgManagedPlan puts a workspace on a plan without Stripe.
+func (h *Handler) AdminGrantOrgManagedPlan(c *gin.Context) {
+	adminID := middleware.GetAdminUserID(c)
+	if adminID == nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	orgID, ok := adminOrgParam(c)
+	if !ok {
+		return
+	}
+	if h.OrganizationService == nil {
+		errx.JSON(c, errx.New(errx.ServiceUnavailable, "organizations are not available on this instance"))
+		return
+	}
+
+	var req adminManagedPlanRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "a plan and a reason are required"))
+		return
+	}
+	planID, err := uuid.Parse(strings.TrimSpace(req.PlanID))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "plan_id must be a plan uuid"))
+		return
+	}
+	reason := strings.TrimSpace(req.Reason)
+	if reason == "" {
+		errx.JSON(c, errx.New(errx.BadRequest, "a reason is required, so the grant is answerable later"))
+		return
+	}
+
+	managed, xerr := h.OrganizationService.GrantManagedPlan(c.Request.Context(), orgID, planID, *adminID, reason, req.Until)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	details := map[string]any{"plan_id": planID.String(), "reason": reason}
+	if req.Until != nil {
+		details["until"] = req.Until.UTC().Format(time.RFC3339)
+	}
+	h.logOrgPlanAction(c, *adminID, orgID, "grant_managed_plan", details)
+	c.JSON(http.StatusOK, managed)
+}
+
+// AdminRevokeOrgManagedPlan ends a grant. The workspace keeps the plan row it
+// was on and stops counting as paid.
+func (h *Handler) AdminRevokeOrgManagedPlan(c *gin.Context) {
+	adminID := middleware.GetAdminUserID(c)
+	if adminID == nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	orgID, ok := adminOrgParam(c)
+	if !ok {
+		return
+	}
+	if h.OrganizationService == nil {
+		errx.JSON(c, errx.New(errx.ServiceUnavailable, "organizations are not available on this instance"))
+		return
+	}
+
+	managed, xerr := h.OrganizationService.RevokeManagedPlan(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	h.logOrgPlanAction(c, *adminID, orgID, "revoke_managed_plan", nil)
+	c.JSON(http.StatusOK, managed)
+}
+
+// logOrgPlanAction records the operator action on the platform-admin trail,
+// which is who-did-what across tenants rather than within one.
+func (h *Handler) logOrgPlanAction(c *gin.Context, adminID, orgID uuid.UUID, action string, details map[string]any) {
+	if h.AdminService == nil {
+		return
+	}
+	h.AdminService.LogAdminAction(c.Request.Context(), adminID, action, "organization", &orgID,
+		details, c.ClientIP(), c.Request.UserAgent())
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -1435,6 +1435,12 @@ func Run(
 		adminRoutes.GET("/organizations/:id/members", middleware.RequireAdminPermission(models.AdminPermViewOrganizations), h.AdminGetOrganizationMembers)
 		adminRoutes.GET("/organizations/:id/overrides", middleware.RequireAdminPermission(models.AdminPermViewOrganizations), h.AdminGetOrgOverrides)
 		adminRoutes.PUT("/organizations/:id/overrides", middleware.RequireAdminPermission(models.AdminPermManageOrganizations), h.AdminUpdateOrgOverrides)
+		// A plan granted by an operator rather than Stripe. Same permission as
+		// the overrides above: it changes what a workspace is entitled to.
+		adminRoutes.GET("/plans", middleware.RequireAdminPermission(models.AdminPermViewOrganizations), h.AdminListPlans)
+		adminRoutes.GET("/organizations/:id/managed-plan", middleware.RequireAdminPermission(models.AdminPermViewOrganizations), h.AdminGetOrgManagedPlan)
+		adminRoutes.PUT("/organizations/:id/managed-plan", middleware.RequireAdminPermission(models.AdminPermManageOrganizations), h.AdminGrantOrgManagedPlan)
+		adminRoutes.DELETE("/organizations/:id/managed-plan", middleware.RequireAdminPermission(models.AdminPermManageOrganizations), h.AdminRevokeOrgManagedPlan)
 
 		// Workspace abuse posture. The customer route withholds the evidence;
 		// this is where an operator reads it, pins a decision over it, and

--- a/internal/app/contact/handler.go
+++ b/internal/app/contact/handler.go
@@ -35,7 +35,7 @@ func (s *contactService) checkContactLimit(ctx context.Context, userID string, a
 	if err != nil || sub == nil {
 		return nil
 	}
-	plan, err := s.planRepo.GetByID(ctx, sub.PlanID)
+	plan, err := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 	if err != nil || plan == nil || plan.MaxContacts <= 0 {
 		return nil
 	}

--- a/internal/app/feature/gate.go
+++ b/internal/app/feature/gate.go
@@ -234,7 +234,7 @@ func (s *featureGateService) GetDailyEmailLimit(ctx context.Context, orgID uuid.
 		if ov := s.dailyOverride(ctx, orgID); ov > 0 {
 			return ov, nil
 		}
-		plan, err := s.planRepo.GetByID(ctx, sub.PlanID)
+		plan, err := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 		if err != nil || plan == nil {
 			return UnlimitedEmails, nil // Default to unlimited if plan not found
 		}
@@ -283,7 +283,7 @@ func (s *featureGateService) GetSubscriptionStatus(ctx context.Context, orgID uu
 	status.IsPaidSubscriber = sub.HasPaidSubscription()
 
 	// Load plan
-	plan, _ := s.planRepo.GetByID(ctx, sub.PlanID)
+	plan, _ := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 	status.Plan = plan
 
 	// Calculate daily limit

--- a/internal/app/organization/service.go
+++ b/internal/app/organization/service.go
@@ -100,6 +100,13 @@ type OrganizationService interface {
 	// MailboxAllowance resolves how many mailboxes the workspace may hold and
 	// why; every connect path checks it and GET /emails/allowance returns it.
 	MailboxAllowance(ctx context.Context, orgID uuid.UUID) (*models.MailboxAllowance, *errx.Error)
+
+	// GrantManagedPlan / RevokeManagedPlan are the operator-granted plan: paid
+	// entitlements without Stripe, for internal workspaces, design partners
+	// and support gestures.
+	GrantManagedPlan(ctx context.Context, orgID, planID, adminID uuid.UUID, reason string, until *time.Time) (*models.ManagedPlan, *errx.Error)
+	RevokeManagedPlan(ctx context.Context, orgID uuid.UUID) (*models.ManagedPlan, *errx.Error)
+	GetManagedPlan(ctx context.Context, orgID uuid.UUID) (*models.ManagedPlan, *errx.Error)
 	GetCampaignCounts(ctx context.Context, orgID uuid.UUID) (total int, active int, err *errx.Error)
 	GetOrganizationLimits(ctx context.Context, orgID uuid.UUID) (*models.OrganizationLimits, *errx.Error)
 	GetOrganizationCounts(ctx context.Context, orgID uuid.UUID) (*models.OrganizationCounts, *errx.Error)
@@ -151,6 +158,9 @@ type organizationService struct {
 	orgRepo  repository.OrganizationRepository
 	subRepo  repository.SubscriptionRepository
 	userRepo repository.UserRepository
+	// planRepo validates a granted plan id before it is written, so a typo is
+	// a 400 naming the problem rather than a foreign-key violation.
+	planRepo repository.PlanRepository
 	throttle dailythrottle.Service
 	// authPolicy is wired after construction, because the policy is loaded
 	// alongside the mail transport and not available at this call site.
@@ -213,11 +223,13 @@ func NewService(
 	orgRepo repository.OrganizationRepository,
 	subRepo repository.SubscriptionRepository,
 	userRepo repository.UserRepository,
+	planRepo repository.PlanRepository,
 	throttle dailythrottle.Service,
 ) OrganizationService {
 	return &organizationService{
 		orgRepo:  orgRepo,
 		subRepo:  subRepo,
+		planRepo: planRepo,
 		userRepo: userRepo,
 		throttle: throttle,
 	}
@@ -1676,4 +1688,61 @@ func (s *organizationService) DeleteRole(ctx context.Context, orgID, actorID, ro
 		return errx.New(errx.Internal, "failed to delete role")
 	}
 	return nil
+}
+
+// GetManagedPlan reports the grant on a workspace, if any.
+func (s *organizationService) GetManagedPlan(ctx context.Context, orgID uuid.UUID) (*models.ManagedPlan, *errx.Error) {
+	sub, err := s.subRepo.GetByOrganizationID(ctx, orgID)
+	if err != nil {
+		errs.CaptureException(err)
+		return nil, errx.New(errx.Internal, "failed to read the subscription")
+	}
+	if sub == nil {
+		return nil, errx.New(errx.NotFound, "that workspace has no subscription")
+	}
+	return managedPlanOf(sub), nil
+}
+
+// GrantManagedPlan puts a workspace on a plan without Stripe.
+func (s *organizationService) GrantManagedPlan(ctx context.Context, orgID, planID, adminID uuid.UUID, reason string, until *time.Time) (*models.ManagedPlan, *errx.Error) {
+	// A grant into the past is almost certainly a timezone or unit mistake,
+	// and it would read as "granted" in the audit trail while entitling
+	// nothing at all.
+	if until != nil && !until.After(time.Now()) {
+		return nil, errx.New(errx.BadRequest, "the grant would already have expired; leave it open-ended or pick a future date")
+	}
+	if s.planRepo != nil {
+		plan, perr := s.planRepo.GetByID(ctx, planID)
+		if perr != nil || plan == nil {
+			return nil, errx.New(errx.BadRequest, "that plan does not exist")
+		}
+	}
+	if err := s.subRepo.SetManagedPlan(ctx, orgID, planID, adminID, reason, until); err != nil {
+		errs.CaptureException(err)
+		return nil, errx.New(errx.Internal, "failed to grant the plan")
+	}
+	return s.GetManagedPlan(ctx, orgID)
+}
+
+// RevokeManagedPlan ends a grant. The workspace keeps the plan row it was on
+// and stops counting as paid, which is where an expired grant leaves it too.
+func (s *organizationService) RevokeManagedPlan(ctx context.Context, orgID uuid.UUID) (*models.ManagedPlan, *errx.Error) {
+	if err := s.subRepo.ClearManagedPlan(ctx, orgID); err != nil {
+		errs.CaptureException(err)
+		return nil, errx.New(errx.Internal, "failed to revoke the plan")
+	}
+	return s.GetManagedPlan(ctx, orgID)
+}
+
+func managedPlanOf(sub *models.Subscription) *models.ManagedPlan {
+	out := &models.ManagedPlan{
+		Managed:   sub.IsManaged(),
+		Expired:   sub.ManagedExpired(),
+		GrantedAt: sub.ManagedAt,
+		GrantedBy: sub.ManagedBy,
+		Reason:    sub.ManagedReason,
+		Until:     sub.ManagedUntil,
+		PlanID:    sub.PlanID,
+	}
+	return out
 }

--- a/internal/app/organization/service.go
+++ b/internal/app/organization/service.go
@@ -1713,7 +1713,11 @@ func (s *organizationService) GrantManagedPlan(ctx context.Context, orgID, planI
 	}
 	if s.planRepo != nil {
 		plan, perr := s.planRepo.GetByID(ctx, planID)
-		if perr != nil || plan == nil {
+		if perr != nil {
+			errs.CaptureException(perr)
+			return nil, errx.New(errx.Internal, "failed to look up the plan")
+		}
+		if plan == nil {
 			return nil, errx.New(errx.BadRequest, "that plan does not exist")
 		}
 	}
@@ -1742,7 +1746,7 @@ func managedPlanOf(sub *models.Subscription) *models.ManagedPlan {
 		GrantedBy: sub.ManagedBy,
 		Reason:    sub.ManagedReason,
 		Until:     sub.ManagedUntil,
-		PlanID:    sub.PlanID,
+		PlanID:    sub.EffectivePlanID(),
 	}
 	return out
 }

--- a/internal/app/subscription/service.go
+++ b/internal/app/subscription/service.go
@@ -47,7 +47,7 @@ func (s *subscriptionService) Get(ctx context.Context, orgID uuid.UUID) (*models
 	}
 
 	// Load plan
-	plan, _ := s.planRepo.GetByID(ctx, sub.PlanID)
+	plan, _ := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 	sub.Plan = plan
 
 	return sub, nil

--- a/internal/app/worker/assignment.go
+++ b/internal/app/worker/assignment.go
@@ -334,7 +334,7 @@ func (s *workerAssignmentService) hasIsolatedEgress(ctx context.Context, orgID u
 	if err != nil || sub == nil {
 		return false
 	}
-	plan, err := s.planRepo.GetByID(ctx, sub.PlanID)
+	plan, err := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 	if err != nil || plan == nil {
 		return false
 	}

--- a/internal/infrastructure/db/migrations/000149_managed_plans.down.sql
+++ b/internal/infrastructure/db/migrations/000149_managed_plans.down.sql
@@ -1,9 +1,7 @@
 -- Reverses 000149. Every granted plan is forgotten, so a workspace that was
 -- paid only because an operator said so becomes unpaid again on the next
--- entitlement check. Nothing else is lost: a Stripe-backed subscription never
--- used these columns.
-DROP INDEX IF EXISTS idx_subscriptions_managed;
-
+-- entitlement check. Nothing else is lost: plan_id was never written by a
+-- grant, so a Stripe-backed workspace is already on the plan it pays for.
 ALTER TABLE public.subscriptions
     DROP CONSTRAINT IF EXISTS subscriptions_managed_complete_check;
 
@@ -11,4 +9,5 @@ ALTER TABLE public.subscriptions
     DROP COLUMN IF EXISTS managed_at,
     DROP COLUMN IF EXISTS managed_by,
     DROP COLUMN IF EXISTS managed_reason,
-    DROP COLUMN IF EXISTS managed_until;
+    DROP COLUMN IF EXISTS managed_until,
+    DROP COLUMN IF EXISTS managed_plan_id;

--- a/internal/infrastructure/db/migrations/000149_managed_plans.down.sql
+++ b/internal/infrastructure/db/migrations/000149_managed_plans.down.sql
@@ -1,0 +1,14 @@
+-- Reverses 000149. Every granted plan is forgotten, so a workspace that was
+-- paid only because an operator said so becomes unpaid again on the next
+-- entitlement check. Nothing else is lost: a Stripe-backed subscription never
+-- used these columns.
+DROP INDEX IF EXISTS idx_subscriptions_managed;
+
+ALTER TABLE public.subscriptions
+    DROP CONSTRAINT IF EXISTS subscriptions_managed_complete_check;
+
+ALTER TABLE public.subscriptions
+    DROP COLUMN IF EXISTS managed_at,
+    DROP COLUMN IF EXISTS managed_by,
+    DROP COLUMN IF EXISTS managed_reason,
+    DROP COLUMN IF EXISTS managed_until;

--- a/internal/infrastructure/db/migrations/000149_managed_plans.up.sql
+++ b/internal/infrastructure/db/migrations/000149_managed_plans.up.sql
@@ -7,23 +7,28 @@
 -- Mirrors organizations.risk_override_*: who, why, when, so the grant is
 -- answerable months later. managed_until NULL is an open-ended grant; a value
 -- expires the grant without anyone having to remember to revoke it.
+--
+-- managed_plan_id is deliberately NOT plan_id. A workspace paying Stripe for
+-- plan A that is granted plan B must go back to A when the grant ends, so the
+-- grant is held beside the real plan rather than on top of it. Resolution is
+-- models.Subscription.EffectivePlanID.
 ALTER TABLE public.subscriptions
-    ADD COLUMN managed_at     timestamptz,
-    ADD COLUMN managed_by     uuid REFERENCES public.users(id) ON DELETE SET NULL,
-    ADD COLUMN managed_reason text,
-    ADD COLUMN managed_until  timestamptz;
+    ADD COLUMN managed_at      timestamptz,
+    ADD COLUMN managed_by      uuid REFERENCES public.users(id) ON DELETE SET NULL,
+    ADD COLUMN managed_reason  text,
+    ADD COLUMN managed_until   timestamptz,
+    ADD COLUMN managed_plan_id uuid REFERENCES public.plans(id) ON DELETE SET NULL;
 
--- A grant is the four fields together. Recording one without a reason leaves
--- an unexplained paid workspace, which is the thing this is meant to prevent.
+-- A grant is the fields together. Recording one without a reason or without a
+-- plan leaves an unexplained or inert paid workspace, which is the thing this
+-- is meant to prevent.
 ALTER TABLE public.subscriptions
     ADD CONSTRAINT subscriptions_managed_complete_check
     CHECK (
         managed_at IS NULL
-        OR (managed_reason IS NOT NULL AND btrim(managed_reason) <> '')
+        OR (
+            managed_plan_id IS NOT NULL
+            AND managed_reason IS NOT NULL
+            AND btrim(managed_reason) <> ''
+        )
     );
-
--- The admin list filters on "managed by us", and an expiring grant is read on
--- every entitlement check, so both want an index rather than a scan.
-CREATE INDEX idx_subscriptions_managed
-    ON public.subscriptions (managed_at, managed_until)
-    WHERE managed_at IS NOT NULL;

--- a/internal/infrastructure/db/migrations/000149_managed_plans.up.sql
+++ b/internal/infrastructure/db/migrations/000149_managed_plans.up.sql
@@ -1,0 +1,29 @@
+-- A plan an operator granted rather than Stripe. Needed for internal
+-- workspaces, design partners and support gestures; before this the only way
+-- to make a workspace paid was a Stripe subscription id, so the alternative
+-- was hand-writing a fake one into this table and hoping no webhook ever
+-- reconciled against an id Stripe has never heard of.
+--
+-- Mirrors organizations.risk_override_*: who, why, when, so the grant is
+-- answerable months later. managed_until NULL is an open-ended grant; a value
+-- expires the grant without anyone having to remember to revoke it.
+ALTER TABLE public.subscriptions
+    ADD COLUMN managed_at     timestamptz,
+    ADD COLUMN managed_by     uuid REFERENCES public.users(id) ON DELETE SET NULL,
+    ADD COLUMN managed_reason text,
+    ADD COLUMN managed_until  timestamptz;
+
+-- A grant is the four fields together. Recording one without a reason leaves
+-- an unexplained paid workspace, which is the thing this is meant to prevent.
+ALTER TABLE public.subscriptions
+    ADD CONSTRAINT subscriptions_managed_complete_check
+    CHECK (
+        managed_at IS NULL
+        OR (managed_reason IS NOT NULL AND btrim(managed_reason) <> '')
+    );
+
+-- The admin list filters on "managed by us", and an expiring grant is read on
+-- every entitlement check, so both want an index rather than a scan.
+CREATE INDEX idx_subscriptions_managed
+    ON public.subscriptions (managed_at, managed_until)
+    WHERE managed_at IS NOT NULL;

--- a/internal/models/admin.go
+++ b/internal/models/admin.go
@@ -662,6 +662,7 @@ type AdminOrgSearch struct {
 	RiskState      string     `form:"risk_state"`      // exact posture: trusted|watch|restricted|suspended
 	RiskFlagged    bool       `form:"risk_flagged"`    // any posture other than trusted
 	Enterprise     bool       `form:"enterprise"`      // has an enterprise subscription
+	ManagedPlan    bool       `form:"managed_plan"`    // plan granted by an operator, not Stripe
 
 	// Subscription state
 	SubscriptionStatus    string `form:"subscription_status"`
@@ -751,6 +752,16 @@ type AdminOrgListItem struct {
 	PlanName     *string `json:"plan_name,omitempty"`
 	PlanPublic   *bool   `json:"plan_public,omitempty"`
 	IsEnterprise bool    `json:"is_enterprise"`
+
+	// ManagedPlan marks a plan an operator granted rather than Stripe, so the
+	// table can answer "which workspaces are paid because we said so" without
+	// a call per row. ManagedPlanExpired is a grant that lapsed, which is
+	// deliberately distinct: the workspace is back on free and the reason is
+	// still on file.
+	ManagedPlan        bool       `json:"managed_plan"`
+	ManagedPlanExpired bool       `json:"managed_plan_expired"`
+	ManagedPlanReason  *string    `json:"managed_plan_reason,omitempty"`
+	ManagedPlanUntil   *time.Time `json:"managed_plan_until,omitempty"`
 }
 
 // AdminOrgsResult is the paginated response for the admin org listing.

--- a/internal/models/subscriptions.go
+++ b/internal/models/subscriptions.go
@@ -140,6 +140,10 @@ type Subscription struct {
 	ManagedBy     *uuid.UUID `json:"managed_by,omitempty"`
 	ManagedReason *string    `json:"managed_reason,omitempty"`
 	ManagedUntil  *time.Time `json:"managed_until,omitempty"`
+	// ManagedPlanID is held beside PlanID, never on top of it, so a workspace
+	// paying Stripe for one plan and granted another goes back to the one it
+	// pays for when the grant ends.
+	ManagedPlanID *uuid.UUID `json:"managed_plan_id,omitempty"`
 
 	// Stripe trial info
 	TrialStart *time.Time `json:"trial_start,omitempty"`
@@ -200,6 +204,20 @@ func (s *Subscription) IsManaged() bool {
 		return true
 	}
 	return time.Now().Before(*s.ManagedUntil)
+}
+
+// EffectivePlanID is the plan that decides entitlements: the granted one while
+// a grant is in force, otherwise the plan the workspace actually pays for.
+// Every lookup of a subscription's plan goes through this; using PlanID
+// directly silently ignores the grant.
+func (s *Subscription) EffectivePlanID() uuid.UUID {
+	if s == nil {
+		return uuid.Nil
+	}
+	if s.IsManaged() && s.ManagedPlanID != nil {
+		return *s.ManagedPlanID
+	}
+	return s.PlanID
 }
 
 // ManagedExpired separates "was granted, has lapsed" from "never granted", so

--- a/internal/models/subscriptions.go
+++ b/internal/models/subscriptions.go
@@ -134,6 +134,13 @@ type Subscription struct {
 	CancelAtPeriodEnd  bool       `json:"cancel_at_period_end"`
 	CanceledAt         *time.Time `json:"canceled_at,omitempty"`
 
+	// A plan an operator granted rather than Stripe: internal workspaces,
+	// design partners, support gestures. ManagedUntil nil is open-ended.
+	ManagedAt     *time.Time `json:"managed_at,omitempty"`
+	ManagedBy     *uuid.UUID `json:"managed_by,omitempty"`
+	ManagedReason *string    `json:"managed_reason,omitempty"`
+	ManagedUntil  *time.Time `json:"managed_until,omitempty"`
+
 	// Stripe trial info
 	TrialStart *time.Time `json:"trial_start,omitempty"`
 	TrialEnd   *time.Time `json:"trial_end,omitempty"`
@@ -173,7 +180,36 @@ func (s *Subscription) IsFreeTrialExpired() bool {
 
 // HasPaidSubscription returns true if user has an active paid Stripe subscription
 func (s *Subscription) HasPaidSubscription() bool {
+	// A granted plan is paid without Stripe ever being involved. Checked
+	// first so a workspace that later subscribes for real is not affected
+	// either way.
+	if s.IsManaged() {
+		return true
+	}
 	return s.StripeSubscriptionID != nil && s.Status.IsActive()
+}
+
+// IsManaged reports whether an operator granted this plan and the grant is
+// still in force. An expired ManagedUntil lapses on its own, so a time-boxed
+// grant needs nobody to remember to revoke it.
+func (s *Subscription) IsManaged() bool {
+	if s == nil || s.ManagedAt == nil {
+		return false
+	}
+	if s.ManagedUntil == nil {
+		return true
+	}
+	return time.Now().Before(*s.ManagedUntil)
+}
+
+// ManagedExpired separates "was granted, has lapsed" from "never granted", so
+// the admin panel can show a grant that ran out instead of silently dropping
+// the workspace back to free with no explanation.
+func (s *Subscription) ManagedExpired() bool {
+	if s == nil || s.ManagedAt == nil || s.ManagedUntil == nil {
+		return false
+	}
+	return !time.Now().Before(*s.ManagedUntil)
 }
 
 // CanSendEmails returns true if user can send campaign emails
@@ -262,4 +298,18 @@ type StripeWebhookEvent struct {
 // simply re-converges.
 func (p *Plan) IsolatedEgress() bool {
 	return p != nil && p.DedicatedWorkers > 0
+}
+
+// ManagedPlan is the admin-facing view of an operator-granted plan. Managed
+// and Expired are deliberately separate: a lapsed grant is not the same as a
+// workspace that was never granted one, and the reason stays readable after
+// it lapses.
+type ManagedPlan struct {
+	Managed   bool       `json:"managed"`
+	Expired   bool       `json:"expired"`
+	PlanID    uuid.UUID  `json:"plan_id"`
+	GrantedAt *time.Time `json:"granted_at,omitempty"`
+	GrantedBy *uuid.UUID `json:"granted_by,omitempty"`
+	Reason    *string    `json:"reason,omitempty"`
+	Until     *time.Time `json:"until,omitempty"`
 }

--- a/internal/models/subscriptions_managed_test.go
+++ b/internal/models/subscriptions_managed_test.go
@@ -1,0 +1,87 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func managed(at *time.Time, until *time.Time) *Subscription {
+	reason := "internal workspace"
+	by := uuid.New()
+	return &Subscription{ManagedAt: at, ManagedUntil: until, ManagedReason: &reason, ManagedBy: &by}
+}
+
+func ptr(t time.Time) *time.Time { return &t }
+
+// The whole point: a granted plan is paid without Stripe. Before this there
+// was no way to make a workspace paid except a Stripe subscription id.
+func TestManagedPlanCountsAsPaid(t *testing.T) {
+	now := time.Now()
+
+	cases := []struct {
+		name string
+		sub  *Subscription
+		paid bool
+	}{
+		{"open-ended grant", managed(ptr(now.Add(-time.Hour)), nil), true},
+		{"grant with time left", managed(ptr(now.Add(-time.Hour)), ptr(now.Add(24*time.Hour))), true},
+		{"lapsed grant", managed(ptr(now.Add(-48*time.Hour)), ptr(now.Add(-time.Hour))), false},
+		{"never granted", &Subscription{}, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.sub.HasPaidSubscription(); got != tc.paid {
+				t.Errorf("HasPaidSubscription() = %v, want %v", got, tc.paid)
+			}
+		})
+	}
+}
+
+// A grant that ran out must be distinguishable from one that never existed,
+// or the admin panel drops a workspace back to free with no explanation.
+func TestManagedExpiredIsDistinctFromNeverGranted(t *testing.T) {
+	now := time.Now()
+
+	lapsed := managed(ptr(now.Add(-48*time.Hour)), ptr(now.Add(-time.Hour)))
+	if !lapsed.ManagedExpired() {
+		t.Error("a lapsed grant should report as expired")
+	}
+	if lapsed.IsManaged() {
+		t.Error("a lapsed grant is not in force")
+	}
+
+	never := &Subscription{}
+	if never.ManagedExpired() {
+		t.Error("a workspace that was never granted has not expired")
+	}
+
+	open := managed(ptr(now.Add(-time.Hour)), nil)
+	if open.ManagedExpired() {
+		t.Error("an open-ended grant never expires")
+	}
+}
+
+// A real Stripe subscription keeps working exactly as before.
+func TestStripeSubscriptionUnaffected(t *testing.T) {
+	id := "sub_123"
+	sub := &Subscription{StripeSubscriptionID: &id, Status: SubscriptionStatusActive}
+	if !sub.HasPaidSubscription() {
+		t.Error("an active Stripe subscription must still be paid")
+	}
+
+	cancelled := &Subscription{StripeSubscriptionID: &id, Status: SubscriptionStatusCanceled}
+	if cancelled.HasPaidSubscription() {
+		t.Error("a cancelled Stripe subscription must not be paid")
+	}
+}
+
+// nil receivers are reached through optional subscription pointers.
+func TestManagedHelpersTolerateNil(t *testing.T) {
+	var sub *Subscription
+	if sub.IsManaged() || sub.ManagedExpired() {
+		t.Error("nil must answer false rather than panic")
+	}
+}

--- a/internal/models/subscriptions_managed_test.go
+++ b/internal/models/subscriptions_managed_test.go
@@ -85,3 +85,50 @@ func TestManagedHelpersTolerateNil(t *testing.T) {
 		t.Error("nil must answer false rather than panic")
 	}
 }
+
+// A workspace paying Stripe for one plan and granted another must go back to
+// the plan it pays for when the grant ends. Writing the grant over plan_id
+// would have stranded it on the granted plan forever.
+func TestEffectivePlanIDKeepsThePaidPlanIntact(t *testing.T) {
+	paid := uuid.New()
+	granted := uuid.New()
+	now := time.Now()
+
+	sub := managed(ptr(now.Add(-time.Hour)), nil)
+	sub.PlanID = paid
+	sub.ManagedPlanID = &granted
+
+	if got := sub.EffectivePlanID(); got != granted {
+		t.Errorf("an in-force grant should decide entitlements, got %v want %v", got, granted)
+	}
+
+	// The grant lapses; the plan they pay for is untouched underneath.
+	sub.ManagedUntil = ptr(now.Add(-time.Minute))
+	if got := sub.EffectivePlanID(); got != paid {
+		t.Errorf("a lapsed grant must fall back to the paid plan, got %v want %v", got, paid)
+	}
+	if sub.PlanID != paid {
+		t.Error("the paid plan must never be overwritten by a grant")
+	}
+}
+
+// A grant recorded without a plan id entitles nothing, so it must not shadow
+// the real plan. The migration's CHECK refuses to store one, but the helper
+// should not depend on that to be safe.
+func TestEffectivePlanIDIgnoresAGrantWithNoPlan(t *testing.T) {
+	paid := uuid.New()
+	sub := managed(ptr(time.Now().Add(-time.Hour)), nil)
+	sub.PlanID = paid
+	sub.ManagedPlanID = nil
+
+	if got := sub.EffectivePlanID(); got != paid {
+		t.Errorf("got %v, want the paid plan %v", got, paid)
+	}
+}
+
+func TestEffectivePlanIDTeleratesNil(t *testing.T) {
+	var sub *Subscription
+	if got := sub.EffectivePlanID(); got != uuid.Nil {
+		t.Errorf("nil should answer uuid.Nil, got %v", got)
+	}
+}

--- a/internal/repository/pg_organization.go
+++ b/internal/repository/pg_organization.go
@@ -809,6 +809,9 @@ func (r *organizationRepository) SearchOrganizationsForAdmin(ctx context.Context
 	if search.Enterprise {
 		where += ` AND s.is_enterprise = TRUE`
 	}
+	if search.ManagedPlan {
+		where += ` AND s.managed_at IS NOT NULL`
+	}
 	if search.CreatedWithin > 0 {
 		where += ` AND o.created_at >= NOW() - ($` + itoa(argNum) + `::int * INTERVAL '1 day')`
 		args = append(args, search.CreatedWithin)
@@ -945,7 +948,8 @@ func (r *organizationRepository) SearchOrganizationsForAdmin(ctx context.Context
 
 	query := `
 		SELECT ` + adminOrgListColumns + `,
-			p.name, p.public, COALESCE(s.is_enterprise, FALSE)
+			p.name, p.public, COALESCE(s.is_enterprise, FALSE),
+			s.managed_at, s.managed_reason, s.managed_until
 		FROM organizations o
 		JOIN users u ON u.id = o.owner_user_id
 		LEFT JOIN subscriptions s ON s.organization_id = o.id
@@ -966,6 +970,9 @@ func (r *organizationRepository) SearchOrganizationsForAdmin(ctx context.Context
 		var planName *string
 		var planPublic *bool
 		var isEnterprise bool
+		var managedAt *time.Time
+		var managedReason *string
+		var managedUntil *time.Time
 		if err := rows.Scan(
 			&item.ID, &item.Name, &item.Slug, &item.OwnerUserID,
 			&item.OwnerEmail, &item.OwnerFirstName, &item.OwnerLastName, &item.OwnerBannedAt,
@@ -974,12 +981,23 @@ func (r *organizationRepository) SearchOrganizationsForAdmin(ctx context.Context
 			&item.RiskState,
 			&item.UTMSource, &item.UTMMedium, &item.UTMCampaign, &item.LandingPath,
 			&planName, &planPublic, &isEnterprise,
+			&managedAt, &managedReason, &managedUntil,
 		); err != nil {
 			return nil, err
 		}
 		item.PlanName = planName
 		item.PlanPublic = planPublic
 		item.IsEnterprise = isEnterprise
+		// Resolved here rather than in SQL so the in-force rule lives in one
+		// place, models.Subscription.IsManaged, and cannot drift between the
+		// list and the entitlement check.
+		if managedAt != nil {
+			probe := models.Subscription{ManagedAt: managedAt, ManagedUntil: managedUntil}
+			item.ManagedPlan = probe.IsManaged()
+			item.ManagedPlanExpired = probe.ManagedExpired()
+			item.ManagedPlanReason = managedReason
+			item.ManagedPlanUntil = managedUntil
+		}
 		items = append(items, item)
 	}
 

--- a/internal/repository/pg_subscription.go
+++ b/internal/repository/pg_subscription.go
@@ -17,7 +17,7 @@ import (
 // order. With `SELECT *`, the trailing NULL free-trial timestamps land in the
 // non-nullable created_at/updated_at scan slots and pgx fails with
 // "cannot scan NULL into *time.Time", 500-ing every subscription read.
-const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at, managed_at, managed_by, managed_reason, managed_until`
+const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at, managed_at, managed_by, managed_reason, managed_until, managed_plan_id`
 
 type SubscriptionRepository interface {
 	Create(ctx context.Context, sub *models.Subscription) error
@@ -138,7 +138,7 @@ func (r *subscriptionRepository) scanSubscription(ctx context.Context, query str
 		&sub.CancelAtPeriodEnd, &sub.CanceledAt, &sub.TrialStart, &sub.TrialEnd,
 		&sub.FreeTrialStartedAt, &sub.FreeTrialEndsAt,
 		&sub.IsEnterprise, &sub.CreatedAt, &sub.UpdatedAt,
-		&sub.ManagedAt, &sub.ManagedBy, &sub.ManagedReason, &sub.ManagedUntil,
+		&sub.ManagedAt, &sub.ManagedBy, &sub.ManagedReason, &sub.ManagedUntil, &sub.ManagedPlanID,
 	)
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -157,7 +157,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 			s.cancel_at_period_end, s.canceled_at, s.trial_start, s.trial_end,
 			s.free_trial_started_at, s.free_trial_ends_at,
 			s.is_enterprise, s.created_at, s.updated_at,
-			s.managed_at, s.managed_by, s.managed_reason, s.managed_until,
+			s.managed_at, s.managed_by, s.managed_reason, s.managed_until, s.managed_plan_id,
 			COALESCE(url.limit_ws_message_pm, prl.limit_ws_message_pm, 120) as limit_ws_message_pm,
 			COALESCE(url.limit_ws_join_pm, prl.limit_ws_join_pm, 30) as limit_ws_join_pm,
 			COALESCE(url.limit_ws_event_pm, prl.limit_ws_event_pm, 60) as limit_ws_event_pm,
@@ -179,7 +179,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 		&result.CancelAtPeriodEnd, &result.CanceledAt, &result.TrialStart, &result.TrialEnd,
 		&result.FreeTrialStartedAt, &result.FreeTrialEndsAt,
 		&result.IsEnterprise, &result.CreatedAt, &result.UpdatedAt,
-		&result.ManagedAt, &result.ManagedBy, &result.ManagedReason, &result.ManagedUntil,
+		&result.ManagedAt, &result.ManagedBy, &result.ManagedReason, &result.ManagedUntil, &result.ManagedPlanID,
 		&limits.LimitWSMessagePM, &limits.LimitWSJoinPM, &limits.LimitWSEventPM, &limits.MaxConnections,
 	)
 	if err == pgx.ErrNoRows {
@@ -217,28 +217,29 @@ func (r *subscriptionRepository) RecordWebhookEvent(ctx context.Context, event *
 func (r *subscriptionRepository) SetManagedPlan(ctx context.Context, orgID, planID, adminID uuid.UUID, reason string, until *time.Time) error {
 	_, err := r.db.Exec(ctx, `
 		UPDATE subscriptions
-		SET plan_id        = $2,
-		    managed_at     = NOW(),
-		    managed_by     = $3,
-		    managed_reason = $4,
-		    managed_until  = $5,
-		    updated_at     = NOW()
+		SET managed_plan_id = $2,
+		    managed_at      = NOW(),
+		    managed_by      = $3,
+		    managed_reason  = $4,
+		    managed_until   = $5,
+		    updated_at      = NOW()
 		WHERE organization_id = $1`,
 		orgID, planID, adminID, reason, until)
 	return err
 }
 
-// ClearManagedPlan revokes a grant. The plan id is left where it is: the
-// workspace keeps the plan row it was on and simply stops counting as paid,
-// which is the same place an expired grant leaves it.
+// ClearManagedPlan revokes a grant. plan_id was never touched by the grant, so
+// the workspace is already on whatever it actually pays for and simply stops
+// counting as paid, which is where an expired grant leaves it too.
 func (r *subscriptionRepository) ClearManagedPlan(ctx context.Context, orgID uuid.UUID) error {
 	_, err := r.db.Exec(ctx, `
 		UPDATE subscriptions
-		SET managed_at     = NULL,
-		    managed_by     = NULL,
-		    managed_reason = NULL,
-		    managed_until  = NULL,
-		    updated_at     = NOW()
+		SET managed_at      = NULL,
+		    managed_by      = NULL,
+		    managed_reason  = NULL,
+		    managed_until   = NULL,
+		    managed_plan_id = NULL,
+		    updated_at      = NOW()
 		WHERE organization_id = $1`, orgID)
 	return err
 }

--- a/internal/repository/pg_subscription.go
+++ b/internal/repository/pg_subscription.go
@@ -17,7 +17,7 @@ import (
 // order. With `SELECT *`, the trailing NULL free-trial timestamps land in the
 // non-nullable created_at/updated_at scan slots and pgx fails with
 // "cannot scan NULL into *time.Time", 500-ing every subscription read.
-const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at`
+const subscriptionColumns = `id, user_id, organization_id, plan_id, stripe_customer_id, stripe_subscription_id, stripe_price_id, status, current_period_start, current_period_end, cancel_at_period_end, canceled_at, trial_start, trial_end, free_trial_started_at, free_trial_ends_at, is_enterprise, created_at, updated_at, managed_at, managed_by, managed_reason, managed_until`
 
 type SubscriptionRepository interface {
 	Create(ctx context.Context, sub *models.Subscription) error
@@ -27,6 +27,11 @@ type SubscriptionRepository interface {
 	GetByOrganizationID(ctx context.Context, orgID uuid.UUID) (*models.Subscription, error)
 	GetByStripeCustomerID(ctx context.Context, customerID string) (*models.Subscription, error)
 	GetByStripeSubscriptionID(ctx context.Context, subscriptionID string) (*models.Subscription, error)
+
+	// SetManagedPlan / ClearManagedPlan are the operator-granted plan, kept
+	// off Update so a Stripe webhook cannot clear a grant as a side effect.
+	SetManagedPlan(ctx context.Context, orgID, planID, adminID uuid.UUID, reason string, until *time.Time) error
+	ClearManagedPlan(ctx context.Context, orgID uuid.UUID) error
 
 	// With limits - for realtime
 	GetWithLimits(ctx context.Context, orgID uuid.UUID) (*models.SubscriptionWithLimits, error)
@@ -133,6 +138,7 @@ func (r *subscriptionRepository) scanSubscription(ctx context.Context, query str
 		&sub.CancelAtPeriodEnd, &sub.CanceledAt, &sub.TrialStart, &sub.TrialEnd,
 		&sub.FreeTrialStartedAt, &sub.FreeTrialEndsAt,
 		&sub.IsEnterprise, &sub.CreatedAt, &sub.UpdatedAt,
+		&sub.ManagedAt, &sub.ManagedBy, &sub.ManagedReason, &sub.ManagedUntil,
 	)
 	if err == pgx.ErrNoRows {
 		return nil, nil
@@ -151,6 +157,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 			s.cancel_at_period_end, s.canceled_at, s.trial_start, s.trial_end,
 			s.free_trial_started_at, s.free_trial_ends_at,
 			s.is_enterprise, s.created_at, s.updated_at,
+			s.managed_at, s.managed_by, s.managed_reason, s.managed_until,
 			COALESCE(url.limit_ws_message_pm, prl.limit_ws_message_pm, 120) as limit_ws_message_pm,
 			COALESCE(url.limit_ws_join_pm, prl.limit_ws_join_pm, 30) as limit_ws_join_pm,
 			COALESCE(url.limit_ws_event_pm, prl.limit_ws_event_pm, 60) as limit_ws_event_pm,
@@ -172,6 +179,7 @@ func (r *subscriptionRepository) GetWithLimits(ctx context.Context, orgID uuid.U
 		&result.CancelAtPeriodEnd, &result.CanceledAt, &result.TrialStart, &result.TrialEnd,
 		&result.FreeTrialStartedAt, &result.FreeTrialEndsAt,
 		&result.IsEnterprise, &result.CreatedAt, &result.UpdatedAt,
+		&result.ManagedAt, &result.ManagedBy, &result.ManagedReason, &result.ManagedUntil,
 		&limits.LimitWSMessagePM, &limits.LimitWSJoinPM, &limits.LimitWSEventPM, &limits.MaxConnections,
 	)
 	if err == pgx.ErrNoRows {
@@ -200,5 +208,37 @@ func (r *subscriptionRepository) WebhookEventExists(ctx context.Context, eventID
 func (r *subscriptionRepository) RecordWebhookEvent(ctx context.Context, event *models.StripeWebhookEvent) error {
 	query := `INSERT INTO stripe_webhook_events (id, event_type, processed_at) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
 	_, err := r.db.Exec(ctx, query, event.ID, event.EventType, event.ProcessedAt)
+	return err
+}
+
+// SetManagedPlan records an operator-granted plan. Kept out of Update so a
+// routine subscription write, in particular a Stripe webhook, can never clear
+// a grant as a side effect.
+func (r *subscriptionRepository) SetManagedPlan(ctx context.Context, orgID, planID, adminID uuid.UUID, reason string, until *time.Time) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE subscriptions
+		SET plan_id        = $2,
+		    managed_at     = NOW(),
+		    managed_by     = $3,
+		    managed_reason = $4,
+		    managed_until  = $5,
+		    updated_at     = NOW()
+		WHERE organization_id = $1`,
+		orgID, planID, adminID, reason, until)
+	return err
+}
+
+// ClearManagedPlan revokes a grant. The plan id is left where it is: the
+// workspace keeps the plan row it was on and simply stops counting as paid,
+// which is the same place an expired grant leaves it.
+func (r *subscriptionRepository) ClearManagedPlan(ctx context.Context, orgID uuid.UUID) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE subscriptions
+		SET managed_at     = NULL,
+		    managed_by     = NULL,
+		    managed_reason = NULL,
+		    managed_until  = NULL,
+		    updated_at     = NOW()
+		WHERE organization_id = $1`, orgID)
 	return err
 }


### PR DESCRIPTION
There was no way to give any workspace a paid plan without Stripe. `HasPaidSubscription()` was:

```go
return s.StripeSubscriptionID != nil && s.Status.IsActive()
```

So an internal workspace, a design partner or a support gesture had exactly one route: hand-write a fake `stripe_subscription_id` into the table and hope no webhook ever reconciled against an id Stripe has never heard of. I checked for an existing concept — `comped`, `manual_plan`, `is_internal`, `granted_plan` — and there was none. Limit overrides move numeric caps only, never feature gates.

This is felt today: the instance owner's own workspace cannot send campaigns, use the unibox, or use AI, so the product cannot be evaluated from the account that runs it.

## The grant

`subscriptions` gains `managed_at`, `managed_by`, `managed_reason`, `managed_until`, mirroring `organizations.risk_override_*` — who, why, when, so a grant is answerable months later. A `CHECK` refuses a grant with no reason, because an unexplained paid workspace is the thing this is meant to prevent.

`managed_until` NULL is open-ended; a date lapses on its own, so a time-boxed grant needs nobody to remember to revoke it.

`IsManaged()` is checked **first** in `HasPaidSubscription()`, so a granted workspace is paid everywhere entitlements are read, and a workspace that later subscribes for real is unaffected either way.

`ManagedExpired()` is deliberately separate from `IsManaged()`. A lapsed grant is not the same as never having had one: the workspace drops back to free, but the reason stays readable instead of the change looking like it happened for no reason.

## Two things that would have bitten

- **`SetManagedPlan` is off `Update`.** Subscription writes come from Stripe webhooks, and a routine write must not be able to clear a grant as a side effect.
- **Both subscription read paths carry the columns.** `subscriptionColumns` feeds the entitlement path; `GetWithLimits` feeds the customer's own billing page. Updating only the first would have made a granted workspace paid everywhere except where the customer looks.

## Admin panel

- **Badge** on the organization list: `managed`, or `grant lapsed`, with the reason on hover. Included in the CSV export.
- **Filter**: "Managed plan", alongside the existing Enterprise and overrides toggles, so "who is paid because we said so" is one click.
- **Card** on the workspace, under Plan: the grant with its reason, who made it and when it expires, plus grant and revoke. Reading needs `view_organizations`; both writes need `manage_organizations`, so an admin without it sees the record rather than buttons that can only answer 403.
- Both writes go through `LogAdminAction`, so the grant is on the platform-admin trail.

`GET /admin/plans` is new because the customer endpoint returns public plans only, and a grant is usually onto a private one.

## Guarded

A grant dated in the past is refused — it would read as "granted" in the audit trail while entitling nothing. An unknown plan id is a 400 naming the problem rather than a foreign-key violation, which is why the org service now takes a `planRepo`.

## Tests

`subscriptions_managed_test.go` covers open-ended and time-boxed grants, a lapsed one, never-granted, that `ManagedExpired` distinguishes lapsed from never, that a real Stripe subscription is unaffected in both directions, and nil receivers.

`make lint` (149 migrations, no duplicates), `go test ./internal/models/`, `pnpm typecheck` and `pnpm lint` in `admin/` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Administrators can grant, update, view, and revoke managed plans for workspaces without requiring Stripe billing.
  * Managed plans support reasons, optional expiry dates, status badges, and plan entitlement details.
  * Organization lists can filter by managed-plan status and display lapsed grants.
  * CSV exports now include managed-plan status.

* **Documentation**
  * Added billing guidance explaining managed plans, expiry, and revocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->