### PR TITLE
fix: the dashboard's own endpoint never reported a granted plan

### DIFF
--- a/internal/app/subscription/service.go
+++ b/internal/app/subscription/service.go
@@ -50,6 +50,7 @@ func (s *subscriptionService) Get(ctx context.Context, orgID uuid.UUID) (*models
 	// Load plan
 	plan, _ := s.planRepo.GetByID(ctx, sub.EffectivePlanID())
 	sub.Plan = plan
+	sub.Managed = sub.IsManaged()
 
 	return sub, nil
 }

--- a/internal/models/subscriptions.go
+++ b/internal/models/subscriptions.go
@@ -144,6 +144,13 @@ type Subscription struct {
 	// paying Stripe for one plan and granted another goes back to the one it
 	// pays for when the grant ends.
 	ManagedPlanID *uuid.UUID `json:"managed_plan_id,omitempty"`
+	// Managed is IsManaged resolved server-side, carried on the base type so
+	// every endpoint that returns a subscription reports it. A granted plan
+	// never touches Stripe, so Status stays whatever it was ("incomplete" on a
+	// workspace that never subscribed); a client deciding "paid" from Status
+	// alone locks a workspace entitled to everything. Not a column: set by the
+	// service, so a repository scan never has to know about it.
+	Managed bool `json:"managed"`
 
 	// Stripe trial info
 	TrialStart *time.Time `json:"trial_start,omitempty"`
@@ -264,12 +271,6 @@ const FreeWorkspaceMailboxLimit = 10
 type SubscriptionWithLimits struct {
 	Subscription
 	RateLimits *RealtimeRateLimits `json:"rate_limits,omitempty"`
-	// Managed is IsManaged resolved server-side. A granted plan never touches
-	// Stripe, so Status stays whatever it was ("incomplete" on a workspace
-	// that never subscribed) and a client deciding "paid" from Status alone
-	// locks a workspace that is entitled to everything. Expiry is applied
-	// here so no client has to reimplement it.
-	Managed bool `json:"managed"`
 }
 
 // RealtimeRateLimits contains WebSocket-specific rate limits

--- a/internal/models/subscriptions_json_test.go
+++ b/internal/models/subscriptions_json_test.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The dashboard calls GET /subscription, which returns a bare Subscription,
+// and decides whether the workspace is paid from this payload. `managed` lived
+// only on SubscriptionWithLimits once, so the endpoint the dashboard actually
+// uses never carried it and a granted plan stayed locked. Both shapes are
+// pinned here.
+func TestManagedIsOnEverySubscriptionPayload(t *testing.T) {
+	at := time.Now().Add(-time.Hour)
+	planID := uuid.New()
+	sub := Subscription{ManagedAt: &at, ManagedPlanID: &planID}
+	sub.Managed = sub.IsManaged()
+
+	for name, payload := range map[string]any{
+		"GET /subscription":        sub,
+		"GET /subscription/limits": SubscriptionWithLimits{Subscription: sub},
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw, err := json.Marshal(payload)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var out map[string]any
+			if err := json.Unmarshal(raw, &out); err != nil {
+				t.Fatal(err)
+			}
+			got, present := out["managed"]
+			if !present {
+				t.Fatalf("`managed` is absent; a client cannot tell a granted plan from an unpaid one\n%s", raw)
+			}
+			if got != true {
+				t.Errorf("`managed` = %v, want true", got)
+			}
+		})
+	}
+}
+
+// Serialized unconditionally, not omitempty: a client reading `managed`
+// as undefined would treat an unpaid workspace and a missing field alike,
+// which is the failure this guards.
+func TestManagedIsPresentEvenWhenFalse(t *testing.T) {
+	raw, err := json.Marshal(Subscription{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatal(err)
+	}
+	if got, present := out["managed"]; !present || got != false {
+		t.Fatalf("want managed=false present, got %v (present=%v)\n%s", got, present, raw)
+	}
+}


### PR DESCRIPTION
#474 added `managed` to the subscription response and the workspace stayed locked. The flag went on the wrong type.

The dashboard calls `GET /subscription` → `GetSubscription` → `SubscriptionService.Get`, which returns a bare `models.Subscription`. `managed` was added to `SubscriptionWithLimits`, which only `GET /subscription/limits` returns. So the one endpoint `useFeatureAccess` reads never carried the field, `sub.data?.managed` was `undefined`, and a granted workspace kept resolving to unpaid.

The visible result was the same contradiction as before: the header naming the granted plan correctly (it resolves through `EffectivePlanID`) while every sidebar entry stayed locked behind `STARTER` and the mailbox panel offered the free allowance.

## The fix

`Managed` moves onto `models.Subscription`, which every subscription response either is or embeds, and both service methods set it:

- `Get` — what `GET /subscription` returns, and what the dashboard reads. This is the one that was missing.
- `GetWithLimits` — already set it; now inherits the field rather than declaring its own.

It is not a column. The service computes it from `IsManaged()`, so expiry stays resolved in one place and no repository scan has to know about it.

## Tests

`subscriptions_json_test.go` marshals both shapes and asserts `managed` is present and true on each, naming the endpoints in the subtests so the reason is visible when one fails. It would have failed on #474 as merged, which is the point of adding it rather than just moving the field.

A second test pins that `managed` serializes even when false. It is deliberately not `omitempty`: a client reading it as `undefined` cannot distinguish "not granted" from "this server does not report it", and that ambiguity is what produced the original bug.

`make lint` and `go test ./internal/models/` pass.